### PR TITLE
Added CMake and lcov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 2.8.4)
+project(json)
+
+# Enable C++11 and set flags for coverage testing
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+
+# If not specified, use Debug as build type (necessary for coverage testing)
+if( NOT CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Debug CACHE STRING
+       ""
+       FORCE )
+endif()
+
+# CMake addons for lcov
+# Only possible with g++ at the moment. We run otherwise just the test
+if(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+  set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
+  include(CodeCoverage)
+
+  setup_coverage(coverage)
+endif()
+
+# Normal sources
+include_directories(src/)
+aux_source_directory(src/ json_list)
+add_library(json ${json_list})
+
+# Testing
+enable_testing()
+
+# Search all test files in the test directory with a .cc suffix
+file(GLOB TEST_FILES "test/*.cc")
+foreach(TEST_FILE ${TEST_FILES})
+  # We use the basename to identify the test. E.g "json_unit" for "json_unit.cc"
+  get_filename_component(BASENAME ${TEST_FILE} NAME_WE)
+  # Create a test executable
+  add_executable(${BASENAME} ${TEST_FILE})
+  # Link it with our main json file
+  target_link_libraries(${BASENAME} json)
+
+  # Add test if people want to use ctest
+  add_test(${BASENAME} ${BASENAME})
+
+  # If we are using g++, we also need to setup the commands for coverage
+  # testing
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    # Add a run_XXX target that runs the executable and produces the
+    # coverage data automatically
+    add_custom_target(run_${BASENAME} COMMAND ./${BASENAME})
+    # Make sure that running requires the executable to be build
+    add_dependencies (run_${BASENAME} ${BASENAME})
+    # To create a valid coverage report, the executable has to be
+    # executed first
+    add_dependencies (coverage run_${BASENAME})
+  endif()
+endforeach()
+

--- a/CMakeModules/CodeCoverage.cmake
+++ b/CMakeModules/CodeCoverage.cmake
@@ -1,0 +1,116 @@
+#
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# USAGE:
+
+# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
+#      http://stackoverflow.com/a/22404544/80480
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt:
+#      INCLUDE(CodeCoverage)
+#
+# 3. Set compiler flags to turn off optimization and enable coverage:
+#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#
+# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
+#    which runs your test executable and produces a lcov code coverage report:
+#    Example:
+#	 SETUP_TARGET_FOR_COVERAGE(
+#				my_coverage_target  # Name for custom target.
+#				test_driver         # Name of the test driver executable that runs the tests.
+#									# NOTE! This should always have a ZERO as exit code
+#									# otherwise the coverage generation will not complete.
+#				coverage            # Name of output directory.
+#				)
+#
+# 4. Build a Debug build:
+#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
+#	 make
+#	 make my_coverage_target
+#
+#
+
+# Check prereqs
+FIND_PROGRAM( GCOV_PATH gcov )
+FIND_PROGRAM( LCOV_PATH lcov )
+FIND_PROGRAM( GENHTML_PATH genhtml )
+FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+
+IF(NOT GCOV_PATH)
+	MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+ENDIF() # NOT GCOV_PATH
+
+IF(NOT CMAKE_COMPILER_IS_GNUCXX)
+	# Clang version 3.0.0 and greater now supports gcov as well.
+	MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
+
+	IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+	ENDIF()
+ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
+
+SET(CMAKE_CXX_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
+  MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
+ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+
+
+# Param _outputname     lcov output is generated as _outputname.info
+#                       HTML report is generated in _outputname/index.html
+FUNCTION(SETUP_COVERAGE _outputname)
+
+	IF(NOT LCOV_PATH)
+		MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+	ENDIF() # NOT LCOV_PATH
+
+	IF(NOT GENHTML_PATH)
+		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+	ENDIF() # NOT GENHTML_PATH
+
+	# Setup target
+	ADD_CUSTOM_TARGET(coverage
+
+
+		# Capturing lcov counters and generating report
+		COMMAND ${LCOV_PATH} --rc lcov_branch_coverage=1 --directory . --capture --output-file ${_outputname}.info
+		COMMAND ${LCOV_PATH} --rc lcov_branch_coverage=1 --remove ${_outputname}.info 'tests/*' '/usr/*' --output-file ${_outputname}.info.cleaned
+		COMMAND ${GENHTML_PATH} --branch-coverage --rc lcov_branch_coverage=1 -o ${_outputname} ${_outputname}.info.cleaned
+		COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
+
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+		# Cleanup lcov
+		${LCOV_PATH} --directory . --zerocounters
+	)
+
+ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE

--- a/README.md
+++ b/README.md
@@ -233,7 +233,26 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-## Execute unit tests
+## Execute unit tests with CMake
+
+# To compile and run the tests, you need to execute
+
+```sh
+$ cmake .
+$ make
+$ ctest
+```
+
+If you want to generate a coverage report with lcov, execute this instead:
+
+```sh
+$ cmake .
+$ make coverage
+```
+
+The report is now in the subfolder coverage/index.html
+
+## Execute unit tests with automake
 
 To compile the unit tests, you need to execute
 


### PR DESCRIPTION
This patch adds

* CMake as an additional build system for the tests
* support for creating a coverage report with lcov (branch coverage, line coverage, function coverage).

I added that CMake treats each file in the 'test' directory as a test. So if you want to split up the json_unit.cc to speed up compilation, then the current CMake script should support it.

Here is an example run of lcov for this branch: http://teemperor.de/pub/json/index.html