### PR TITLE
replaced ssize_t occurrences with auto (addresses #204)

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -34,23 +34,10 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 #include <utility>
 #include <vector>
 
-// enable ssize_t on MinGW
-#ifdef __GNUC__
-    #ifdef __MINGW32__
-        #include <sys/types.h>
-    #endif
-#endif
-
 // disable float-equal warnings on GCC/clang
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wfloat-equal"
-#endif
-
-// enable ssize_t for MSVC
-#ifdef _MSC_VER
-    #include <basetsd.h>
-    using ssize_t = SSIZE_T;
 #endif
 
 /*!
@@ -7983,9 +7970,9 @@ basic_json_parser_63:
                 return;
             }
 
-            const ssize_t offset_start = m_start - m_content;
-            const ssize_t offset_marker = m_marker - m_start;
-            const ssize_t offset_cursor = m_cursor - m_start;
+            const std::ptrdiff_t offset_start = m_start - m_content;
+            const std::ptrdiff_t offset_marker = m_marker - m_start;
+            const std::ptrdiff_t offset_cursor = m_cursor - m_start;
 
             m_buffer.erase(0, static_cast<size_t>(offset_start));
             std::string line;

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7970,9 +7970,9 @@ basic_json_parser_63:
                 return;
             }
 
-            const std::ptrdiff_t offset_start = m_start - m_content;
-            const std::ptrdiff_t offset_marker = m_marker - m_start;
-            const std::ptrdiff_t offset_cursor = m_cursor - m_start;
+            const auto offset_start = m_start - m_content;
+            const auto offset_marker = m_marker - m_start;
+            const auto offset_cursor = m_cursor - m_start;
 
             m_buffer.erase(0, static_cast<size_t>(offset_start));
             std::string line;

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -7280,9 +7280,9 @@ class basic_json
                 return;
             }
 
-            const std::ptrdiff_t offset_start = m_start - m_content;
-            const std::ptrdiff_t offset_marker = m_marker - m_start;
-            const std::ptrdiff_t offset_cursor = m_cursor - m_start;
+            const auto offset_start = m_start - m_content;
+            const auto offset_marker = m_marker - m_start;
+            const auto offset_cursor = m_cursor - m_start;
 
             m_buffer.erase(0, static_cast<size_t>(offset_start));
             std::string line;

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -34,23 +34,10 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 #include <utility>
 #include <vector>
 
-// enable ssize_t on MinGW
-#ifdef __GNUC__
-    #ifdef __MINGW32__
-        #include <sys/types.h>
-    #endif
-#endif
-
 // disable float-equal warnings on GCC/clang
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wfloat-equal"
-#endif
-
-// enable ssize_t for MSVC
-#ifdef _MSC_VER
-    #include <basetsd.h>
-    using ssize_t = SSIZE_T;
 #endif
 
 /*!
@@ -7293,9 +7280,9 @@ class basic_json
                 return;
             }
 
-            const ssize_t offset_start = m_start - m_content;
-            const ssize_t offset_marker = m_marker - m_start;
-            const ssize_t offset_cursor = m_cursor - m_start;
+            const std::ptrdiff_t offset_start = m_start - m_content;
+            const std::ptrdiff_t offset_marker = m_marker - m_start;
+            const std::ptrdiff_t offset_cursor = m_cursor - m_start;
 
             m_buffer.erase(0, static_cast<size_t>(offset_start));
             std::string line;


### PR DESCRIPTION
In issue #204, an issue with MSVC was reported where `ssize_t` was defined differently than by the header included by `json.hpp`. In fact, `ssize_t` only appears in one function (`lexer::yyfill()`) and can be replaced by `auto`. Removing `ssize_t` has the advantage of being able to also remove several conditional header includes.