### PR TITLE
Adding first and second properties to iteration_proxy_internal

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7877,6 +7877,44 @@ class basic_json
     class iteration_proxy
     {
       private:
+        /// helper class for first "property"
+        template<typename ProxyType>
+        class iterator_key_property
+        {
+          private:
+            /// the reference to the proxy
+            ProxyType& proxy;
+
+          public:
+            explicit iterator_key_property(ProxyType& proxyRef) noexcept
+                : proxy(proxyRef) {}
+
+            /// conversion operator (calls key())
+            operator typename basic_json::string_t() const
+            {
+              return proxy.key();
+            }
+        };
+
+        /// helper class for second "property"
+        template<typename ProxyType>
+        class iterator_value_property
+        {
+          private:
+            /// the reference to the proxy
+            ProxyType& proxy;
+
+          public:
+            explicit iterator_value_property(ProxyType& proxyRef) noexcept
+                : proxy(proxyRef) {}
+
+            /// conversion operator (calls value())
+            operator typename IteratorType::reference() const
+            {
+              return proxy.value();
+            }
+        };
+
         /// helper class for iteration
         class iteration_proxy_internal
         {
@@ -7887,8 +7925,11 @@ class basic_json
             size_t array_index = 0;
 
           public:
+            iterator_key_property<iteration_proxy_internal> first;
+            iterator_value_property<iteration_proxy_internal> second;
+
             explicit iteration_proxy_internal(IteratorType it) noexcept
-                : anchor(it)
+                : anchor(it), first(*this), second(*this)
             {}
 
             /// dereference operator (needed for range-based for)


### PR DESCRIPTION
This PR fixes #350 by adding property-like members to the iterator_proxy_internal class.

The fix proposed in that issue looks as if you pay for it even if you don't use .first or .second (at least the .first shows a copy of a string each time the iterator is incremented). That cost shouldn't have to be payed, but we don't have to sacrifice the interface that we want.

This solution provides the .first and .second interface as outlined in the issue, but shouldn't cost anything, and is likely inlined out of existence after compilation.