### PR TITLE
Define CMake/CTest tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.0)
 # define the project
 project(nlohmann_json VERSION 2.0.0 LANGUAGES CXX)
 
+enable_testing()
+
 option(BuildTests "Build the unit tests" ON)
 
 # define project variables

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,4 @@ build_script:
 - cmake . -G "Visual Studio 14 2015"
 - cmake --build . --config Release
 test_script:
-- test\Release\json_unit.exe
-- test\Release\json_unit.exe "*"
+- ctest -C Release -V

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,21 +1,25 @@
 # The unit test executable.
-add_executable(json_unit
+set(JSON_UNITTEST_TARGET_NAME "json_unit")
+add_executable(${JSON_UNITTEST_TARGET_NAME}
     "src/catch.hpp"
     "src/unit.cpp"
 )
 
-set_target_properties(json_unit PROPERTIES
+set_target_properties(${JSON_UNITTEST_TARGET_NAME} PROPERTIES
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED ON
     COMPILE_DEFINITIONS "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
     COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>"
 )
 
-# Install the test binary.
-install(TARGETS json_unit RUNTIME DESTINATION test/bin)
+target_include_directories(${JSON_UNITTEST_TARGET_NAME} PRIVATE "src")
+target_link_libraries(${JSON_UNITTEST_TARGET_NAME} ${JSON_TARGET_NAME})
 
-# Copy the test data to the install tree.
-install(DIRECTORY data/ DESTINATION test/data)
-
-target_include_directories(json_unit PRIVATE "src")
-target_link_libraries(json_unit ${JSON_TARGET_NAME})
+add_test(NAME "${JSON_UNITTEST_TARGET_NAME}_default"
+	COMMAND ${JSON_UNITTEST_TARGET_NAME}
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+add_test(NAME "${JSON_UNITTEST_TARGET_NAME}_all"
+	COMMAND ${JSON_UNITTEST_TARGET_NAME} "*"
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)


### PR DESCRIPTION
In #241 @ChrisKitching described that tests on out of source builds fail because the test executable can't find the JSON files it needs. It's great that he noticed this and provided a fix for it, I totally missed this issue when I rewrote the CMake lists file.
In #242 the issue is fixed by installing the test executable and test files. There are two problems with this approach:
1. The test executable is used only once by the users of the library. It's executed only after a successful build and never used again, so there is no need to install it on the system level.
2. For executing the tests in out of source builds we don't need to copy any files at all. In CMake we can define tests with the source directory as their working directory, so tests will be able to find the JSON files no matter where the project is built.

In this PR I defined two CMake/CTest test configurations. 
- `json_unit_default` for running the default tests by executing
`json_unit` without any arguments
- `json_unit_all` for running all the tests by executing `json_unit`
with the `"*"` argument

So the tests can be now executed by building the `test` target:
```
make test
```
or by running `ctest` in the build directory.

The tests can be selectively executed as well with `ctest`:
```
ctest -R json_unit_default
```
or
```
ctest -R json_unit_all
```