### PR TITLE
Make the indirection and dereference operators of iterator const

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7000,13 +7000,13 @@ class basic_json
         }
 
         /// return a reference to the value pointed to by the iterator
-        reference operator*()
+        reference operator*() const
         {
             return const_cast<reference>(base_iterator::operator*());
         }
 
         /// dereference the iterator
-        pointer operator->()
+        pointer operator->() const
         {
             return const_cast<pointer>(base_iterator::operator->());
         }

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -7000,13 +7000,13 @@ class basic_json
         }
 
         /// return a reference to the value pointed to by the iterator
-        reference operator*()
+        reference operator*() const
         {
             return const_cast<reference>(base_iterator::operator*());
         }
 
         /// dereference the iterator
-        pointer operator->()
+        pointer operator->() const
         {
             return const_cast<pointer>(base_iterator::operator->());
         }

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -12407,5 +12407,16 @@ TEST_CASE("regression tests")
         CHECK(j3b.dump() == "1E04");
         CHECK(j3c.dump() == "1e04");
     }
+
+    SECTION("issue #233 - Can't use basic_json::iterator as a base iterator for std::move_iterator")
+    {
+        json source = {"a", "b", "c"};   
+        json expected = {"a", "b"};
+        json dest;
+
+        std::copy_n(std::make_move_iterator(source.begin()), 2, std::back_inserter(dest));
+
+        CHECK(dest == expected);
+    }
 }
 


### PR DESCRIPTION
This is an attempt to fix #233, by making the indirection and dereference operators of `basic_json::iterator` `const`.