### PR TITLE
Overload parse() to accept an rvalue reference

### DIFF
--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -4471,6 +4471,11 @@ class basic_json
         return parser(i, cb).parse();
     }
 
+    static basic_json parse(std::istream&& i, parser_callback_t cb = nullptr)
+    {
+        return parser(i, cb).parse();
+    }
+
     /*!
     @brief deserialize from stream
 


### PR DESCRIPTION
Currently, one cannot directly pass a `std::ifstream` to the `parse` function: 
```c++
const char *filename = "my_file.json";
json my_json = json::parse(std::ifstream(filename));
```
This fails with the error: 
```
error: invalid initialization of non-const reference of type ‘std::istream& {aka std::basic_istream<char>&}’ from an rvalue of type ‘std::basic_istream<char>’
 json my_json = json::parse(std::ifstream(filename));
```
If I'm not mistaken, this happens because a temporary `ifstream` is created which cannot be bound to a non-const reference, as it's required from the signature of `parse(std::istream&, parser_callback_t)`.

Overloading `parse` to accept an rvalue reference (valid C++11) solves the problem and allows to move the ownership of the temporary stream to the function.