### PR TITLE
Make immutable array static and constexpr

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -300,7 +300,7 @@ class basic_json
     */
     friend bool operator<(const value_t lhs, const value_t rhs)
     {
-        std::array<uint8_t, 7> order = {{
+        static constexpr std::array<uint8_t, 7> order = {{
                 0, // null
                 3, // object
                 4, // array

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -300,7 +300,7 @@ class basic_json
     */
     friend bool operator<(const value_t lhs, const value_t rhs)
     {
-        static constexpr std::array<uint8_t, 7> order = {{
+        std::array<uint8_t, 7> order = {{
                 0, // null
                 3, // object
                 4, // array

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -300,7 +300,7 @@ class basic_json
     */
     friend bool operator<(const value_t lhs, const value_t rhs)
     {
-        std::array<uint8_t, 7> order = {{
+        static constexpr  std::array<uint8_t, 7> order = {{
                 0, // null
                 3, // object
                 4, // array


### PR DESCRIPTION
This array is only read and is always initialized with the same values, thus it's useless to construct it for each call of operator<() .
I'm not sure it will have any impact on performances, but the immutability is clearly asserted by making this array static and constexpr.