### PR TITLE
fixed typos in comments for examples

### DIFF
--- a/doc/examples/get__PointerType.cpp
+++ b/doc/examples/get__PointerType.cpp
@@ -4,7 +4,7 @@ using namespace nlohmann;
 
 int main()
 {
-    // create a JSON boolean
+    // create a JSON number
     json value = 17;
 
     // explicitly getting pointers

--- a/doc/examples/get_ptr.cpp
+++ b/doc/examples/get_ptr.cpp
@@ -4,7 +4,7 @@ using namespace nlohmann;
 
 int main()
 {
-    // create a JSON boolean
+    // create a JSON number
     json value = 17;
 
     // explicitly getting pointers

--- a/doc/examples/object.cpp
+++ b/doc/examples/object.cpp
@@ -4,13 +4,13 @@ using namespace nlohmann;
 
 int main()
 {
-    // create JSON arrays
+    // create JSON objects
     json j_no_init_list = json::object();
     json j_empty_init_list = json::object({});
     json j_list_of_pairs = json::object({ {"one", 1}, {"two", 2} });
     //json j_invalid_list = json::object({ "one", 1 }); // would throw
 
-    // serialize the JSON arrays
+    // serialize the JSON objects
     std::cout << j_no_init_list << '\n';
     std::cout << j_empty_init_list << '\n';
     std::cout << j_list_of_pairs << '\n';


### PR DESCRIPTION
Minor fixes to comments in examples.

BTW, I don't see the examples compiled as part of the tests.
How do you make sure they compile?