### PR TITLE
#550 Fix iterator related compiling issues for Intel icc

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8054,11 +8054,12 @@ class basic_json
         }
 
         /*!
-        @note The conventional copy constructor is not defined. It is replaced
-		      by either of the following two converting constructors.
-              They support copy from iterator to iterator,
-                           copy from const iterator to const iterator, 
-                           and conversion from iterator to const iterator.
+        @note The conventional copy constructor and copy assignment are
+              implicitly defined.
+			  Combined with the following converting constructor and assigment,
+			  they support: copy from iterator to iterator,
+                            copy from const iterator to const iterator, 
+                            and conversion from iterator to const iterator.
               However conversion from const iterator to iterator is not defined.
         */
 
@@ -8072,39 +8073,12 @@ class basic_json
         {}
 
         /*!
-        @brief converting constructor
-        @param[in] other  const iterator to copy from
-        @note It is not checked whether @a other is initialized.
-        */
-        iter_impl<const basic_json>(const iter_impl<const basic_json>& other) noexcept
-            : m_object(other.m_object), m_it(other.m_it)
-        {}
-
-        /*!
-        @brief copy assignment
+        @brief converting assignment
         @param[in,out] other  non-const iterator to copy from
 		@return const/non-const iterator
         @note It is not checked whether @a other is initialized.
         */
         iter_impl& operator=(iter_impl<basic_json> other) noexcept(
-            std::is_nothrow_move_constructible<pointer>::value and
-            std::is_nothrow_move_assignable<pointer>::value and
-            std::is_nothrow_move_constructible<struct internal_iterator>::value and
-            std::is_nothrow_move_assignable<struct internal_iterator>::value
-        )
-        {
-            std::swap(m_object, other.m_object);
-            std::swap(m_it, other.m_it);
-            return *this;
-        }
-
-        /*!
-        @brief copy assignment
-        @param[in,out] other  const iterator to copy from
-		@return const iterator
-        @note It is not checked whether @a other is initialized.
-        */
-        iter_impl<const basic_json>& operator=(iter_impl<const basic_json> other) noexcept(
             std::is_nothrow_move_constructible<pointer>::value and
             std::is_nothrow_move_assignable<pointer>::value and
             std::is_nothrow_move_constructible<struct internal_iterator>::value and

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8056,9 +8056,9 @@ class basic_json
         /*!
         @note The conventional copy constructor and copy assignment are
               implicitly defined.
-			  Combined with the following converting constructor and assigment,
-			  they support: copy from iterator to iterator,
-                            copy from const iterator to const iterator, 
+              Combined with the following converting constructor and assigment,
+              they support: copy from iterator to iterator,
+                            copy from const iterator to const iterator,
                             and conversion from iterator to const iterator.
               However conversion from const iterator to iterator is not defined.
         */
@@ -8075,7 +8075,7 @@ class basic_json
         /*!
         @brief converting assignment
         @param[in,out] other  non-const iterator to copy from
-		@return const/non-const iterator
+        @return const/non-const iterator
         @note It is not checked whether @a other is initialized.
         */
         iter_impl& operator=(iter_impl<basic_json> other) noexcept(

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8053,42 +8053,58 @@ class basic_json
             }
         }
 
-        /*
-        Use operator `const_iterator` instead of `const_iterator(const iterator&
-        other) noexcept` to avoid two class definitions for @ref iterator and
-        @ref const_iterator.
-
-        This function is only called if this class is an @ref iterator. If this
-        class is a @ref const_iterator this function is not called.
+        /*!
+        @note The conventional copy constructor is not defined. It is replaced
+		      by either of the following two converting constructors.
+              They support copy from iterator to iterator,
+                           copy from const iterator to const iterator, 
+                           and conversion from iterator to const iterator.
+              However conversion from const iterator to iterator is not defined.
         */
-        operator const_iterator() const
-        {
-            const_iterator ret;
-
-            if (m_object)
-            {
-                ret.m_object = m_object;
-                ret.m_it = m_it;
-            }
-
-            return ret;
-        }
 
         /*!
-        @brief copy constructor
-        @param[in] other  iterator to copy from
+        @brief converting constructor
+        @param[in] other  non-const iterator to copy from
         @note It is not checked whether @a other is initialized.
         */
-        iter_impl(const iter_impl& other) noexcept
+        iter_impl(const iter_impl<basic_json>& other) noexcept
+            : m_object(other.m_object), m_it(other.m_it)
+        {}
+
+        /*!
+        @brief converting constructor
+        @param[in] other  const iterator to copy from
+        @note It is not checked whether @a other is initialized.
+        */
+        iter_impl<const basic_json>(const iter_impl<const basic_json>& other) noexcept
             : m_object(other.m_object), m_it(other.m_it)
         {}
 
         /*!
         @brief copy assignment
-        @param[in,out] other  iterator to copy from
+        @param[in,out] other  non-const iterator to copy from
+		@return const/non-const iterator
         @note It is not checked whether @a other is initialized.
         */
