### PR TITLE
README: adjust boost::optional example

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,9 @@ namespace nlohmann {
         }
 
         static void from_json(const json& j, boost::optional<T>& opt) {
-            if (!j.is_null()) {
+            if (j.is_null()) {
+                opt = boost::none;
+            } else {
                 opt = j.get<T>(); // same as above, but with 
                                   // adl_serializer<T>::from_json
             }


### PR DESCRIPTION
The "from_json" example for boost::optional is not complete and should also handle the 'none' case. I'm modifying it to be symmetric with the to_json example.