### PR TITLE
Remove useless typename

### DIFF
--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -2358,7 +2358,7 @@ class basic_json
         /// defines a reference to the type iterated over (value_type)
         using reference = typename basic_json::reference;
         /// the category of the iterator
-        using iterator_category = typename std::bidirectional_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
 
         /// default constructor
         inline iterator() = default;
@@ -2874,7 +2874,7 @@ class basic_json
         /// defines a reference to the type iterated over (value_type)
         using reference = typename basic_json::const_reference;
         /// the category of the iterator
-        using iterator_category = typename std::bidirectional_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
 
         /// default constructor
         inline const_iterator() = default;


### PR DESCRIPTION
It avoids a warning with GCC 4.9:

```
json.hpp:2361:49: warning: declaration 'struct std::bidirectional_iterator_tag' does not declare anything
         using iterator_category = typename std::bidirectional_iterator_tag;
                                                 ^
```

I don't add the generated `json.hpp` as my re2c version makes a very different version from the one in the repo. Or maybe I should directly modify `json.hpp`?