### PR TITLE
Make basic_json allocate-aware, as mentioned in #161 + unrelated changes for #164

### DIFF
--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -11216,7 +11216,7 @@ TEST_CASE("regression tests")
     SECTION("issue #89 - nonstandard integer type")
     {
         // create JSON class with nonstandard integer number type
-        nlohmann::basic_json<std::map, std::vector, std::string, bool, int32_t, float> j;
+        nlohmann::basic_json<nlohmann::default_object_type, nlohmann::default_array_type, std::string, bool, int32_t, float> j;
         j["int_1"] = 1;
         // we need to cast to int to compile with Catch - the value is int32_t
         CHECK(static_cast<int>(j["int_1"]) == 1);

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -916,7 +916,7 @@ TEST_CASE("constructors")
     SECTION("create an array of n copies of a given value")
     {
         json v = {1, "foo", 34.23, {1, 2, 3}, {{"A", 1}, {"B", 2}}};
-        json arr(3, v);
+        json arr = json::array(3, v);
         CHECK(arr.size() == 3);
         for (auto& x : arr)
         {


### PR DESCRIPTION
This is an attempt to make it work with #164.
The thing is that the current code attempts to define containers with incomplete types,
this is not supported by the standard and does not work with unordered_map. std::vector and
std::map work but we might be in the realm of undefined behaviour.
