### PR TITLE
Added missing cerrno header to fix ERANGE compile error on android

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -14,6 +14,7 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cerrno>
 #include <ciso646>
 #include <cmath>
 #include <cstddef>

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -14,6 +14,7 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cerrno>
 #include <ciso646>
 #include <cmath>
 #include <cstddef>


### PR DESCRIPTION
See #219.