### PR TITLE
[BugFix] Add parentheses around std::min

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8987,7 +8987,7 @@ class basic_json
         {
             // avoid reading too many characters
             const size_t max_length = static_cast<size_t>(limit - start);
-            return std::string(start + offset, std::min(length, max_length - offset));
+            return std::string(start + offset, (std::min)(length, max_length - offset));
         }
 
       private:


### PR DESCRIPTION
Add parentheses around std::min so it bypasses the macro introduced by windows.h. This fixes issues in Visual Studio 2017.