### PR TITLE
Feature/user defined types

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -154,10 +154,10 @@ struct to_json_fn
 
 struct from_json_fn
 {
-  template <typename T>
-  constexpr auto operator()(T&& val) const -> decltype(from_json(std::forward<T>(val)))
+  template <typename Json, typename T>
+  constexpr auto operator()(Json const& from, T& to) const -> decltype(from_json(from, to))
   {
-    return from_json(std::forward<T>(val));
+    return from_json(from, to);
   }
 };
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -102,6 +102,17 @@ namespace nlohmann
 template <typename T, typename = void>
 struct json_traits;
 
+// alias templates to reduce boilerplate
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template <typename T>
+using remove_cv_t = typename std::remove_cv<T>::type;
+
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+
+// TODO update this doc
 /*!
 @brief unnamed namespace with internal helper functions
 @since version 1.0.0
@@ -1304,15 +1315,11 @@ class basic_json
     // auto j = json{{"a", json(not_equality_comparable{})}};
     // 
     // we can remove this constraint though, since lots of ctor are not explicit already
-    template <
-        typename T,
-        typename =
-            typename std::enable_if<detail::has_json_traits<typename std::remove_cv<
-                typename std::remove_reference<T>::type>::type>::value>::type>
+    template <typename T, typename = enable_if_t<detail::has_json_traits<
+                              remove_cv_t<remove_reference_t<T>>>::value>>
     explicit basic_json(T &&val)
-        : basic_json(json_traits<typename std::remove_cv<
-                         typename std::remove_reference<T>::type>::type>::
-                         to_json(std::forward<T>(val))) {}
+        : basic_json(json_traits<remove_cv_t<remove_reference_t<T>>>::to_json(
+              std::forward<T>(val))) {}
     /*!
     @brief create a string (explicit)
 
@@ -2673,17 +2680,12 @@ class basic_json
 
     // get_impl overload chosen if json_traits struct is specialized for type T
     // simply returns json_traits<T>::from_json(*this);
-    // TODO add alias templates (enable_if_t etc)
-    template <
-        typename T,
-        typename = typename std::enable_if<
-            detail::has_json_traits<typename std::remove_cv<
-                typename std::remove_reference<T>::type>::type>::value>::type>
-    auto get_impl(T *) const -> decltype(
-        json_traits<typename std::remove_cv<typename std::remove_reference<
-            T>::type>::type>::from_json(std::declval<basic_json>())) {
-      return json_traits<typename std::remove_cv<
-          typename std::remove_reference<T>::type>::type>::from_json(*this);
+    template <typename T, typename = enable_if_t<detail::has_json_traits<
+                              remove_cv_t<remove_reference_t<T>>>::value>>
+    auto get_impl(T *) const
+        -> decltype(json_traits<remove_cv_t<remove_reference_t<T>>>::from_json(
+            std::declval<basic_json>())) {
+      return json_traits<remove_cv_t<remove_reference_t<T>>>::from_json(*this);
     }
 
     // this one is quite atrocious
@@ -2691,15 +2693,19 @@ class basic_json
     // I chose to prefer the json_traits specialization if it exists, since it's a more advanced use.
     // But we can of course change this behaviour
     template <typename T>
-    auto get_impl(T *) const -> typename std::enable_if<
-        not detail::has_json_traits<typename std::remove_cv<T>::type>::value,
-        typename std::remove_cv<typename std::remove_reference<
-            decltype(::nlohmann::from_json(std::declval<basic_json>(),
-                                           std::declval<T &>()),
-                     std::declval<T>())>::type>::type>::type
+    auto get_impl(T *) const
+        -> enable_if_t<not detail::has_json_traits<remove_cv_t<T>>::value,
+                       remove_cv_t<remove_reference_t<decltype(
+                           ::nlohmann::from_json(std::declval<basic_json>(),
+                                                 std::declval<T &>()),
+                           std::declval<T>())>>>
     {
-      typename std::remove_cv<typename std::remove_reference<T>::type>::type
-          ret;
+      remove_cv_t<T> ret;
+      // I guess this output parameter is the only way to get ADL
+      // Even if users can use the get<T> method to have a more 'functional' behaviour
+      // i.e. having a return type, could there be a way to have the same behaviour with from_json?
+      // e.g. auto t = nlohmann::from_json<T>(json{});
+      // this seems to require variable templates though... (at least it did when I tried to implement it)
       ::nlohmann::from_json(*this, ret);
       return ret;
     }

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -112,6 +112,9 @@ using remove_cv_t = typename std::remove_cv<T>::type;
 template <typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
 
+template <typename T>
+using uncvref_t = remove_cv_t<remove_reference_t<T>>;
+
 // TODO update this doc
 /*!
 @brief unnamed namespace with internal helper functions
@@ -1315,11 +1318,12 @@ class basic_json
     // auto j = json{{"a", json(not_equality_comparable{})}};
     // 
     // we can remove this constraint though, since lots of ctor are not explicit already
-    template <typename T, typename = enable_if_t<detail::has_json_traits<
-                              remove_cv_t<remove_reference_t<T>>>::value>>
+    template <typename T, typename = enable_if_t<
+                              detail::has_json_traits<uncvref_t<T>>::value>>
     explicit basic_json(T &&val)
-        : basic_json(json_traits<remove_cv_t<remove_reference_t<T>>>::to_json(
-              std::forward<T>(val))) {}
+        : basic_json(json_traits<uncvref_t<T>>::to_json(std::forward<T>(val)))
+    {
+    }
     /*!
     @brief create a string (explicit)
 
@@ -2681,12 +2685,12 @@ class basic_json
 
     // get_impl overload chosen if json_traits struct is specialized for type T
     // simply returns json_traits<T>::from_json(*this);
-    template <typename T, typename = enable_if_t<detail::has_json_traits<
-                              remove_cv_t<remove_reference_t<T>>>::value>>
-    auto get_impl(T *) const
-        -> decltype(json_traits<remove_cv_t<remove_reference_t<T>>>::from_json(
-            std::declval<basic_json>())) {
-      return json_traits<remove_cv_t<remove_reference_t<T>>>::from_json(*this);
+    template <typename T, typename = enable_if_t<
+                              detail::has_json_traits<uncvref_t<T>>::value>>
+    auto get_impl(T *) const -> decltype(
+        json_traits<uncvref_t<T>>::from_json(std::declval<basic_json>()))
+    {
+      return json_traits<uncvref_t<T>>::from_json(*this);
     }
 
     // this one is quite atrocious
@@ -2694,12 +2698,11 @@ class basic_json
     // I chose to prefer the json_traits specialization if it exists, since it's a more advanced use.
     // But we can of course change this behaviour
     template <typename T>
-    auto get_impl(T *) const
-        -> enable_if_t<not detail::has_json_traits<remove_cv_t<T>>::value,
-                       remove_cv_t<remove_reference_t<decltype(
-                           ::nlohmann::from_json(std::declval<basic_json>(),
+    auto get_impl(T *) const -> enable_if_t<
+        not detail::has_json_traits<remove_cv_t<T>>::value,
+        uncvref_t<decltype(::nlohmann::from_json(std::declval<basic_json>(),
                                                  std::declval<T &>()),
-                           std::declval<T>())>>>
+                           std::declval<T>())>>
     {
       remove_cv_t<T> ret;
       // I guess this output parameter is the only way to get ADL

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -146,26 +146,6 @@ struct has_mapped_type
         std::is_integral<decltype(detect(std::declval<T>()))>::value;
 };
 
-// taken from http://stackoverflow.com/questions/10711952/how-to-detect-existence-of-a-class-using-sfinae
-// used to determine if json_traits is defined for a given type T
-template <typename T>
-struct has_destructor
-{
-  template <typename U>
-  static std::true_type detect(decltype(std::declval<U>().~U())*);
-
-  template <typename>
-  static std::false_type detect(...);
-
-  static constexpr bool value = decltype(detect<T>(0))::value;
-};
-
-template<typename T>
-struct has_json_traits
-{
-  static constexpr bool value = has_destructor<json_traits<T>>::value;
-};
-
 struct to_json_fn
 {
   template <typename T>
@@ -1318,8 +1298,7 @@ class basic_json
     // auto j = json{{"a", json(not_equality_comparable{})}};
     // 
     // we can remove this constraint though, since lots of ctor are not explicit already
-    template <typename T, typename = enable_if_t<
-                              detail::has_json_traits<uncvref_t<T>>::value>>
+    template <typename T, typename = decltype(json_traits<uncvref_t<T>>::to_json(std::declval<uncvref_t<T>>()))>
     explicit basic_json(T &&val)
         : basic_json(json_traits<uncvref_t<T>>::to_json(std::forward<T>(val)))
     {
@@ -2685,24 +2664,19 @@ class basic_json
 
     // get_impl overload chosen if json_traits struct is specialized for type T
     // simply returns json_traits<T>::from_json(*this);
-    template <typename T, typename = enable_if_t<
-                              detail::has_json_traits<uncvref_t<T>>::value>>
-    auto get_impl(T *) const -> decltype(
-        json_traits<uncvref_t<T>>::from_json(std::declval<basic_json>()))
+    // dual argument to avoid conflicting with get_impl overloads taking a pointer
+    template <typename T>
+    auto get_impl(int, int) const -> decltype(json_traits<uncvref_t<T>>::from_json(*this))
     {
       return json_traits<uncvref_t<T>>::from_json(*this);
     }
 
-    // this one is quite atrocious
     // this overload is chosen ONLY if json_traits struct is not specialized, and if the expression nlohmann::from_json(*this, T&) is valid
     // I chose to prefer the json_traits specialization if it exists, since it's a more advanced use.
     // But we can of course change this behaviour
     template <typename T>
-    auto get_impl(T *) const -> enable_if_t<
-        not detail::has_json_traits<remove_cv_t<T>>::value,
-        uncvref_t<decltype(::nlohmann::from_json(std::declval<basic_json>(),
-                                                 std::declval<T &>()),
-                           std::declval<T>())>>
+    auto get_impl(long, long) const -> uncvref_t<decltype(::nlohmann::from_json(*this, std::declval<T &>()),
+                                                    std::declval<T>())>
     {
       remove_cv_t<T> ret;
       // I guess this output parameter is the only way to get ADL
@@ -3027,11 +3001,16 @@ class basic_json
     */
     template<typename ValueType, typename std::enable_if<
                  not std::is_pointer<ValueType>::value, int>::type = 0>
