### PR TITLE
Use namespace std for int64_t and uint64_t

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -183,8 +183,8 @@ template <
     template<typename U, typename... Args> class ArrayType = std::vector,
     class StringType = std::string,
     class BooleanType = bool,
-    class NumberIntegerType = int64_t,
-    class NumberUnsignedType = uint64_t,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
     class NumberFloatType = double,
     template<typename U> class AllocatorType = std::allocator
     >

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -183,8 +183,8 @@ template <
     template<typename U, typename... Args> class ArrayType = std::vector,
     class StringType = std::string,
     class BooleanType = bool,
-    class NumberIntegerType = int64_t,
-    class NumberUnsignedType = uint64_t,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
     class NumberFloatType = double,
     template<typename U> class AllocatorType = std::allocator
     >


### PR DESCRIPTION
According to the c++11 standard, the declarations are within namespace
scope of the namespace `std`. Add `std::` to avoid unnecessary
assumptions of implementations.

References:
http://stackoverflow.com/questions/13129945/use-types-in-cstdint-with-ot-without-namespace
http://en.cppreference.com/w/cpp/header/cstdint
https://msdn.microsoft.com/en-us/library/hh874765.aspx