### PR TITLE
support enum

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -417,6 +417,11 @@ class basic_json
     inline basic_json(const number_integer_t& value)
         : m_type(value_t::number_integer), m_value(value)
     {}
+    
+    /// create an int number to support enum type (implicit)
+    inline basic_json(int int_enum)
+	    : m_type(value_t::number_integer), m_value((NumberIntegerType)int_enum)
+    {}
 
     /// create an integer number (implicit)
     template<typename T, typename


### PR DESCRIPTION
construct enum type to basic_json (proxy by int type)
```
    enum { t = 0 };
    json  j = json::array();
    j.push_back(t);

    j.push_back(json::object({
         {"game_type", t}
    }));
```