### PR TITLE
Fix double delete on std::bad_alloc exception

### DIFF
--- a/src/json.cc
+++ b/src/json.cc
@@ -1192,6 +1192,7 @@ json::iterator json::find(const char* key)
         {
             json::iterator result(this);
             delete result.oi_;
+            result.oi_ = nullptr;
             result.oi_ = new object_t::iterator(i);
             return result;
         }
@@ -1215,6 +1216,7 @@ json::const_iterator json::find(const char* key) const
         {
             json::const_iterator result(this);
             delete result.oi_;
+            result.oi_ = nullptr;
             result.oi_ = new object_t::const_iterator(i);
             return result;
         }


### PR DESCRIPTION
If the new operator throws in the json::find methods then result.oi_ is
deleted again in the destructor of json::iterator/json::const_iterator,
which is a double delete and undefined behaviour.