### PR TITLE
Fix string conversion under Clang

### DIFF
--- a/src/json.cc
+++ b/src/json.cc
@@ -442,7 +442,7 @@ json::object_t json::get() const
     }
 }
 
-json::operator const std::string() const
+json::operator std::string() const
 {
     return get<std::string>();
 }

--- a/src/json.h
+++ b/src/json.h
@@ -175,7 +175,7 @@ class json
     T get() const;
 
     /// implicit conversion to string representation
-    operator const std::string() const;
+    operator std::string() const;
     /// implicit conversion to integer (only for numbers)
     operator int() const;
     /// implicit conversion to double (only for numbers)

--- a/test/json_unit.cc
+++ b/test/json_unit.cc
@@ -773,6 +773,7 @@ TEST_CASE("string")
         CHECK_NOTHROW(auto v = j.get<json::array_t>());
         CHECK_THROWS_AS(auto v = j.get<json::object_t>(), std::logic_error);
         CHECK_NOTHROW(auto v = j.get<std::string>());
+        CHECK_NOTHROW(auto v = static_cast<std::string>(j));
         CHECK_THROWS_AS(auto v = j.get<bool>(), std::logic_error);
         CHECK_THROWS_AS(auto v = j.get<int>(), std::logic_error);
         CHECK_THROWS_AS(auto v = j.get<double>(), std::logic_error);


### PR DESCRIPTION
Explicit conversion to `std::string` by `static_cast<>` causes compilation error when using Clang (3.5).
(Casting to `const std::string` doesn't work either.)

This PR fixed it by removing `const` from the casting operator.
And I think it also makes casting operator more consistent with `get<>()` method.