### PR TITLE
Issue #195 - update Travis to Trusty due to gcc/clang strtod() bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.6']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
           packages: ['clang-3.6', 'valgrind']
       env: COMPILER=clang++-3.6
 
@@ -42,7 +42,7 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.7']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
           packages: ['clang-3.7', 'valgrind']
       env: COMPILER=clang++-3.7
      

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 
-sudo: false
+dist: trusty
+sudo: required
 
 # from http://stackoverflow.com/a/32127147/266378
 matrix:
@@ -33,7 +34,7 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.6']
           packages: ['clang-3.6', 'valgrind']
       env: COMPILER=clang++-3.6
 
@@ -41,7 +42,7 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.7']
           packages: ['clang-3.7', 'valgrind']
       env: COMPILER=clang++-3.7
      

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -6831,789 +6831,386 @@ class basic_json
             m_start = m_cursor;
             assert(m_start != nullptr);
 
-
-            {
-                lexer_char_t yych;
-                unsigned int yyaccept = 0;
-                static const unsigned char yybm[] =
-                {
-                    0,   0,   0,   0,   0,   0,   0,   0,
-                    0,  32,  32,   0,   0,  32,   0,   0,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    96,  64,   0,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    192, 192, 192, 192, 192, 192, 192, 192,
-                    192, 192,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,   0,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                    64,  64,  64,  64,  64,  64,  64,  64,
-                };
-                if ((m_limit - m_cursor) < 5)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
+            
+    {
+        lexer_char_t yych;
+        unsigned int yyaccept = 0;
+        static const unsigned char yybm[] = {
+              0,   0,   0,   0,   0,   0,   0,   0, 
+              0,  32,  32,   0,   0,  32,   0,   0, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             96,  64,   0,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+            192, 192, 192, 192, 192, 192, 192, 192, 
+            192, 192,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,   0,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+             64,  64,  64,  64,  64,  64,  64,  64, 
+        };
+        if ((m_limit - m_cursor) < 5) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= ':') {
+            if (yych <= ' ') {
+                if (yych <= '\n') {
+                    if (yych <= 0x00) goto basic_json_parser_28;
+                    if (yych <= 0x08) goto basic_json_parser_30;
+                    if (yych >= '\n') goto basic_json_parser_4;
+                } else {
+                    if (yych == '\r') goto basic_json_parser_2;
+                    if (yych <= 0x1F) goto basic_json_parser_30;
                 }
-                yych = *m_cursor;
-                if (yych <= ':')
-                {
-                    if (yych <= ' ')
-                    {
-                        if (yych <= '\n')
-                        {
-                            if (yych <= 0x00)
-                            {
-                                goto basic_json_parser_28;
-                            }
-                            if (yych <= 0x08)
-                            {
-                                goto basic_json_parser_30;
-                            }
-                            if (yych >= '\n')
-                            {
-                                goto basic_json_parser_4;
-                            }
-                        }
-                        else
-                        {
-                            if (yych == '\r')
-                            {
-                                goto basic_json_parser_2;
-                            }
-                            if (yych <= 0x1F)
-                            {
-                                goto basic_json_parser_30;
-                            }
-                        }
+            } else {
+                if (yych <= ',') {
+                    if (yych == '"') goto basic_json_parser_27;
+                    if (yych <= '+') goto basic_json_parser_30;
+                    goto basic_json_parser_16;
+                } else {
+                    if (yych <= '/') {
+                        if (yych <= '-') goto basic_json_parser_23;
+                        goto basic_json_parser_30;
+                    } else {
+                        if (yych <= '0') goto basic_json_parser_24;
+                        if (yych <= '9') goto basic_json_parser_26;
+                        goto basic_json_parser_18;
                     }
-                    else
-                    {
-                        if (yych <= ',')
-                        {
-                            if (yych == '"')
-                            {
-                                goto basic_json_parser_27;
-                            }
-                            if (yych <= '+')
-                            {
-                                goto basic_json_parser_30;
-                            }
-                            goto basic_json_parser_16;
-                        }
-                        else
-                        {
-                            if (yych <= '/')
-                            {
-                                if (yych <= '-')
-                                {
-                                    goto basic_json_parser_23;
-                                }
-                                goto basic_json_parser_30;
-                            }
-                            else
-                            {
-                                if (yych <= '0')
-                                {
-                                    goto basic_json_parser_24;
-                                }
-                                if (yych <= '9')
-                                {
-                                    goto basic_json_parser_26;
-                                }
-                                goto basic_json_parser_18;
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    if (yych <= 'n')
-                    {
-                        if (yych <= ']')
-                        {
-                            if (yych == '[')
-                            {
-                                goto basic_json_parser_8;
-                            }
-                            if (yych <= '\\')
-                            {
-                                goto basic_json_parser_30;
-                            }
-                            goto basic_json_parser_10;
-                        }
-                        else
-                        {
-                            if (yych == 'f')
-                            {
-                                goto basic_json_parser_22;
-                            }
-                            if (yych <= 'm')
-                            {
-                                goto basic_json_parser_30;
-                            }
-                            goto basic_json_parser_20;
-                        }
-                    }
-                    else
-                    {
-                        if (yych <= '{')
-                        {
-                            if (yych == 't')
-                            {
-                                goto basic_json_parser_21;
-                            }
-                            if (yych <= 'z')
-                            {
-                                goto basic_json_parser_30;
-                            }
-                            goto basic_json_parser_12;
-                        }
-                        else
-                        {
-                            if (yych <= '}')
-                            {
-                                if (yych <= '|')
-                                {
-                                    goto basic_json_parser_30;
-                                }
-                                goto basic_json_parser_14;
-                            }
-                            else
-                            {
-                                if (yych == 0xEF)
-                                {
-                                    goto basic_json_parser_6;
-                                }
-                                goto basic_json_parser_30;
-                            }
-                        }
-                    }
-                }
-basic_json_parser_2:
-                ++m_cursor;
-                yych = *m_cursor;
-                goto basic_json_parser_5;
-basic_json_parser_3:
-                {
-                    return scan();
-                }
-basic_json_parser_4:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-basic_json_parser_5:
-                if (yybm[0 + yych] & 32)
-                {
-                    goto basic_json_parser_4;
-                }
-                goto basic_json_parser_3;
-basic_json_parser_6:
-                yyaccept = 0;
-                yych = *(m_marker = ++m_cursor);
-                if (yych == 0xBB)
-                {
-                    goto basic_json_parser_64;
-                }
-basic_json_parser_7:
-                {
-                    return token_type::parse_error;
-                }
-basic_json_parser_8:
-                ++m_cursor;
-                {
-                    return token_type::begin_array;
-                }
-basic_json_parser_10:
-                ++m_cursor;
-                {
-                    return token_type::end_array;
-                }
-basic_json_parser_12:
-                ++m_cursor;
-                {
-                    return token_type::begin_object;
-                }
-basic_json_parser_14:
-                ++m_cursor;
-                {
-                    return token_type::end_object;
-                }
-basic_json_parser_16:
-                ++m_cursor;
-                {
-                    return token_type::value_separator;
-                }
-basic_json_parser_18:
-                ++m_cursor;
-                {
-                    return token_type::name_separator;
-                }
-basic_json_parser_20:
-                yyaccept = 0;
-                yych = *(m_marker = ++m_cursor);
-                if (yych == 'u')
-                {
-                    goto basic_json_parser_60;
-                }
-                goto basic_json_parser_7;
-basic_json_parser_21:
-                yyaccept = 0;
-                yych = *(m_marker = ++m_cursor);
-                if (yych == 'r')
-                {
-                    goto basic_json_parser_56;
-                }
-                goto basic_json_parser_7;
-basic_json_parser_22:
-                yyaccept = 0;
-                yych = *(m_marker = ++m_cursor);
-                if (yych == 'a')
-                {
-                    goto basic_json_parser_51;
-                }
-                goto basic_json_parser_7;
-basic_json_parser_23:
-                yych = *++m_cursor;
-                if (yych <= '/')
-                {
-                    goto basic_json_parser_7;
-                }
-                if (yych <= '0')
-                {
-                    goto basic_json_parser_50;
-                }
-                if (yych <= '9')
-                {
-                    goto basic_json_parser_41;
-                }
-                goto basic_json_parser_7;
-basic_json_parser_24:
-                yyaccept = 1;
-                yych = *(m_marker = ++m_cursor);
-                if (yych <= 'D')
-                {
-                    if (yych == '.')
-                    {
-                        goto basic_json_parser_43;
-                    }
-                }
-                else
-                {
-                    if (yych <= 'E')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    if (yych == 'e')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                }
-basic_json_parser_25:
-                {
-                    return token_type::value_number;
-                }
-basic_json_parser_26:
-                yyaccept = 1;
-                yych = *(m_marker = ++m_cursor);
-                goto basic_json_parser_42;
-basic_json_parser_27:
-                yyaccept = 0;
-                yych = *(m_marker = ++m_cursor);
-                if (yych <= 0x0F)
-                {
-                    goto basic_json_parser_7;
-                }
-                goto basic_json_parser_32;
-basic_json_parser_28:
-                ++m_cursor;
-                {
-                    return token_type::end_of_input;
-                }
-basic_json_parser_30:
-                yych = *++m_cursor;
-                goto basic_json_parser_7;
-basic_json_parser_31:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-basic_json_parser_32:
-                if (yybm[0 + yych] & 64)
-                {
-                    goto basic_json_parser_31;
-                }
-                if (yych <= 0x0F)
-                {
-                    goto basic_json_parser_33;
-                }
-                if (yych <= '"')
-                {
-                    goto basic_json_parser_35;
-                }
-                goto basic_json_parser_34;
-basic_json_parser_33:
-                m_cursor = m_marker;
-                if (yyaccept == 0)
-                {
-                    goto basic_json_parser_7;
-                }
-                else
-                {
-                    goto basic_json_parser_25;
-                }
-basic_json_parser_34:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= 'e')
-                {
-                    if (yych <= '/')
-                    {
-                        if (yych == '"')
-                        {
-                            goto basic_json_parser_31;
-                        }
-                        if (yych <= '.')
-                        {
-                            goto basic_json_parser_33;
-                        }
-                        goto basic_json_parser_31;
-                    }
-                    else
-                    {
-                        if (yych <= '\\')
-                        {
-                            if (yych <= '[')
-                            {
-                                goto basic_json_parser_33;
-                            }
-                            goto basic_json_parser_31;
-                        }
-                        else
-                        {
-                            if (yych == 'b')
-                            {
-                                goto basic_json_parser_31;
-                            }
-                            goto basic_json_parser_33;
-                        }
-                    }
-                }
-                else
-                {
-                    if (yych <= 'q')
-                    {
-                        if (yych <= 'f')
-                        {
-                            goto basic_json_parser_31;
-                        }
-                        if (yych == 'n')
-                        {
-                            goto basic_json_parser_31;
-                        }
-                        goto basic_json_parser_33;
-                    }
-                    else
-                    {
-                        if (yych <= 's')
-                        {
-                            if (yych <= 'r')
-                            {
-                                goto basic_json_parser_31;
-                            }
-                            goto basic_json_parser_33;
-                        }
-                        else
-                        {
-                            if (yych <= 't')
-                            {
-                                goto basic_json_parser_31;
-                            }
-                            if (yych <= 'u')
-                            {
-                                goto basic_json_parser_37;
-                            }
-                            goto basic_json_parser_33;
-                        }
-                    }
-                }
-basic_json_parser_35:
-                ++m_cursor;
-                {
-                    return token_type::value_string;
-                }
-basic_json_parser_37:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= '@')
-                {
-                    if (yych <= '/')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych >= ':')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-                else
-                {
-                    if (yych <= 'F')
-                    {
-                        goto basic_json_parser_38;
-                    }
-                    if (yych <= '`')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych >= 'g')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-basic_json_parser_38:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= '@')
-                {
-                    if (yych <= '/')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych >= ':')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-                else
-                {
-                    if (yych <= 'F')
-                    {
-                        goto basic_json_parser_39;
-                    }
-                    if (yych <= '`')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych >= 'g')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-basic_json_parser_39:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= '@')
-                {
-                    if (yych <= '/')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych >= ':')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-                else
-                {
-                    if (yych <= 'F')
-                    {
-                        goto basic_json_parser_40;
-                    }
-                    if (yych <= '`')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych >= 'g')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-basic_json_parser_40:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= '@')
-                {
-                    if (yych <= '/')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych <= '9')
-                    {
-                        goto basic_json_parser_31;
-                    }
-                    goto basic_json_parser_33;
-                }
-                else
-                {
-                    if (yych <= 'F')
-                    {
-                        goto basic_json_parser_31;
-                    }
-                    if (yych <= '`')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych <= 'f')
-                    {
-                        goto basic_json_parser_31;
-                    }
-                    goto basic_json_parser_33;
-                }
-basic_json_parser_41:
-                yyaccept = 1;
-                m_marker = ++m_cursor;
-                if ((m_limit - m_cursor) < 3)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-basic_json_parser_42:
-                if (yybm[0 + yych] & 128)
-                {
-                    goto basic_json_parser_41;
-                }
-                if (yych <= 'D')
-                {
-                    if (yych != '.')
-                    {
-                        goto basic_json_parser_25;
-                    }
-                }
-                else
-                {
-                    if (yych <= 'E')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    if (yych == 'e')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    goto basic_json_parser_25;
-                }
-basic_json_parser_43:
-                yych = *++m_cursor;
-                if (yych <= '/')
-                {
-                    goto basic_json_parser_33;
-                }
-                if (yych <= '9')
-                {
-                    goto basic_json_parser_48;
-                }
-                goto basic_json_parser_33;
-basic_json_parser_44:
-                yych = *++m_cursor;
-                if (yych <= ',')
-                {
-                    if (yych != '+')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                }
-                else
-                {
-                    if (yych <= '-')
-                    {
-                        goto basic_json_parser_45;
-                    }
-                    if (yych <= '/')
-                    {
-                        goto basic_json_parser_33;
-                    }
-                    if (yych <= '9')
-                    {
-                        goto basic_json_parser_46;
-                    }
-                    goto basic_json_parser_33;
-                }
-basic_json_parser_45:
-                yych = *++m_cursor;
-                if (yych <= '/')
-                {
-                    goto basic_json_parser_33;
-                }
-                if (yych >= ':')
-                {
-                    goto basic_json_parser_33;
-                }
-basic_json_parser_46:
-                ++m_cursor;
-                if (m_limit <= m_cursor)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= '/')
-                {
-                    goto basic_json_parser_25;
-                }
-                if (yych <= '9')
-                {
-                    goto basic_json_parser_46;
-                }
-                goto basic_json_parser_25;
-basic_json_parser_48:
-                yyaccept = 1;
-                m_marker = ++m_cursor;
-                if ((m_limit - m_cursor) < 3)
-                {
-                    yyfill();    // LCOV_EXCL_LINE;
-                }
-                yych = *m_cursor;
-                if (yych <= 'D')
-                {
-                    if (yych <= '/')
-                    {
-                        goto basic_json_parser_25;
-                    }
-                    if (yych <= '9')
-                    {
-                        goto basic_json_parser_48;
-                    }
-                    goto basic_json_parser_25;
-                }
-                else
-                {
-                    if (yych <= 'E')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    if (yych == 'e')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    goto basic_json_parser_25;
-                }
-basic_json_parser_50:
-                yyaccept = 1;
-                yych = *(m_marker = ++m_cursor);
-                if (yych <= 'D')
-                {
-                    if (yych == '.')
-                    {
-                        goto basic_json_parser_43;
-                    }
-                    goto basic_json_parser_25;
-                }
-                else
-                {
-                    if (yych <= 'E')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    if (yych == 'e')
-                    {
-                        goto basic_json_parser_44;
-                    }
-                    goto basic_json_parser_25;
-                }
-basic_json_parser_51:
-                yych = *++m_cursor;
-                if (yych != 'l')
-                {
-                    goto basic_json_parser_33;
-                }
-                yych = *++m_cursor;
-                if (yych != 's')
-                {
-                    goto basic_json_parser_33;
-                }
-                yych = *++m_cursor;
-                if (yych != 'e')
-                {
-                    goto basic_json_parser_33;
-                }
-                ++m_cursor;
-                {
-                    return token_type::literal_false;
-                }
-basic_json_parser_56:
-                yych = *++m_cursor;
-                if (yych != 'u')
-                {
-                    goto basic_json_parser_33;
-                }
-                yych = *++m_cursor;
-                if (yych != 'e')
-                {
-                    goto basic_json_parser_33;
-                }
-                ++m_cursor;
-                {
-                    return token_type::literal_true;
-                }
-basic_json_parser_60:
-                yych = *++m_cursor;
-                if (yych != 'l')
-                {
-                    goto basic_json_parser_33;
-                }
-                yych = *++m_cursor;
-                if (yych != 'l')
-                {
-                    goto basic_json_parser_33;
-                }
-                ++m_cursor;
-                {
-                    return token_type::literal_null;
-                }
-basic_json_parser_64:
-                yych = *++m_cursor;
-                if (yych != 0xBF)
-                {
-                    goto basic_json_parser_33;
-                }
-                ++m_cursor;
-                {
-                    return scan();
                 }
             }
