### PR TITLE
Add Visual Studio 17 image to appveyor build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,12 @@
 version: '{build}'
-os: Visual Studio 2015
+os: 
+- Visual Studio 2015
+- Visual Studio 2017
 init: []
 install: []
 build_script:
-- set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
-- cmake . -G "Visual Studio 14 2015"
+- IF "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" ( SET GEN="Visual Studio 14 2015") ELSE (SET GEN="Visual Studio 15 2017")
+- cmake . -G%GEN% 
 - cmake --build . --config Release
 test_script:
 - ctest -C Release -V


### PR DESCRIPTION
I would like to propose a small addition to the current `appveyor.yml` file that adds Visual Studio 17 image to the build matrix. So, now it is possible to track a build status with brand new MS's Studio.