### PR TITLE
Properly pop diagnostics

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -13886,6 +13886,9 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic pop
 #endif
+#if defined(__clang__)
+    #pragma GCC diagnostic pop
+#endif
 
 // clean up
 #undef JSON_CATCH

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -12919,6 +12919,9 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic pop
 #endif
+#if defined(__clang__)
+    #pragma GCC diagnostic pop
+#endif
 
 // clean up
 #undef JSON_CATCH


### PR DESCRIPTION
Currently, with clang, the diagnostics are push()ed twice, but pop()ed only once. Fixing this by adding a "pragma diagnostics pop".