-        iter_impl& operator=(iter_impl other) noexcept(
+        iter_impl& operator=(iter_impl<basic_json> other) noexcept(
+            std::is_nothrow_move_constructible<pointer>::value and
+            std::is_nothrow_move_assignable<pointer>::value and
+            std::is_nothrow_move_constructible<internal_iterator>::value and
+            std::is_nothrow_move_assignable<internal_iterator>::value
+        )
+        {
+            std::swap(m_object, other.m_object);
+            std::swap(m_it, other.m_it);
+            return *this;
+        }
+
+        /*!
+        @brief copy assignment
+        @param[in,out] other  const iterator to copy from
+		@return const iterator
+        @note It is not checked whether @a other is initialized.
+        */
+        iter_impl<const basic_json>& operator=(iter_impl<const basic_json> other) noexcept(
             std::is_nothrow_move_constructible<pointer>::value and
             std::is_nothrow_move_assignable<pointer>::value and
             std::is_nothrow_move_constructible<internal_iterator>::value and

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8078,15 +8078,10 @@ class basic_json
         @return const/non-const iterator
         @note It is not checked whether @a other is initialized.
         */
-        iter_impl& operator=(iter_impl<basic_json> other) noexcept(
-            std::is_nothrow_move_constructible<pointer>::value and
-            std::is_nothrow_move_assignable<pointer>::value and
-            std::is_nothrow_move_constructible<struct internal_iterator>::value and
-            std::is_nothrow_move_assignable<struct internal_iterator>::value
-        )
+        iter_impl& operator=(const iter_impl<basic_json>& other) noexcept
         {
-            std::swap(m_object, other.m_object);
-            std::swap(m_it, other.m_it);
+            m_object = other.m_object;
+            m_it = other.m_it;
             return *this;
         }
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8089,8 +8089,8 @@ class basic_json
         iter_impl& operator=(iter_impl<basic_json> other) noexcept(
             std::is_nothrow_move_constructible<pointer>::value and
             std::is_nothrow_move_assignable<pointer>::value and
-            std::is_nothrow_move_constructible<internal_iterator>::value and
-            std::is_nothrow_move_assignable<internal_iterator>::value
+            std::is_nothrow_move_constructible<struct internal_iterator>::value and
+            std::is_nothrow_move_assignable<struct internal_iterator>::value
         )
         {
             std::swap(m_object, other.m_object);
@@ -8107,8 +8107,8 @@ class basic_json
         iter_impl<const basic_json>& operator=(iter_impl<const basic_json> other) noexcept(
             std::is_nothrow_move_constructible<pointer>::value and
             std::is_nothrow_move_assignable<pointer>::value and
-            std::is_nothrow_move_constructible<internal_iterator>::value and
-            std::is_nothrow_move_assignable<internal_iterator>::value
+            std::is_nothrow_move_constructible<struct internal_iterator>::value and
+            std::is_nothrow_move_assignable<struct internal_iterator>::value
         )
         {
             std::swap(m_object, other.m_object);
@@ -8601,7 +8601,7 @@ class basic_json
         /// associated JSON instance
         pointer m_object = nullptr;
         /// the actual iterator of the associated instance
-        internal_iterator m_it = internal_iterator();
+        struct internal_iterator m_it = internal_iterator();
     };
 
     /*!

--- a/test/src/unit-iterators1.cpp
+++ b/test/src/unit-iterators1.cpp
@@ -1519,11 +1519,15 @@ TEST_CASE("iterators 1")
             json j = true;
 			json::const_iterator it = j.begin();
 			CHECK(it == j.cbegin());
+			it = j.begin();
+			CHECK(it == j.cbegin());
 		}
         SECTION("string")
 		{
             json j = "hello world";
 			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+			it = j.begin();
 			CHECK(it == j.cbegin());
 		}
         SECTION("array")
@@ -1531,11 +1535,15 @@ TEST_CASE("iterators 1")
             json j = {1, 2, 3};
 			json::const_iterator it = j.begin();
 			CHECK(it == j.cbegin());
+			it = j.begin();
+			CHECK(it == j.cbegin());
 		}
         SECTION("object")
 		{
             json j = {{"A", 1}, {"B", 2}, {"C", 3}};
 			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+			it = j.begin();
 			CHECK(it == j.cbegin());
 		}
         SECTION("number (integer)")
@@ -1543,11 +1551,15 @@ TEST_CASE("iterators 1")
             json j = 23;
 			json::const_iterator it = j.begin();
 			CHECK(it == j.cbegin());
+			it = j.begin();
+			CHECK(it == j.cbegin());
 		}
         SECTION("number (unsigned)")
 		{
             json j = 23u;
 			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+			it = j.begin();
 			CHECK(it == j.cbegin());
 		}
         SECTION("number (float)")
@@ -1555,11 +1567,15 @@ TEST_CASE("iterators 1")
             json j = 23.42;
 			json::const_iterator it = j.begin();
 			CHECK(it == j.cbegin());
+			it = j.begin();
+			CHECK(it == j.cbegin());
 		}
         SECTION("null")
 		{
             json j = nullptr;
 			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+			it = j.begin();
 			CHECK(it == j.cbegin());
 		}
 	}

--- a/test/src/unit-iterators1.cpp
+++ b/test/src/unit-iterators1.cpp
@@ -1511,4 +1511,56 @@ TEST_CASE("iterators 1")
             }
         }
     }
+
+    SECTION("conversion from iterator to const iterator")
+	{
+        SECTION("boolean")
+		{
+            json j = true;
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("string")
+		{
+            json j = "hello world";
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("array")
+		{
+            json j = {1, 2, 3};
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("object")
+		{
+            json j = {{"A", 1}, {"B", 2}, {"C", 3}};
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("number (integer)")
+		{
+            json j = 23;
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("number (unsigned)")
+		{
+            json j = 23u;
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("number (float)")
+		{
+            json j = 23.42;
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+        SECTION("null")
+		{
+            json j = nullptr;
+			json::const_iterator it = j.begin();
+			CHECK(it == j.cbegin());
+		}
+	}
 }


### PR DESCRIPTION
Currently there are two know issues when compiling with Intel icc:
1. The `operator()` in iterator causes warning
2. The use of `internal_iterator` causes error

The first issue can be resolved by replacing the `operator()` with a converting constructor and assignment. Because the existence of the copy constructor may bring ambiguity, I removed it and the copy constructor will be defined implicitly.

The second issue is fixed by adding a `struct` keyword in front of the type name.