### PR TITLE
Issue #593 Fix the arithmetic operators in the iterator and reverse iterator

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8015,7 +8015,7 @@ class basic_json
               typename basic_json::const_reference,
               typename basic_json::reference>::type;
         /// the category of the iterator
-        using iterator_category = std::bidirectional_iterator_tag;
+        using iterator_category = std::random_access_iterator_tag;
 
         /// default constructor
         iter_impl() = default;

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8686,7 +8686,7 @@ class basic_json
         /// access to successor
         reference operator[](difference_type n) const
         {
-            return base_iterator::operator[](n);
+            return *(this->operator+(n));
         }
 
         /// return the key of an object iterator

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8672,7 +8672,7 @@ class basic_json
         json_reverse_iterator operator+(difference_type i) const
         {
             auto result = *this;
-            result += i;
+            result -= i;
             return result;
         }
 
@@ -8680,14 +8680,14 @@ class basic_json
         json_reverse_iterator operator-(difference_type i) const
         {
             auto result = *this;
-            result -= i;
+            result += i;
             return result;
         }
 
         /// return difference
         difference_type operator-(const json_reverse_iterator& other) const
         {
-            return this->base() - other.base();
+            return other.base() - this->base();
         }
 
         /// access to successor

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8626,7 +8626,7 @@ class basic_json
         using reference = typename Base::reference;
 
         /// create reverse iterator from iterator
-        json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
+		json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
             : base_iterator(it)
         {}
 
@@ -8671,29 +8671,25 @@ class basic_json
         /// add to iterator
         json_reverse_iterator operator+(difference_type i) const
         {
-            auto result = *this;
-            result -= i;
-            return result;
+            return json_reverse_iterator(base_iterator::operator+(i));
         }
 
         /// subtract from iterator
         json_reverse_iterator operator-(difference_type i) const
         {
-            auto result = *this;
-            result += i;
-            return result;
+            return json_reverse_iterator(base_iterator::operator-(i));
         }
 
         /// return difference
         difference_type operator-(const json_reverse_iterator& other) const
         {
-            return other.base() - this->base();
+            return base_iterator(*this) - base_iterator(other);
         }
 
         /// access to successor
         reference operator[](difference_type n) const
         {
-            return *(this->operator+(n));
+            return base_iterator::operator[](n);
         }
 
         /// return the key of an object iterator

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8474,9 +8474,20 @@ class basic_json
         @brief  add to iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        iter_impl operator+(difference_type i)
+        iter_impl operator+(difference_type i) const
         {
             auto result = *this;
+            result += i;
+            return result;
+        }
+
+        /*!
+        @brief  addition of distance and iterator
+        @pre The iterator is initialized; i.e. `m_object != nullptr`.
+        */
+        friend iter_impl operator+(difference_type i, const iter_impl& it)
+        {
+            auto result = it;
             result += i;
             return result;
         }
@@ -8485,7 +8496,7 @@ class basic_json
         @brief  subtract from iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        iter_impl operator-(difference_type i)
+        iter_impl operator-(difference_type i) const
         {
             auto result = *this;
             result -= i;

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8626,7 +8626,7 @@ class basic_json
         using reference = typename Base::reference;
 
         /// create reverse iterator from iterator
-		json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
+        json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
             : base_iterator(it)
         {}
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8638,46 +8638,43 @@ class basic_json
         /// post-increment (it++)
         json_reverse_iterator operator++(int)
         {
-            return base_iterator::operator++(1);
+            return static_cast<json_reverse_iterator>(base_iterator::operator++(1));
         }
 
         /// pre-increment (++it)
         json_reverse_iterator& operator++()
         {
-            base_iterator::operator++();
-            return *this;
+            return static_cast<json_reverse_iterator&>(base_iterator::operator++());
         }
 
         /// post-decrement (it--)
         json_reverse_iterator operator--(int)
         {
-            return base_iterator::operator--(1);
+            return static_cast<json_reverse_iterator>(base_iterator::operator--(1));
         }
 
         /// pre-decrement (--it)
         json_reverse_iterator& operator--()
         {
-            base_iterator::operator--();
-            return *this;
+            return static_cast<json_reverse_iterator&>(base_iterator::operator--());
         }
 
         /// add to iterator
         json_reverse_iterator& operator+=(difference_type i)
         {
-            base_iterator::operator+=(i);
-            return *this;
+            return static_cast<json_reverse_iterator&>(base_iterator::operator+=(i));
         }
 
         /// add to iterator
         json_reverse_iterator operator+(difference_type i) const
         {
-            return json_reverse_iterator(base_iterator::operator+(i));
+            return static_cast<json_reverse_iterator>(base_iterator::operator+(i));
         }
 
         /// subtract from iterator
         json_reverse_iterator operator-(difference_type i) const
         {
-            return json_reverse_iterator(base_iterator::operator-(i));
+            return static_cast<json_reverse_iterator>(base_iterator::operator-(i));
         }
 
         /// return difference

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8015,7 +8015,7 @@ class basic_json
               typename basic_json::const_reference,
               typename basic_json::reference>::type;
         /// the category of the iterator
-        using iterator_category = std::random_access_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
 
         /// default constructor
         iter_impl() = default;

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -833,15 +833,15 @@ TEST_CASE("iterators 2")
                     auto it = j_object.rbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
-                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
                 }
                 {
                     auto it = j_object.crbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
-                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
                 }
             }
 
