### PR TITLE
Implement additional integration options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,25 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(json CXX)
+# define the project
+project(json VERSION 2.0.0 LANGUAGES CXX)
 
+# define project variables
 set(JSON_TARGET_NAME ${PROJECT_NAME})
 set(JSON_UNITTEST_TARGET_NAME "json_unit")
 set(JSON_PACKAGE_NAME ${JSON_TARGET_NAME})
 set(JSON_TARGETS_FILENAME "${JSON_PACKAGE_NAME}Targets.cmake")
+set(JSON_CONFIG_FILENAME "${JSON_PACKAGE_NAME}Config.cmake")
+set(JSON_CONFIGVERSION_FILENAME "${JSON_PACKAGE_NAME}ConfigVersion.cmake")
+set(JSON_CONFIG_DESTINATION "cmake")
+set(JSON_INCLUDE_DESTINATION "include/nlohmann")
 
+# create and configure the library target
 add_library(${JSON_TARGET_NAME} INTERFACE)
 target_include_directories(${JSON_TARGET_NAME} INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:${JSON_INCLUDE_DESTINATION}>)
 
+# create and configure the unit test target
 add_executable(${JSON_UNITTEST_TARGET_NAME}
     "test/catch.hpp" "test/unit.cpp")
 set_target_properties(${JSON_UNITTEST_TARGET_NAME} PROPERTIES
@@ -21,6 +30,28 @@ set_target_properties(${JSON_UNITTEST_TARGET_NAME} PROPERTIES
 target_include_directories(${JSON_UNITTEST_TARGET_NAME} PRIVATE "test")
 target_link_libraries(${JSON_UNITTEST_TARGET_NAME} ${JSON_TARGET_NAME})
 
+# generate a config and config version file for the package
+include(CMakePackageConfigHelpers)
+configure_package_config_file("cmake/config.cmake.in"
+    "${CMAKE_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
+    INSTALL_DESTINATION ${JSON_CONFIG_DESTINATION})
+write_basic_package_version_file("${CMAKE_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
+# export the library target and store build directory in package registry
 export(TARGETS ${JSON_TARGET_NAME}
 	FILE "${CMAKE_BINARY_DIR}/${JSON_TARGETS_FILENAME}")
 export(PACKAGE ${JSON_PACKAGE_NAME})
+
+# install library target and config files
+install(TARGETS ${JSON_TARGET_NAME}
+	EXPORT ${JSON_PACKAGE_NAME})
+install(FILES "src/json.hpp"
+	DESTINATION ${JSON_INCLUDE_DESTINATION})
+install(EXPORT ${JSON_PACKAGE_NAME}
+	FILE ${JSON_TARGETS_FILENAME}
+	DESTINATION ${JSON_CONFIG_DESTINATION})
+install(FILES "${CMAKE_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
+	"${CMAKE_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
+	DESTINATION ${JSON_CONFIG_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,26 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(json CXX)
 
-add_library(${PROJECT_NAME} INTERFACE IMPORTED GLOBAL)
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(JSON_TARGET_NAME ${PROJECT_NAME})
+set(JSON_UNITTEST_TARGET_NAME "json_unit")
+set(JSON_PACKAGE_NAME ${JSON_TARGET_NAME})
+set(JSON_TARGETS_FILENAME "${JSON_PACKAGE_NAME}Targets.cmake")
 
-set(UNIT_TEST_NAME "json_unit")
-add_executable(${UNIT_TEST_NAME}
+add_library(${JSON_TARGET_NAME} INTERFACE)
+target_include_directories(${JSON_TARGET_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+
+add_executable(${JSON_UNITTEST_TARGET_NAME}
     "test/catch.hpp" "test/unit.cpp")
-set_target_properties(${UNIT_TEST_NAME} PROPERTIES
+set_target_properties(${JSON_UNITTEST_TARGET_NAME} PROPERTIES
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED ON
     COMPILE_DEFINITIONS "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
     COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>")
-target_include_directories(${UNIT_TEST_NAME} PRIVATE "test")
-target_link_libraries(${UNIT_TEST_NAME} ${PROJECT_NAME})
+target_include_directories(${JSON_UNITTEST_TARGET_NAME} PRIVATE "test")
+target_link_libraries(${JSON_UNITTEST_TARGET_NAME} ${JSON_TARGET_NAME})
+
+export(TARGETS ${JSON_TARGET_NAME}
+	FILE "${CMAKE_BINARY_DIR}/${JSON_TARGETS_FILENAME}")
+export(PACKAGE ${JSON_PACKAGE_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,24 +2,17 @@ cmake_minimum_required(VERSION 2.8)
 
 project(json CXX)
 
-add_executable(json_unit
-    src/json.hpp test/catch.hpp test/unit.cpp
-)
+add_library(${PROJECT_NAME} INTERFACE IMPORTED GLOBAL)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-if(MSVC)
-    set(CMAKE_CXX_FLAGS
-        "/EHsc"
-    )
-
-    STRING(REPLACE "/O2" "/Od" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
-
-    add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-else(MSVC)
-    set(CMAKE_CXX_FLAGS
-        "-std=c++11"
-    )
-endif(MSVC)
-
-include_directories(
-    src test
-)
+set(UNIT_TEST_NAME "json_unit")
+add_executable(${UNIT_TEST_NAME}
+    "test/catch.hpp" "test/unit.cpp")
+set_target_properties(${UNIT_TEST_NAME} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    COMPILE_DEFINITIONS "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
+    COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>")
+target_include_directories(${UNIT_TEST_NAME} PRIVATE "test")
+target_link_libraries(${UNIT_TEST_NAME} ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,15 @@ target_link_libraries(${JSON_UNITTEST_TARGET_NAME} ${JSON_TARGET_NAME})
 # generate a config and config version file for the package
 include(CMakePackageConfigHelpers)
 configure_package_config_file("cmake/config.cmake.in"
-    "${CMAKE_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
+    "${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
     INSTALL_DESTINATION ${JSON_CONFIG_DESTINATION})
-write_basic_package_version_file("${CMAKE_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion)
 
 # export the library target and store build directory in package registry
 export(TARGETS ${JSON_TARGET_NAME}
-	FILE "${CMAKE_BINARY_DIR}/${JSON_TARGETS_FILENAME}")
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/${JSON_TARGETS_FILENAME}")
 export(PACKAGE ${JSON_PACKAGE_NAME})
 
 # install library target and config files
@@ -52,6 +52,6 @@ install(FILES "src/json.hpp"
 install(EXPORT ${JSON_PACKAGE_NAME}
 	FILE ${JSON_TARGETS_FILENAME}
 	DESTINATION ${JSON_CONFIG_DESTINATION})
-install(FILES "${CMAKE_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
-	"${CMAKE_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
+	"${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
 	DESTINATION ${JSON_CONFIG_DESTINATION})

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0024 OLD)
+include(${CMAKE_CURRENT_LIST_DIR}/@JSON_TARGETS_FILENAME@)
+cmake_policy(POP)


### PR DESCRIPTION
This PR contains the implementation of the changes suggested in #237.
The listfile is quite different then it was. The required c++ standard is now specified as a target property for the `json_unit` executable which is more portable, and compiler flags and definitions are also specified using target properties using generator expressions instead of variables, but they result in the same compiler flags.
The only longterm change that this PR brings is that from now on the version number of the library must be changed in the listfile as well when a new release is published so CMake can generate the appropriate config version file for the package when it's installed.