+        } else {
+            if (yych <= 'n') {
+                if (yych <= ']') {
+                    if (yych == '[') goto basic_json_parser_8;
+                    if (yych <= '\\') goto basic_json_parser_30;
+                    goto basic_json_parser_10;
+                } else {
+                    if (yych == 'f') goto basic_json_parser_22;
+                    if (yych <= 'm') goto basic_json_parser_30;
+                    goto basic_json_parser_20;
+                }
+            } else {
+                if (yych <= '{') {
+                    if (yych == 't') goto basic_json_parser_21;
+                    if (yych <= 'z') goto basic_json_parser_30;
+                    goto basic_json_parser_12;
+                } else {
+                    if (yych <= '}') {
+                        if (yych <= '|') goto basic_json_parser_30;
+                        goto basic_json_parser_14;
+                    } else {
+                        if (yych == 0xEF) goto basic_json_parser_6;
+                        goto basic_json_parser_30;
+                    }
+                }
+            }
+        }
+basic_json_parser_2:
+        ++m_cursor;
+        yych = *m_cursor;
+        goto basic_json_parser_5;
+basic_json_parser_3:
+        { return scan(); }
+basic_json_parser_4:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+basic_json_parser_5:
+        if (yybm[0+yych] & 32) {
+            goto basic_json_parser_4;
+        }
+        goto basic_json_parser_3;
+basic_json_parser_6:
+        yyaccept = 0;
+        yych = *(m_marker = ++m_cursor);
+        if (yych == 0xBB) goto basic_json_parser_64;
+basic_json_parser_7:
+        { return token_type::parse_error; }
+basic_json_parser_8:
+        ++m_cursor;
+        { return token_type::begin_array; }
+basic_json_parser_10:
+        ++m_cursor;
+        { return token_type::end_array; }
+basic_json_parser_12:
+        ++m_cursor;
+        { return token_type::begin_object; }
+basic_json_parser_14:
+        ++m_cursor;
+        { return token_type::end_object; }
+basic_json_parser_16:
+        ++m_cursor;
+        { return token_type::value_separator; }
+basic_json_parser_18:
+        ++m_cursor;
+        { return token_type::name_separator; }
+basic_json_parser_20:
+        yyaccept = 0;
+        yych = *(m_marker = ++m_cursor);
+        if (yych == 'u') goto basic_json_parser_60;
+        goto basic_json_parser_7;
+basic_json_parser_21:
+        yyaccept = 0;
+        yych = *(m_marker = ++m_cursor);
+        if (yych == 'r') goto basic_json_parser_56;
+        goto basic_json_parser_7;
+basic_json_parser_22:
+        yyaccept = 0;
+        yych = *(m_marker = ++m_cursor);
+        if (yych == 'a') goto basic_json_parser_51;
+        goto basic_json_parser_7;
+basic_json_parser_23:
+        yych = *++m_cursor;
+        if (yych <= '/') goto basic_json_parser_7;
+        if (yych <= '0') goto basic_json_parser_50;
+        if (yych <= '9') goto basic_json_parser_41;
+        goto basic_json_parser_7;
+basic_json_parser_24:
+        yyaccept = 1;
+        yych = *(m_marker = ++m_cursor);
+        if (yych <= 'D') {
+            if (yych == '.') goto basic_json_parser_43;
+        } else {
+            if (yych <= 'E') goto basic_json_parser_44;
+            if (yych == 'e') goto basic_json_parser_44;
+        }
+basic_json_parser_25:
+        { return token_type::value_number; }
+basic_json_parser_26:
+        yyaccept = 1;
+        yych = *(m_marker = ++m_cursor);
+        goto basic_json_parser_42;
+basic_json_parser_27:
+        yyaccept = 0;
+        yych = *(m_marker = ++m_cursor);
+        if (yych <= 0x0F) goto basic_json_parser_7;
+        goto basic_json_parser_32;
+basic_json_parser_28:
+        ++m_cursor;
+        { return token_type::end_of_input; }
+basic_json_parser_30:
+        yych = *++m_cursor;
+        goto basic_json_parser_7;
+basic_json_parser_31:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+basic_json_parser_32:
+        if (yybm[0+yych] & 64) {
+            goto basic_json_parser_31;
+        }
+        if (yych <= 0x0F) goto basic_json_parser_33;
+        if (yych <= '"') goto basic_json_parser_35;
+        goto basic_json_parser_34;
+basic_json_parser_33:
+        m_cursor = m_marker;
+        if (yyaccept == 0) {
+            goto basic_json_parser_7;
+        } else {
+            goto basic_json_parser_25;
+        }
+basic_json_parser_34:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= 'e') {
+            if (yych <= '/') {
+                if (yych == '"') goto basic_json_parser_31;
+                if (yych <= '.') goto basic_json_parser_33;
+                goto basic_json_parser_31;
+            } else {
+                if (yych <= '\\') {
+                    if (yych <= '[') goto basic_json_parser_33;
+                    goto basic_json_parser_31;
+                } else {
+                    if (yych == 'b') goto basic_json_parser_31;
+                    goto basic_json_parser_33;
+                }
+            }
+        } else {
+            if (yych <= 'q') {
+                if (yych <= 'f') goto basic_json_parser_31;
+                if (yych == 'n') goto basic_json_parser_31;
+                goto basic_json_parser_33;
+            } else {
+                if (yych <= 's') {
+                    if (yych <= 'r') goto basic_json_parser_31;
+                    goto basic_json_parser_33;
+                } else {
+                    if (yych <= 't') goto basic_json_parser_31;
+                    if (yych <= 'u') goto basic_json_parser_37;
+                    goto basic_json_parser_33;
+                }
+            }
+        }
+basic_json_parser_35:
+        ++m_cursor;
+        { return token_type::value_string; }
+basic_json_parser_37:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= '@') {
+            if (yych <= '/') goto basic_json_parser_33;
+            if (yych >= ':') goto basic_json_parser_33;
+        } else {
+            if (yych <= 'F') goto basic_json_parser_38;
+            if (yych <= '`') goto basic_json_parser_33;
+            if (yych >= 'g') goto basic_json_parser_33;
+        }
+basic_json_parser_38:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= '@') {
+            if (yych <= '/') goto basic_json_parser_33;
+            if (yych >= ':') goto basic_json_parser_33;
+        } else {
+            if (yych <= 'F') goto basic_json_parser_39;
+            if (yych <= '`') goto basic_json_parser_33;
+            if (yych >= 'g') goto basic_json_parser_33;
+        }
+basic_json_parser_39:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= '@') {
+            if (yych <= '/') goto basic_json_parser_33;
+            if (yych >= ':') goto basic_json_parser_33;
+        } else {
+            if (yych <= 'F') goto basic_json_parser_40;
+            if (yych <= '`') goto basic_json_parser_33;
+            if (yych >= 'g') goto basic_json_parser_33;
+        }
+basic_json_parser_40:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= '@') {
+            if (yych <= '/') goto basic_json_parser_33;
+            if (yych <= '9') goto basic_json_parser_31;
+            goto basic_json_parser_33;
+        } else {
+            if (yych <= 'F') goto basic_json_parser_31;
+            if (yych <= '`') goto basic_json_parser_33;
+            if (yych <= 'f') goto basic_json_parser_31;
+            goto basic_json_parser_33;
+        }
+basic_json_parser_41:
+        yyaccept = 1;
+        m_marker = ++m_cursor;
+        if ((m_limit - m_cursor) < 3) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+basic_json_parser_42:
+        if (yybm[0+yych] & 128) {
+            goto basic_json_parser_41;
+        }
+        if (yych <= 'D') {
+            if (yych != '.') goto basic_json_parser_25;
+        } else {
+            if (yych <= 'E') goto basic_json_parser_44;
+            if (yych == 'e') goto basic_json_parser_44;
+            goto basic_json_parser_25;
+        }
+basic_json_parser_43:
+        yych = *++m_cursor;
+        if (yych <= '/') goto basic_json_parser_33;
+        if (yych <= '9') goto basic_json_parser_48;
+        goto basic_json_parser_33;
+basic_json_parser_44:
+        yych = *++m_cursor;
+        if (yych <= ',') {
+            if (yych != '+') goto basic_json_parser_33;
+        } else {
+            if (yych <= '-') goto basic_json_parser_45;
+            if (yych <= '/') goto basic_json_parser_33;
+            if (yych <= '9') goto basic_json_parser_46;
+            goto basic_json_parser_33;
+        }
+basic_json_parser_45:
+        yych = *++m_cursor;
+        if (yych <= '/') goto basic_json_parser_33;
+        if (yych >= ':') goto basic_json_parser_33;
+basic_json_parser_46:
+        ++m_cursor;
+        if (m_limit <= m_cursor) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= '/') goto basic_json_parser_25;
+        if (yych <= '9') goto basic_json_parser_46;
+        goto basic_json_parser_25;
+basic_json_parser_48:
+        yyaccept = 1;
+        m_marker = ++m_cursor;
+        if ((m_limit - m_cursor) < 3) yyfill(); // LCOV_EXCL_LINE;
+        yych = *m_cursor;
+        if (yych <= 'D') {
+            if (yych <= '/') goto basic_json_parser_25;
+            if (yych <= '9') goto basic_json_parser_48;
+            goto basic_json_parser_25;
+        } else {
+            if (yych <= 'E') goto basic_json_parser_44;
+            if (yych == 'e') goto basic_json_parser_44;
+            goto basic_json_parser_25;
+        }
+basic_json_parser_50:
+        yyaccept = 1;
+        yych = *(m_marker = ++m_cursor);
+        if (yych <= 'D') {
+            if (yych == '.') goto basic_json_parser_43;
+            goto basic_json_parser_25;
+        } else {
+            if (yych <= 'E') goto basic_json_parser_44;
+            if (yych == 'e') goto basic_json_parser_44;
+            goto basic_json_parser_25;
+        }
+basic_json_parser_51:
+        yych = *++m_cursor;
+        if (yych != 'l') goto basic_json_parser_33;
+        yych = *++m_cursor;
+        if (yych != 's') goto basic_json_parser_33;
+        yych = *++m_cursor;
+        if (yych != 'e') goto basic_json_parser_33;
+        ++m_cursor;
+        { return token_type::literal_false; }
+basic_json_parser_56:
+        yych = *++m_cursor;
+        if (yych != 'u') goto basic_json_parser_33;
+        yych = *++m_cursor;
+        if (yych != 'e') goto basic_json_parser_33;
+        ++m_cursor;
+        { return token_type::literal_true; }
+basic_json_parser_60:
+        yych = *++m_cursor;
+        if (yych != 'l') goto basic_json_parser_33;
+        yych = *++m_cursor;
+        if (yych != 'l') goto basic_json_parser_33;
+        ++m_cursor;
+        { return token_type::literal_null; }
+basic_json_parser_64:
+        yych = *++m_cursor;
+        if (yych != 0xBF) goto basic_json_parser_33;
+        ++m_cursor;
+        { return scan(); }
+    }
 
 
         }

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -11572,12 +11572,8 @@ TEST_CASE("regression tests")
         j = json::parse("0.999999999999999944488848768742172978818416595458984374");
         CHECK(j.get<double>() == 0.99999999999999989);
 
