### PR TITLE
Detect correctly pointer-to-const

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -2385,7 +2385,7 @@ class basic_json
     template<typename PointerType, typename
              std::enable_if<
                  std::is_pointer<PointerType>::value
-                 and std::is_const<PointerType>::value
+                 and std::is_const< typename std::remove_pointer<PointerType>::type >::value
                  , int>::type = 0>
     const PointerType get_ptr() const noexcept
     {

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -2385,7 +2385,7 @@ class basic_json
     template<typename PointerType, typename
              std::enable_if<
                  std::is_pointer<PointerType>::value
-                 and std::is_const<PointerType>::value
+                 and std::is_const< typename std::remove_pointer<PointerType>::type >::value
                  , int>::type = 0>
     const PointerType get_ptr() const noexcept
     {


### PR DESCRIPTION
The intention of the current code is to detect a pointer-to-const but instead it is detecting a const-pointer. See #134