### PR TITLE
Implemented the JSON spec for string parsing for everything but the \uXXXX escaping

### DIFF
--- a/test/json_unit.cc
+++ b/test/json_unit.cc
@@ -1618,10 +1618,39 @@ TEST_CASE("Parser")
         CHECK(json::parse("\"\"") == json(""));
         CHECK(json::parse("\"foo\"") == json("foo"));
 
-        // escape characters
+        // escaping quotes
         CHECK_THROWS_AS(json::parse("\"\\\""), std::invalid_argument);
         CHECK_NOTHROW(json::parse("\"\\\"\""));
-        CHECK_NOTHROW(json::parse("\"\\\\\""));
+
+        // escaping backslashes
+        CHECK(json::parse("\"a\\\\z\"") == json("a\\z"));
+        CHECK(json::parse("\"\\\\\"") == json("\\"));
+        CHECK(json::parse("\"\\\\a\\\\\"") == json("\\a\\"));
+        CHECK(json::parse("\"\\\\\\\\\"") == json("\\\\"));
+
+        // escaping slash
+        CHECK(json::parse("\"a\\/z\"") == json("a/z"));
+        CHECK(json::parse("\"\\/\"") == json("/"));
+
+        // escaping tabs
+        CHECK(json::parse("\"a\\tz\"") == json("a\tz"));
+        CHECK(json::parse("\"\\t\"") == json("\t"));
+
+        // escaping formfeed
+        CHECK(json::parse("\"a\\fz\"") == json("a\fz"));
+        CHECK(json::parse("\"\\f\"") == json("\f"));
+
+        // escaping carriage return
+        CHECK(json::parse("\"a\\rz\"") == json("a\rz"));
+        CHECK(json::parse("\"\\r\"") == json("\r"));
+
+        // escaping backspace
+        CHECK(json::parse("\"a\\bz\"") == json("a\bz"));
+        CHECK(json::parse("\"\\b\"") == json("\b"));
+
+        // escaping newline
+        CHECK(json::parse("\"a\\nz\"") == json("a\nz"));
+        CHECK(json::parse("\"\\n\"") == json("\n"));
 
         // quotes must be closed
         CHECK_THROWS_AS(json::parse("\""), std::invalid_argument);

--- a/test/json_unit.cc
+++ b/test/json_unit.cc
@@ -1652,6 +1652,11 @@ TEST_CASE("Parser")
         CHECK(json::parse("\"a\\nz\"") == json("a\nz"));
         CHECK(json::parse("\"\\n\"") == json("\n"));
 
+        // escaping senseless stuff
+        CHECK_THROWS_AS(json::parse("\"\\z\""), std::invalid_argument);
+        CHECK_THROWS_AS(json::parse("\"\\ \""), std::invalid_argument);
+        CHECK_THROWS_AS(json::parse("\"\\9\""), std::invalid_argument);
+
         // quotes must be closed
         CHECK_THROWS_AS(json::parse("\""), std::invalid_argument);
     }


### PR DESCRIPTION
Everything that is mentioned in #12 (beside the \uXXXX escaping) is fixed in this branch.

The \uXXXX-PR follows ASAP.