### PR TITLE
Add parser callback with the ability to filter results.

### DIFF
--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -1717,6 +1717,12 @@ class basic_json
     }
 
     /// deserialize from stream
+    static basic_json parse(std::istream& i)
+    {
+        return parser(i).parse();
+    }
+
+    /// deserialize from stream
     friend std::istream& operator>>(std::istream& i, basic_json& j)
     {
         j = parser(i).parse();

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3267,7 +3267,7 @@ class basic_json
 			std::getline(*m_stream, line);
 			m_buffer += line;
 
-			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str()); //reinterpret_cast<lexer_char_t*>(endptr)
+			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
 			m_start  = m_content + offset_start;
 			m_marker = m_start + offset_marker;
 			m_cursor = m_start + offset_cursor;

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3052,18 +3052,18 @@ class basic_json
         using lexer_char_t = unsigned char;
 
         /// constructor with a given buffer
-		inline lexer(const string_t& s) noexcept
-		: m_buffer(s), m_stream(nullptr)
-		{
-			m_content = reinterpret_cast<const lexer_char_t*>(s.c_str());
-			m_start = m_cursor = m_content;
-			m_limit = m_content + s.size();
-		}
-		inline lexer(std::istream* s) noexcept
+        inline lexer(const string_t& s) noexcept
+        : m_buffer(s), m_stream(nullptr)
+        {
+            m_content = reinterpret_cast<const lexer_char_t*>(s.c_str());
+            m_start = m_cursor = m_content;
+            m_limit = m_content + s.size();
+        }
+        inline lexer(std::istream* s) noexcept
             : m_stream(s)
         {
-			getline(*m_stream, m_buffer);
-			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
+            getline(*m_stream, m_buffer);
+            m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
             m_start = m_cursor = m_content;
             m_limit = m_content + m_buffer.size();
         }
@@ -3259,26 +3259,26 @@ class basic_json
 
         }
 
-		/// append data from the stream to the internal buffer
-		void yyfill() noexcept
-		{
-			if (not m_stream or not *m_stream) return;
+        /// append data from the stream to the internal buffer
+        void yyfill() noexcept
+        {
+            if (not m_stream or not *m_stream) return;
 
-			ssize_t offset_start  = m_start  - m_content;
-			ssize_t offset_marker = m_marker - m_start;
-			ssize_t offset_cursor = m_cursor - m_start;
+            ssize_t offset_start  = m_start  - m_content;
+            ssize_t offset_marker = m_marker - m_start;
+            ssize_t offset_cursor = m_cursor - m_start;
 
-			m_buffer.erase(0, offset_start);
-			std::string line;
-			std::getline(*m_stream, line);
-			m_buffer += line;
+            m_buffer.erase(0, offset_start);
+            std::string line;
+            std::getline(*m_stream, line);
+            m_buffer += line;
 
-			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
-			m_start  = m_content;
-			m_marker = m_start + offset_marker;
-			m_cursor = m_start + offset_cursor;
-			m_limit  = m_start + m_buffer.size() - 1;
-		}
+            m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
+            m_start  = m_content;
+            m_marker = m_start + offset_marker;
+            m_cursor = m_start + offset_cursor;
+            m_limit  = m_start + m_buffer.size() - 1;
+        }
 
         /// return string representation of last read token
         inline string_t get_token() const noexcept

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3253,6 +3253,7 @@ class basic_json
 
         }
 
