### PR TITLE
Clang: quiet a warning

### DIFF
--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -73,6 +73,7 @@ SOFTWARE.
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wfloat-equal"
+    #pragma GCC diagnostic ignored "-Wdocumentation"
 #endif
 
 // allow for portable deprecation warnings


### PR DESCRIPTION
In my project I have a lot of warnings enabled and -Wdocumentation fires a lot in this header (-Wdocuemntation does a check on Doxygen comments to see how they match what they're attached to; I dont see much value in trying to fix the comments so I'd like to quiet the warning).

Note I tried running re2c but it added a lot of other changes, so I think maybe I have a different version or 'develop' is dirty?