### PR TITLE
remove invalid parameter '-stdlib=libc++' in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(MSVC)
     add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 else(MSVC)
     set(CMAKE_CXX_FLAGS
-        "-std=c++11 -stdlib=libc++"
+        "-std=c++11"
     )
 endif(MSVC)
 


### PR DESCRIPTION
I remove the following invalid parameter : -stdlib=libc++
This produce a compilation error with my compiler : g++ 4.9.3
c++: error: unrecognized command line option ‘-stdlib=libc++’
CMakeFiles/json_unit.dir/build.make:54: recipe for target 'CMakeFiles/json_unit.dir/test/unit.cpp.o' failed
make[2]: *** [CMakeFiles/json_unit.dir/test/unit.cpp.o] Error 1
CMakeFiles/Makefile2:60: recipe for target 'CMakeFiles/json_unit.dir/all' failed
make[1]: *** [CMakeFiles/json_unit.dir/all] Error 2
Makefile:75: recipe for target 'all' failed
make: *** [all] Error 2
