### PR TITLE
Fixed stream precision issue.

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -5986,10 +5986,10 @@ class basic_json
             {
                 // If the number is an integer then output as a fixed with with
                 // precision 1 to output "0.0", "1.0" etc as expected for some
-                // round trip tests otherwise  15 digits of precision allows
+                // round trip tests otherwise 17 digits of precision allows
                 // round-trip IEEE 754 string->double->string; to be safe, we
                 // read this value from
-                // std::numeric_limits<number_float_t>::digits10
+                // std::numeric_limits<number_float_t>::max_digits10
                 if (std::fmod(m_value.number_float, 1) == 0)
                 {
                     o << std::fixed << std::setprecision(1);
@@ -5998,7 +5998,7 @@ class basic_json
                 {
                     // std::defaultfloat not supported in gcc version < 5
                     o.unsetf(std::ios_base::floatfield);
-                    o << std::setprecision(std::numeric_limits<double>::digits10);
+                    o << std::setprecision(std::numeric_limits<double>::max_digits10);
                 }
                 o << m_value.number_float;
                 return;

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -5986,10 +5986,10 @@ class basic_json
             {
                 // If the number is an integer then output as a fixed with with
                 // precision 1 to output "0.0", "1.0" etc as expected for some
-                // round trip tests otherwise  15 digits of precision allows
+                // round trip tests otherwise 17 digits of precision allows
                 // round-trip IEEE 754 string->double->string; to be safe, we
                 // read this value from
-                // std::numeric_limits<number_float_t>::digits10
+                // std::numeric_limits<number_float_t>::max_digits10
                 if (std::fmod(m_value.number_float, 1) == 0)
                 {
                     o << std::fixed << std::setprecision(1);
@@ -5998,7 +5998,7 @@ class basic_json
                 {
                     // std::defaultfloat not supported in gcc version < 5
                     o.unsetf(std::ios_base::floatfield);
-                    o << std::setprecision(std::numeric_limits<double>::digits10);
+                    o << std::setprecision(std::numeric_limits<double>::max_digits10);
                 }
                 o << m_value.number_float;
                 return;


### PR DESCRIPTION
Double->text->double or float->text->float round trip conversions were giving inexact results. Max_digits10 is the correct limit.