### PR TITLE
Fix MSVC warning C4819

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -10865,16 +10865,16 @@ class basic_json
     boolean         | `false`                           | false            | 0xc2
     number_integer  | -9223372036854775808..-2147483649 | int64            | 0xd3
     number_integer  | -2147483648..-32769               | int32            | 0xd2
-    number_integer  | -32768..-129                      | int16            | 0xd1
+    number_integer  | -32768..-129                      | int16            | 0xd1
     number_integer  | -128..-33                         | int8             | 0xd0
     number_integer  | -32..-1                           | negative fixint  | 0xe0..0xff
     number_integer  | 0..127                            | positive fixint  | 0x00..0x7f
-    number_integer  | 128..255                          | uint 8           | 0xcc
+    number_integer  | 128..255                          | uint 8           | 0xcc
     number_integer  | 256..65535                        | uint 16          | 0xcd
     number_integer  | 65536..4294967295                 | uint 32          | 0xce
     number_integer  | 4294967296..18446744073709551615  | uint 64          | 0xcf
     number_unsigned | 0..127                            | positive fixint  | 0x00..0x7f
-    number_unsigned | 128..255                          | uint 8           | 0xcc
+    number_unsigned | 128..255                          | uint 8           | 0xcc
     number_unsigned | 256..65535                        | uint 16          | 0xcd
     number_unsigned | 65536..4294967295                 | uint 32          | 0xce
     number_unsigned | 4294967296..18446744073709551615  | uint 64          | 0xcf
@@ -10970,7 +10970,7 @@ class basic_json
     map                    | object          | 0xbb
     map                    | object          | 0xbf
     False                  | `false`         | 0xf4
-    True                   | `true`          | 0xf5
+    True                   | `true`          | 0xf5
     Nill                   | `null`          | 0xf6
     Half-Precision Float   | number_float    | 0xf9
     Single-Precision Float | number_float    | 0xfa


### PR DESCRIPTION
Replace unicode whitespaces by ASCII whitespace 0x20
