### PR TITLE
Make exception base class visible in basic_json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: pretty clean ChangeLog.md
 
 # used programs
-RE2C = re2c
+RE2C := $(shell command -v re2c 2> /dev/null)
 SED = sed
 
 # main target
@@ -185,6 +185,9 @@ clang_sanitize: clean
 
 # create scanner with re2c
 re2c: src/json.hpp.re2c
+ifndef RE2C
+	$(error "re2c is not available, please install re2c")
+endif
 	$(RE2C) -W --utf-8 --encoding-policy fail --bit-vectors --nested-ifs --no-debug-info $< | $(SED) '1d' > src/json.hpp
 
 # pretty printer

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1264,6 +1264,8 @@ class basic_json
     /// Classes to implement user-defined exceptions.
     /// @{
 
+    /// @copydoc detail::exception
+    using exception = detail::exception;
     /// @copydoc detail::parse_error
     using parse_error = detail::parse_error;
     /// @copydoc detail::invalid_iterator

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -1264,6 +1264,8 @@ class basic_json
     /// Classes to implement user-defined exceptions.
     /// @{
 
+    /// @copydoc detail::exception
+    using exception = detail::exception;
     /// @copydoc detail::parse_error
     using parse_error = detail::parse_error;
     /// @copydoc detail::invalid_iterator


### PR DESCRIPTION
Implements change proposed in #525 plus sanity check testing whether `re2c` is installed in order to print a nice error message if it's not.