### PR TITLE
Make the library available through Conan package

### DIFF
--- a/conan/.gitignore
+++ b/conan/.gitignore
@@ -1,0 +1,4 @@
+test_package/build
+*.pyc
+conanbuildinfo.cmake
+conaninfo.txt

--- a/conan/build.py
+++ b/conan/build.py
@@ -1,0 +1,7 @@
+from conan.packager import ConanMultiPackager
+
+
+if __name__ == "__main__":
+    builder = ConanMultiPackager(username="nlohmann", channel="stable")
+    builder.add_common_builds(pure_c=False)
+    builder.run()

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,0 +1,21 @@
+from conans import ConanFile
+from conans.tools import download
+
+class JsonForModernCppConan(ConanFile):
+    name = "jsonformoderncpp"
+    version = "2.1.1"
+    license = "MIT"
+    url = "https://github.com/nlohmann/json"
+    author = "Niels Lohmann (mail@nlohmann.me)"
+    settings = None
+    options = {"path": "ANY"}
+    default_options = "path="
+
+    def source(self):
+        download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")
+
+    def package(self):
+        header_dir = "include"
+        if self.options.path != "":
+            header_dir += "/" + str(self.options.path)
+        self.copy("*.hpp", dst=header_dir)

--- a/conan/test_package/.gitignore
+++ b/conan/test_package/.gitignore
@@ -1,0 +1,2 @@
+build/
+conanfile.pyc

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(PackageTest CXX)
+cmake_minimum_required(VERSION 3.0)
+add_compile_options(-std=c++11)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -1,0 +1,22 @@
+from conans import ConanFile, CMake
+import os
+
+version = "2.1.1"
+channel = os.getenv("CONAN_CHANNEL", "stable")
+username = os.getenv("CONAN_USERNAME", "nlohmann")
+
+
+class JsonForModernCppTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    requires = "jsonformoderncpp/%s@%s/%s" % (version, username, channel)
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self.settings)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
+        cmake.configure(self, source_dir=self.conanfile_directory, build_dir="./")
+        cmake.build(self)
+
+    def test(self):
+        os.chdir("bin")
+        self.run(".%sexample" % os.sep)

--- a/conan/test_package/example.cpp
+++ b/conan/test_package/example.cpp
@@ -1,0 +1,16 @@
+#include "json.hpp"
+#include <iostream>
+
+using nlohmann::json;
+
+int main()
+{
+    const json myJson = {
+        { "Hello", "World" }
+    };
+
+    for (auto it{ myJson.cbegin() }; it != myJson.cend(); ++it)
+    {
+        std::cout << it.key() << " " << it.value() << std::endl;
+    }
+}


### PR DESCRIPTION
This PR addresses the issue #566 by adding the conanfile.py, build.py and test_package necessary to package and test the conan package.

The version is set to 2.1.1 and will have to be bumped when releasing.

In order to test that the package works properly, simply do `conan test_package` in the conan folder.
In order to upload the package, follow the [documentation](http://docs.conan.io/en/latest/move_to_bintray.html).