### PR TITLE
Adding support for Meson.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,29 +66,8 @@ to the files you want to use JSON objects. That's it. Do not forget to set the n
 
 :beer: If you are using OS X and [Homebrew](http://brew.sh), just type `brew tap nlohmann/json` and `brew install nlohmann_json` and you're set. If you want the bleeding edge rather than the latest release, use `brew install nlohmann_json --HEAD`.
 
-If you are using the Meson Build System, then add a file called `nlohmann_json.wrap` to a file to your `subprojects` directory with the following 4 lines:
-
-```
-[wrap-git]
-directory=nlohmann_json
-url=https://github.com/nlohmann/json.git
-revision=head
-```
-
+If you are using the Meson Build System, then you can wrap this repo as a subproject.
 You can then create a reference to it in your `meson.build` file by adding the line:
-
-```
-nlohmann_json_sp = subproject('nlohmann_json')
-```
-
-Here's an example of an executable called `awesomeness` that uses this library through the reference created above.
-
-```
-executable('awesomeness',
-  'awesomeness.cpp',
-  dependencies: nlohmann_json_sp.get_variable('nlohmann_json_dep')
-)
-```
 
 :warning: [Version 3.0.0](https://github.com/nlohmann/json/wiki/Road-toward-3.0.0) is currently under development. Branch `develop` is used for the ongoing work and is probably **unstable**. Please use the `master` branch for the last stable version 2.1.1.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ to the files you want to use JSON objects. That's it. Do not forget to set the n
 :beer: If you are using OS X and [Homebrew](http://brew.sh), just type `brew tap nlohmann/json` and `brew install nlohmann_json` and you're set. If you want the bleeding edge rather than the latest release, use `brew install nlohmann_json --HEAD`.
 
 If you are using the Meson Build System, then you can wrap this repo as a subproject.
-You can then create a reference to it in your `meson.build` file by adding the line:
 
 :warning: [Version 3.0.0](https://github.com/nlohmann/json/wiki/Road-toward-3.0.0) is currently under development. Branch `develop` is used for the ongoing work and is probably **unstable**. Please use the `master` branch for the last stable version 2.1.1.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ to the files you want to use JSON objects. That's it. Do not forget to set the n
 
 :beer: If you are using OS X and [Homebrew](http://brew.sh), just type `brew tap nlohmann/json` and `brew install nlohmann_json` and you're set. If you want the bleeding edge rather than the latest release, use `brew install nlohmann_json --HEAD`.
 
+If you are using the Meson Build System, then add a file called `nlohmann_json.wrap` to a file to your `subprojects` directory with the following 4 lines:
+
+```
+[wrap-git]
+directory=nlohmann_json
+url=https://github.com/nlohmann/json.git
+revision=head
+```
+
+You can then create a reference to it in your `meson.build` file by adding the line:
+
+```
+nlohmann_json_sp = subproject('nlohmann_json')
+```
+
+Here's an example of an executable called `awesomeness` that uses this library through the reference created above.
+
+```
+executable('awesomeness',
+  'awesomeness.cpp',
+  dependencies: nlohmann_json_sp.get_variable('nlohmann_json_dep')
+)
+```
+
 :warning: [Version 3.0.0](https://github.com/nlohmann/json/wiki/Road-toward-3.0.0) is currently under development. Branch `develop` is used for the ongoing work and is probably **unstable**. Please use the `master` branch for the last stable version 2.1.1.
 
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,7 @@
+project('nlohmann_json', 'cpp')
+
+nlohmann_json_inc = include_directories('src')
+
+nlohmann_json_dep = declare_dependency(
+  include_directories : nlohmann_json_inc
+)


### PR DESCRIPTION
Although the use of this library is very convenient by just copying over the header to another project, this makes it easy for those who want to checkout a particular commit or the HEAD at the build time of their project when they use the [Meson Build System](http://mesonbuild.com/).

It adds only 1 file (`meson.build`), and some usage info in the `README.md` file.

Meson is a C++ build system, like CMake, but simpler. It aims to cut down on the time spent working on build files, and the time spent compiling.