### PR TITLE
Fix compilation of json_unit with GCC 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 
 # build unit tests
 json_unit: test/unit.cpp src/json.hpp test/catch.hpp
-	$(CXX) -std=c++11 $(CXXFLAGS) $(FLAGS) $(CPPFLAGS) -I src -I test -Dprivate=public $< $(LDFLAGS) -o $@
+	$(CXX) -std=c++11 $(CXXFLAGS) $(FLAGS) $(CPPFLAGS) -I src -I test $< $(LDFLAGS) -o $@
 
 # create scanner with re2c
 re2c: src/json.hpp.re2c

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -10,9 +10,6 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include "json.hpp"
-using nlohmann::json;
-
 #include <array>
 #include <deque>
 #include <forward_list>
@@ -23,6 +20,10 @@ using nlohmann::json;
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#define private public
+#include "json.hpp"
+using nlohmann::json;
 
 TEST_CASE("constructors")
 {


### PR DESCRIPTION
Addressing:
```
+ make json_unit
g++ -std=c++11  -Wall -Wextra -pedantic -Weffc++ -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-declarations -Wmissing-include-dirs -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch -Wundef -Wno-unused -Wnon-virtual-dtor -Wreorder -Wdeprecated -Wfloat-equal  -I src -I test -Dprivate=public test/unit.cpp  -o json_unit
In file included from test/catch.hpp:65:0,
                 from test/unit.cpp:11:
/usr/include/c++/5.0.0/sstream:300:7: error: 'struct std::__cxx11::basic_stringbuf<_CharT, _Traits, _Alloc>::__xfer_bufptrs' redeclared with different access
       struct __xfer_bufptrs
```