### PR TITLE
make has_mapped_type struct friendly

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -112,10 +112,13 @@ template<typename T>
 struct has_mapped_type
 {
   private:
-    template<typename C> static char test(typename C::mapped_type*);
-    template<typename C> static char (&test(...))[2];
+    template <typename U, typename = typename U::mapped_type>
+    static int detect(U&&);
+
+    static void detect(...);
   public:
-    static constexpr bool value = sizeof(test<T>(0)) == 1;
+    static constexpr bool value =
+        std::is_integral<decltype(detect(std::declval<T>()))>::value;
 };
 
 /*!

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -112,10 +112,13 @@ template<typename T>
 struct has_mapped_type
 {
   private:
-    template<typename C> static char test(typename C::mapped_type*);
-    template<typename C> static char (&test(...))[2];
+    template <typename U, typename = typename U::mapped_type>
+    static int detect(U&&);
+
+    static void detect(...);
   public:
-    static constexpr bool value = sizeof(test<T>(0)) == 1;
+    static constexpr bool value =
+        std::is_integral<decltype(detect(std::declval<T>()))>::value;
 };
 
 /*!


### PR DESCRIPTION
I'd like to propose slightly different implemenation of `struct has_mapped_type` that use Type traits added in C++11. It doesn't change current functionality, but looks more natural.
