### PR TITLE
Issue #593 Override operator+(n, iterator) in the iterator class

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -9317,9 +9317,20 @@ class basic_json
         @brief  add to iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        iter_impl operator+(difference_type i)
+        iter_impl operator+(difference_type i) const
         {
             auto result = *this;
+            result += i;
+            return result;
+        }
+
+        /*!
+        @brief  addition of distance and iterator
+        @pre The iterator is initialized; i.e. `m_object != nullptr`.
+        */
+        friend iter_impl operator+(difference_type i, const iter_impl& it)
+        {
+            auto result = it;
             result += i;
             return result;
         }
@@ -9328,7 +9339,7 @@ class basic_json
         @brief  subtract from iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        iter_impl operator-(difference_type i)
+        iter_impl operator-(difference_type i) const
         {
             auto result = *this;
             result -= i;

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -9317,9 +9317,20 @@ class basic_json
         @brief  add to iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        iter_impl operator+(difference_type i)
+        iter_impl operator+(difference_type i) const
         {
             auto result = *this;
+            result += i;
+            return result;
+        }
+
+        /*!
+        @brief  addition of distance and iterator
+        @pre The iterator is initialized; i.e. `m_object != nullptr`.
+        */
+        friend iter_impl operator+(difference_type i, const iter_impl& it)
+        {
+            auto result = it;
             result += i;
             return result;
         }
@@ -9328,7 +9339,7 @@ class basic_json
         @brief  subtract from iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        iter_impl operator-(difference_type i)
+        iter_impl operator-(difference_type i) const
         {
             auto result = *this;
             result -= i;

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -271,6 +271,16 @@ TEST_CASE("iterators 2")
                 }
                 {
                     auto it = j_object.begin();
+                    CHECK_THROWS_AS(1 + it, std::domain_error);
+                    CHECK_THROWS_WITH(1 + it, "cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.cbegin();
+                    CHECK_THROWS_AS(1 + it, std::domain_error);
+                    CHECK_THROWS_WITH(1 + it, "cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.begin();
                     CHECK_THROWS_AS(it -= 1, std::domain_error);
                     CHECK_THROWS_WITH(it -= 1, "cannot use offsets with object iterators");
                 }
@@ -687,6 +697,16 @@ TEST_CASE("iterators 2")
                     auto it = j_object.crbegin();
                     CHECK_THROWS_AS(it + 1, std::domain_error);
                     CHECK_THROWS_WITH(it + 1, "cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.rbegin();
+                    CHECK_THROWS_AS(1 + it, std::domain_error);
+                    CHECK_THROWS_WITH(1 + it, "cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.crbegin();
+                    CHECK_THROWS_AS(1 + it, std::domain_error);
+                    CHECK_THROWS_WITH(1 + it, "cannot use offsets with object iterators");
                 }
                 {
                     auto it = j_object.rbegin();


### PR DESCRIPTION
Changes include:
1. Override `operator+(difference_type, const iter_impl&)` in the iterator class
2. Add `const` qualifier in the member `operator+(difference_type)` function
3. Add test cases of the relevant issue