+		/// append data from the stream to the internal buffer
 		void yyfill(int n) noexcept
 		{
 			if (not m_stream or not *m_stream) return;
@@ -3261,6 +3262,9 @@ class basic_json
 			ssize_t offset_marker = m_marker - m_start;
 			ssize_t offset_cursor = m_cursor - m_start;
 
+			// The parser generator expects a minimum of n bytes to be appended,
+			// but by appending a line of data we will never split a token, so
+			// it should be safe to ignore the parameter.
 			m_buffer.erase(0, offset_start);
 			std::string line;
 			std::getline(*m_stream, line);

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3191,13 +3191,13 @@ class basic_json
             // remember the begin of the token
             m_start = m_cursor;
 
-#define YYFILL(n) { yyfill(n); }
-
             /*!re2c
                 re2c:define:YYCTYPE  = lexer_char_t;
                 re2c:define:YYCURSOR = m_cursor;
                 re2c:define:YYLIMIT  = m_limit;
                 re2c:define:YYMARKER = m_marker;
+                re2c:define:YYFILL   = "{ yyfill(); }";
+                re2c:yyfill:parameter = 0;
                 re2c:indent:string   = "    ";
                 re2c:indent:top      = 1;
                 re2c:labelprefix     = "basic_json_parser_";
@@ -3254,7 +3254,7 @@ class basic_json
         }
 
 		/// append data from the stream to the internal buffer
-		void yyfill(int n) noexcept
+		void yyfill() noexcept
 		{
 			if (not m_stream or not *m_stream) return;
 
@@ -3262,9 +3262,6 @@ class basic_json
 			ssize_t offset_marker = m_marker - m_start;
 			ssize_t offset_cursor = m_cursor - m_start;
 
-			// The parser generator expects a minimum of n bytes to be appended,
-			// but by appending a line of data we will never split a token, so
-			// it should be safe to ignore the parameter.
 			m_buffer.erase(0, offset_start);
 			std::string line;
 			std::getline(*m_stream, line);

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3468,16 +3468,6 @@ class basic_json
         /// a parser reading from an input stream
 		inline parser(std::istream& _is) : m_lexer(&_is)
         {
-//            while (_is)
-//            {
-//                string_t input_line;
-//                std::getline(_is, input_line);
-//                m_buffer += input_line;
-//            }
-
-            // initializer lexer
-//			m_lexer = std::move(lexer(_is));
-
             // read first token
             get_token();
         }

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3191,7 +3191,7 @@ class basic_json
             // remember the begin of the token
             m_start = m_cursor;
 
-#define YYFILL(n)       { size_t offset_marker = m_marker - m_start; yyfill(n);  m_marker = m_start + offset_marker; }
+#define YYFILL(n) { yyfill(n); }
 
             /*!re2c
                 re2c:define:YYCTYPE  = lexer_char_t;

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3186,7 +3186,7 @@ class basic_json
         inline token_type scan() noexcept
         {
             // pointer for backtracking information
-            const lexer_char_t* m_marker = nullptr;
+            m_marker = nullptr;
 
             // remember the begin of the token
             m_start = m_cursor;
@@ -3258,6 +3258,7 @@ class basic_json
 			if (not m_stream or not *m_stream) return;
 
 			ssize_t offset_start  = m_start  - m_content;
+			ssize_t offset_marker = m_marker - m_start;
 			ssize_t offset_cursor = m_cursor - m_start;
 			ssize_t offset_limit  = m_limit  - m_start;
 
@@ -3268,6 +3269,7 @@ class basic_json
 
 			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str()); //reinterpret_cast<lexer_char_t*>(endptr)
 			m_start  = m_content + offset_start;
+			m_marker = m_start + offset_marker;
 			m_cursor = m_start + offset_cursor;
 			m_limit  = m_start + offset_limit;
 		}
@@ -3442,6 +3444,8 @@ class basic_json
         const lexer_char_t* m_content = nullptr;
         /// pointer to the beginning of the current symbol
         const lexer_char_t* m_start = nullptr;
+        /// pointer for backtracking information
+        const lexer_char_t* m_marker = nullptr;
         /// pointer to the current symbol
         const lexer_char_t* m_cursor = nullptr;
         /// pointer to the end of the buffer

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3046,11 +3046,20 @@ class basic_json
         using lexer_char_t = unsigned char;
 
         /// constructor with a given buffer
-        inline lexer(const string_t& s) noexcept
-            : m_content(reinterpret_cast<const lexer_char_t*>(s.c_str()))
+		inline lexer(const string_t& s) noexcept
+		: m_buffer(s), m_stream(nullptr)
+		{
+			m_content = reinterpret_cast<const lexer_char_t*>(s.c_str());
+			m_start = m_cursor = m_content;
+			m_limit = m_content + s.size();
+		}
+		inline lexer(std::istream* s) noexcept
+            : m_stream(s)
         {
+			getline(*m_stream, m_buffer);
+			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
             m_start = m_cursor = m_content;
-            m_limit = m_content + s.size();
+            m_limit = m_content + m_buffer.size();
         }
 
         /// default constructor
@@ -3182,6 +3191,8 @@ class basic_json
             // remember the begin of the token
             m_start = m_cursor;
 
+#define YYFILL(n)       { size_t offset_marker = m_marker - m_start; yyfill(n);  m_marker = m_start + offset_marker; }
+
             /*!re2c
                 re2c:define:YYCTYPE  = lexer_char_t;
                 re2c:define:YYCURSOR = m_cursor;
@@ -3190,7 +3201,6 @@ class basic_json
                 re2c:indent:string   = "    ";
                 re2c:indent:top      = 1;
                 re2c:labelprefix     = "basic_json_parser_";
-                re2c:yyfill:enable   = 0;
 
                 // whitespace
                 ws = [ \t\n\r]+;
@@ -3240,7 +3250,27 @@ class basic_json
                 // anything else is an error
                 .              { return token_type::parse_error; }
              */
+
         }
