### PR TITLE
Update the README to give better instructions for Android.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,16 @@ I would be happy to learn about other compilers/versions.
 Please note:
 
 - GCC 4.8 does not work because of two bugs ([55817](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55817) and [57824](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57824)) in the C++11 support.
-- For GCC running on MinGW or Android SDK, the error `'to_string' is not a member of 'std'` (or similarly, for `strtod`) may occur. Note this is not an issue with the code,  but rather with the compiler itself. Please refer to [this site](http://tehsausage.com/mingw-to-string) and [this discussion](https://github.com/nlohmann/json/issues/136) for information on how to fix this bug.
+- Android defaults to using very old compilers and C++ libraries.  To fix this, add the following to your Application.mk.  
+This will switch to the LLVM C++ library, the Clang compiler, and enable C++11 and other features disabled by default.
+
+```
+APP_STL := c++_shared
+NDK_TOOLCHAIN_VERSION := clang3.6
+APP_CPPFLAGS += -frtti -fexceptions
+```
+
+- For GCC running on MinGW or Android SDK, the error `'to_string' is not a member of 'std'` (or similarly, for `strtod`) may occur. Note this is not an issue with the code,  but rather with the compiler itself. On Android, see above to build with a newer environment.  For MingW, please refer to [this site](http://tehsausage.com/mingw-to-string) and [this discussion](https://github.com/nlohmann/json/issues/136) for information on how to fix this bug.
 
 ## Examples
 


### PR DESCRIPTION
The MingW link doesn't help for Android, and points people down the wrong path.  On Android all you need to do is tell the build system to use a newer compiler and standard library.

The unit tests run successfully with this configuration on Android.

Related to #136.

(I've left Android mentioned in the MingW line, so people searching for "to_string" and finding that line are pointed upwards.)