-    ValueType get() const
+    auto get() const -> decltype(get_impl(static_cast<ValueType*>(nullptr)))
     {
         return get_impl(static_cast<ValueType*>(nullptr));
     }
 
+    template <typename ValueType>
+    auto get() const -> decltype(get_impl<ValueType>(0, 0))
+    {
+        return get_impl<ValueType>(0, 0);
+    }
     /*!
     @brief get a pointer value (explicit)
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -148,20 +148,65 @@ struct has_mapped_type
 
 struct to_json_fn
 {
-  template <typename T>
-  constexpr auto operator()(T&& val) const -> decltype(to_json(std::forward<T>(val)))
-  {
-    return to_json(std::forward<T>(val));
-  }
+  private:
+    // fallback overload
+    template <typename T>
+    static constexpr auto
+    impl(T &&val, long) noexcept(noexcept(to_json(std::forward<T>(val))))
+        -> decltype(to_json(std::forward<T>(val)))
+    {
+      return to_json(std::forward<T>(val));
+    }
+
+    // preferred overload
+    template <typename T>
+    static constexpr auto impl(T &&val, int) noexcept(
+        noexcept(json_traits<uncvref_t<T>>::to_json(std::forward<T>(val))))
+        -> decltype(json_traits<uncvref_t<T>>::to_json(std::forward<T>(val)))
+    {
+      return json_traits<uncvref_t<T>>::to_json(std::forward<T>(val));
+    }
+
+  public:
+    template <typename T>
+    constexpr auto operator()(T &&val) const
+        noexcept(noexcept(to_json_fn::impl(std::forward<T>(val), 0)))
+            -> decltype(to_json_fn::impl(std::forward<T>(val), 0))
+    {
+      // decltype(0) -> int, so the compiler will try to take the 'preferred overload'
+      // if there is no specialization, the 'fallback overload' will be taken by converting 0 to long
+      return to_json_fn::impl(std::forward<T>(val), 0);
+    }
 };
 
 struct from_json_fn
 {
-  template <typename Json, typename T>
-  constexpr auto operator()(Json const& from, T& to) const -> decltype(from_json(from, to))
-  {
-    return from_json(from, to);
-  }
+  private:
+    template <typename T, typename Json>
+    static constexpr auto impl(Json const &j, T &val,
+                               long) noexcept(noexcept(from_json(j, val)))
+        -> decltype(from_json(j, val))
+    {
+      return from_json(j, val);
+    }
+
+    template <typename T, typename Json>
+    static constexpr auto
+    impl(Json const &j, T &val,
+         int) noexcept(noexcept(json_traits<T>::from_json(j, val)))
+        -> decltype(json_traits<T>::from_json(j, val))
+    {
+      return json_traits<T>::from_json(j, val);
+    }
+
+  public:
+    template <typename T, typename Json>
+    constexpr auto operator()(Json const &j, T &val) const
+        noexcept(noexcept(from_json_fn::impl(j, val, 0)))
+            -> decltype(from_json_fn::impl(j, val, 0))
+    {
+      return from_json_fn::impl(j, val, 0);
+    }
 };
 
 /*!
@@ -1284,7 +1329,13 @@ class basic_json
         assert_invariant();
     }
 
-    // constructor chosen if json_traits is specialized for type T
+    // constructor chosen for user-defined types that either have:
+    // - a to_json free function in their type's namespace
+    // - a json_traits specialization for their type
+    //
+    // If there is both a free function and a specialization, the latter will be chosen,
+    // since it is a more advanced use
+    //
     // note: constructor is marked explicit to avoid the following issue:
     //
     // struct not_equality_comparable{};
@@ -1294,15 +1345,15 @@ class basic_json
     // this will construct implicitely 2 json objects and call operator== on them
     // which can cause nasty bugs on the user's in json-unrelated code
     // 
-    // the trade-off is expressivety in initializer-lists
+    // the trade-off is expressiveness in initializer-lists
     // auto j = json{{"a", json(not_equality_comparable{})}};
     // 
     // we can remove this constraint though, since lots of ctor are not explicit already
-    template <typename T, typename = decltype(json_traits<uncvref_t<T>>::to_json(std::declval<uncvref_t<T>>()))>
+    template <typename T, typename = decltype(::nlohmann::to_json(
+                              std::declval<uncvref_t<T>>()))>
     explicit basic_json(T &&val)
-        : basic_json(json_traits<uncvref_t<T>>::to_json(std::forward<T>(val)))
-    {
-    }
+        : basic_json(::nlohmann::to_json(std::forward<T>(val))) {}
+
     /*!
     @brief create a string (explicit)
 
@@ -2662,32 +2713,6 @@ class basic_json
     // value access //
     //////////////////
 
-    // get_impl overload chosen if json_traits struct is specialized for type T
-    // simply returns json_traits<T>::from_json(*this);
-    // dual argument to avoid conflicting with get_impl overloads taking a pointer
-    template <typename T>
-    auto get_impl(int, int) const -> decltype(json_traits<uncvref_t<T>>::from_json(*this))
-    {
-      return json_traits<uncvref_t<T>>::from_json(*this);
-    }
-
-    // this overload is chosen ONLY if json_traits struct is not specialized, and if the expression nlohmann::from_json(*this, T&) is valid
-    // I chose to prefer the json_traits specialization if it exists, since it's a more advanced use.
-    // But we can of course change this behaviour
-    template <typename T>
-    auto get_impl(long, long) const -> uncvref_t<decltype(::nlohmann::from_json(*this, std::declval<T &>()),
-                                                    std::declval<T>())>
-    {
-      remove_cv_t<T> ret;
-      // I guess this output parameter is the only way to get ADL
-      // Even if users can use the get<T> method to have a more 'functional' behaviour
-      // i.e. having a return type, could there be a way to have the same behaviour with from_json?
-      // e.g. auto t = nlohmann::from_json<T>(json{});
-      // this seems to require variable templates though... (at least it did when I tried to implement it)
-      ::nlohmann::from_json(*this, ret);
-      return ret;
-    }
-
     template<class T, typename std::enable_if<
                  std::is_convertible<typename object_t::key_type, typename T::key_type>::value and
                  std::is_convertible<basic_json_t, typename T::mapped_type>::value, int>::type = 0>
@@ -3007,10 +3032,18 @@ class basic_json
     }
 
     template <typename ValueType>
-    auto get() const -> decltype(get_impl<ValueType>(0, 0))
+    auto get() const -> remove_reference_t<
+        decltype(::nlohmann::from_json(*this, std::declval<ValueType &>()),
+                 std::declval<ValueType>())>
     {
-        return get_impl<ValueType>(0, 0);
+      static_assert(std::is_default_constructible<ValueType>::value,
+                    "ValueType must be default-constructible when user-defined "
+                    "from_json method is used");
+      ValueType ret;
+      ::nlohmann::from_json(*this, ret);
+      return ret;
     }
+
     /*!
     @brief get a pointer value (explicit)
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1336,14 +1336,15 @@ class basic_json
 
     @sa @ref basic_json(const typename string_t::value_type*) -- create a
     string value from a character pointer
-    @sa @ref basic_json(const CompatibleStringType&) -- create a string
-    value
+    @sa @ref basic_json(const CompatibleStringType&) -- create a string value
     from a compatible string container
 
     @since version 1.0.0
     */
