### PR TITLE
Update hexify to use array lookup instead of ternary (#270)

### DIFF
--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -5959,9 +5959,11 @@ class basic_json
                         // (0..f)
                         const auto hexify = [](const int v) -> char
                         {
-                            return (v < 10)
-                            ? ('0' + static_cast<char>(v))
-                            : ('a' + static_cast<char>((v - 10) & 0x1f));
+						    static const char hex[16] = { '0', '1', '2', '3',
+                                                          '4', '5', '6', '7',
+                                                          '8', '9', 'a', 'b',
+                                                          'c', 'd', 'e', 'f' };
+						    return hex[v];
                         };
 
                         // print character c as \uxxxx


### PR DESCRIPTION
https://github.com/nlohmann/json/issues/270

Ended up using an array of char rather than std::array, because `std::array::[]` only accepts unsigneds, thus we'd get a conversion warning.