### PR TITLE
Feature/small float serialization

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1853,7 +1853,8 @@ class basic_json
     recursively. Note that
 
     - strings and object keys are escaped using escape_string()
-    - numbers are converted to a string before output using std::to_string()
+    - integer numbers are converted to a string before output using std::to_string()
+    - floating-point numbers are converted to a string using "%g" format
 
     @param prettyPrint    whether the output shall be pretty-printed
     @param indentStep     the indent level
@@ -1961,7 +1962,12 @@ class basic_json
 
             case (value_t::number_float):
             {
-                return std::to_string(m_value.number_float);
+                // 15 digits of precision allows round-trip IEEE 754 string->double->string
+                unsigned int sz = (unsigned int)std::snprintf(nullptr, 0, "%.15g", m_value.number_float);
+                std::vector<char> buf(sz + 1);
+                std::snprintf(&buf[0], buf.size(), "%.15g", m_value.number_float);
+                string_t formatted = buf.data();
+                return formatted;
             }
 
             default:

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -1160,6 +1160,12 @@ TEST_CASE("object inspection")
             CHECK(s.find("42.23") != std::string::npos);
         }
 
+        SECTION("dump and small floating-point numbers")
+        {
+            auto s = json(1.23456e-78).dump();
+            CHECK(s.find("1.23456e-78") != std::string::npos);
+        }
+
         SECTION("dump and non-ASCII characters")
         {
             CHECK(json("ä").dump() == "\"ä\"");


### PR DESCRIPTION
Adds a test for small floats (which previously failed) along with a fix 
for dump() that makes the test pass. 

Now uses std::snprintf() to generate a "%.15g" formatted string
for JSON values of type number_float. 15 decimals digits are
enough to round-trip an IEEE 754 double from string->double->string
and get an identical result.

std::snprintf is called twice. Once to determine the required
buffer size and then again after allocating a buffer of that
size.

Note that the buffer size *could* be hardcoded for better
performance. "%.15g" should result in strings of maximum length
23, plus one character for the terminating null for a buffer size
of 24. Let me know if you'd like me to switch to a fixed buffer 
size to avoid the extra call to snprintf and the overhead of 
dynamic memory allocation. 

Fixes #37 