### PR TITLE
support cmake package config file : find_package support + auto-install 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,49 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.0)
 
 project(json CXX)
+
+set (json_VERSION "1.0.0-rc1")
 
 add_executable(json_unit
     src/json.hpp test/catch.hpp test/unit.cpp
 )
 
-if(MSVC)
-    set(CMAKE_CXX_FLAGS
-        "/EHsc"
-    )
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
 
-    STRING(REPLACE "/O2" "/Od" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "-std=c++11")
 
-    add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-else(MSVC)
-    set(CMAKE_CXX_FLAGS
-        "-std=c++11 -stdlib=libc++"
-    )
-endif(MSVC)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  set(CMAKE_CXX_FLAGS "/EHsc")
+
+  STRING(REPLACE "/O2" "/Od" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+
+  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+endif()
 
 include_directories(
     src test
 )
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/src/ DESTINATION include/nlohmann
+        FILES_MATCHING PATTERN "*.[ih]pp")
+
+include(CMakePackageConfigHelpers)
+set(INCLUDE_INSTALL_DIR include/)
+set(DEFINITIONS "${CMAKE_CXX_FLAGS}")
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/modules/nlohmann-json-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/nlohmann-json-config.cmake
+  INSTALL_DESTINATION lib/cmake/nlohmann-json-${json_VERSION}
+  PATH_VARS INCLUDE_INSTALL_DIR)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/nlohmann-json-config-version.cmake
+    VERSION ${json_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/nlohmann-json-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/nlohmann-json-config-version.cmake
+    DESTINATION lib/cmake/nlohmann-json-${json_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,26 @@
 cmake_minimum_required(VERSION 3.0.0)
 
-project(json CXX)
-
-set (json_VERSION "1.0.0-rc1")
+project(json
+  LANGUAGES CXX 
+  VERSION "1.0.0")
 
 add_executable(json_unit
     src/json.hpp test/catch.hpp test/unit.cpp
 )
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
+  set(CMAKE_CXX_FLAGS "-std=c++11")
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(CMAKE_CXX_FLAGS "/EHsc")
 
   STRING(REPLACE "/O2" "/Od" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 
+  # See https://msdn.microsoft.com/fr-fr/library/aa985974.aspx?f=255&MSPPError=-2147217396
+  # Avoid warnings for unsafe STL methods call
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 endif()
 
@@ -40,7 +42,6 @@ configure_package_config_file(
 
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/nlohmann-json-config-version.cmake
-    VERSION ${json_VERSION}
     COMPATIBILITY AnyNewerVersion)
 
 install(FILES

--- a/cmake/modules/nlohmann-json-config.cmake.in
+++ b/cmake/modules/nlohmann-json-config.cmake.in
@@ -1,0 +1,23 @@
+# It can be used as :
+#  
+# find_package(nlohmann-json)
+# target_link_libraries(program nlohmann-json::nlohmann-json)
+#
+# It also defines 
+#   - ${NLOHMANN_JSON_INCLUDE_DIRS}
+#   - ${NLOHMANN_JSON_DEFINITIONS}
+#
+set(NLOHMANN_JSON_VERSION @json_VERSION@)
+
+@PACKAGE_INIT@
+
+set_and_check(NLOHMANN_JSON_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set(NLOHMANN_JSON_DEFINITIONS "@CMAKE_CXX_FLAGS@")
+check_required_components(nlohmann_json) 
+
+if (NOT TARGET "nlohmann-json::nlohmann-json")
+  add_library("nlohmann-json::nlohmann-json" INTERFACE IMPORTED)
+  set_target_properties("nlohmann-json::nlohmann-json"
+    PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${NLOHMANN_JSON_INCLUDE_DIRS}")
+endif()

--- a/cmake/modules/nlohmann-json-config.cmake.in
+++ b/cmake/modules/nlohmann-json-config.cmake.in
@@ -19,5 +19,6 @@ if (NOT TARGET "nlohmann-json::nlohmann-json")
   add_library("nlohmann-json::nlohmann-json" INTERFACE IMPORTED)
   set_target_properties("nlohmann-json::nlohmann-json"
     PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${NLOHMANN_JSON_INCLUDE_DIRS}")
+    INTERFACE_INCLUDE_DIRECTORIES "${NLOHMANN_JSON_INCLUDE_DIRS}"
+    INTERFACE_COMPILE_OPTIONS ${NLOHMANN_JSON_DEFINITIONS})
 endif()


### PR DESCRIPTION
Dear @nlohmann,

I wish to submit you these changes which adds the possibility for dependent programs of your library to use it easily via cmake `find_package`, and therefore auto-download+install via `hunter_add_package` ( *i.e.* see [example cmake](https://github.com/daminetreg/hunter/blob/pull-request/add-nlohmann-json/examples/nlohmann-json/) )..

```cmake

HunterGate(
    URL "https://github.com/ruslo/hunter/archive/vUPCOMING.tar.gz"
    SHA1 "53b198e364dc7bc8360fc545f798563229bd7e20"
)

project(dowload-nlohmann-json)

hunter_add_package(nlohmann-json)
find_package(nlohmann-json)

add_executable(main main.cpp)

target_link_libraries(main
  nlohmann-json::nlohmann-json)
```

For the moment this is not in Hunter ( *i.e.* See PR [#239](https://github.com/ruslo/hunter/pull/239) ), but even if it isn't accepted in Hunter, it is useful for code depending on your library, as the changes aren't Hunter specific, they allow the standard cmake `find_package` mechanism to be used to find your library.

Thank you very much for your awesome library to handle json. I like it. :smile: 
Cheers,