@@ -873,15 +873,15 @@ TEST_CASE("iterators 2")
                     auto it = j_null.rbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
                 }
                 {
                     auto it = j_null.crbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
                 }
             }
 

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -747,7 +747,7 @@ TEST_CASE("iterators 2")
                     it += 3;
                     CHECK((j_array.rbegin() + 3) == it);
                     CHECK((it - 3) == j_array.rbegin());
-                    CHECK((j_array.rbegin() - it) == 3);
+                    CHECK((it - j_array.rbegin()) == 3);
                     CHECK(*it == json(3));
                     it -= 2;
                     CHECK(*it == json(5));
@@ -757,7 +757,7 @@ TEST_CASE("iterators 2")
                     it += 3;
                     CHECK((j_array.crbegin() + 3) == it);
                     CHECK((it - 3) == j_array.crbegin());
-                    CHECK((j_array.crbegin() - it) == 3);
+                    CHECK((it - j_array.crbegin()) == 3);
                     CHECK(*it == json(3));
                     it -= 2;
                     CHECK(*it == json(5));
@@ -769,9 +769,9 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_null.rbegin();
                     it += 3;
-                    CHECK((j_null.rbegin() + 3) == it);
-                    CHECK((it - 3) == j_null.rbegin());
-                    CHECK((j_null.rbegin() - it) == 3);
+                    CHECK((j_null.rbegin() - 3) == it);
+                    CHECK((it + 3) == j_null.rbegin());
+                    CHECK((it - j_null.rbegin()) == 3);
                     CHECK(it != j_null.rend());
                     it -= 3;
                     CHECK(it == j_null.rend());
@@ -779,9 +779,9 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_null.crbegin();
                     it += 3;
-                    CHECK((j_null.crbegin() + 3) == it);
-                    CHECK((it - 3) == j_null.crbegin());
-                    CHECK((j_null.crbegin() - it) == 3);
+                    CHECK((j_null.crbegin() - 3) == it);
+                    CHECK((it + 3) == j_null.crbegin());
+                    CHECK((it - j_null.crbegin()) == 3);
                     CHECK(it != j_null.crend());
                     it -= 3;
                     CHECK(it == j_null.crend());
@@ -793,9 +793,9 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_value.rbegin();
                     it += 3;
-                    CHECK((j_value.rbegin() + 3) == it);
-                    CHECK((it - 3) == j_value.rbegin());
-                    CHECK((j_value.rbegin() - it) == 3);
+                    CHECK((j_value.rbegin() - 3) == it);
+                    CHECK((it + 3) == j_value.rbegin());
+                    CHECK((it - j_value.rbegin()) == 3);
                     CHECK(it != j_value.rend());
                     it -= 3;
                     CHECK(*it == json(42));
@@ -803,9 +803,9 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_value.crbegin();
                     it += 3;
-                    CHECK((j_value.crbegin() + 3) == it);
-                    CHECK((it - 3) == j_value.crbegin());
-                    CHECK((j_value.crbegin() - it) == 3);
+                    CHECK((j_value.crbegin() - 3) == it);
+                    CHECK((it + 3) == j_value.crbegin());
+                    CHECK((it - j_value.crbegin()) == 3);
                     CHECK(it != j_value.crend());
                     it -= 3;
                     CHECK(*it == json(42));

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -317,6 +317,7 @@ TEST_CASE("iterators 2")
                     auto it = j_array.begin();
                     it += 3;
                     CHECK((j_array.begin() + 3) == it);