-    basic_json(const string_t &val) : m_type(value_t::string), m_value(val) {
-      assert_invariant();
+    basic_json(const string_t& val)
+        : m_type(value_t::string), m_value(val)
+    {
+        assert_invariant();
     }
 
     /*!
@@ -2710,20 +2711,19 @@ class basic_json
       return ret;
     }
 
-    /// get an object (explicit)
-    template <class T,
-              typename std::enable_if<
-                  std::is_convertible<typename object_t::key_type,
-                                      typename T::key_type>::value and
-                      std::is_convertible<basic_json_t,
-                                          typename T::mapped_type>::value,
-                  int>::type = 0>
-    T get_impl(T *) const {
-      if (is_object()) {
-        return T(m_value.object->begin(), m_value.object->end());
-      } else {
-        throw std::domain_error("type must be object, but is " + type_name());
-      }
+    template<class T, typename std::enable_if<
+                 std::is_convertible<typename object_t::key_type, typename T::key_type>::value and
+                 std::is_convertible<basic_json_t, typename T::mapped_type>::value, int>::type = 0>
+    T get_impl(T*) const
+    {
+        if (is_object())
+        {
+            return T(m_value.object->begin(), m_value.object->end());
+        }
+        else
+        {
+            throw std::domain_error("type must be object, but is " + type_name());
+        }
     }
 
     /// get an object (explicit)

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -143,6 +143,24 @@ struct has_json_traits
   static constexpr bool value = has_destructor<json_traits<T>>::value;
 };
 
+struct to_json_fn
+{
+  template <typename T>
+  constexpr auto operator()(T&& val) const -> decltype(to_json(std::forward<T>(val)))
+  {
+    return to_json(std::forward<T>(val));
+  }
+};
+
+struct from_json_fn
+{
+  template <typename T>
+  constexpr auto operator()(T&& val) const -> decltype(from_json(std::forward<T>(val)))
+  {
+    return from_json(std::forward<T>(val));
+  }
+};
+
 /*!
 @brief helper class to create locales with decimal point
 
@@ -163,6 +181,22 @@ struct DecimalSeparator : std::numpunct<char>
     }
 };
 
+}
+
+// taken from ranges-v3
+template <typename T>
+struct __static_const
+{
+  static constexpr T value{};
+};
+
+template <typename T>
+constexpr T __static_const<T>::value;
+
+inline namespace
+{
+  constexpr auto const& to_json = __static_const<detail::to_json_fn>::value;
+  constexpr auto const& from_json = __static_const<detail::from_json_fn>::value;
 }
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -146,6 +146,9 @@ struct has_mapped_type
         std::is_integral<decltype(detect(std::declval<T>()))>::value;
 };
 
+void to_json();
+void from_json();
+
 struct to_json_fn
 {
   private:

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -98,8 +98,8 @@ struct json_traits;
 @brief unnamed namespace with internal helper functions
 @since version 1.0.0
 */
-// TODO transform this anon ns to detail?
-namespace
+
+namespace detail
 {
 /*!
 @brief Helper to determine whether there's a key_type for T.
@@ -142,8 +142,6 @@ struct has_json_traits
 {
   static constexpr bool value = has_destructor<json_traits<T>>::value;
 };
-
-template <> struct has_json_traits<void> : std::false_type {};
 
 /*!
 @brief helper class to create locales with decimal point
@@ -1251,7 +1249,7 @@ class basic_json
     template <
         typename T,
         typename =
-            typename std::enable_if<has_json_traits<typename std::remove_cv<
+            typename std::enable_if<detail::has_json_traits<typename std::remove_cv<
                 typename std::remove_reference<T>::type>::type>::value>::type>
     explicit basic_json(T &&val)
         : basic_json(json_traits<typename std::remove_cv<
@@ -2232,7 +2230,7 @@ class basic_json
     {
         std::stringstream ss;
         // fix locale problems
-        const static std::locale loc(std::locale(), new DecimalSeparator);
+        const static std::locale loc(std::locale(), new detail::DecimalSeparator);
         ss.imbue(loc);
 
         // 6, 15 or 16 digits of precision allows round-trip IEEE 754
@@ -2618,7 +2616,7 @@ class basic_json
     template <
         typename T,
         typename =
-            typename std::enable_if<has_json_traits<typename std::remove_cv<
+            typename std::enable_if<detail::has_json_traits<typename std::remove_cv<
                 typename std::remove_reference<T>::type>::type>::value>::type>
     auto get_impl(T *) const -> decltype(
         json_traits<typename std::remove_cv<typename std::remove_reference<
@@ -2662,7 +2660,7 @@ class basic_json
                  not std::is_same<basic_json_t, typename T::value_type>::value and
                  not std::is_arithmetic<T>::value and
                  not std::is_convertible<std::string, T>::value and
-                 not has_mapped_type<T>::value, int>::type = 0>
+                 not detail::has_mapped_type<T>::value, int>::type = 0>
     T get_impl(T*) const
     {
         if (is_array())
@@ -2707,7 +2705,7 @@ class basic_json
     /// get an array (explicit)
     template<class T, typename std::enable_if<
                  std::is_same<basic_json, typename T::value_type>::value and
-                 not has_mapped_type<T>::value, int>::type = 0>
+                 not detail::has_mapped_type<T>::value, int>::type = 0>
     T get_impl(T*) const
     {
         if (is_array())
@@ -5872,7 +5870,7 @@ class basic_json
         o.width(0);
 
         // fix locale problems
-        const auto old_locale = o.imbue(std::locale(std::locale(), new DecimalSeparator));
+        const auto old_locale = o.imbue(std::locale(std::locale(), new detail::DecimalSeparator));
         // set precision
 
         // 6, 15 or 16 digits of precision allows round-trip IEEE 754

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -206,18 +206,18 @@ struct DecimalSeparator : std::numpunct<char>
 // taken from ranges-v3
 // TODO add doc
 template <typename T>
-struct __static_const
+struct _static_const
 {
   static constexpr T value{};
 };
 
 template <typename T>
-constexpr T __static_const<T>::value;
+constexpr T _static_const<T>::value;
 
 inline namespace
 {
-  constexpr auto const& to_json = __static_const<detail::to_json_fn>::value;
-  constexpr auto const& from_json = __static_const<detail::from_json_fn>::value;
+  constexpr auto const& to_json = _static_const<detail::to_json_fn>::value;
+  constexpr auto const& from_json = _static_const<detail::from_json_fn>::value;
 }
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3029,7 +3029,7 @@ class basic_json
     */
     template<typename ValueType, typename std::enable_if<
                  not std::is_pointer<ValueType>::value, int>::type = 0>
-    auto get() const -> decltype(get_impl(static_cast<ValueType*>(nullptr)))
+    auto get() const -> decltype(this->get_impl(static_cast<ValueType*>(nullptr)))
     {
         return get_impl(static_cast<ValueType*>(nullptr));
     }

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -91,12 +91,14 @@ SOFTWARE.
 */
 namespace nlohmann
 {
-
+template <typename T, typename = void>
+struct json_traits;
 
 /*!
 @brief unnamed namespace with internal helper functions
 @since version 1.0.0
 */
+// TODO transform this anon ns to detail?
 namespace
 {
 /*!
@@ -121,6 +123,27 @@ struct has_mapped_type
     static constexpr bool value =
         std::is_integral<decltype(detect(std::declval<T>()))>::value;
 };
+
+// taken from http://stackoverflow.com/questions/10711952/how-to-detect-existence-of-a-class-using-sfinae
+template <typename T>
+struct has_destructor
+{
+  template <typename U>
+  static std::true_type detect(decltype(std::declval<U>().~U())*);
+
+  template <typename>
+  static std::false_type detect(...);
+
+  static constexpr bool value = decltype(detect<T>(0))::value;
+};
+
+template<typename T>
+struct has_json_traits
+{
+  static constexpr bool value = has_destructor<json_traits<T>>::value;
+};
+
+template <> struct has_json_traits<void> : std::false_type {};
 
 /*!
 @brief helper class to create locales with decimal point
@@ -1225,6 +1248,15 @@ class basic_json
         assert_invariant();
     }
 
+    template <
+        typename T,
+        typename =
+            typename std::enable_if<has_json_traits<typename std::remove_cv<
+                typename std::remove_reference<T>::type>::type>::value>::type>
+    explicit basic_json(T &&val)
+        : basic_json(json_traits<typename std::remove_cv<
+                         typename std::remove_reference<T>::type>::type>::
+                         to_json(std::forward<T>(val))) {}
     /*!
     @brief create a string (explicit)
 
@@ -1241,15 +1273,14 @@ class basic_json
 
     @sa @ref basic_json(const typename string_t::value_type*) -- create a
     string value from a character pointer
-    @sa @ref basic_json(const CompatibleStringType&) -- create a string value
+    @sa @ref basic_json(const CompatibleStringType&) -- create a string
+    value
     from a compatible string container
 
     @since version 1.0.0
     */
-    basic_json(const string_t& val)
-        : m_type(value_t::string), m_value(val)
-    {
-        assert_invariant();
+    basic_json(const string_t &val) : m_type(value_t::string), m_value(val) {
+      assert_invariant();
     }
 
     /*!
@@ -2584,20 +2615,32 @@ class basic_json
     // value access //
     //////////////////
 
+    template <
+        typename T,
+        typename =
+            typename std::enable_if<has_json_traits<typename std::remove_cv<
+                typename std::remove_reference<T>::type>::type>::value>::type>
+    auto get_impl(T *) const -> decltype(
+        json_traits<typename std::remove_cv<typename std::remove_reference<
+            T>::type>::type>::from_json(std::declval<basic_json>())) {
+      return json_traits<typename std::remove_cv<
+          typename std::remove_reference<T>::type>::type>::from_json(*this);
+    }
+
     /// get an object (explicit)
-    template<class T, typename std::enable_if<
-                 std::is_convertible<typename object_t::key_type, typename T::key_type>::value and
-                 std::is_convertible<basic_json_t, typename T::mapped_type>::value, int>::type = 0>
-    T get_impl(T*) const
-    {
-        if (is_object())
-        {
-            return T(m_value.object->begin(), m_value.object->end());
-        }
-        else
-        {
-            throw std::domain_error("type must be object, but is " + type_name());
-        }
+    template <class T,
+              typename std::enable_if<
+                  std::is_convertible<typename object_t::key_type,
+                                      typename T::key_type>::value and
+                      std::is_convertible<basic_json_t,
+                                          typename T::mapped_type>::value,
+                  int>::type = 0>
+    T get_impl(T *) const {
+      if (is_object()) {
+        return T(m_value.object->begin(), m_value.object->end());
+      } else {
+        throw std::domain_error("type must be object, but is " + type_name());
+      }
     }
 
     /// get an object (explicit)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${JSON_UNITTEST_TARGET_NAME}
     "src/unit-concepts.cpp"
     "src/unit-constructor1.cpp"
     "src/unit-constructor2.cpp"
+    "src/unit-constructor3.cpp"
     "src/unit-convenience.cpp"
     "src/unit-conversions.cpp"
     "src/unit-deserialization.cpp"

--- a/test/src/unit-constructor3.cpp
+++ b/test/src/unit-constructor3.cpp
@@ -84,17 +84,13 @@ inline bool operator==(optional_type<T> const& lhs, optional_type<T> const& rhs)
 }
 }
 
-template <typename T>
-struct type_helper
-{
-  using type = T;
-};
-
 namespace nlohmann
 {
 template <>
-struct json_traits<udt::empty_type> : type_helper<udt::empty_type>
+struct json_traits<udt::empty_type>
 {
+  using type = udt::empty_type;
+
   static json to_json(type)
   {
     return json::object();
@@ -108,8 +104,10 @@ struct json_traits<udt::empty_type> : type_helper<udt::empty_type>
 };
 
 template <>
-struct json_traits<udt::pod_type> : type_helper<udt::pod_type>
-{
+struct json_traits<udt::pod_type>
+{  
+  using type = udt::pod_type;
+
   static json to_json(type const& t)
   {
     return {{"a", t.a}, {"b", t.b}, {"c", t.c}};
@@ -124,8 +122,9 @@ struct json_traits<udt::pod_type> : type_helper<udt::pod_type>
 
 template <>
 struct json_traits<udt::bit_more_complex_type>
-    : type_helper<udt::bit_more_complex_type>
 {
+  using type = udt::bit_more_complex_type;
+
   static json to_json(type const& t)
   {
     return json{{"a", json{t.a}}, {"b", json{t.b}}, {"c", t.c}};
@@ -139,8 +138,11 @@ struct json_traits<udt::bit_more_complex_type>
 };
 
 template <typename T>
-struct json_traits<udt::optional_type<T>> : type_helper<udt::optional_type<T>> {
-  static json to_json(type const&t)
+struct json_traits<udt::optional_type<T>>
+{
+  using type = udt::optional_type<T>;
+
+  static json to_json(type const& t)
   {
     if (t)
       return json(*t);

--- a/test/src/unit-constructor3.cpp
+++ b/test/src/unit-constructor3.cpp
@@ -1,0 +1,300 @@
+/*
+    __ _____ _____ _____
+ __|  |   __|     |   | |  JSON for Modern C++ (test suite)
+|  |  |__   |  |  | | | |  version 2.0.5
+|_____|_____|_____|_|___|  https://github.com/nlohmann/json
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+Copyright (c) 2013-2016 Niels Lohmann <http://nlohmann.me>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <string>
+#include <memory>
+#include "catch.hpp"
+
+#include "json.hpp"
+using nlohmann::json;
+
+namespace udt
+{
+struct empty_type {};
+struct pod_type {
+  int a;
+  char b;
+  short c;
+};
+
+inline bool operator==(pod_type const& lhs, pod_type const& rhs) noexcept
+{
+  return std::tie(lhs.a, lhs.b, lhs.c) == std::tie(rhs.a, rhs.b, rhs.c);
+}
+
+struct bit_more_complex_type {
+  pod_type a;
+  pod_type b;
+  std::string c;
+};
+
+inline bool operator==(bit_more_complex_type const &lhs,
+                       bit_more_complex_type const &rhs) noexcept {
+  return std::tie(lhs.a, lhs.b, lhs.c) == std::tie(rhs.a, rhs.b, rhs.c);
+}
+
+// best optional implementation ever
+template <typename T>
+class optional_type
+{
+public:
+  optional_type() = default;
+  explicit optional_type(T val) : _val(std::make_shared<T>(std::move(val))) {}
+  explicit operator bool() const noexcept { return _val != nullptr; }
+
+  T const &operator*() const { return *_val; }
+
+private:
+  std::shared_ptr<T> _val;
+};
+
+template <typename T>
+inline bool operator==(optional_type<T> const& lhs, optional_type<T> const& rhs)
+{
+  if (!lhs && !rhs)
+    return true;
+  if (!lhs || !rhs)
+    return false;
+  return *lhs == *rhs;
+}
+}
+
+template <typename T>
+struct type_helper
+{
+  using type = T;
+};
+
+namespace nlohmann
+{
+template <>
+struct json_traits<udt::empty_type> : type_helper<udt::empty_type>
+{
+  static json to_json(type)
+  {
+    return json::object();
+  }
+  
+  static type from_json(json const& j)
+  {
+    assert(j.is_object() and j.empty());
+    return {};
+  }
+};
+
+template <>
+struct json_traits<udt::pod_type> : type_helper<udt::pod_type>
+{
+  static json to_json(type const& t)
+  {
+    return {{"a", t.a}, {"b", t.b}, {"c", t.c}};
+  }
+  
+  static type from_json(json const& j)
+  {
+    assert(j.is_object());
+    return {j["a"].get<int>(), j["b"].get<char>(), j["c"].get<short>()};
+  }
+};
+
+template <>
+struct json_traits<udt::bit_more_complex_type>
+    : type_helper<udt::bit_more_complex_type>
+{
+  static json to_json(type const& t)
+  {
+    return json{{"a", json{t.a}}, {"b", json{t.b}}, {"c", t.c}};
+  }
+
+  static type from_json(json const& j)
+  {
+    return {j["a"].get<udt::pod_type>(), j["b"].get<udt::pod_type>(),
+            j["c"].get<std::string>()};
+  }
+};
+
+template <typename T>
+struct json_traits<udt::optional_type<T>> : type_helper<udt::optional_type<T>> {
+  static json to_json(type const&t)
+  {
+    if (t)
+      return json(*t);
+    return {};
+  }
+
+  static type from_json(json const& j)
+  {
+    if (j.is_null())
+      return {};
+    return type{j.get<T>()};
+  }
+};
+}
+
+
+TEST_CASE("constructors for user-defined types", "[udt]")
+{
+  SECTION("empty type")
+  {
+    udt::empty_type const e;
+    auto const j = json{e};
+    auto k = json::object();
+    CHECK(j == k);
+  }
+
+  SECTION("pod type")
+  {
+    auto const e = udt::pod_type{42, 42, 42};
+    auto j = json{e};
+    auto k = json{{"a", 42}, {"b", 42}, {"c", 42}};
+    CHECK(j == k);
+  }
+
+  SECTION("bit more complex type")
+  {
+    auto const e =
+        udt::bit_more_complex_type{{42, 42, 42}, {41, 41, 41}, "forty"};
+
+    auto j = json{e};
+    auto k = json{{"a", {{"a", 42}, {"b", 42}, {"c", 42}}},
+                  {"b", {{"a", 41}, {"b", 41}, {"c", 41}}},
+                  {"c", "forty"}};
+    CHECK(j == k);
+  }
+
+  SECTION("vector of udt")
+  {
+    std::vector<udt::bit_more_complex_type> v;
+    auto const e =
+        udt::bit_more_complex_type{{42, 42, 42}, {41, 41, 41}, "forty"};
+
+    v.emplace_back(e);
+    v.emplace_back(e);
+    v.emplace_back(e);
+
+    json j = v;
+    auto k = json{{"a", {{"a", 42}, {"b", 42}, {"c", 42}}},
+                  {"b", {{"a", 41}, {"b", 41}, {"c", 41}}},
+                  {"c", "forty"}};
+    auto l = json{k, k, k};
+    CHECK(j == l);
+  }
+
+  SECTION("optional type") {
+    SECTION("regular case") {
+      udt::optional_type<int> u{3};
+      CHECK(json{u} == json(3));
+    }
+
+    SECTION("nullopt case") {
+      udt::optional_type<float> v;
+      CHECK(json{v} == json{});
+    }
+
+    SECTION("optional of json convertible type")
+    {
+      auto const e =
+          udt::bit_more_complex_type{{42, 42, 42}, {41, 41, 41}, "forty"};
+      udt::optional_type<udt::bit_more_complex_type> o{e};
+      auto k = json{{"a", {{"a", 42}, {"b", 42}, {"c", 42}}},
+                    {"b", {{"a", 41}, {"b", 41}, {"c", 41}}},
+                    {"c", "forty"}};
+      CHECK(json{o} == k);
+    }
+
+    SECTION("optional of vector of json convertible type")
+    {
+      std::vector<udt::bit_more_complex_type> v;
+      auto const e =
+          udt::bit_more_complex_type{{42, 42, 42}, {41, 41, 41}, "forty"};
+      v.emplace_back(e);
+      v.emplace_back(e);
+      v.emplace_back(e);
+      udt::optional_type<std::vector<udt::bit_more_complex_type>> o{v};
+      auto k = json{{"a", {{"a", 42}, {"b", 42}, {"c", 42}}},
+                    {"b", {{"a", 41}, {"b", 41}, {"c", 41}}},
+                    {"c", "forty"}};
+      auto l = json{k, k, k};
+      CHECK(json{o} == l);
+    }
+  }
+}
+
+TEST_CASE("get<> for user-defined types", "[udt]")
+{
+  SECTION("pod type")
+  {
+    auto const e = udt::pod_type{42, 42, 42};
+    auto const j = json{{"a", 42}, {"b", 42}, {"c", 42}};
+
+    auto const obj = j.get<udt::pod_type>();
+    CHECK(e == obj);
+  }
+
+  SECTION("bit more complex type")
+  {
+    auto const e =
+        udt::bit_more_complex_type{{42, 42, 42}, {41, 41, 41}, "forty"};
+    auto const j = json{{"a", {{"a", 42}, {"b", 42}, {"c", 42}}},
+                        {"b", {{"a", 41}, {"b", 41}, {"c", 41}}},
+                        {"c", "forty"}};
+
+    auto const obj = j.get<udt::bit_more_complex_type>();
+    CHECK(e == obj);
+  }
+
+  SECTION("vector of udt")
+  {
+    auto const e =
+        udt::bit_more_complex_type{{42, 42, 42}, {41, 41, 41}, "forty"};
+    std::vector<udt::bit_more_complex_type> v{e, e, e};
+    auto const j = json(v);
+
+    auto const obj = j.get<decltype(v)>();
+    CHECK(v == obj);
+  }
+
+  SECTION("optional")
+  {
+    SECTION("from null")
+    {
+      udt::optional_type<int> o;
+      json j;
+      CHECK(j.get<decltype(o)>() == o);
+    }
+
+    SECTION("from value")
+    {
+      json j{{"a", 42}, {"b", 42}, {"c", 42}};
+      auto v = j.get<udt::optional_type<udt::pod_type>>();
+      auto expected = udt::pod_type{42,42,42};
+      REQUIRE(v);
+      CHECK(*v == expected);
+    }
+  }
+}


### PR DESCRIPTION
WIP: This PR is **NOT** ready to be merged, its purpose is to facilitate review/discussions.
## Files to change

There are currently two files which need to be edited:
1. [`src/json.hpp.re2c`](https://github.com/nlohmann/json/blob/master/src/json.hpp.re2c) (note the `.re2c` suffix) - This file contains a comment section which describes the JSON lexic. This section is translated by [`re2c`](http://re2c.org) into file [`src/json.hpp`](https://github.com/nlohmann/json/blob/master/src/json.hpp) which is plain "vanilla" C++11 code. (In fact, the generated lexer consists of some hundred lines of `goto`s, which is a hint you never want to edit this file...).
   
   If you only edit file `src/json.hpp` (without the `.re2c` suffix), your changes will be overwritten as soon as the lexer is touched again. To generate the `src/json.hpp` file which is actually used during compilation of the tests and all other code, please execute
   
   ``` sh
   make re2c
   ```
   
   To run [`re2c`](http://re2c.org) and generate/overwrite file `src/json.hpp` with your changes in file `src/json.hpp.re2c`.
2. [`test/src/unit.cpp`](https://github.com/nlohmann/json/blob/master/test/unit.cpp) - This contains the [Catch](https://github.com/philsquared/Catch) unit tests which currently cover [100 %](https://coveralls.io/github/nlohmann/json) of the library's code.
   
   If you add or change a feature, please also add a unit test to this file. The unit tests can be compiled with
   
   ``` sh
   make
   ```
   
   and can be executed with
   
   ``` sh
   ./json_unit
   ```
   
   The test cases are also executed with several different compilers on [Travis](https://travis-ci.org/nlohmann/json) once you open a pull request.

Please understand that I cannot accept pull requests changing only file `src/json.hpp`.
## Note
- If you open a pull request, the code will be automatically tested with [Valgrind](http://valgrind.org)'s Memcheck tool to detect memory leaks. Please be aware that the execution with Valgrind _may_ in rare cases yield different behavior than running the code directly. This can result in failing unit tests which run successfully without Valgrind.
## Please don't
- Only make changes to file `src/json.hpp` -- please read the paragraph above and understand why `src/json.hpp.re2c` exists.
- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
