### PR TITLE
Quick fix to address subsequent unicode chars prob

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -4692,6 +4692,8 @@ class basic_json
                         // print character c as \uxxxx
                         sprintf(&result[pos + 1], "u%04x", int(c));
                         pos += 6;
+                        // overwrite trailing null character
+                        result[pos] = '\\';
                     }
                     else
                     {


### PR DESCRIPTION
sprintf prints a null character at the end of the string and overwrites the \\ character that was set during initalization (line 4625). Whenever there are two subsequent characters that are escaped, the first one ends up overwriting the second's backslash. In case there's a non-escaped string between them, the string itself overwrites the null character.

Here's an easy way to reproduce this issue:

```
string bytes{0x7, 0x7};
cout << "bytes: " << bytes << endl;
json j;
j["string"] = bytes;
cout << j.dump() << endl;
```

// expected result: \u0007\u0007
// actual result: \u0007\0u0007