### PR TITLE
disabled "CopyAssignable" test for MSVC in Debug mode, see #125

### DIFF
--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -9229,7 +9229,7 @@ TEST_CASE("concepts")
         SECTION("CopyAssignable")
         {
 // STL iterators used by json::iterator don't pass this test in Debug mode
-#if defined(_MSC_VER) && (_ITERATOR_DEBUG_LEVEL == 0)
+#if !defined(_MSC_VER) || (_ITERATOR_DEBUG_LEVEL == 0)
             CHECK(std::is_nothrow_copy_assignable<json::iterator>::value);
             CHECK(std::is_nothrow_copy_assignable<json::const_iterator>::value);
 #endif

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -9228,8 +9228,11 @@ TEST_CASE("concepts")
 
         SECTION("CopyAssignable")
         {
+// STL iterators used by json::iterator don't pass this test in Debug mode
+#if defined(_MSC_VER) && (_ITERATOR_DEBUG_LEVEL == 0)
             CHECK(std::is_nothrow_copy_assignable<json::iterator>::value);
             CHECK(std::is_nothrow_copy_assignable<json::const_iterator>::value);
+#endif
         }
 
         SECTION("Destructible")


### PR DESCRIPTION
STL iterators used by json::iterator don't pass this test in Debug mode.
The test does pass in Release mode, so I felt the best thing to do was selectively disable that test.
More details in #125 