+
+		void yyfill(int n) noexcept
+		{
+			if (not m_stream or not *m_stream) return;
+
+			ssize_t offset_start  = m_start  - m_content;
+			ssize_t offset_cursor = m_cursor - m_start;
+			ssize_t offset_limit  = m_limit  - m_start;
+
+			m_buffer.erase(0, offset_start);
+			std::string line;
+			std::getline(*m_stream, line);
+			m_buffer += line;
+
+			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str()); //reinterpret_cast<lexer_char_t*>(endptr)
+			m_start  = m_content + offset_start;
+			m_cursor = m_start + offset_cursor;
+			m_limit  = m_start + offset_limit;
+		}
 
         /// return string representation of last read token
         inline string_t get_token() const noexcept
@@ -3404,14 +3434,20 @@ class basic_json
         }
 
       private:
+        /// optional input stream
+        std::istream* m_stream;
         /// the buffer
+        string_t m_buffer;
+        /// the buffer pointer
         const lexer_char_t* m_content = nullptr;
-        /// pointer to he beginning of the current symbol
+        /// pointer to the beginning of the current symbol
         const lexer_char_t* m_start = nullptr;
         /// pointer to the current symbol
         const lexer_char_t* m_cursor = nullptr;
         /// pointer to the end of the buffer
         const lexer_char_t* m_limit = nullptr;
