### PR TITLE
Replace `default_callback` function with `nullptr` and check for null…

### DIFF
--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -291,12 +291,6 @@ class basic_json
     using parser_callback_t = std::function<bool(int depth, parse_event_t event,
                               const basic_json& parsed)>;
 
-    /// default parser callback returns true to keep all elements
-    static bool default_callback(int, parse_event_t, const basic_json&)
-    {
-        return true;
-    }
-
     /*!
     @brief comparison operator for JSON value types
 
@@ -2002,13 +1996,13 @@ class basic_json
     /////////////////////
 
     /// deserialize from string
-    static basic_json parse(const string_t& s, parser_callback_t cb = default_callback)
+    static basic_json parse(const string_t& s, parser_callback_t cb = nullptr)
     {
         return parser(s, cb).parse();
     }
 
     /// deserialize from stream
-    static basic_json parse(std::istream& i, parser_callback_t cb = default_callback)
+    static basic_json parse(std::istream& i, parser_callback_t cb = nullptr)
     {
         return parser(i, cb).parse();
     }
@@ -3893,14 +3887,14 @@ class basic_json
     {
       public:
         /// constructor for strings
-        inline parser(const string_t& s, parser_callback_t cb = default_callback) : callback(cb), m_lexer(s)
+        inline parser(const string_t& s, parser_callback_t cb = nullptr) : callback(cb), m_lexer(s)
         {
             // read first token
             get_token();
         }
 
         /// a parser reading from an input stream
-        inline parser(std::istream& _is, parser_callback_t cb = default_callback) : callback(cb),
+        inline parser(std::istream& _is, parser_callback_t cb = nullptr) : callback(cb),
             m_lexer(&_is)
         {
             // read first token
@@ -3927,7 +3921,7 @@ class basic_json
             {
                 case (lexer::token_type::begin_object):
                 {
-                    if (keep and (keep = callback(depth++, parse_event_t::object_start, result)))
+                    if (keep and (not callback or (keep = callback(depth++, parse_event_t::object_start, result))))
                     {
                         // explicitly set result to object to cope with {}
                         result.m_type = value_t::object;
@@ -3941,7 +3935,7 @@ class basic_json
                     if (last_token == lexer::token_type::end_object)
                     {
                         get_token();
-                        if (keep and not (keep = callback(--depth, parse_event_t::object_end, result)))
+                        if (keep and callback and not callback(--depth, parse_event_t::object_end, result))
                         {
                             result = basic_json(value_t::discarded);
                         }
@@ -3967,7 +3961,7 @@ class basic_json
                         bool keep_tag = false;
                         if (keep)
                         {
-                            keep_tag = callback(depth, parse_event_t::key, basic_json(key));
+							keep_tag = callback ? callback(depth, parse_event_t::key, basic_json(key)) : true;
                         }
 
                         // parse separator (:)
@@ -3987,7 +3981,7 @@ class basic_json
                     // closing }
                     expect(lexer::token_type::end_object);
                     get_token();
-                    if (keep and not callback(--depth, parse_event_t::object_end, result))
+                    if (keep and callback and not callback(--depth, parse_event_t::object_end, result))
                     {
                         result = basic_json(value_t::discarded);
                     }
@@ -3997,7 +3991,7 @@ class basic_json
 
                 case (lexer::token_type::begin_array):
                 {
-                    if (keep and (keep = callback(depth++, parse_event_t::array_start, result)))
+                    if (keep and (not callback or (keep = callback(depth++, parse_event_t::array_start, result))))
                     {
                         // explicitly set result to object to cope with []
                         result.m_type = value_t::array;
@@ -4011,7 +4005,7 @@ class basic_json
                     if (last_token == lexer::token_type::end_array)
                     {
                         get_token();
-                        if (not callback(--depth, parse_event_t::array_end, result))
+                        if (callback and not callback(--depth, parse_event_t::array_end, result))
                         {
                             result = basic_json(value_t::discarded);
                         }
@@ -4042,7 +4036,7 @@ class basic_json
                     // closing ]
                     expect(lexer::token_type::end_array);
                     get_token();
-                    if (keep and not callback(--depth, parse_event_t::array_end, result))
+                    if (keep and callback and not callback(--depth, parse_event_t::array_end, result))
                     {
                         result = basic_json(value_t::discarded);
                     }
@@ -4119,7 +4113,7 @@ class basic_json
                 }
             }
 
-            if (keep and not callback(depth, parse_event_t::value, result))
+            if (keep and callback and not callback(depth, parse_event_t::value, result))
             {
                 result = basic_json(value_t::discarded);
             }


### PR DESCRIPTION
… callback function before calling it. This is cleaner and better performing.

This is in response to your question about performance and the temporary object for the callback. This does not eliminate the temporary object, but it replaces the default callback with a check for null on the callback member variable, which is faster and avoids the temp object in the default case. In the case where the caller has supplied a callback function, presumably the overhead of a temp object is negligible compared to the processing that will be performed in the callback.

If you would like to optimize the callback to avoid the temp object, the only solution I can think of at the moment is to change the `basic_json` reference parameter of the callback function to a `void *` and require the callback function to cast it to a `string` pointer or `basic_json` pointer based on the event type. This solution sounds really ugly to me, so my vote is in favor of the temp object. 