### PR TITLE
Fixed dumping of strings

### DIFF
--- a/src/json.cc
+++ b/src/json.cc
@@ -492,7 +492,7 @@ std::string json::dump(const bool prettyPrint, const unsigned int indentStep,
     {
         case (value_type::string):
         {
-            return std::string("\"") + *value_.string + "\"";
+            return std::string("\"") + escapeString(*value_.string) + "\"";
         }
 
         case (value_type::boolean):
@@ -587,6 +587,49 @@ std::string json::dump(const bool prettyPrint, const unsigned int indentStep,
             return "null";
         }
     }
+}
+
+/*!
+Internal function to replace all occurrences of a character in a given string
+with another string.
+
+\param str            the string that contains tokens to replace
+\param c     the character that needs to be replaced
+\param replacement  the string that is the replacement for the character
+*/
+void json::replaceChar(std::string& str, char c, const std::string& replacement)
+                       const
+{
+    size_t start_pos = 0;
+    while((start_pos = str.find(c, start_pos)) != std::string::npos) {
+        str.replace(start_pos, 1, replacement);
+        start_pos += replacement.length();
+    }
+}
+
+/*!
+Escapes all special characters in the given string according to ECMA-404.
+Necessary as some characters such as quotes, backslashes and so on
+can't be used as is when dumping a string value.
+
+\param str        the string that should be escaped.
+
+\return a copy of the given string with all special characters escaped.
+*/
+std::string json::escapeString(const std::string& str) const
+{
+    std::string result(str);
+    // we first need to escape the backslashes as all other methods will insert
+    // legitimate backslashes into the result.
+    replaceChar(result, '\\', "\\\\");
+    // replace all other characters
+    replaceChar(result, '"', "\\\"");
+    replaceChar(result, '\n', "\\n");
+    replaceChar(result, '\r', "\\r");
+    replaceChar(result, '\f', "\\f");
+    replaceChar(result, '\b', "\\b");
+    replaceChar(result, '\t', "\\t");
+    return result;
 }
 
 /*!

--- a/src/json.h
+++ b/src/json.h
@@ -165,7 +165,10 @@ class json
 
     /// dump the object (with pretty printer)
     std::string dump(const bool, const unsigned int, unsigned int = 0) const noexcept;
-
+    /// replaced a character in a string with another string
+    void replaceChar(std::string& str, char c, const std::string& replacement) const;
+    /// escapes special characters to safely dump the string
+    std::string escapeString(const std::string&) const;
   public:
     /// explicit value conversion
     template<typename T>

--- a/test/json_unit.cc
+++ b/test/json_unit.cc
@@ -819,6 +819,17 @@ TEST_CASE("string")
         j1.clear();
         CHECK(j1.get<std::string>() == "");
     }
+
+    SECTION("Dumping")
+    {
+        CHECK(json("\"").dump(0) == "\"\\\"\"");
+        CHECK(json("\\").dump(0) == "\"\\\\\"");
+        CHECK(json("\n").dump(0) == "\"\\n\"");
+        CHECK(json("\t").dump(0) == "\"\\t\"");
+        CHECK(json("\b").dump(0) == "\"\\b\"");
+        CHECK(json("\f").dump(0) == "\"\\f\"");
+        CHECK(json("\r").dump(0) == "\"\\r\"");
+    }
 }
 
 TEST_CASE("boolean")


### PR DESCRIPTION
Dumping strings containing special characters such as quotes, backslashes, newlines and so on results in invalid results.

This patch adds a escaping mechanism that fixes this problem.

A possible (but not required by the standard) escaping of unicode characters is not included in this patch.