-        // Test fails under GCC/clang due to strtod() error (may originate in libstdc++
-        // but seems to have been fixed in the most current versions - just not on Travis)
-#if !defined(__clang__) && !defined(__GNUC__) && !defined(__GNUG__)
         j = json::parse("1.00000000000000011102230246251565404236316680908203126");
         CHECK(j.get<double>() == 1.00000000000000022);
-#endif
 
         j = json::parse("7205759403792793199999e-5");
         CHECK(j.get<double>() == 72057594037927928.0);


### PR DESCRIPTION
This pull request updates Travis to use the Ubuntu Trusty distribution instead of Precise.  This is required due to the bug in `strtod()` that is uncorrected in Precise builds of the standard library but fixed in Trusty.  This bug causes a single bit rounding error that may occur in as many as 1 in 4096 of the possible double values.

Note that currently this PR still uses the `llvm-toolchain-precise*` repositories because the  `llvm-toolchain-trusty*` ones have not been added to the Travis white-list.  This works because clang is not the problem, rather it is the standard library. 

There is an open issue on Travis [APT source whitelist request for llvm-toolchain-trusty #199](https://github.com/travis-ci/apt-source-whitelist/issues/199
) to add the repositories to the white-list at which point `.travis.yml` can be further updated.  It is suggested that perhaps this pull be merged but issue #195 be left open until the trusty llvm repos can be added as well.