### PR TITLE
Create lugares

### DIFF
--- a/lugares
+++ b/lugares
@@ -1,0 +1,123 @@
+{
+	"lugares": [{
+		"nombre": "Nueva York",
+		"apodo": "La Gran Manzana",
+		"longitud": -74.00594130000002,
+		"latitud": 40.7127837,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/1.jpg "
+	}, {
+		"nombre": "Miami",
+		"apodo": "La Ciudad Mágica",
+		"longitud": -80.19179020000001,
+		"latitud": 25.7616798,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/2.jpg "
+	}, {
+		"nombre": "Orlando",
+		"apodo": " La Ciudad Bella",
+		"longitud": -81.37923649999999,
+		"latitud": 28.5383355,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/3.jpg "
+	}, {
+		"nombre": "Chile",
+		"apodo": "Como la Víbora",
+		"longitud": -71.54296899999997,
+		"latitud": -35.675147,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/4.jpg "
+	}, {
+		"nombre": "México",
+		"apodo": "Raza de Bronce",
+		"longitud": -102.55278399999997,
+		"latitud": 23.634501,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/5.jpg "
+	}, {
+		"nombre": "Los Ángeles",
+		"apodo": "La Gran Naranja ",
+		"longitud": -118.2436849,
+		"latitud": 34.0522342,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/6.jpg "
+	}, {
+		"nombre": "Washington",
+		"apodo": "El Estado de la Hoja Perenne",
+		"longitud": -77.03687070000001,
+		"latitud": 38.9071923,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/7.jpg "
+	}, {
+		"nombre": "Vancouver",
+		"apodo": "La Ciudad del Capitán",
+		"longitud": -123.12073750000002,
+		"latitud": 49.2827291,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/8.jpg "
+	}, {
+		"nombre": "Bethel",
+		"apodo": "La Última frontera",
+		"longitud": -161.7558333,
+		"latitud": 60.7922222,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/9.jpg"
+	}, {
+		"nombre": "Regina",
+		"apodo": "La Ciudad de la Reina",
+		"longitud": -104.61889439999999,
+		"latitud": 50.4452112,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/10.jpg"
+	}, {
+		"nombre": "Bogotá",
+		"apodo": "La Atenas Suramericana",
+		"longitud": -74.072092,
+		"latitud": 4.710988599999999,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/11.jpg"
+	}, {
+		"nombre": "Caracas",
+		"apodo": "La Sucursal del Cielo",
+		"longitud": -66.90360629999998,
+		"latitud": 10.4805937,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/12.jpg"
+	}, {
+		"nombre": "Quito",
+		"apodo": "La Luz de América",
+		"longitud": -78.46783820000002,
+		"latitud": -0.1806532,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/13.jpg"
+	}, {
+		"nombre": "Cajamarca",
+		"apodo": "Hermosa Tierra del Cumbe",
+		"longitud": -78.5127855,
+		"latitud": -7.1617465,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/14.jpg"
+	}, {
+		"nombre": "Lima",
+		"apodo": "La Ciudad de los Reyes",
+		"longitud": -77.042754,
+		"latitud": -12.0463731,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/15.jpg"
+	}, {
+		"nombre": "Rio de Janeiro",
+		"apodo": "La Ciudad Maravillosa",
+		"longitud": -43.17289649999998,
+		"latitud": -22.9068467,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/16.jpg"
+	}, {
+		"nombre": "Sao Paulo",
+		"apodo": "Ciudad de la Garúa",
+		"longitud": -46.63330939999997,
+		"latitud": -23.5505199,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/17.jpg"
+	}, {
+		"nombre": "Buenos Aires",
+		"apodo": "El París de América del Sur",
+		"longitud": -58.381559100000004,
+		"latitud": -34.6036844,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/18.jpg"
+	}, {
+		"nombre": "Montevideo",
+		"apodo": "La ciudad de los Palacios ",
+		"longitud": -56.16453139999999,
+		"latitud": -34.9011127,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/19.jpg"
+	}, {
+		"nombre": "Cuba",
+		"apodo": "Donde abundan las Tierras fértiles",
+		"longitud": -77.78116699999998,
+		"latitud": 21.521757,
+		"imagen": "https://www.openprocessing.org/sketch/421502/files/20.jpg"
+	}]
+}


### PR DESCRIPTION
## Files to change

There are currently two files which need to be edited:

1. [`src/json.hpp.re2c`](https://github.com/nlohmann/json/blob/master/src/json.hpp.re2c) (note the `.re2c` suffix) - This file contains a comment section which describes the JSON lexic. This section is translated by [`re2c`](http://re2c.org) into file [`src/json.hpp`](https://github.com/nlohmann/json/blob/master/src/json.hpp) which is plain "vanilla" C++11 code. (In fact, the generated lexer consists of some hundred lines of `goto`s, which is a hint you never want to edit this file...).

   If you only edit file `src/json.hpp` (without the `.re2c` suffix), your changes will be overwritten as soon as the lexer is touched again. To generate the `src/json.hpp` file which is actually used during compilation of the tests and all other code, please execute

   ```sh
   make re2c
   ```

   To run [`re2c`](http://re2c.org) and generate/overwrite file `src/json.hpp` with your changes in file `src/json.hpp.re2c`.


2. [`test/src/unit.cpp`](https://github.com/nlohmann/json/blob/master/test/unit.cpp) - This contains the [Catch](https://github.com/philsquared/Catch) unit tests which currently cover [100 %](https://coveralls.io/github/nlohmann/json) of the library's code.

   If you add or change a feature, please also add a unit test to this file. The unit tests can be compiled with

   ```sh
   make
   ```

   and can be executed with

   ```sh
   ./json_unit
   ```

   The test cases are also executed with several different compilers on [Travis](https://travis-ci.org/nlohmann/json) once you open a pull request.

Please understand that I cannot accept pull requests changing only file `src/json.hpp`.


## Note

- If you open a pull request, the code will be automatically tested with [Valgrind](http://valgrind.org)'s Memcheck tool to detect memory leaks. Please be aware that the execution with Valgrind _may_ in rare cases yield different behavior than running the code directly. This can result in failing unit tests which run successfully without Valgrind.

## Please don't

- Only make changes to file `src/json.hpp` -- please read the paragraph above and understand why `src/json.hpp.re2c` exists.
- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