+                    CHECK(json::iterator(3 + j_array.begin()) == it);
                     CHECK((it - 3) == j_array.begin());
                     CHECK((it - j_array.begin()) == 3);
                     CHECK(*it == json(4));
@@ -327,6 +328,7 @@ TEST_CASE("iterators 2")
                     auto it = j_array.cbegin();
                     it += 3;
                     CHECK((j_array.cbegin() + 3) == it);
+                    CHECK(json::const_iterator(3 + j_array.cbegin()) == it);
                     CHECK((it - 3) == j_array.cbegin());
                     CHECK((it - j_array.cbegin()) == 3);
                     CHECK(*it == json(4));
@@ -341,6 +343,7 @@ TEST_CASE("iterators 2")
                     auto it = j_null.begin();
                     it += 3;
                     CHECK((j_null.begin() + 3) == it);
+                    CHECK(json::iterator(3 + j_null.begin()) == it);
                     CHECK((it - 3) == j_null.begin());
                     CHECK((it - j_null.begin()) == 3);
                     CHECK(it != j_null.end());
@@ -351,6 +354,7 @@ TEST_CASE("iterators 2")
                     auto it = j_null.cbegin();
                     it += 3;
                     CHECK((j_null.cbegin() + 3) == it);
+                    CHECK(json::const_iterator(3 + j_null.cbegin()) == it);
                     CHECK((it - 3) == j_null.cbegin());
                     CHECK((it - j_null.cbegin()) == 3);
                     CHECK(it != j_null.cend());
@@ -365,6 +369,7 @@ TEST_CASE("iterators 2")
                     auto it = j_value.begin();
                     it += 3;
                     CHECK((j_value.begin() + 3) == it);
+                    CHECK(json::iterator(3 + j_value.begin()) == it);
                     CHECK((it - 3) == j_value.begin());
                     CHECK((it - j_value.begin()) == 3);
                     CHECK(it != j_value.end());
@@ -375,6 +380,7 @@ TEST_CASE("iterators 2")
                     auto it = j_value.cbegin();
                     it += 3;
                     CHECK((j_value.cbegin() + 3) == it);
+                    CHECK(json::const_iterator(3 + j_value.cbegin()) == it);
                     CHECK((it - 3) == j_value.cbegin());
                     CHECK((it - j_value.cbegin()) == 3);
                     CHECK(it != j_value.cend());
@@ -746,6 +752,7 @@ TEST_CASE("iterators 2")
                     auto it = j_array.rbegin();
                     it += 3;
                     CHECK((j_array.rbegin() + 3) == it);
+                    CHECK(json::reverse_iterator(3 + j_array.rbegin()) == it);
                     CHECK((it - 3) == j_array.rbegin());
                     CHECK((it - j_array.rbegin()) == 3);
                     CHECK(*it == json(3));
@@ -756,6 +763,7 @@ TEST_CASE("iterators 2")
                     auto it = j_array.crbegin();
                     it += 3;
                     CHECK((j_array.crbegin() + 3) == it);
+                    CHECK(json::const_reverse_iterator(3 + j_array.crbegin()) == it);
                     CHECK((it - 3) == j_array.crbegin());
                     CHECK((it - j_array.crbegin()) == 3);
                     CHECK(*it == json(3));
@@ -770,6 +778,7 @@ TEST_CASE("iterators 2")
                     auto it = j_null.rbegin();
                     it += 3;
                     CHECK((j_null.rbegin() + 3) == it);
+                    CHECK(json::reverse_iterator(3 + j_null.rbegin()) == it);
                     CHECK((it - 3) == j_null.rbegin());
                     CHECK((it - j_null.rbegin()) == 3);
                     CHECK(it != j_null.rend());
@@ -780,6 +789,7 @@ TEST_CASE("iterators 2")
                     auto it = j_null.crbegin();
                     it += 3;
                     CHECK((j_null.crbegin() + 3) == it);
+                    CHECK(json::const_reverse_iterator(3 + j_null.crbegin()) == it);
                     CHECK((it - 3) == j_null.crbegin());
                     CHECK((it - j_null.crbegin()) == 3);
                     CHECK(it != j_null.crend());
@@ -794,6 +804,7 @@ TEST_CASE("iterators 2")
                     auto it = j_value.rbegin();
                     it += 3;
                     CHECK((j_value.rbegin() + 3) == it);
