### PR TITLE
Fix usage examples' comments for std::multiset

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ json j_uset(c_uset); // only one entry for "one" is used
 // maybe ["two", "three", "four", "one"]
 
 std::multiset<std::string> c_mset {"one", "two", "one", "four"};
-json j_mset(c_mset); // only one entry for "one" is used
-// maybe ["one", "two", "four"]
+json j_mset(c_mset); // both entries for "one" are used
+// maybe ["one", "two", "one", "four"]
 
 std::unordered_multiset<std::string> c_umset {"one", "two", "one", "four"};
 json j_umset(c_umset); // both entries for "one" are used

--- a/doc/examples/basic_json__CompatibleArrayType.cpp
+++ b/doc/examples/basic_json__CompatibleArrayType.cpp
@@ -39,7 +39,7 @@ int main()
 
     // create an array from std::multiset
     std::multiset<std::string> c_mset {"one", "two", "one", "four"};
-    json j_mset(c_mset); // only one entry for "one" is used
+    json j_mset(c_mset); // both entries for "one" are used
 
     // create an array from std::unordered_multiset
     std::unordered_multiset<std::string> c_umset {"one", "two", "one", "four"};

--- a/test/src/unit-readme.cpp
+++ b/test/src/unit-readme.cpp
@@ -208,8 +208,8 @@ TEST_CASE("README", "[hide]")
             // maybe ["two", "three", "four", "one"]
 
             std::multiset<std::string> c_mset {"one", "two", "one", "four"};
-            json j_mset(c_mset); // only one entry for "one" is used
-            // maybe ["one", "two", "four"]
+            json j_mset(c_mset); // both entries for "one" are used
+            // maybe ["one", "two", "one", "four"]
 
             std::unordered_multiset<std::string> c_umset {"one", "two", "one", "four"};
             json j_umset(c_umset); // both entries for "one" are used


### PR DESCRIPTION
Fix usage examples' comments for std::multiset