+        /// YYSTATE
+        int m_state;
     };
 
     /*!
@@ -3421,24 +3457,24 @@ class basic_json
     {
       public:
         /// constructor for strings
-        inline parser(const string_t& s) : m_buffer(s), m_lexer(m_buffer)
+		inline parser(const string_t& s) : m_lexer(s)
         {
             // read first token
             get_token();
         }
 
         /// a parser reading from an input stream
-        inline parser(std::istream& _is)
+		inline parser(std::istream& _is) : m_lexer(&_is)
         {
-            while (_is)
-            {
-                string_t input_line;
-                std::getline(_is, input_line);
-                m_buffer += input_line;
-            }
+//            while (_is)
+//            {
+//                string_t input_line;
+//                std::getline(_is, input_line);
+//                m_buffer += input_line;
+//            }
 
             // initializer lexer
-            m_lexer = lexer(m_buffer);
+//			m_lexer = std::move(lexer(_is));
 
             // read first token
             get_token();
@@ -3625,8 +3661,6 @@ class basic_json
         }
 
       private:
-        /// the buffer
-        string_t m_buffer;
         /// the type of the last read token
         typename lexer::token_type last_token = lexer::token_type::uninitialized;
         /// the lexer

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3260,7 +3260,6 @@ class basic_json
 			ssize_t offset_start  = m_start  - m_content;
 			ssize_t offset_marker = m_marker - m_start;
 			ssize_t offset_cursor = m_cursor - m_start;
-			ssize_t offset_limit  = m_limit  - m_start;
 
 			m_buffer.erase(0, offset_start);
 			std::string line;
@@ -3268,10 +3267,10 @@ class basic_json
 			m_buffer += line;
 
 			m_content = reinterpret_cast<const lexer_char_t*>(m_buffer.c_str());
-			m_start  = m_content + offset_start;
+			m_start  = m_content;
 			m_marker = m_start + offset_marker;
 			m_cursor = m_start + offset_cursor;
-			m_limit  = m_start + offset_limit;
+			m_limit  = m_start + m_buffer.size() - 1;
 		}
 
         /// return string representation of last read token

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -3450,8 +3450,6 @@ class basic_json
         const lexer_char_t* m_cursor = nullptr;
         /// pointer to the end of the buffer
         const lexer_char_t* m_limit = nullptr;
-        /// YYSTATE
-        int m_state;
     };
 
     /*!

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -230,8 +230,34 @@ class basic_json
         string,         ///< string value
         boolean,        ///< boolean value
         number_integer, ///< number value (integer)
-        number_float    ///< number value (floating-point)
+        number_float,   ///< number value (floating-point)
+        discarded       ///< (internal) indicates the parser callback chose not to keep the value
     };
+
+    //////////////////////////
+    // JSON parser callback //
+    //////////////////////////
+
+    /// JSON callback event enumeration
+    enum class parse_event_t : uint8_t
+    {
+        object_start,  ///< start an object scope (found a '{' token)
+        object_end,    ///< end of an object scope (found '}' token)
+        array_start,   ///< start of an array scope (found '[' token)
+        array_end,     ///< end of an array scope (found ']' token)
+        key,           ///< found an object key within an object scope
+        value          ///< a value in an appropriate context (i.e., following a tag in an object scope)
+    };
+
+    /// per-element parser callback type
+    using parser_callback_t = std::function<bool(int depth, parse_event_t event,
+        const nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberFloatType, Allocator>& parsed)>;
+
+    /// default parser callback returns true to keep all elements
+    static bool default_callback(int, parse_event_t, const nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberFloatType, Allocator>&)
+    {
+        return true;
+    }
 
     /*!
     @brief comparison operator for JSON value types
@@ -331,6 +357,7 @@ class basic_json
         switch (m_type)
         {
             case (value_t::null):
+            case (value_t::discarded):
             {
                 break;
             }
@@ -596,6 +623,7 @@ class basic_json
         switch (m_type)
         {
             case (value_t::null):
+            case (value_t::discarded):
             {
                 break;
             }
@@ -785,6 +813,12 @@ class basic_json
     inline bool is_string() const noexcept
     {
         return m_type == value_t::string;
+    }
+
+    // return whether value is discarded
+    inline bool is_discarded() const noexcept
+    {
+        return m_type == value_t::discarded;
     }
 
     /// return the type of the object (implicit)
@@ -1310,6 +1344,7 @@ class basic_json
         switch (m_type)
         {
             case (value_t::null):
+            case (value_t::discarded):
             {
                 break;
             }
@@ -1572,6 +1607,11 @@ class basic_json
                 }
                 break;
             }
+            case (value_t::discarded):
+            {
+                return false;
+                break;
+            }
         }
 
         return false;
@@ -1655,6 +1695,11 @@ class basic_json
                 }
                 break;
             }
+            case (value_t::discarded):
+            {
+                return false;
+                break;
+            }
         }
 
         // We only reach this line if we cannot compare values. In that case,
@@ -1711,15 +1756,15 @@ class basic_json
     /////////////////////
 
     /// deserialize from string
-    static basic_json parse(const string_t& s)
+    static basic_json parse(const string_t& s, parser_callback_t cb = default_callback)
     {
-        return parser(s).parse();
+        return parser(s, cb).parse();
     }
 
     /// deserialize from stream
-    static basic_json parse(std::istream& i)
+    static basic_json parse(std::istream& i, parser_callback_t cb = default_callback)
     {
-        return parser(i).parse();
+        return parser(i, cb).parse();
     }
 
     /// deserialize from stream
@@ -1770,6 +1815,11 @@ class basic_json
             case (value_t::boolean):
             {
                 return "boolean";
+            }
+
+            case (value_t::discarded):
+            {
+                return "discarded";
             }
 
             default:
@@ -1993,6 +2043,10 @@ class basic_json
                 return std::to_string(m_value.number_float);
             }
 
+            case (value_t::discarded):
+            {
+                return "<discarded>";
+            }
             default:
             {
                 return "null";
@@ -3465,14 +3519,14 @@ class basic_json
     {
       public:
         /// constructor for strings
-		inline parser(const string_t& s) : m_lexer(s)
+        inline parser(const string_t& s, parser_callback_t cb = default_callback) : callback(cb), m_lexer(s)
         {
             // read first token
             get_token();
         }
 
         /// a parser reading from an input stream
-		inline parser(std::istream& _is) : m_lexer(&_is)
+        inline parser(std::istream& _is, parser_callback_t cb = default_callback) : callback(cb), m_lexer(&_is)
         {
             // read first token
             get_token();
@@ -3481,7 +3535,7 @@ class basic_json
         /// public parser interface
         inline basic_json parse()
         {
-            basic_json result = parse_internal();
+            basic_json result = parse_internal(true);
 
             expect(lexer::token_type::end_of_input);
 
@@ -3490,14 +3544,19 @@ class basic_json
 
       private:
         /// the actual parser
-        inline basic_json parse_internal()
+        inline basic_json parse_internal(bool keep)
         {
+            auto result = basic_json(value_t::discarded);
+
             switch (last_token)
             {
                 case (lexer::token_type::begin_object):
                 {
-                    // explicitly set result to object to cope with {}
-                    basic_json result(value_t::object);
+                    if (keep and (keep = callback(depth++, parse_event_t::object_start, result)))
+                    {
+                        // explicitly set result to object to cope with {}
+                        result = basic_json(value_t::object);
+                    }
 
                     // read next token
                     get_token();
@@ -3506,6 +3565,10 @@ class basic_json
                     if (last_token == lexer::token_type::end_object)
                     {
                         get_token();
+                        if (keep and not (keep = callback(--depth, parse_event_t::object_end, result)))
+                        {
+                            result = basic_json(value_t::discarded);
+                        }
                         return result;
                     }
 
@@ -3522,27 +3585,44 @@ class basic_json
                         expect(lexer::token_type::value_string);
                         const auto key = m_lexer.get_string();
 
+                        bool keep_tag = false;
+                        if (keep)
+                        {
+                            keep_tag = callback(depth, parse_event_t::key, basic_json(key));
+                        }
+
                         // parse separator (:)
                         get_token();
                         expect(lexer::token_type::name_separator);
 
                         // parse value
                         get_token();
-                        result[key] = parse_internal();
+                        auto value = parse_internal(keep);
+                        if (keep and keep_tag and not value.is_discarded())
+                        {
+                            result[key] = value;
+                        }
                     }
                     while (last_token == lexer::token_type::value_separator);
 
                     // closing }
                     expect(lexer::token_type::end_object);
                     get_token();
+                    if (keep and not callback(--depth, parse_event_t::object_end, result))
+                    {
+                        result = basic_json(value_t::discarded);
+                    }
 
                     return result;
                 }
 
                 case (lexer::token_type::begin_array):
                 {
-                    // explicitly set result to object to cope with []
-                    basic_json result(value_t::array);
+                    if (keep and (keep = callback(depth++, parse_event_t::array_start, result)))
+                    {
+                        // explicitly set result to object to cope with []
+                        result = basic_json(value_t::array);
+                    }
 
                     // read next token
                     get_token();
@@ -3551,6 +3631,10 @@ class basic_json
                     if (last_token == lexer::token_type::end_array)
                     {
                         get_token();
+                        if (not callback(--depth, parse_event_t::array_end, result))
+                        {
+                            result = basic_json(value_t::discarded);
+                        }
                         return result;
                     }
 
@@ -3564,13 +3648,21 @@ class basic_json
                         }
 
                         // parse value
-                        result.push_back(parse_internal());
+                        auto value = parse_internal(keep);
+                        if (keep and not value.is_discarded())
+                        {
+                            result.push_back(value);
+                        }
                     }
                     while (last_token == lexer::token_type::value_separator);
 
                     // closing ]
                     expect(lexer::token_type::end_array);
                     get_token();
+                    if (keep and not callback(--depth, parse_event_t::array_end, result))
+                    {
+                        result = basic_json(value_t::discarded);
+                    }
 
                     return result;
                 }
@@ -3578,26 +3670,30 @@ class basic_json
                 case (lexer::token_type::literal_null):
                 {
                     get_token();
-                    return basic_json(nullptr);
+                    result = basic_json(nullptr);
+                    break;
                 }
 
                 case (lexer::token_type::value_string):
                 {
                     const auto s = m_lexer.get_string();
                     get_token();
-                    return basic_json(s);
+                    result = basic_json(s);
+                    break;
                 }
 
                 case (lexer::token_type::literal_true):
                 {
                     get_token();
-                    return basic_json(true);
+                    result = basic_json(true);
+                    break;
                 }
 
                 case (lexer::token_type::literal_false):
                 {
                     get_token();
-                    return basic_json(false);
+                    result = basic_json(false);
+                    break;
                 }
 
                 case (lexer::token_type::value_number):
@@ -3619,13 +3715,14 @@ class basic_json
                     if (float_val == int_val)
                     {
                         // we basic_json not lose precision -> return int
-                        return basic_json(int_val);
+                        result = basic_json(int_val);
                     }
                     else
                     {
                         // we would lose precision -> returnfloat
-                        return basic_json(float_val);
+                        result = basic_json(float_val);
                     }
+                    break;
                 }
 
                 default:
@@ -3637,6 +3734,12 @@ class basic_json
                     throw std::invalid_argument(error_msg);
                 }
             }
+
+            if (keep and not callback(depth, parse_event_t::value, result))
+            {
+                result = basic_json(value_t::discarded);
+            }
+            return result;
         }
 
         /// get next token from lexer
@@ -3659,6 +3762,10 @@ class basic_json
         }
 
       private:
+        /// levels of recursion
+        int depth = 0;
+        /// callback function
+        parser_callback_t callback;
         /// the type of the last read token
         typename lexer::token_type last_token = lexer::token_type::uninitialized;
         /// the lexer


### PR DESCRIPTION
This request builds on the "incremental" pull request. I separated the two in case you find this change objectionable. The changes implement a callback to a user-provided function (which can be a closure) to notify the user of key parser events: entering object and array elements, closing object and array elements, parsing an object key, and parsing a value. This enables processing elements as they are parsed, for example to provide progress feedback. More importantly, the user function returns a bool to indicate whether to keep the value. This can be used to filter the accumulated elements to reduce memory consumption. There is a default callback provided, so it existing code should compile and work as before.

Below is an example use case. It parses a JSON file that consists of an array (which is inside a simple object) of a large number of objects. The example just pretty-prints the result, discarding all dictionaries at a depth of 2, but it could do more interesting processing. Without the callback, a 4.1 MB test file uses 12.5 MB of memory. With the callback, it peaks at around 680 KB, most of which is process overhead.

```C++
using namespace std;
using json = nlohmann::json;

static const auto tab = '\t';
ifstream stream("/tmp/test/json/data.json");

...
{
		bool keyed = false;

		json j = json::parse(stream, [&keyed] (int depth, json::parse_event_t event, const json& element) -> bool {

			switch (event) {
				case json::parse_event_t::object_start:
					if (not keyed)
						for (int i = 0; i < depth; i++) cout << tab;
					cout << '{' << endl;
					keyed = false;
					break;

				case json::parse_event_t::object_end:
					for (int i = 0; i < depth; i++) cout << tab;
					cout << '}' << endl;
					if (depth == 2) return false;
					break;

				case json::parse_event_t::array_start:
					if (not keyed)
						for (int i = 0; i < depth; i++) cout << tab;
					cout << '[' << endl;
					keyed = false;
					break;

				case json::parse_event_t::array_end:
					for (int i = 0; i < depth; i++) cout << tab;
					cout << ']' << endl;
					break;

				case json::parse_event_t::key:
					for (int i = 0; i < depth; i++) cout << tab;
					cout << element << " = ";
					keyed = true;
					break;

				case json::parse_event_t::value:
					if (keyed) {
						cout << element << endl;
					}
					else {
						for (int i = 0; i < depth; i++) cout << tab;
						cout << element << endl;
					}
					keyed = false;
					break;

				default:
					break;
			}
			return true;
		});
	}
```