+                    CHECK(json::reverse_iterator(3 + j_value.rbegin()) == it);
                     CHECK((it - 3) == j_value.rbegin());
                     CHECK((it - j_value.rbegin()) == 3);
                     CHECK(it != j_value.rend());
@@ -804,6 +815,7 @@ TEST_CASE("iterators 2")
                     auto it = j_value.crbegin();
                     it += 3;
                     CHECK((j_value.crbegin() + 3) == it);
+                    CHECK(json::const_reverse_iterator(3 + j_value.crbegin()) == it);
                     CHECK((it - 3) == j_value.crbegin());
                     CHECK((it - j_value.crbegin()) == 3);
                     CHECK(it != j_value.crend());

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -821,15 +821,15 @@ TEST_CASE("iterators 2")
                     auto it = j_object.rbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
                 }
                 {
                     auto it = j_object.crbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
                 }
             }
 
@@ -861,15 +861,15 @@ TEST_CASE("iterators 2")
                     auto it = j_null.rbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
+                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
                 }
                 {
                     auto it = j_null.crbegin();
                     CHECK_THROWS_AS(it[0], json::invalid_iterator);
                     CHECK_THROWS_AS(it[1], json::invalid_iterator);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    //CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
+                    //CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
                 }
             }
 

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -769,8 +769,8 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_null.rbegin();
                     it += 3;
-                    CHECK((j_null.rbegin() - 3) == it);
-                    CHECK((it + 3) == j_null.rbegin());
+                    CHECK((j_null.rbegin() + 3) == it);
+                    CHECK((it - 3) == j_null.rbegin());
                     CHECK((it - j_null.rbegin()) == 3);
                     CHECK(it != j_null.rend());
                     it -= 3;
@@ -779,8 +779,8 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_null.crbegin();
                     it += 3;
-                    CHECK((j_null.crbegin() - 3) == it);
-                    CHECK((it + 3) == j_null.crbegin());
+                    CHECK((j_null.crbegin() + 3) == it);
+                    CHECK((it - 3) == j_null.crbegin());
                     CHECK((it - j_null.crbegin()) == 3);
                     CHECK(it != j_null.crend());
                     it -= 3;
@@ -793,8 +793,8 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_value.rbegin();
                     it += 3;
-                    CHECK((j_value.rbegin() - 3) == it);
-                    CHECK((it + 3) == j_value.rbegin());
+                    CHECK((j_value.rbegin() + 3) == it);
+                    CHECK((it - 3) == j_value.rbegin());
                     CHECK((it - j_value.rbegin()) == 3);
                     CHECK(it != j_value.rend());
                     it -= 3;
@@ -803,8 +803,8 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_value.crbegin();
                     it += 3;
-                    CHECK((j_value.crbegin() - 3) == it);
-                    CHECK((it + 3) == j_value.crbegin());
+                    CHECK((j_value.crbegin() + 3) == it);
+                    CHECK((it - 3) == j_value.crbegin());
                     CHECK((it - j_value.crbegin()) == 3);
                     CHECK(it != j_value.crend());
                     it -= 3;

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -271,6 +271,16 @@ TEST_CASE("iterators 2")
                 }
                 {
                     auto it = j_object.begin();
+                    CHECK_THROWS_AS(1 + it, json::invalid_iterator);
+                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.cbegin();
+                    CHECK_THROWS_AS(1 + it, json::invalid_iterator);
+                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.begin();
                     CHECK_THROWS_AS(it -= 1, json::invalid_iterator);
                     CHECK_THROWS_WITH(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
                 }
@@ -687,6 +697,16 @@ TEST_CASE("iterators 2")
                     auto it = j_object.crbegin();
                     CHECK_THROWS_AS(it + 1, json::invalid_iterator);
                     CHECK_THROWS_WITH(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.rbegin();
+                    CHECK_THROWS_AS(1 + it, json::invalid_iterator);
+                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                }
+                {
+                    auto it = j_object.crbegin();
+                    CHECK_THROWS_AS(1 + it, json::invalid_iterator);
+                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
                 }
                 {
                     auto it = j_object.rbegin();


### PR DESCRIPTION
Changes include:
1.     Override operator+(difference_type, const iter_impl&) in the iterator class
2.     Add const qualifier in the member operator+(difference_type) function
3.     Add test cases of the relevant issue
