### PR TITLE
Refacto/split basic json

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1529,8 +1529,2047 @@ struct input_adapter_factory
     }
 };
 
-} // namespace detail
+//////////////////////
+// lexer and parser //
+//////////////////////
 
+/*!
+@brief lexical analysis
+
+This class organizes the lexical analysis during JSON deserialization.
+*/
+template <typename BasicJsonType>
+class lexer
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+
+  public:
+    /// token types for the parser
+    enum class token_type
+    {
+        uninitialized,  ///< indicating the scanner is uninitialized
+        literal_true,   ///< the `true` literal
+        literal_false,  ///< the `false` literal
+        literal_null,   ///< the `null` literal
+        value_string,   ///< a string -- use get_string() for actual value
+        value_unsigned, ///< an unsigned integer -- use get_number_unsigned() for
+        ///actual value
+        value_integer,  ///< a signed integer -- use get_number_integer() for actual
+        ///value
+        value_float,    ///< an floating point number -- use get_number_float() for
+        ///actual value
+        begin_array,    ///< the character for array begin `[`
+        begin_object,   ///< the character for object begin `{`
+        end_array,      ///< the character for array end `]`
+        end_object,     ///< the character for object end `}`
+        name_separator, ///< the name separator `:`
+        value_separator, ///< the value separator `,`
+        parse_error,     ///< indicating a parse error
+        end_of_input,    ///< indicating the end of the input buffer
+        literal_or_value ///< a literal or the begin of a value (only for
+        ///diagnostics)
+    };
+
+    /// return name of values of type token_type (only used for errors)
+    static const char* token_type_name(const token_type t) noexcept
+    {
+        switch (t)
+        {
+            case token_type::uninitialized:
+                return "<uninitialized>";
+            case token_type::literal_true:
+                return "true literal";
+            case token_type::literal_false:
+                return "false literal";
+            case token_type::literal_null:
+                return "null literal";
+            case token_type::value_string:
+                return "string literal";
+            case lexer::token_type::value_unsigned:
+            case lexer::token_type::value_integer:
+            case lexer::token_type::value_float:
+                return "number literal";
+            case token_type::begin_array:
+                return "'['";
+            case token_type::begin_object:
+                return "'{'";
+            case token_type::end_array:
+                return "']'";
+            case token_type::end_object:
+                return "'}'";
+            case token_type::name_separator:
+                return "':'";
+            case token_type::value_separator:
+                return "','";
+            case token_type::parse_error:
+                return "<parse error>";
+            case token_type::end_of_input:
+                return "end of input";
+            case token_type::literal_or_value:
+                return "'[', '{', or a literal";
+            default:
+            {
+                // catch non-enum values
+                return "unknown token"; // LCOV_EXCL_LINE
+            }
+        }
+    }
+
+    explicit lexer(detail::input_adapter_t adapter)
+        : ia(adapter), decimal_point_char(get_decimal_point()) {}
+
+    // delete because of pointer members
+    lexer(const lexer&) = delete;
+    lexer& operator=(lexer&) = delete;
+
+  private:
+    /////////////////////
+    // locales
+    /////////////////////
+
+    /// return the locale-dependent decimal point
+    static char get_decimal_point() noexcept
+    {
+        const auto loc = localeconv();
+        assert(loc != nullptr);
+        return (loc->decimal_point == nullptr) ? '.' : loc->decimal_point[0];
+    }
+
+    /////////////////////
+    // scan functions
+    /////////////////////
+
+    /*!
+    @brief get codepoint from 4 hex characters following `\u`
+
+    @return codepoint or -1 in case of an error (e.g. EOF or non-hex
+            character)
+    */
+    int get_codepoint()
+    {
+        // this function only makes sense after reading `\u`
+        assert(current == 'u');
+        int codepoint = 0;
+
+        // byte 1: \uXxxx
+        switch (get())
+        {
+            case '0':
+                break;
+            case '1':
+                codepoint += 0x1000;
+                break;
+            case '2':
+                codepoint += 0x2000;
+                break;
+            case '3':
+                codepoint += 0x3000;
+                break;
+            case '4':
+                codepoint += 0x4000;
+                break;
+            case '5':
+                codepoint += 0x5000;
+                break;
+            case '6':
+                codepoint += 0x6000;
+                break;
+            case '7':
+                codepoint += 0x7000;
+                break;
+            case '8':
+                codepoint += 0x8000;
+                break;
+            case '9':
+                codepoint += 0x9000;
+                break;
+            case 'A':
+            case 'a':
+                codepoint += 0xa000;
+                break;
+            case 'B':
+            case 'b':
+                codepoint += 0xb000;
+                break;
+            case 'C':
+            case 'c':
+                codepoint += 0xc000;
+                break;
+            case 'D':
+            case 'd':
+                codepoint += 0xd000;
+                break;
+            case 'E':
+            case 'e':
+                codepoint += 0xe000;
+                break;
+            case 'F':
+            case 'f':
+                codepoint += 0xf000;
+                break;
+            default:
+                return -1;
+        }
+
+        // byte 2: \uxXxx
+        switch (get())
+        {
+            case '0':
+                break;
+            case '1':
+                codepoint += 0x0100;
+                break;
+            case '2':
+                codepoint += 0x0200;
+                break;
+            case '3':
+                codepoint += 0x0300;
+                break;
+            case '4':
+                codepoint += 0x0400;
+                break;
+            case '5':
+                codepoint += 0x0500;
+                break;
+            case '6':
+                codepoint += 0x0600;
+                break;
+            case '7':
+                codepoint += 0x0700;
+                break;
+            case '8':
+                codepoint += 0x0800;
+                break;
+            case '9':
+                codepoint += 0x0900;
+                break;
+            case 'A':
+            case 'a':
+                codepoint += 0x0a00;
+                break;
+            case 'B':
+            case 'b':
+                codepoint += 0x0b00;
+                break;
+            case 'C':
+            case 'c':
+                codepoint += 0x0c00;
+                break;
+            case 'D':
+            case 'd':
+                codepoint += 0x0d00;
+                break;
+            case 'E':
+            case 'e':
+                codepoint += 0x0e00;
+                break;
+            case 'F':
+            case 'f':
+                codepoint += 0x0f00;
+                break;
+            default:
+                return -1;
+        }
+
+        // byte 3: \uxxXx
+        switch (get())
+        {
+            case '0':
+                break;
+            case '1':
+                codepoint += 0x0010;
+                break;
+            case '2':
+                codepoint += 0x0020;
+                break;
+            case '3':
+                codepoint += 0x0030;
+                break;
+            case '4':
+                codepoint += 0x0040;
+                break;
+            case '5':
+                codepoint += 0x0050;
+                break;
+            case '6':
+                codepoint += 0x0060;
+                break;
+            case '7':
+                codepoint += 0x0070;
+                break;
+            case '8':
+                codepoint += 0x0080;
+                break;
+            case '9':
+                codepoint += 0x0090;
+                break;
+            case 'A':
+            case 'a':
+                codepoint += 0x00a0;
+                break;
+            case 'B':
+            case 'b':
+                codepoint += 0x00b0;
+                break;
+            case 'C':
+            case 'c':
+                codepoint += 0x00c0;
+                break;
+            case 'D':
+            case 'd':
+                codepoint += 0x00d0;
+                break;
+            case 'E':
+            case 'e':
+                codepoint += 0x00e0;
+                break;
+            case 'F':
+            case 'f':
+                codepoint += 0x00f0;
+                break;
+            default:
+                return -1;
+        }
+
+        // byte 4: \uxxxX
+        switch (get())
+        {
+            case '0':
+                break;
+            case '1':
+                codepoint += 0x0001;
+                break;
+            case '2':
+                codepoint += 0x0002;
+                break;
+            case '3':
+                codepoint += 0x0003;
+                break;
+            case '4':
+                codepoint += 0x0004;
+                break;
+            case '5':
+                codepoint += 0x0005;
+                break;
+            case '6':
+                codepoint += 0x0006;
+                break;
+            case '7':
+                codepoint += 0x0007;
+                break;
+            case '8':
+                codepoint += 0x0008;
+                break;
+            case '9':
+                codepoint += 0x0009;
+                break;
+            case 'A':
+            case 'a':
+                codepoint += 0x000a;
+                break;
+            case 'B':
+            case 'b':
+                codepoint += 0x000b;
+                break;
+            case 'C':
+            case 'c':
+                codepoint += 0x000c;
+                break;
+            case 'D':
+            case 'd':
+                codepoint += 0x000d;
+                break;
+            case 'E':
+            case 'e':
+                codepoint += 0x000e;
+                break;
+            case 'F':
+            case 'f':
+                codepoint += 0x000f;
+                break;
+            default:
+                return -1;
+        }
+
+        return codepoint;
+    }
+
+    /*!
+    @brief scan a string literal
+
+    This function scans a string according to Sect. 7 of RFC 7159. While
+    scanning, bytes are escaped and copied into buffer yytext. Then the
+    function returns successfully, yytext is null-terminated and yylen
+    contains the number of bytes in the string.
+
+    @return token_type::value_string if string could be successfully
+            scanned, token_type::parse_error otherwise
+
+    @note In case of errors, variable error_message contains a textual
+          description.
+    */
+    token_type scan_string()
+    {
+        // reset yytext (ignore opening quote)
+        reset();
+
+        // we entered the function by reading an open quote
+        assert(current == '\"');
+
+        while (true)
+        {
+            // get next character
+            switch (get())
+            {
+                // end of file while parsing string
+                case std::char_traits<char>::eof():
+                {
+                    error_message = "invalid string: missing closing quote";
+                    return token_type::parse_error;
+                }
+
+                // closing quote
+                case '\"':
+                {
+                    // terminate yytext
+                    add('\0');
+                    --yylen;
+                    return token_type::value_string;
+                }
+
+                // escapes
+                case '\\':
+                {
+                    switch (get())
+                    {
+                        // quotation mark
+                        case '\"':
+                            add('\"');
+                            break;
+                        // reverse solidus
+                        case '\\':
+                            add('\\');
+                            break;
+                        // solidus
+                        case '/':
+                            add('/');
+                            break;
+                        // backspace
+                        case 'b':
+                            add('\b');
+                            break;
+                        // form feed
+                        case 'f':
+                            add('\f');
+                            break;
+                        // line feed
+                        case 'n':
+                            add('\n');
+                            break;
+                        // carriage return
+                        case 'r':
+                            add('\r');
+                            break;
+                        // tab
+                        case 't':
+                            add('\t');
+                            break;
+
+                        // unicode escapes
+                        case 'u':
+                        {
+                            int codepoint;
+                            int codepoint1 = get_codepoint();
+
+                            if (JSON_UNLIKELY(codepoint1 == -1))
+                            {
+                                error_message =
+                                    "invalid string: '\\u' must be followed by 4 hex digits";
+                                return token_type::parse_error;
+                            }
+
+                            // check if code point is a high surrogate
+                            if (0xD800 <= codepoint1 and codepoint1 <= 0xDBFF)
+                            {
+                                // expect next \uxxxx entry
+                                if (JSON_LIKELY(get() == '\\' and get() == 'u'))
+                                {
+                                    const int codepoint2 = get_codepoint();
+
+                                    if (JSON_UNLIKELY(codepoint2 == -1))
+                                    {
+                                        error_message =
+                                            "invalid string: '\\u' must be followed by 4 hex digits";
+                                        return token_type::parse_error;
+                                    }
+
+                                    // check if codepoint2 is a low surrogate
+                                    if (JSON_LIKELY(0xDC00 <= codepoint2 and codepoint2 <= 0xDFFF))
+                                    {
+                                        codepoint =
+                                            // high surrogate occupies the most significant 22 bits
+                                            (codepoint1 << 10)
+                                            // low surrogate occupies the least significant 15 bits
+                                            + codepoint2
+                                            // there is still the 0xD800, 0xDC00 and 0x10000 noise
+                                            // in the result so we have to subtract with:
+                                            // (0xD800 << 10) + DC00 - 0x10000 = 0x35FDC00
+                                            - 0x35FDC00;
+                                    }
+                                    else
+                                    {
+                                        error_message = "invalid string: surrogate U+DC00..U+DFFF must "
+                                                        "be followed by U+DC00..U+DFFF";
+                                        return token_type::parse_error;
+                                    }
+                                }
+                                else
+                                {
+                                    error_message = "invalid string: surrogate U+DC00..U+DFFF must "
+                                                    "be followed by U+DC00..U+DFFF";
+                                    return token_type::parse_error;
+                                }
+                            }
+                            else
+                            {
+                                if (JSON_UNLIKELY(0xDC00 <= codepoint1 and codepoint1 <= 0xDFFF))
+                                {
+                                    error_message = "invalid string: surrogate U+DC00..U+DFFF must "
+                                                    "follow U+D800..U+DBFF";
+                                    return token_type::parse_error;
+                                }
+
+                                // only work with first code point
+                                codepoint = codepoint1;
+                            }
+
+                            // result of the above calculation yields a proper codepoint
+                            assert(0x00 <= codepoint and codepoint <= 0x10FFFF);
+
+                            // translate code point to bytes
+                            if (codepoint < 0x80)
+                            {
+                                // 1-byte characters: 0xxxxxxx (ASCII)
+                                add(codepoint);
+                            }
+                            else if (codepoint <= 0x7ff)
+                            {
+                                // 2-byte characters: 110xxxxx 10xxxxxx
+                                add(0xC0 | (codepoint >> 6));
+                                add(0x80 | (codepoint & 0x3F));
+                            }
+                            else if (codepoint <= 0xffff)
+                            {
+                                // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
+                                add(0xE0 | (codepoint >> 12));
+                                add(0x80 | ((codepoint >> 6) & 0x3F));
+                                add(0x80 | (codepoint & 0x3F));
+                            }
+                            else
+                            {
+                                // 4-byte characters: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                                add(0xF0 | (codepoint >> 18));
+                                add(0x80 | ((codepoint >> 12) & 0x3F));
+                                add(0x80 | ((codepoint >> 6) & 0x3F));
+                                add(0x80 | (codepoint & 0x3F));
+                            }
+
+                            break;
+                        }
+
+                        // other characters after escape
+                        default:
+                            error_message = "invalid string: forbidden character after backslash";
+                            return token_type::parse_error;
+                    }
+
+                    break;
+                }
+
+                // invalid control characters
+                case 0x00:
+                case 0x01:
+                case 0x02:
+                case 0x03:
+                case 0x04:
+                case 0x05:
+                case 0x06:
+                case 0x07:
+                case 0x08:
+                case 0x09:
+                case 0x0a:
+                case 0x0b:
+                case 0x0c:
+                case 0x0d:
+                case 0x0e:
+                case 0x0f:
+                case 0x10:
+                case 0x11:
+                case 0x12:
+                case 0x13:
+                case 0x14:
+                case 0x15:
+                case 0x16:
+                case 0x17:
+                case 0x18:
+                case 0x19:
+                case 0x1a:
+                case 0x1b:
+                case 0x1c:
+                case 0x1d:
+                case 0x1e:
+                case 0x1f:
+                {
+                    error_message = "invalid string: control character must be escaped";
+                    return token_type::parse_error;
+                }
+
+                // U+0020..U+007F (except U+0022 (quote) and U+005C (backspace))
+                case 0x20:
+                case 0x21:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2a:
+                case 0x2b:
+                case 0x2c:
+                case 0x2d:
+                case 0x2e:
+                case 0x2f:
+                case 0x30:
+                case 0x31:
+                case 0x32:
+                case 0x33:
+                case 0x34:
+                case 0x35:
+                case 0x36:
+                case 0x37:
+                case 0x38:
+                case 0x39:
+                case 0x3a:
+                case 0x3b:
+                case 0x3c:
+                case 0x3d:
+                case 0x3e:
+                case 0x3f:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4a:
+                case 0x4b:
+                case 0x4c:
+                case 0x4d:
+                case 0x4e:
+                case 0x4f:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5a:
+                case 0x5b:
+                case 0x5d:
+                case 0x5e:
+                case 0x5f:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 0x63:
+                case 0x64:
+                case 0x65:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6a:
+                case 0x6b:
+                case 0x6c:
+                case 0x6d:
+                case 0x6e:
+                case 0x6f:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7a:
+                case 0x7b:
+                case 0x7c:
+                case 0x7d:
+                case 0x7e:
+                case 0x7f:
+                {
+                    add(current);
+                    break;
+                }
+
+                // U+0080..U+07FF: bytes C2..DF 80..BF
+                case 0xc2:
+                case 0xc3:
+                case 0xc4:
+                case 0xc5:
+                case 0xc6:
+                case 0xc7:
+                case 0xc8:
+                case 0xc9:
+                case 0xca:
+                case 0xcb:
+                case 0xcc:
+                case 0xcd:
+                case 0xce:
+                case 0xcf:
+                case 0xd0:
+                case 0xd1:
+                case 0xd2:
+                case 0xd3:
+                case 0xd4:
+                case 0xd5:
+                case 0xd6:
+                case 0xd7:
+                case 0xd8:
+                case 0xd9:
+                case 0xda:
+                case 0xdb:
+                case 0xdc:
+                case 0xdd:
+                case 0xde:
+                case 0xdf:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                    {
+                        add(current);
+                        continue;
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // U+0800..U+0FFF: bytes E0 A0..BF 80..BF
+                case 0xe0:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0xa0 <= current and current <= 0xbf))
+                    {
+                        add(current);
+                        get();
+                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                        {
+                            add(current);
+                            continue;
+                        }
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // U+1000..U+CFFF: bytes E1..EC 80..BF 80..BF
+                // U+E000..U+FFFF: bytes EE..EF 80..BF 80..BF
+                case 0xe1:
+                case 0xe2:
+                case 0xe3:
+                case 0xe4:
+                case 0xe5:
+                case 0xe6:
+                case 0xe7:
+                case 0xe8:
+                case 0xe9:
+                case 0xea:
+                case 0xeb:
+                case 0xec:
+                case 0xee:
+                case 0xef:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                    {
+                        add(current);
+                        get();
+                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                        {
+                            add(current);
+                            continue;
+                        }
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // U+D000..U+D7FF: bytes ED 80..9F 80..BF
+                case 0xed:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0x80 <= current and current <= 0x9f))
+                    {
+                        add(current);
+                        get();
+                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                        {
+                            add(current);
+                            continue;
+                        }
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // U+10000..U+3FFFF F0 90..BF 80..BF 80..BF
+                case 0xf0:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0x90 <= current and current <= 0xbf))
+                    {
+                        add(current);
+                        get();
+                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                        {
+                            add(current);
+                            get();
+                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                            {
+                                add(current);
+                                continue;
+                            }
+                        }
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // U+40000..U+FFFFF F1..F3 80..BF 80..BF 80..BF
+                case 0xf1:
+                case 0xf2:
+                case 0xf3:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                    {
+                        add(current);
+                        get();
+                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                        {
+                            add(current);
+                            get();
+                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                            {
+                                add(current);
+                                continue;
+                            }
+                        }
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // U+100000..U+10FFFF F4 80..8F 80..BF 80..BF
+                case 0xf4:
+                {
+                    add(current);
+                    get();
+                    if (JSON_LIKELY(0x80 <= current and current <= 0x8f))
+                    {
+                        add(current);
+                        get();
+                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                        {
+                            add(current);
+                            get();
+                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
+                            {
+                                add(current);
+                                continue;
+                            }
+                        }
+                    }
+
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+
+                // remaining bytes (80..C1 and F5..FF) are ill-formed
+                default:
+                {
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+            }
+        }
+    }
+
+    static void strtof(float& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtof(str, endptr);
+    }
+
+    static void strtof(double& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtod(str, endptr);
+    }
+
+    static void strtof(long double& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtold(str, endptr);
+    }
+
+    /*!
+    @brief scan a number literal
+
+    This function scans a string according to Sect. 6 of RFC 7159.
+
+    The function is realized with a deterministic finite state machine
+    derived from the grammar described in RFC 7159. Starting in state
+    "init", the input is read and used to determined the next state. Only
+    state "done" accepts the number. State "error" is a trap state to model
+    errors. In the table below, "anything" means any character but the ones
+    listed before.
+
+    state    | 0        | 1-9      | e E      | +       | -       | .        |
+    anything
+    ---------|----------|----------|----------|---------|---------|----------|-----------
+    init     | zero     | any1     | [error]  | [error] | minus   | [error]  |
+    [error]
+    minus    | zero     | any1     | [error]  | [error] | [error] | [error]  |
+    [error]
+    zero     | done     | done     | exponent | done    | done    | decimal1 |
+    done
+    any1     | any1     | any1     | exponent | done    | done    | decimal1 |
+    done
+    decimal1 | decimal2 | [error]  | [error]  | [error] | [error] | [error]  |
+    [error]
+    decimal2 | decimal2 | decimal2 | exponent | done    | done    | done     |
+    done
+    exponent | any2     | any2     | [error]  | sign    | sign    | [error]  |
+    [error]
+    sign     | any2     | any2     | [error]  | [error] | [error] | [error]  |
+    [error]
+    any2     | any2     | any2     | done     | done    | done    | done     |
+    done
+
+    The state machine is realized with one label per state (prefixed with
+    "scan_number_") and `goto` statements between them. The state machine
+    contains cycles, but any cycle can be left when EOF is read. Therefore,
+    the function is guaranteed to terminate.
+
+    During scanning, the read bytes are stored in yytext. This string is
+    then converted to a signed integer, an unsigned integer, or a
+    floating-point number.
+
+    @return token_type::value_unsigned, token_type::value_integer, or
+            token_type::value_float if number could be successfully scanned,
+            token_type::parse_error otherwise
+
+    @note The scanner is independent of the current locale. Internally, the
+          locale's decimal point is used instead of `.` to work with the
+          locale-dependent converters.
+    */
+    token_type scan_number()
+    {
+        // reset yytext to store the number's bytes
+        reset();
+
+        // the type of the parsed number; initially set to unsigned; will be
+        // changed if minus sign, decimal point or exponent is read
+        token_type number_type = token_type::value_unsigned;
+
+        // state (init): we just found out we need to scan a number
+        switch (current)
+        {
+            case '-':
+            {
+                add(current);
+                goto scan_number_minus;
+            }
+
+            case '0':
+            {
+                add(current);
+                goto scan_number_zero;
+            }
+
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any1;
+            }
+
+            default:
+            {
+                // all other characters are rejected outside scan_number()
+                assert(false); // LCOV_EXCL_LINE
+            }
+        }
+
+scan_number_minus:
+        // state: we just parsed a leading minus sign
+        number_type = token_type::value_integer;
+        switch (get())
+        {
+            case '0':
+            {
+                add(current);
+                goto scan_number_zero;
+            }
+
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any1;
+            }
+
+            default:
+            {
+                error_message = "invalid number; expected digit after '-'";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_zero:
+        // state: we just parse a zero (maybe with a leading minus sign)
+        switch (get())
+        {
+            case '.':
+            {
+                add(decimal_point_char);
+                goto scan_number_decimal1;
+            }
+
+            case 'e':
+            case 'E':
+            {
+                add(current);
+                goto scan_number_exponent;
+            }
+
+            default:
+            {
+                goto scan_number_done;
+            }
+        }
+
+scan_number_any1:
+        // state: we just parsed a number 0-9 (maybe with a leading minus sign)
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any1;
+            }
+
+            case '.':
+            {
+                add(decimal_point_char);
+                goto scan_number_decimal1;
+            }
+
+            case 'e':
+            case 'E':
+            {
+                add(current);
+                goto scan_number_exponent;
+            }
+
+            default:
+            {
+                goto scan_number_done;
+            }
+        }
+
+scan_number_decimal1:
+        // state: we just parsed a decimal point
+        number_type = token_type::value_float;
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_decimal2;
+            }
+
+            default:
+            {
+                error_message = "invalid number; expected digit after '.'";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_decimal2:
+        // we just parsed at least one number after a decimal point
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_decimal2;
+            }
+
+            case 'e':
+            case 'E':
+            {
+                add(current);
+                goto scan_number_exponent;
+            }
+
+            default:
+            {
+                goto scan_number_done;
+            }
+        }
+
+scan_number_exponent:
+        // we just parsed an exponent
+        number_type = token_type::value_float;
+        switch (get())
+        {
+            case '+':
+            case '-':
+            {
+                add(current);
+                goto scan_number_sign;
+            }
+
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any2;
+            }
+
+            default:
+            {
+                error_message =
+                    "invalid number; expected '+', '-', or digit after exponent";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_sign:
+        // we just parsed an exponent sign
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any2;
+            }
+
+            default:
+            {
+                error_message = "invalid number; expected digit after exponent sign";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_any2:
+        // we just parsed a number after the exponent or exponent sign
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any2;
+            }
+
+            default:
+            {
+                goto scan_number_done;
+            }
+        }
+
+scan_number_done:
+        // unget the character after the number (we only read it to know
+        // that we are done scanning a number)
+        --chars_read;
+        next_unget = true;
+
+        // terminate token
+        add('\0');
+        --yylen;
+
+        // try to parse integers first and fall back to floats
+        if (number_type == token_type::value_unsigned)
+        {
+            char* endptr = nullptr;
+            errno = 0;
+            const auto x = std::strtoull(yytext.data(), &endptr, 10);
+
+            // we checked the number format before
+            assert(endptr == yytext.data() + yylen);
+
+            if (errno == 0)
+            {
+                value_unsigned = static_cast<number_unsigned_t>(x);
+                if (value_unsigned == x)
+                {
+                    return token_type::value_unsigned;
+                }
+            }
+        }
+        else if (number_type == token_type::value_integer)
+        {
+            char* endptr = nullptr;
+            errno = 0;
+            const auto x = std::strtoll(yytext.data(), &endptr, 10);
+
+            // we checked the number format before
+            assert(endptr == yytext.data() + yylen);
+
+            if (errno == 0)
+            {
+                value_integer = static_cast<number_integer_t>(x);
+                if (value_integer == x)
+                {
+                    return token_type::value_integer;
+                }
+            }
+        }
+
+        // this code is reached if we parse a floating-point number or if
+        // an integer conversion above failed
+        strtof(value_float, yytext.data(), nullptr);
+        return token_type::value_float;
+    }
+
+    /*!
+    @param[in] literal_text  the literal text to expect
+    @param[in] length        the length of the passed literal text
+    @param[in] return_type   the token type to return on success
+    */
+    token_type scan_literal(const char* literal_text, const size_t length,
+                            token_type return_type)
+    {
+        assert(current == literal_text[0]);
+        for (size_t i = 1; i < length; ++i)
+        {
+            if (JSON_UNLIKELY(get() != literal_text[i]))
+            {
+                error_message = "invalid literal";
+                return token_type::parse_error;
+            }
+        }
+        return return_type;
+    }
+
+    /////////////////////
+    // input management
+    /////////////////////
+
+    /// reset yytext
+    void reset() noexcept
+    {
+        yylen = 0;
+        start_pos = chars_read - 1;
+    }
+
+    /// get a character from the input
+    int get()
+    {
+        ++chars_read;
+        return next_unget ? (next_unget = false, current)
+               : (current = ia->get_character());
+    }
+
+    /// add a character to yytext
+    void add(int c)
+    {
+        // resize yytext if necessary; this condition is deemed unlikely,
+        // because we start with a 1024-byte buffer
+        if (JSON_UNLIKELY((yylen + 1 > yytext.capacity())))
+        {
+            yytext.resize(2 * yytext.capacity(), '\0');
+        }
+        assert(yylen < yytext.size());
+        yytext[yylen++] = static_cast<char>(c);
+    }
+
+  public:
+    /////////////////////
+    // value getters
+    /////////////////////
+
+    /// return integer value
+    constexpr number_integer_t get_number_integer() const noexcept
+    {
+        return value_integer;
+    }
+
+    /// return unsigned integer value
+    constexpr number_unsigned_t get_number_unsigned() const noexcept
+    {
+        return value_unsigned;
+    }
+
+    /// return floating-point value
+    constexpr number_float_t get_number_float() const noexcept
+    {
+        return value_float;
+    }
+
+    /// return string value
+    const std::string get_string()
+    {
+        // yytext cannot be returned as char*, because it may contain a
+        // null byte (parsed as "\u0000")
+        return std::string(yytext.data(), yylen);
+    }
+
+    /////////////////////
+    // diagnostics
+    /////////////////////
+
+    /// return position of last read token
+    constexpr size_t get_position() const noexcept
+    {
+        return chars_read;
+    }
+
+    /// return the last read token (for errors only)
+    std::string get_token_string() const
+    {
+        // get the raw byte sequence of the last token
+        std::string s = ia->read(start_pos, chars_read - start_pos);
+
+        // escape control characters
+        std::string result;
+        for (auto c : s)
+        {
+            if (c == '\0' or c == std::char_traits<char>::eof())
+            {
+                // ignore EOF
+                continue;
+            }
+            else if ('\x00' <= c and c <= '\x1f')
+            {
+                // escape control characters
+                std::stringstream ss;
+                ss << "<U+" << std::setw(4) << std::uppercase << std::setfill('0')
+                   << std::hex << static_cast<int>(c) << ">";
+                result += ss.str();
+            }
+            else
+            {
+                // add character as is
+                result.append(1, c);
+            }
+        }
+
+        return result;
+    }
+
+    /// return syntax error message
+    constexpr const char* get_error_message() const noexcept
+    {
+        return error_message;
+    }
+
+    /////////////////////
+    // actual scanner
+    /////////////////////
+
+    token_type scan()
+    {
+        // read next character and ignore whitespace
+        do
+        {
+            get();
+        }
+        while (current == ' ' or current == '\t' or current == '\n' or
+                current == '\r');
+
+        switch (current)
+        {
+            // structural characters
+            case '[':
+                return token_type::begin_array;
+            case ']':
+                return token_type::end_array;
+            case '{':
+                return token_type::begin_object;
+            case '}':
+                return token_type::end_object;
+            case ':':
+                return token_type::name_separator;
+            case ',':
+                return token_type::value_separator;
+
+            // literals
+            case 't':
+                return scan_literal("true", 4, token_type::literal_true);
+            case 'f':
+                return scan_literal("false", 5, token_type::literal_false);
+            case 'n':
+                return scan_literal("null", 4, token_type::literal_null);
+
+            // string
+            case '\"':
+                return scan_string();
+
+            // number
+            case '-':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return scan_number();
+
+            // end of input (the null byte is needed when parsing from
+            // string literals)
+            case '\0':
+            case std::char_traits<char>::eof():
+                return token_type::end_of_input;
+
+            // error
+            default:
+                error_message = "invalid literal";
+                return token_type::parse_error;
+        }
+    }
+
+  private:
+    /// input adapter
+    detail::input_adapter_t ia = nullptr;
+
+    /// the current character
+    int current = std::char_traits<char>::eof();
+
+    /// whether get() should return the last character again
+    bool next_unget = false;
+
+    /// the number of characters read
+    size_t chars_read = 0;
+    /// the start position of the current token
+    size_t start_pos = 0;
+
+    /// buffer for variable-length tokens (numbers, strings)
+    std::vector<char> yytext = std::vector<char>(1024, '\0');
+    /// current index in yytext
+    size_t yylen = 0;
+
+    /// a description of occurred lexer errors
+    const char* error_message = "";
+
+    // number values
+    number_integer_t value_integer = 0;
+    number_unsigned_t value_unsigned = 0;
+    number_float_t value_float = 0;
+
+    /// the decimal point
+    const char decimal_point_char = '.';
+};
+
+/*!
+@brief syntax analysis
+
+This class implements a recursive decent parser.
+*/
+template <typename BasicJsonType>
+class parser
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+
+    using lexer_t = lexer<BasicJsonType>;
+    using token_type = typename lexer_t::token_type;
+
+  public:
+    enum class parse_event_t : uint8_t
+    {
+        /// the parser read `{` and started to process a JSON object
+        object_start,
+        /// the parser read `}` and finished processing a JSON object
+        object_end,
+        /// the parser read `[` and started to process a JSON array
+        array_start,
+        /// the parser read `]` and finished processing a JSON array
+        array_end,
+        /// the parser read a key of a value in an object
+        key,
+        /// the parser finished reading a JSON value
+        value
+    };
+
+    using parser_callback_t =
+        std::function<bool(int depth, parse_event_t event, BasicJsonType& parsed)>;
+
+    /// a parser reading from an input adapter
+    explicit parser(detail::input_adapter_t adapter,
+                    const parser_callback_t cb = nullptr)
+        : callback(cb), m_lexer(adapter) {}
+
+    /*!
+    @brief public parser interface
+
+    @param[in] strict  whether to expect the last token to be EOF
+    @return parsed JSON value
+
+    @throw parse_error.101 in case of an unexpected token
+    @throw parse_error.102 if to_unicode fails or surrogate error
+    @throw parse_error.103 if to_unicode fails
+    */
+    BasicJsonType parse(const bool strict = true)
+    {
+        // read first token
+        get_token();
+
+        BasicJsonType result = parse_internal(true);
+        result.assert_invariant();
+
+        if (strict)
+        {
+            get_token();
+            expect(token_type::end_of_input);
+        }
+
+        // return parser result and replace it with null in case the
+        // top-level value was discarded by the callback function
+        return result.is_discarded() ? BasicJsonType() : std::move(result);
+    }
+
+    /*!
+    @brief public accept interface
+
+    @param[in] strict  whether to expect the last token to be EOF
+    @return whether the input is a proper JSON text
+    */
+    bool accept(const bool strict = true)
+    {
+        // read first token
+        get_token();
+
+        if (not accept_internal())
+        {
+            return false;
+        }
+
+        if (strict and get_token() != token_type::end_of_input)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+  private:
+    /*!
+    @brief the actual parser
+    @throw parse_error.101 in case of an unexpected token
+    @throw parse_error.102 if to_unicode fails or surrogate error
+    @throw parse_error.103 if to_unicode fails
+    */
+    BasicJsonType parse_internal(bool keep)
+    {
+        auto result = BasicJsonType(value_t::discarded);
+
+        switch (last_token)
+        {
+            case token_type::begin_object:
+            {
+                if (keep and (not callback or
+                              ((keep = callback(depth++, parse_event_t::object_start,
+                                                result)) != 0)))
+                {
+                    // explicitly set result to object to cope with {}
+                    result.m_type = value_t::object;
+                    result.m_value = value_t::object;
+                }
+
+                // read next token
+                get_token();
+
+                // closing } -> we are done
+                if (last_token == token_type::end_object)
+                {
+                    if (keep and callback and
+                            not callback(--depth, parse_event_t::object_end, result))
+                    {
+                        result = BasicJsonType(value_t::discarded);
+                    }
+                    return result;
+                }
+
+                // parse values
+                while (true)
+                {
+                    // store key
+                    expect(token_type::value_string);
+                    const auto key = m_lexer.get_string();
+
+                    bool keep_tag = false;
+                    if (keep)
+                    {
+                        if (callback)
+                        {
+                            BasicJsonType k(key);
+                            keep_tag = callback(depth, parse_event_t::key, k);
+                        }
+                        else
+                        {
+                            keep_tag = true;
+                        }
+                    }
+
+                    // parse separator (:)
+                    get_token();
+                    expect(token_type::name_separator);
+
+                    // parse and add value
+                    get_token();
+                    auto value = parse_internal(keep);
+                    if (keep and keep_tag and not value.is_discarded())
+                    {
+                        result[key] = std::move(value);
+                    }
+
+                    // comma -> next value
+                    get_token();
+                    if (last_token == token_type::value_separator)
+                    {
+                        get_token();
+                        continue;
+                    }
+
+                    // closing }
+                    expect(token_type::end_object);
+                    break;
+                }
+
+                if (keep and callback and
+                        not callback(--depth, parse_event_t::object_end, result))
+                {
+                    result = BasicJsonType(value_t::discarded);
+                }
+
+                return result;
+            }
+
+            case token_type::begin_array:
+            {
+                if (keep and (not callback or
+                              ((keep = callback(depth++, parse_event_t::array_start,
+                                                result)) != 0)))
+                {
+                    // explicitly set result to object to cope with []
+                    result.m_type = value_t::array;
+                    result.m_value = value_t::array;
+                }
+
+                // read next token
+                get_token();
+
+                // closing ] -> we are done
+                if (last_token == token_type::end_array)
+                {
+                    if (callback and
+                            not callback(--depth, parse_event_t::array_end, result))
+                    {
+                        result = BasicJsonType(value_t::discarded);
+                    }
+                    return result;
+                }
+
+                // parse values
+                while (true)
+                {
+                    // parse value
+                    auto value = parse_internal(keep);
+                    if (keep and not value.is_discarded())
+                    {
+                        result.push_back(std::move(value));
+                    }
+
+                    // comma -> next value
+                    get_token();
+                    if (last_token == token_type::value_separator)
+                    {
+                        get_token();
+                        continue;
+                    }
+
+                    // closing ]
+                    expect(token_type::end_array);
+                    break;
+                }
+
+                if (keep and callback and
+                        not callback(--depth, parse_event_t::array_end, result))
+                {
+                    result = BasicJsonType(value_t::discarded);
+                }
+
+                return result;
+            }
+
+            case token_type::literal_null:
+            {
+                result.m_type = value_t::null;
+                break;
+            }
+
+            case token_type::value_string:
+            {
+                result = BasicJsonType(m_lexer.get_string());
+                break;
+            }
+
+            case token_type::literal_true:
+            {
+                result.m_type = value_t::boolean;
+                result.m_value = true;
+                break;
+            }
+
+            case token_type::literal_false:
+            {
+                result.m_type = value_t::boolean;
+                result.m_value = false;
+                break;
+            }
+
+            case token_type::value_unsigned:
+            {
+                result.m_type = value_t::number_unsigned;
+                result.m_value = m_lexer.get_number_unsigned();
+                break;
+            }
+
+            case token_type::value_integer:
+            {
+                result.m_type = value_t::number_integer;
+                result.m_value = m_lexer.get_number_integer();
+                break;
+            }
+
+            case token_type::value_float:
+            {
+                result.m_type = value_t::number_float;
+                result.m_value = m_lexer.get_number_float();
+
+                // throw in case of infinity or NAN
+                if (JSON_UNLIKELY(not std::isfinite(result.m_value.number_float)))
+                {
+                    JSON_THROW(out_of_range::create(406, "number overflow parsing '" +
+                                                    m_lexer.get_token_string() +
+                                                    "'"));
+                }
+
+                break;
+            }
+
+            case token_type::parse_error:
+            {
+                // using "uninitialized" to avoid "expected" message
+                expect(token_type::uninitialized);
+                break; // LCOV_EXCL_LINE
+            }
+
+            default:
+            {
+                // the last token was unexpected; we expected a value
+                expect(token_type::literal_or_value);
+                break; // LCOV_EXCL_LINE
+            }
+        }
+
+        if (keep and callback and
+                not callback(depth, parse_event_t::value, result))
+        {
+            result = BasicJsonType(value_t::discarded);
+        }
+        return result;
+    }
+
+    /*!
+    @brief the acutal acceptor
+
+    @invariant 1. The last token is not yet processed. Therefore, the
+                  caller of this function must make sure a token has
+                  been read.
+               2. When this function returns, the last token is processed.
+                  That is, the last read character was already considered.
+
+    This invariant makes sure that no token needs to be "unput".
+    */
+    bool accept_internal()
+    {
+        switch (last_token)
+        {
+            case token_type::begin_object:
+            {
+                // read next token
+                get_token();
+
+                // closing } -> we are done
+                if (last_token == token_type::end_object)
+                {
+                    return true;
+                }
+
+                // parse values
+                while (true)
+                {
+                    // parse key
+                    if (last_token != token_type::value_string)
+                    {
+                        return false;
+                    }
+
+                    // parse separator (:)
+                    get_token();
+                    if (last_token != token_type::name_separator)
+                    {
+                        return false;
+                    }
+
+                    // parse value
+                    get_token();
+                    if (not accept_internal())
+                    {
+                        return false;
+                    }
+
+                    // comma -> next value
+                    get_token();
+                    if (last_token == token_type::value_separator)
+                    {
+                        get_token();
+                        continue;
+                    }
+
+                    // closing }
+                    if (last_token != token_type::end_object)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+            }
+
+            case token_type::begin_array:
+            {
+                // read next token
+                get_token();
+
+                // closing ] -> we are done
+                if (last_token == token_type::end_array)
+                {
+                    return true;
+                }
+
+                // parse values
+                while (true)
+                {
+                    // parse value
+                    if (not accept_internal())
+                    {
+                        return false;
+                    }
+
+                    // comma -> next value
+                    get_token();
+                    if (last_token == token_type::value_separator)
+                    {
+                        get_token();
+                        continue;
+                    }
+
+                    // closing ]
+                    if (last_token != token_type::end_array)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+            }
+
+            case token_type::literal_false:
+            case token_type::literal_null:
+            case token_type::literal_true:
+            case token_type::value_float:
+            case token_type::value_integer:
+            case token_type::value_string:
+            case token_type::value_unsigned:
+            {
+                return true;
+            }
+
+            default:
+            {
+                // the last token was unexpected
+                return false;
+            }
+        }
+    }
+
+    /// get next token from lexer
+    token_type get_token()
+    {
+        return (last_token = m_lexer.scan());
+    }
+
+    /*!
+    @throw parse_error.101 if expected token did not occur
+    */
+    void expect(token_type t)
+    {
+        if (JSON_UNLIKELY(t != last_token))
+        {
+            errored = true;
+            expected = t;
+            throw_exception();
+        }
+    }
+
+    [[noreturn]] void throw_exception() const
+    {
+        std::string error_msg = "syntax error - ";
+        if (last_token == token_type::parse_error)
+        {
+            error_msg += std::string(m_lexer.get_error_message()) + "; last read: '" +
+                         m_lexer.get_token_string() + "'";
+        }
+        else
+        {
+            error_msg +=
+                "unexpected " + std::string(lexer_t::token_type_name(last_token));
+        }
+
+        if (expected != token_type::uninitialized)
+        {
+            error_msg +=
+                "; expected " + std::string(lexer_t::token_type_name(expected));
+        }
+
+        JSON_THROW(parse_error::create(101, m_lexer.get_position(), error_msg));
+    }
+
+  private:
+    /// current level of recursion
+    int depth = 0;
+    /// callback function
+    const parser_callback_t callback = nullptr;
+    /// the type of the last read token
+    token_type last_token = token_type::uninitialized;
+    /// the lexer
+    lexer_t m_lexer;
+    /// whether a syntax error occurred
+    bool errored = false;
+    /// possible reason for the syntax error
+    token_type expected = token_type::uninitialized;
+};
+} // namespace detail
 
 /// namespace to hold default `to_json` / `from_json` functions
 namespace
@@ -1999,9 +4038,14 @@ class basic_json
 {
   private:
     template<detail::value_t> friend struct detail::external_constructor;
+    friend ::nlohmann::json_pointer;
+    friend ::nlohmann::detail::parser<basic_json>;
     /// workaround type for MSVC
     using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
-    friend ::nlohmann::json_pointer;
+
+    // convenience aliases for types residing in namespace detail;
+    using lexer = ::nlohmann::detail::lexer<basic_json>;
+    using parser = ::nlohmann::detail::parser<basic_json>;
 
   public:
     using value_t = detail::value_t;
@@ -2774,31 +4818,7 @@ class basic_json
     // JSON parser callback //
     //////////////////////////
 
-    /*!
-    @brief JSON callback events
-
-    This enumeration lists the parser events that can trigger calling a
-    callback function of type @ref parser_callback_t during parsing.
-
-    @image html callback_events.png "Example when certain parse events are triggered"
-
-    @since version 1.0.0
-    */
-    enum class parse_event_t : uint8_t
-    {
-        /// the parser read `{` and started to process a JSON object
-        object_start,
-        /// the parser read `}` and finished processing a JSON object
-        object_end,
-        /// the parser read `[` and started to process a JSON array
-        array_start,
-        /// the parser read `]` and finished processing a JSON array
-        array_end,
-        /// the parser read a key of a value in an object
-        key,
-        /// the parser finished reading a JSON value
-        value
-    };
+    using parse_event_t = typename parser::parse_event_t;
 
     /*!
     @brief per-element parser callback type
@@ -2852,9 +4872,7 @@ class basic_json
 
     @since version 1.0.0
     */
-    using parser_callback_t = std::function<bool(int depth,
-                              parse_event_t event,
-                              basic_json& parsed)>;
+    using parser_callback_t = typename parser::parser_callback_t;
 
 
     //////////////////
@@ -11386,1986 +13404,6 @@ class basic_json
 
     /// @}
 
-    //////////////////////
-    // lexer and parser //
-    //////////////////////
-
-  private:
-    /*!
-    @brief lexical analysis
-
-    This class organizes the lexical analysis during JSON deserialization.
-    */
-    class lexer
-    {
-      public:
-        /// token types for the parser
-        enum class token_type
-        {
-            uninitialized,   ///< indicating the scanner is uninitialized
-            literal_true,    ///< the `true` literal
-            literal_false,   ///< the `false` literal
-            literal_null,    ///< the `null` literal
-            value_string,    ///< a string -- use get_string() for actual value
-            value_unsigned,  ///< an unsigned integer -- use get_number_unsigned() for actual value
-            value_integer,   ///< a signed integer -- use get_number_integer() for actual value
-            value_float,     ///< an floating point number -- use get_number_float() for actual value
-            begin_array,     ///< the character for array begin `[`
-            begin_object,    ///< the character for object begin `{`
-            end_array,       ///< the character for array end `]`
-            end_object,      ///< the character for object end `}`
-            name_separator,  ///< the name separator `:`
-            value_separator, ///< the value separator `,`
-            parse_error,     ///< indicating a parse error
-            end_of_input,    ///< indicating the end of the input buffer
-            literal_or_value ///< a literal or the begin of a value (only for diagnostics)
-        };
-
-        /// return name of values of type token_type (only used for errors)
-        static const char* token_type_name(const token_type t) noexcept
-        {
-            switch (t)
-            {
-                case token_type::uninitialized:
-                    return "<uninitialized>";
-                case token_type::literal_true:
-                    return "true literal";
-                case token_type::literal_false:
-                    return "false literal";
-                case token_type::literal_null:
-                    return "null literal";
-                case token_type::value_string:
-                    return "string literal";
-                case lexer::token_type::value_unsigned:
-                case lexer::token_type::value_integer:
-                case lexer::token_type::value_float:
-                    return "number literal";
-                case token_type::begin_array:
-                    return "'['";
-                case token_type::begin_object:
-                    return "'{'";
-                case token_type::end_array:
-                    return "']'";
-                case token_type::end_object:
-                    return "'}'";
-                case token_type::name_separator:
-                    return "':'";
-                case token_type::value_separator:
-                    return "','";
-                case token_type::parse_error:
-                    return "<parse error>";
-                case token_type::end_of_input:
-                    return "end of input";
-                case token_type::literal_or_value:
-                    return "'[', '{', or a literal";
-                default:
-                {
-                    // catch non-enum values
-                    return "unknown token"; // LCOV_EXCL_LINE
-                }
-            }
-        }
-
-        explicit lexer(detail::input_adapter_t adapter)
-            : ia(adapter), decimal_point_char(get_decimal_point())
-        {}
-
-        // delete because of pointer members
-        lexer(const lexer&) = delete;
-        lexer& operator=(lexer&) = delete;
-
-      private:
-        /////////////////////
-        // locales
-        /////////////////////
-
-        /// return the locale-dependent decimal point
-        static char get_decimal_point() noexcept
-        {
-            const auto loc = localeconv();
-            assert(loc != nullptr);
-            return (loc->decimal_point == nullptr) ? '.' : loc->decimal_point[0];
-        }
-
-        /////////////////////
-        // scan functions
-        /////////////////////
-
-        /*!
-        @brief get codepoint from 4 hex characters following `\u`
-
-        @return codepoint or -1 in case of an error (e.g. EOF or non-hex
-                character)
-        */
-        int get_codepoint()
-        {
-            // this function only makes sense after reading `\u`
-            assert(current == 'u');
-            int codepoint = 0;
-
-            // byte 1: \uXxxx
-            switch (get())
-            {
-                case '0':
-                    break;
-                case '1':
-                    codepoint += 0x1000;
-                    break;
-                case '2':
-                    codepoint += 0x2000;
-                    break;
-                case '3':
-                    codepoint += 0x3000;
-                    break;
-                case '4':
-                    codepoint += 0x4000;
-                    break;
-                case '5':
-                    codepoint += 0x5000;
-                    break;
-                case '6':
-                    codepoint += 0x6000;
-                    break;
-                case '7':
-                    codepoint += 0x7000;
-                    break;
-                case '8':
-                    codepoint += 0x8000;
-                    break;
-                case '9':
-                    codepoint += 0x9000;
-                    break;
-                case 'A':
-                case 'a':
-                    codepoint += 0xa000;
-                    break;
-                case 'B':
-                case 'b':
-                    codepoint += 0xb000;
-                    break;
-                case 'C':
-                case 'c':
-                    codepoint += 0xc000;
-                    break;
-                case 'D':
-                case 'd':
-                    codepoint += 0xd000;
-                    break;
-                case 'E':
-                case 'e':
-                    codepoint += 0xe000;
-                    break;
-                case 'F':
-                case 'f':
-                    codepoint += 0xf000;
-                    break;
-                default:
-                    return -1;
-            }
-
-            // byte 2: \uxXxx
-            switch (get())
-            {
-                case '0':
-                    break;
-                case '1':
-                    codepoint += 0x0100;
-                    break;
-                case '2':
-                    codepoint += 0x0200;
-                    break;
-                case '3':
-                    codepoint += 0x0300;
-                    break;
-                case '4':
-                    codepoint += 0x0400;
-                    break;
-                case '5':
-                    codepoint += 0x0500;
-                    break;
-                case '6':
-                    codepoint += 0x0600;
-                    break;
-                case '7':
-                    codepoint += 0x0700;
-                    break;
-                case '8':
-                    codepoint += 0x0800;
-                    break;
-                case '9':
-                    codepoint += 0x0900;
-                    break;
-                case 'A':
-                case 'a':
-                    codepoint += 0x0a00;
-                    break;
-                case 'B':
-                case 'b':
-                    codepoint += 0x0b00;
-                    break;
-                case 'C':
-                case 'c':
-                    codepoint += 0x0c00;
-                    break;
-                case 'D':
-                case 'd':
-                    codepoint += 0x0d00;
-                    break;
-                case 'E':
-                case 'e':
-                    codepoint += 0x0e00;
-                    break;
-                case 'F':
-                case 'f':
-                    codepoint += 0x0f00;
-                    break;
-                default:
-                    return -1;
-            }
-
-            // byte 3: \uxxXx
-            switch (get())
-            {
-                case '0':
-                    break;
-                case '1':
-                    codepoint += 0x0010;
-                    break;
-                case '2':
-                    codepoint += 0x0020;
-                    break;
-                case '3':
-                    codepoint += 0x0030;
-                    break;
-                case '4':
-                    codepoint += 0x0040;
-                    break;
-                case '5':
-                    codepoint += 0x0050;
-                    break;
-                case '6':
-                    codepoint += 0x0060;
-                    break;
-                case '7':
-                    codepoint += 0x0070;
-                    break;
-                case '8':
-                    codepoint += 0x0080;
-                    break;
-                case '9':
-                    codepoint += 0x0090;
-                    break;
-                case 'A':
-                case 'a':
-                    codepoint += 0x00a0;
-                    break;
-                case 'B':
-                case 'b':
-                    codepoint += 0x00b0;
-                    break;
-                case 'C':
-                case 'c':
-                    codepoint += 0x00c0;
-                    break;
-                case 'D':
-                case 'd':
-                    codepoint += 0x00d0;
-                    break;
-                case 'E':
-                case 'e':
-                    codepoint += 0x00e0;
-                    break;
-                case 'F':
-                case 'f':
-                    codepoint += 0x00f0;
-                    break;
-                default:
-                    return -1;
-            }
-
-            // byte 4: \uxxxX
-            switch (get())
-            {
-                case '0':
-                    break;
-                case '1':
-                    codepoint += 0x0001;
-                    break;
-                case '2':
-                    codepoint += 0x0002;
-                    break;
-                case '3':
-                    codepoint += 0x0003;
-                    break;
-                case '4':
-                    codepoint += 0x0004;
-                    break;
-                case '5':
-                    codepoint += 0x0005;
-                    break;
-                case '6':
-                    codepoint += 0x0006;
-                    break;
-                case '7':
-                    codepoint += 0x0007;
-                    break;
-                case '8':
-                    codepoint += 0x0008;
-                    break;
-                case '9':
-                    codepoint += 0x0009;
-                    break;
-                case 'A':
-                case 'a':
-                    codepoint += 0x000a;
-                    break;
-                case 'B':
-                case 'b':
-                    codepoint += 0x000b;
-                    break;
-                case 'C':
-                case 'c':
-                    codepoint += 0x000c;
-                    break;
-                case 'D':
-                case 'd':
-                    codepoint += 0x000d;
-                    break;
-                case 'E':
-                case 'e':
-                    codepoint += 0x000e;
-                    break;
-                case 'F':
-                case 'f':
-                    codepoint += 0x000f;
-                    break;
-                default:
-                    return -1;
-            }
-
-            return codepoint;
-        }
-
-        /*!
-        @brief scan a string literal
-
-        This function scans a string according to Sect. 7 of RFC 7159. While
-        scanning, bytes are escaped and copied into buffer yytext. Then the
-        function returns successfully, yytext is null-terminated and yylen
-        contains the number of bytes in the string.
-
-        @return token_type::value_string if string could be successfully
-                scanned, token_type::parse_error otherwise
-
-        @note In case of errors, variable error_message contains a textual
-              description.
-        */
-        token_type scan_string()
-        {
-            // reset yytext (ignore opening quote)
-            reset();
-
-            // we entered the function by reading an open quote
-            assert(current == '\"');
-
-            while (true)
-            {
-                // get next character
-                switch (get())
-                {
-                    // end of file while parsing string
-                    case std::char_traits<char>::eof():
-                    {
-                        error_message = "invalid string: missing closing quote";
-                        return token_type::parse_error;
-                    }
-
-                    // closing quote
-                    case '\"':
-                    {
-                        // terminate yytext
-                        add('\0');
-                        --yylen;
-                        return token_type::value_string;
-                    }
-
-                    // escapes
-                    case '\\':
-                    {
-                        switch (get())
-                        {
-                            // quotation mark
-                            case '\"':
-                                add('\"');
-                                break;
-                            // reverse solidus
-                            case '\\':
-                                add('\\');
-                                break;
-                            // solidus
-                            case '/':
-                                add('/');
-                                break;
-                            // backspace
-                            case 'b':
-                                add('\b');
-                                break;
-                            // form feed
-                            case 'f':
-                                add('\f');
-                                break;
-                            // line feed
-                            case 'n':
-                                add('\n');
-                                break;
-                            // carriage return
-                            case 'r':
-                                add('\r');
-                                break;
-                            // tab
-                            case 't':
-                                add('\t');
-                                break;
-
-                            // unicode escapes
-                            case 'u':
-                            {
-                                int codepoint;
-                                int codepoint1 = get_codepoint();
-
-                                if (JSON_UNLIKELY(codepoint1 == -1))
-                                {
-                                    error_message = "invalid string: '\\u' must be followed by 4 hex digits";
-                                    return token_type::parse_error;
-                                }
-
-                                // check if code point is a high surrogate
-                                if (0xD800 <= codepoint1 and codepoint1 <= 0xDBFF)
-                                {
-                                    // expect next \uxxxx entry
-                                    if (JSON_LIKELY(get() == '\\' and get() == 'u'))
-                                    {
-                                        const int codepoint2 = get_codepoint();
-
-                                        if (JSON_UNLIKELY(codepoint2 == -1))
-                                        {
-                                            error_message = "invalid string: '\\u' must be followed by 4 hex digits";
-                                            return token_type::parse_error;
-                                        }
-
-                                        // check if codepoint2 is a low surrogate
-                                        if (JSON_LIKELY(0xDC00 <= codepoint2 and codepoint2 <= 0xDFFF))
-                                        {
-                                            codepoint =
-                                                // high surrogate occupies the most significant 22 bits
-                                                (codepoint1 << 10)
-                                                // low surrogate occupies the least significant 15 bits
-                                                + codepoint2
-                                                // there is still the 0xD800, 0xDC00 and 0x10000 noise
-                                                // in the result so we have to subtract with:
-                                                // (0xD800 << 10) + DC00 - 0x10000 = 0x35FDC00
-                                                - 0x35FDC00;
-                                        }
-                                        else
-                                        {
-                                            error_message = "invalid string: surrogate U+DC00..U+DFFF must be followed by U+DC00..U+DFFF";
-                                            return token_type::parse_error;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        error_message = "invalid string: surrogate U+DC00..U+DFFF must be followed by U+DC00..U+DFFF";
-                                        return token_type::parse_error;
-                                    }
-                                }
-                                else
-                                {
-                                    if (JSON_UNLIKELY(0xDC00 <= codepoint1 and codepoint1 <= 0xDFFF))
-                                    {
-                                        error_message = "invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF";
-                                        return token_type::parse_error;
-                                    }
-
-                                    // only work with first code point
-                                    codepoint = codepoint1;
-                                }
-
-                                // result of the above calculation yields a proper codepoint
-                                assert(0x00 <= codepoint and codepoint <= 0x10FFFF);
-
-                                // translate code point to bytes
-                                if (codepoint < 0x80)
-                                {
-                                    // 1-byte characters: 0xxxxxxx (ASCII)
-                                    add(codepoint);
-                                }
-                                else if (codepoint <= 0x7ff)
-                                {
-                                    // 2-byte characters: 110xxxxx 10xxxxxx
-                                    add(0xC0 | (codepoint >> 6));
-                                    add(0x80 | (codepoint & 0x3F));
-                                }
-                                else if (codepoint <= 0xffff)
-                                {
-                                    // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
-                                    add(0xE0 | (codepoint >> 12));
-                                    add(0x80 | ((codepoint >> 6) & 0x3F));
-                                    add(0x80 | (codepoint & 0x3F));
-                                }
-                                else
-                                {
-                                    // 4-byte characters: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-                                    add(0xF0 | (codepoint >> 18));
-                                    add(0x80 | ((codepoint >> 12) & 0x3F));
-                                    add(0x80 | ((codepoint >> 6) & 0x3F));
-                                    add(0x80 | (codepoint & 0x3F));
-                                }
-
-                                break;
-                            }
-
-                            // other characters after escape
-                            default:
-                                error_message = "invalid string: forbidden character after backslash";
-                                return token_type::parse_error;
-                        }
-
-                        break;
-                    }
-
-                    // invalid control characters
-                    case 0x00:
-                    case 0x01:
-                    case 0x02:
-                    case 0x03:
-                    case 0x04:
-                    case 0x05:
-                    case 0x06:
-                    case 0x07:
-                    case 0x08:
-                    case 0x09:
-                    case 0x0a:
-                    case 0x0b:
-                    case 0x0c:
-                    case 0x0d:
-                    case 0x0e:
-                    case 0x0f:
-                    case 0x10:
-                    case 0x11:
-                    case 0x12:
-                    case 0x13:
-                    case 0x14:
-                    case 0x15:
-                    case 0x16:
-                    case 0x17:
-                    case 0x18:
-                    case 0x19:
-                    case 0x1a:
-                    case 0x1b:
-                    case 0x1c:
-                    case 0x1d:
-                    case 0x1e:
-                    case 0x1f:
-                    {
-                        error_message = "invalid string: control character must be escaped";
-                        return token_type::parse_error;
-                    }
-
-                    // U+0020..U+007F (except U+0022 (quote) and U+005C (backspace))
-                    case 0x20:
-                    case 0x21:
-                    case 0x23:
-                    case 0x24:
-                    case 0x25:
-                    case 0x26:
-                    case 0x27:
-                    case 0x28:
-                    case 0x29:
-                    case 0x2a:
-                    case 0x2b:
-                    case 0x2c:
-                    case 0x2d:
-                    case 0x2e:
-                    case 0x2f:
-                    case 0x30:
-                    case 0x31:
-                    case 0x32:
-                    case 0x33:
-                    case 0x34:
-                    case 0x35:
-                    case 0x36:
-                    case 0x37:
-                    case 0x38:
-                    case 0x39:
-                    case 0x3a:
-                    case 0x3b:
-                    case 0x3c:
-                    case 0x3d:
-                    case 0x3e:
-                    case 0x3f:
-                    case 0x40:
-                    case 0x41:
-                    case 0x42:
-                    case 0x43:
-                    case 0x44:
-                    case 0x45:
-                    case 0x46:
-                    case 0x47:
-                    case 0x48:
-                    case 0x49:
-                    case 0x4a:
-                    case 0x4b:
-                    case 0x4c:
-                    case 0x4d:
-                    case 0x4e:
-                    case 0x4f:
-                    case 0x50:
-                    case 0x51:
-                    case 0x52:
-                    case 0x53:
-                    case 0x54:
-                    case 0x55:
-                    case 0x56:
-                    case 0x57:
-                    case 0x58:
-                    case 0x59:
-                    case 0x5a:
-                    case 0x5b:
-                    case 0x5d:
-                    case 0x5e:
-                    case 0x5f:
-                    case 0x60:
-                    case 0x61:
-                    case 0x62:
-                    case 0x63:
-                    case 0x64:
-                    case 0x65:
-                    case 0x66:
-                    case 0x67:
-                    case 0x68:
-                    case 0x69:
-                    case 0x6a:
-                    case 0x6b:
-                    case 0x6c:
-                    case 0x6d:
-                    case 0x6e:
-                    case 0x6f:
-                    case 0x70:
-                    case 0x71:
-                    case 0x72:
-                    case 0x73:
-                    case 0x74:
-                    case 0x75:
-                    case 0x76:
-                    case 0x77:
-                    case 0x78:
-                    case 0x79:
-                    case 0x7a:
-                    case 0x7b:
-                    case 0x7c:
-                    case 0x7d:
-                    case 0x7e:
-                    case 0x7f:
-                    {
-                        add(current);
-                        break;
-                    }
-
-                    // U+0080..U+07FF: bytes C2..DF 80..BF
-                    case 0xc2:
-                    case 0xc3:
-                    case 0xc4:
-                    case 0xc5:
-                    case 0xc6:
-                    case 0xc7:
-                    case 0xc8:
-                    case 0xc9:
-                    case 0xca:
-                    case 0xcb:
-                    case 0xcc:
-                    case 0xcd:
-                    case 0xce:
-                    case 0xcf:
-                    case 0xd0:
-                    case 0xd1:
-                    case 0xd2:
-                    case 0xd3:
-                    case 0xd4:
-                    case 0xd5:
-                    case 0xd6:
-                    case 0xd7:
-                    case 0xd8:
-                    case 0xd9:
-                    case 0xda:
-                    case 0xdb:
-                    case 0xdc:
-                    case 0xdd:
-                    case 0xde:
-                    case 0xdf:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                        {
-                            add(current);
-                            continue;
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // U+0800..U+0FFF: bytes E0 A0..BF 80..BF
-                    case 0xe0:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0xa0 <= current and current <= 0xbf))
-                        {
-                            add(current);
-                            get();
-                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                            {
-                                add(current);
-                                continue;
-                            }
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // U+1000..U+CFFF: bytes E1..EC 80..BF 80..BF
-                    // U+E000..U+FFFF: bytes EE..EF 80..BF 80..BF
-                    case 0xe1:
-                    case 0xe2:
-                    case 0xe3:
-                    case 0xe4:
-                    case 0xe5:
-                    case 0xe6:
-                    case 0xe7:
-                    case 0xe8:
-                    case 0xe9:
-                    case 0xea:
-                    case 0xeb:
-                    case 0xec:
-                    case 0xee:
-                    case 0xef:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                        {
-                            add(current);
-                            get();
-                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                            {
-                                add(current);
-                                continue;
-                            }
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // U+D000..U+D7FF: bytes ED 80..9F 80..BF
-                    case 0xed:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0x80 <= current and current <= 0x9f))
-                        {
-                            add(current);
-                            get();
-                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                            {
-                                add(current);
-                                continue;
-                            }
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // U+10000..U+3FFFF F0 90..BF 80..BF 80..BF
-                    case 0xf0:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0x90 <= current and current <= 0xbf))
-                        {
-                            add(current);
-                            get();
-                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                            {
-                                add(current);
-                                get();
-                                if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                                {
-                                    add(current);
-                                    continue;
-                                }
-                            }
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // U+40000..U+FFFFF F1..F3 80..BF 80..BF 80..BF
-                    case 0xf1:
-                    case 0xf2:
-                    case 0xf3:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                        {
-                            add(current);
-                            get();
-                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                            {
-                                add(current);
-                                get();
-                                if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                                {
-                                    add(current);
-                                    continue;
-                                }
-                            }
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // U+100000..U+10FFFF F4 80..8F 80..BF 80..BF
-                    case 0xf4:
-                    {
-                        add(current);
-                        get();
-                        if (JSON_LIKELY(0x80 <= current and current <= 0x8f))
-                        {
-                            add(current);
-                            get();
-                            if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                            {
-                                add(current);
-                                get();
-                                if (JSON_LIKELY(0x80 <= current and current <= 0xbf))
-                                {
-                                    add(current);
-                                    continue;
-                                }
-                            }
-                        }
-
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-
-                    // remaining bytes (80..C1 and F5..FF) are ill-formed
-                    default:
-                    {
-                        error_message = "invalid string: ill-formed UTF-8 byte";
-                        return token_type::parse_error;
-                    }
-                }
-            }
-        }
-
-        static void strtof(float& f, const char* str, char** endptr) noexcept
-        {
-            f = std::strtof(str, endptr);
-        }
-
-        static void strtof(double& f, const char* str, char** endptr) noexcept
-        {
-            f = std::strtod(str, endptr);
-        }
-
-        static void strtof(long double& f, const char* str, char** endptr) noexcept
-        {
-            f = std::strtold(str, endptr);
-        }
-
-        /*!
-        @brief scan a number literal
-
-        This function scans a string according to Sect. 6 of RFC 7159.
-
-        The function is realized with a deterministic finite state machine
-        derived from the grammar described in RFC 7159. Starting in state
-        "init", the input is read and used to determined the next state. Only
-        state "done" accepts the number. State "error" is a trap state to model
-        errors. In the table below, "anything" means any character but the ones
-        listed before.
-
-        state    | 0        | 1-9      | e E      | +       | -       | .        | anything
-        ---------|----------|----------|----------|---------|---------|----------|-----------
-        init     | zero     | any1     | [error]  | [error] | minus   | [error]  | [error]
-        minus    | zero     | any1     | [error]  | [error] | [error] | [error]  | [error]
-        zero     | done     | done     | exponent | done    | done    | decimal1 | done
-        any1     | any1     | any1     | exponent | done    | done    | decimal1 | done
-        decimal1 | decimal2 | [error]  | [error]  | [error] | [error] | [error]  | [error]
-        decimal2 | decimal2 | decimal2 | exponent | done    | done    | done     | done
-        exponent | any2     | any2     | [error]  | sign    | sign    | [error]  | [error]
-        sign     | any2     | any2     | [error]  | [error] | [error] | [error]  | [error]
-        any2     | any2     | any2     | done     | done    | done    | done     | done
-
-        The state machine is realized with one label per state (prefixed with
-        "scan_number_") and `goto` statements between them. The state machine
-        contains cycles, but any cycle can be left when EOF is read. Therefore,
-        the function is guaranteed to terminate.
-
-        During scanning, the read bytes are stored in yytext. This string is
-        then converted to a signed integer, an unsigned integer, or a
-        floating-point number.
-
-        @return token_type::value_unsigned, token_type::value_integer, or
-                token_type::value_float if number could be successfully scanned,
-                token_type::parse_error otherwise
-
-        @note The scanner is independent of the current locale. Internally, the
-              locale's decimal point is used instead of `.` to work with the
-              locale-dependent converters.
-        */
-        token_type scan_number()
-        {
-            // reset yytext to store the number's bytes
-            reset();
-
-            // the type of the parsed number; initially set to unsigned; will be
-            // changed if minus sign, decimal point or exponent is read
-            token_type number_type = token_type::value_unsigned;
-
-            // state (init): we just found out we need to scan a number
-            switch (current)
-            {
-                case '-':
-                {
-                    add(current);
-                    goto scan_number_minus;
-                }
-
-                case '0':
-                {
-                    add(current);
-                    goto scan_number_zero;
-                }
-
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_any1;
-                }
-
-                default:
-                {
-                    // all other characters are rejected outside scan_number()
-                    assert(false);  // LCOV_EXCL_LINE
-                }
-            }
-
-scan_number_minus:
-            // state: we just parsed a leading minus sign
-            number_type = token_type::value_integer;
-            switch (get())
-            {
-                case '0':
-                {
-                    add(current);
-                    goto scan_number_zero;
-                }
-
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_any1;
-                }
-
-                default:
-                {
-                    error_message = "invalid number; expected digit after '-'";
-                    return token_type::parse_error;
-                }
-            }
-
-scan_number_zero:
-            // state: we just parse a zero (maybe with a leading minus sign)
-            switch (get())
-            {
-                case '.':
-                {
-                    add(decimal_point_char);
-                    goto scan_number_decimal1;
-                }
-
-                case 'e':
-                case 'E':
-                {
-                    add(current);
-                    goto scan_number_exponent;
-                }
-
-                default:
-                {
-                    goto scan_number_done;
-                }
-            }
-
-scan_number_any1:
-            // state: we just parsed a number 0-9 (maybe with a leading minus sign)
-            switch (get())
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_any1;
-                }
-
-                case '.':
-                {
-                    add(decimal_point_char);
-                    goto scan_number_decimal1;
-                }
-
-                case 'e':
-                case 'E':
-                {
-                    add(current);
-                    goto scan_number_exponent;
-                }
-
-                default:
-                {
-                    goto scan_number_done;
-                }
-            }
-
-scan_number_decimal1:
-            // state: we just parsed a decimal point
-            number_type = token_type::value_float;
-            switch (get())
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_decimal2;
-                }
-
-                default:
-                {
-                    error_message = "invalid number; expected digit after '.'";
-                    return token_type::parse_error;
-                }
-            }
-
-scan_number_decimal2:
-            // we just parsed at least one number after a decimal point
-            switch (get())
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_decimal2;
-                }
-
-                case 'e':
-                case 'E':
-                {
-                    add(current);
-                    goto scan_number_exponent;
-                }
-
-                default:
-                {
-                    goto scan_number_done;
-                }
-            }
-
-scan_number_exponent:
-            // we just parsed an exponent
-            number_type = token_type::value_float;
-            switch (get())
-            {
-                case '+':
-                case '-':
-                {
-                    add(current);
-                    goto scan_number_sign;
-                }
-
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_any2;
-                }
-
-                default:
-                {
-                    error_message = "invalid number; expected '+', '-', or digit after exponent";
-                    return token_type::parse_error;
-                }
-            }
-
-scan_number_sign:
-            // we just parsed an exponent sign
-            switch (get())
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_any2;
-                }
-
-                default:
-                {
-                    error_message = "invalid number; expected digit after exponent sign";
-                    return token_type::parse_error;
-                }
-            }
-
-scan_number_any2:
-            // we just parsed a number after the exponent or exponent sign
-            switch (get())
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                {
-                    add(current);
-                    goto scan_number_any2;
-                }
-
-                default:
-                {
-                    goto scan_number_done;
-                }
-            }
-
-scan_number_done:
-            // unget the character after the number (we only read it to know
-            // that we are done scanning a number)
-            --chars_read;
-            next_unget = true;
-
-            // terminate token
-            add('\0');
-            --yylen;
-
-            // try to parse integers first and fall back to floats
-            if (number_type == token_type::value_unsigned)
-            {
-                char* endptr = nullptr;
-                errno = 0;
-                const auto x = std::strtoull(yytext.data(), &endptr, 10);
-
-                // we checked the number format before
-                assert(endptr == yytext.data() + yylen);
-
-                if (errno == 0)
-                {
-                    value_unsigned = static_cast<number_unsigned_t>(x);
-                    if (value_unsigned == x)
-                    {
-                        return token_type::value_unsigned;
-                    }
-                }
-            }
-            else if (number_type == token_type::value_integer)
-            {
-                char* endptr = nullptr;
-                errno = 0;
-                const auto x = std::strtoll(yytext.data(), &endptr, 10);
-
-                // we checked the number format before
-                assert(endptr == yytext.data() + yylen);
-
-                if (errno == 0)
-                {
-                    value_integer = static_cast<number_integer_t>(x);
-                    if (value_integer == x)
-                    {
-                        return token_type::value_integer;
-                    }
-                }
-            }
-
-            // this code is reached if we parse a floating-point number or if
-            // an integer conversion above failed
-            strtof(value_float, yytext.data(), nullptr);
-            return token_type::value_float;
-        }
-
-        /*!
-        @param[in] literal_text  the literal text to expect
-        @param[in] length        the length of the passed literal text
-        @param[in] return_type   the token type to return on success
-        */
-        token_type scan_literal(const char* literal_text, const size_t length,
-                                token_type return_type)
-        {
-            assert(current == literal_text[0]);
-            for (size_t i = 1; i < length; ++i)
-            {
-                if (JSON_UNLIKELY(get() != literal_text[i]))
-                {
-                    error_message = "invalid literal";
-                    return token_type::parse_error;
-                }
-            }
-            return return_type;
-        }
-
-        /////////////////////
-        // input management
-        /////////////////////
-
-        /// reset yytext
-        void reset() noexcept
-        {
-            yylen = 0;
-            start_pos = chars_read - 1;
-        }
-
-        /// get a character from the input
-        int get()
-        {
-            ++chars_read;
-            return next_unget
-                   ? (next_unget = false, current)
-                   : (current = ia->get_character());
-        }
-
-        /// add a character to yytext
-        void add(int c)
-        {
-            // resize yytext if necessary; this condition is deemed unlikely,
-            // because we start with a 1024-byte buffer
-            if (JSON_UNLIKELY((yylen + 1 > yytext.capacity())))
-            {
-                yytext.resize(2 * yytext.capacity(), '\0');
-            }
-            assert(yylen < yytext.size());
-            yytext[yylen++] = static_cast<char>(c);
-        }
-
-      public:
-        /////////////////////
-        // value getters
-        /////////////////////
-
-        /// return integer value
-        constexpr number_integer_t get_number_integer() const noexcept
-        {
-            return value_integer;
-        }
-
-        /// return unsigned integer value
-        constexpr number_unsigned_t get_number_unsigned() const noexcept
-        {
-            return value_unsigned;
-        }
-
-        /// return floating-point value
-        constexpr number_float_t get_number_float() const noexcept
-        {
-            return value_float;
-        }
-
-        /// return string value
-        const std::string get_string()
-        {
-            // yytext cannot be returned as char*, because it may contain a
-            // null byte (parsed as "\u0000")
-            return std::string(yytext.data(), yylen);
-        }
-
-        /////////////////////
-        // diagnostics
-        /////////////////////
-
-        /// return position of last read token
-        constexpr size_t get_position() const noexcept
-        {
-            return chars_read;
-        }
-
-        /// return the last read token (for errors only)
-        std::string get_token_string() const
-        {
-            // get the raw byte sequence of the last token
-            std::string s = ia->read(start_pos, chars_read - start_pos);
-
-            // escape control characters
-            std::string result;
-            for (auto c : s)
-            {
-                if (c == '\0' or c == std::char_traits<char>::eof())
-                {
-                    // ignore EOF
-                    continue;
-                }
-                else if ('\x00' <= c and c <= '\x1f')
-                {
-                    // escape control characters
-                    std::stringstream ss;
-                    ss << "<U+" << std::setw(4) << std::uppercase << std::setfill('0') << std::hex << static_cast<int>(c) << ">";
-                    result += ss.str();
-                }
-                else
-                {
-                    // add character as is
-                    result.append(1, c);
-                }
-            }
-
-            return result;
-        }
-
-        /// return syntax error message
-        constexpr const char* get_error_message() const noexcept
-        {
-            return error_message;
-        }
-
-        /////////////////////
-        // actual scanner
-        /////////////////////
-
-        token_type scan()
-        {
-            // read next character and ignore whitespace
-            do
-            {
-                get();
-            }
-            while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
-
-            switch (current)
-            {
-                // structural characters
-                case '[':
-                    return token_type::begin_array;
-                case ']':
-                    return token_type::end_array;
-                case '{':
-                    return token_type::begin_object;
-                case '}':
-                    return token_type::end_object;
-                case ':':
-                    return token_type::name_separator;
-                case ',':
-                    return token_type::value_separator;
-
-                // literals
-                case 't':
-                    return scan_literal("true", 4, token_type::literal_true);
-                case 'f':
-                    return scan_literal("false", 5, token_type::literal_false);
-                case 'n':
-                    return scan_literal("null", 4, token_type::literal_null);
-
-                // string
-                case '\"':
-                    return scan_string();
-
-                // number
-                case '-':
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                    return scan_number();
-
-                // end of input (the null byte is needed when parsing from
-                // string literals)
-                case '\0':
-                case std::char_traits<char>::eof():
-                    return token_type::end_of_input;
-
-                // error
-                default:
-                    error_message = "invalid literal";
-                    return token_type::parse_error;
-            }
-        }
-
-      private:
-        /// input adapter
-        detail::input_adapter_t ia = nullptr;
-
-        /// the current character
-        int current = std::char_traits<char>::eof();
-
-        /// whether get() should return the last character again
-        bool next_unget = false;
-
-        /// the number of characters read
-        size_t chars_read = 0;
-        /// the start position of the current token
-        size_t start_pos = 0;
-
-        /// buffer for variable-length tokens (numbers, strings)
-        std::vector<char> yytext = std::vector<char>(1024, '\0');
-        /// current index in yytext
-        size_t yylen = 0;
-
-        /// a description of occurred lexer errors
-        const char* error_message = "";
-
-        // number values
-        number_integer_t value_integer = 0;
-        number_unsigned_t value_unsigned = 0;
-        number_float_t value_float = 0;
-
-        /// the decimal point
-        const char decimal_point_char = '.';
-    };
-
-    /*!
-    @brief syntax analysis
-
-    This class implements a recursive decent parser.
-    */
-    class parser
-    {
-      public:
-        /// a parser reading from an input adapter
-        explicit parser(detail::input_adapter_t adapter,
-                        const parser_callback_t cb = nullptr)
-            : callback(cb), m_lexer(adapter)
-        {}
-
-        /*!
-        @brief public parser interface
-
-        @param[in] strict  whether to expect the last token to be EOF
-        @return parsed JSON value
-
-        @throw parse_error.101 in case of an unexpected token
-        @throw parse_error.102 if to_unicode fails or surrogate error
-        @throw parse_error.103 if to_unicode fails
-        */
-        basic_json parse(const bool strict = true)
-        {
-            // read first token
-            get_token();
-
-            basic_json result = parse_internal(true);
-            result.assert_invariant();
-
-            if (strict)
-            {
-                get_token();
-                expect(lexer::token_type::end_of_input);
-            }
-
-            // return parser result and replace it with null in case the
-            // top-level value was discarded by the callback function
-            return result.is_discarded() ? basic_json() : std::move(result);
-        }
-
-        /*!
-        @brief public accept interface
-
-        @param[in] strict  whether to expect the last token to be EOF
-        @return whether the input is a proper JSON text
-        */
-        bool accept(const bool strict = true)
-        {
-            // read first token
-            get_token();
-
-            if (not accept_internal())
-            {
-                return false;
-            }
-
-            if (strict and get_token() != lexer::token_type::end_of_input)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-      private:
-        /*!
-        @brief the actual parser
-        @throw parse_error.101 in case of an unexpected token
-        @throw parse_error.102 if to_unicode fails or surrogate error
-        @throw parse_error.103 if to_unicode fails
-        */
-        basic_json parse_internal(bool keep)
-        {
-            auto result = basic_json(value_t::discarded);
-
-            switch (last_token)
-            {
-                case lexer::token_type::begin_object:
-                {
-                    if (keep and (not callback
-                                  or ((keep = callback(depth++, parse_event_t::object_start, result)) != 0)))
-                    {
-                        // explicitly set result to object to cope with {}
-                        result.m_type = value_t::object;
-                        result.m_value = value_t::object;
-                    }
-
-                    // read next token
-                    get_token();
-
-                    // closing } -> we are done
-                    if (last_token == lexer::token_type::end_object)
-                    {
-                        if (keep and callback and not callback(--depth, parse_event_t::object_end, result))
-                        {
-                            result = basic_json(value_t::discarded);
-                        }
-                        return result;
-                    }
-
-                    // parse values
-                    while (true)
-                    {
-                        // store key
-                        expect(lexer::token_type::value_string);
-                        const auto key = m_lexer.get_string();
-
-                        bool keep_tag = false;
-                        if (keep)
-                        {
-                            if (callback)
-                            {
-                                basic_json k(key);
-                                keep_tag = callback(depth, parse_event_t::key, k);
-                            }
-                            else
-                            {
-                                keep_tag = true;
-                            }
-                        }
-
-                        // parse separator (:)
-                        get_token();
-                        expect(lexer::token_type::name_separator);
-
-                        // parse and add value
-                        get_token();
-                        auto value = parse_internal(keep);
-                        if (keep and keep_tag and not value.is_discarded())
-                        {
-                            result[key] = std::move(value);
-                        }
-
-                        // comma -> next value
-                        get_token();
-                        if (last_token == lexer::token_type::value_separator)
-                        {
-                            get_token();
-                            continue;
-                        }
-
-                        // closing }
-                        expect(lexer::token_type::end_object);
-                        break;
-                    }
-
-                    if (keep and callback and not callback(--depth, parse_event_t::object_end, result))
-                    {
-                        result = basic_json(value_t::discarded);
-                    }
-
-                    return result;
-                }
-
-                case lexer::token_type::begin_array:
-                {
-                    if (keep and (not callback
-                                  or ((keep = callback(depth++, parse_event_t::array_start, result)) != 0)))
-                    {
-                        // explicitly set result to object to cope with []
-                        result.m_type = value_t::array;
-                        result.m_value = value_t::array;
-                    }
-
-                    // read next token
-                    get_token();
-
-                    // closing ] -> we are done
-                    if (last_token == lexer::token_type::end_array)
-                    {
-                        if (callback and not callback(--depth, parse_event_t::array_end, result))
-                        {
-                            result = basic_json(value_t::discarded);
-                        }
-                        return result;
-                    }
-
-                    // parse values
-                    while (true)
-                    {
-                        // parse value
-                        auto value = parse_internal(keep);
-                        if (keep and not value.is_discarded())
-                        {
-                            result.push_back(std::move(value));
-                        }
-
-                        // comma -> next value
-                        get_token();
-                        if (last_token == lexer::token_type::value_separator)
-                        {
-                            get_token();
-                            continue;
-                        }
-
-                        // closing ]
-                        expect(lexer::token_type::end_array);
-                        break;
-                    }
-
-                    if (keep and callback and not callback(--depth, parse_event_t::array_end, result))
-                    {
-                        result = basic_json(value_t::discarded);
-                    }
-
-                    return result;
-                }
-
-                case lexer::token_type::literal_null:
-                {
-                    result.m_type = value_t::null;
-                    break;
-                }
-
-                case lexer::token_type::value_string:
-                {
-                    result = basic_json(m_lexer.get_string());
-                    break;
-                }
-
-                case lexer::token_type::literal_true:
-                {
-                    result.m_type = value_t::boolean;
-                    result.m_value = true;
-                    break;
-                }
-
-                case lexer::token_type::literal_false:
-                {
-                    result.m_type = value_t::boolean;
-                    result.m_value = false;
-                    break;
-                }
-
-                case lexer::token_type::value_unsigned:
-                {
-                    result.m_type = value_t::number_unsigned;
-                    result.m_value = m_lexer.get_number_unsigned();
-                    break;
-                }
-
-                case lexer::token_type::value_integer:
-                {
-                    result.m_type = value_t::number_integer;
-                    result.m_value = m_lexer.get_number_integer();
-                    break;
-                }
-
-                case lexer::token_type::value_float:
-                {
-                    result.m_type = value_t::number_float;
-                    result.m_value = m_lexer.get_number_float();
-
-                    // throw in case of infinity or NAN
-                    if (JSON_UNLIKELY(not std::isfinite(result.m_value.number_float)))
-                    {
-                        JSON_THROW(out_of_range::create(406, "number overflow parsing '" + m_lexer.get_token_string() + "'"));
-                    }
-
-                    break;
-                }
-
-                case lexer::token_type::parse_error:
-                {
-                    // using "uninitialized" to avoid "expected" message
-                    expect(lexer::token_type::uninitialized);
-                    break;  // LCOV_EXCL_LINE
-                }
-
-                default:
-                {
-                    // the last token was unexpected; we expected a value
-                    expect(lexer::token_type::literal_or_value);
-                    break;  // LCOV_EXCL_LINE
-                }
-            }
-
-            if (keep and callback and not callback(depth, parse_event_t::value, result))
-            {
-                result = basic_json(value_t::discarded);
-            }
-            return result;
-        }
-
-        /*!
-        @brief the acutal acceptor
-
-        @invariant 1. The last token is not yet processed. Therefore, the
-                      caller of this function must make sure a token has
-                      been read.
-                   2. When this function returns, the last token is processed.
-                      That is, the last read character was already considered.
-
-        This invariant makes sure that no token needs to be "unput".
-        */
-        bool accept_internal()
-        {
-            switch (last_token)
-            {
-                case lexer::token_type::begin_object:
-                {
-                    // read next token
-                    get_token();
-
-                    // closing } -> we are done
-                    if (last_token == lexer::token_type::end_object)
-                    {
-                        return true;
-                    }
-
-                    // parse values
-                    while (true)
-                    {
-                        // parse key
-                        if (last_token != lexer::token_type::value_string)
-                        {
-                            return false;
-                        }
-
-                        // parse separator (:)
-                        get_token();
-                        if (last_token != lexer::token_type::name_separator)
-                        {
-                            return false;
-                        }
-
-                        // parse value
-                        get_token();
-                        if (not accept_internal())
-                        {
-                            return false;
-                        }
-
-                        // comma -> next value
-                        get_token();
-                        if (last_token == lexer::token_type::value_separator)
-                        {
-                            get_token();
-                            continue;
-                        }
-
-                        // closing }
-                        if (last_token != lexer::token_type::end_object)
-                        {
-                            return false;
-                        }
-
-                        return true;
-                    }
-                }
-
-                case lexer::token_type::begin_array:
-                {
-                    // read next token
-                    get_token();
-
-                    // closing ] -> we are done
-                    if (last_token == lexer::token_type::end_array)
-                    {
-                        return true;
-                    }
-
-                    // parse values
-                    while (true)
-                    {
-                        // parse value
-                        if (not accept_internal())
-                        {
-                            return false;
-                        }
-
-                        // comma -> next value
-                        get_token();
-                        if (last_token == lexer::token_type::value_separator)
-                        {
-                            get_token();
-                            continue;
-                        }
-
-                        // closing ]
-                        if (last_token != lexer::token_type::end_array)
-                        {
-                            return false;
-                        }
-
-                        return true;
-                    }
-                }
-
-                case lexer::token_type::literal_false:
-                case lexer::token_type::literal_null:
-                case lexer::token_type::literal_true:
-                case lexer::token_type::value_float:
-                case lexer::token_type::value_integer:
-                case lexer::token_type::value_string:
-                case lexer::token_type::value_unsigned:
-                {
-                    return true;
-                }
-
-                default:
-                {
-                    // the last token was unexpected
-                    return false;
-                }
-            }
-        }
-
-        /// get next token from lexer
-        typename lexer::token_type get_token()
-        {
-            return (last_token = m_lexer.scan());
-        }
-
-        /*!
-        @throw parse_error.101 if expected token did not occur
-        */
-        void expect(typename lexer::token_type t)
-        {
-            if (JSON_UNLIKELY(t != last_token))
-            {
-                errored = true;
-                expected = t;
-                throw_exception();
-            }
-        }
-
-        [[noreturn]] void throw_exception() const
-        {
-            std::string error_msg = "syntax error - ";
-            if (last_token == lexer::token_type::parse_error)
-            {
-                error_msg += std::string(m_lexer.get_error_message()) + "; last read: '" + m_lexer.get_token_string() + "'";
-            }
-            else
-            {
-                error_msg += "unexpected " + std::string(lexer::token_type_name(last_token));
-            }
-
-            if (expected != lexer::token_type::uninitialized)
-            {
-                error_msg += "; expected " + std::string(lexer::token_type_name(expected));
-            }
-
-            JSON_THROW(parse_error::create(101, m_lexer.get_position(), error_msg));
-        }
-
-      private:
-        /// current level of recursion
-        int depth = 0;
-        /// callback function
-        const parser_callback_t callback = nullptr;
-        /// the type of the last read token
-        typename lexer::token_type last_token = lexer::token_type::uninitialized;
-        /// the lexer
-        lexer m_lexer;
-        /// whether a syntax error occurred
-        bool errored = false;
-        /// possible reason for the syntax error
-        typename lexer::token_type expected = lexer::token_type::uninitialized;
-    };
-
-  public:
     //////////////////////////
     // JSON Pointer support //
     //////////////////////////

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -115,6 +115,39 @@ SOFTWARE.
 */
 namespace nlohmann
 {
+template<typename = void, typename = void>
+struct adl_serializer;
+
+// forward declaration of basic_json (required to split the class)
+template <template <typename U, typename V, typename... Args> class ObjectType =
+          std::map,
+          template <typename U, typename... Args> class ArrayType = std::vector,
+          class StringType = std::string, class BooleanType = bool,
+          class NumberIntegerType = std::int64_t,
+          class NumberUnsignedType = std::uint64_t,
+          class NumberFloatType = double,
+          template <typename U> class AllocatorType = std::allocator,
+          template <typename T, typename SFINAE = void> class JSONSerializer =
+          adl_serializer>
+class basic_json;
+
+// Ugly macros to avoid uglier copy-paste when specializing basic_json
+// This is only temporary and will be removed in 3.0
+
+#define NLOHMANN_BASIC_JSON_TPL_DECLARATION                                    \
+    template <template <typename, typename, typename...> class ObjectType,       \
+              template <typename, typename...> class ArrayType,                  \
+              class StringType, class BooleanType, class NumberIntegerType,      \
+              class NumberUnsignedType, class NumberFloatType,                   \
+              template <typename> class AllocatorType,                           \
+              template <typename, typename = void> class JSONSerializer>
+
+#define NLOHMANN_BASIC_JSON_TPL                                                \
+    basic_json<ObjectType, ArrayType, StringType, BooleanType,                   \
+    NumberIntegerType, NumberUnsignedType, NumberFloatType,           \
+    AllocatorType, JSONSerializer>
+
+
 
 /*!
 @brief unnamed namespace with internal helper functions
@@ -1251,7 +1284,7 @@ This serializer ignores the template arguments and uses ADL
 ([argument-dependent lookup](http://en.cppreference.com/w/cpp/language/adl))
 for serialization.
 */
-template<typename = void, typename = void>
+template<typename, typename>
 struct adl_serializer
 {
     /*!
@@ -1369,25 +1402,13 @@ Format](http://rfc7159.net/rfc7159)
 
 @nosubgrouping
 */
-template <
-    template<typename U, typename V, typename... Args> class ObjectType = std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string,
-    class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer = adl_serializer
-    >
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
 class basic_json
 {
   private:
     template<detail::value_t> friend struct detail::external_constructor;
     /// workaround type for MSVC
-    using basic_json_t = basic_json<ObjectType, ArrayType, StringType,
-          BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType,
-          AllocatorType, JSONSerializer>;
+    using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
 
   public:
     using value_t = detail::value_t;
@@ -14512,5 +14533,7 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 #undef JSON_LIKELY
 #undef JSON_UNLIKELY
 #undef JSON_DEPRECATED
+#undef NLOHMANN_BASIC_JSON_TPL_DECLARATION
+#undef NLOHMANN_BASIC_JSON_TPL
 
 #endif

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -748,8 +748,7 @@ struct is_basic_json_nested_type
     static auto constexpr value = std::is_same<T, typename BasicJsonType::iterator>::value or
                                   std::is_same<T, typename BasicJsonType::const_iterator>::value or
                                   std::is_same<T, typename BasicJsonType::reverse_iterator>::value or
-                                  std::is_same<T, typename BasicJsonType::const_reverse_iterator>::value or
-                                  std::is_same<T, typename BasicJsonType::json_pointer>::value;
+                                  std::is_same<T, typename BasicJsonType::const_reverse_iterator>::value;
 };
 
 template<class BasicJsonType, class CompatibleArrayType>
@@ -1320,6 +1319,335 @@ struct adl_serializer
     }
 };
 
+/*!
+@brief JSON Pointer
+
+A JSON pointer defines a string syntax for identifying a specific value
+within a JSON document. It can be used with functions `at` and
+`operator[]`. Furthermore, JSON pointers are the base for JSON patches.
+
+@sa [RFC 6901](https://tools.ietf.org/html/rfc6901)
+
+@since version 2.0.0
+*/
+class json_pointer
+{
+    /// allow basic_json to access private members
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    friend class basic_json;
+
+  public:
+    /*!
+      @brief create JSON pointer
+
+      Create a JSON pointer according to the syntax described in
+      [Section 3 of RFC6901](https://tools.ietf.org/html/rfc6901#section-3).
+
+      @param[in] s  string representing the JSON pointer; if omitted, the
+      empty string is assumed which references the whole JSON
+      value
+
+      @throw parse_error.107 if the given JSON pointer @a s is nonempty and
+      does not begin with a slash (`/`); see example below
+
+      @throw parse_error.108 if a tilde (`~`) in the given JSON pointer @a s
+      is not followed by `0` (representing `~`) or `1` (representing `/`);
+      see example below
+
+      @liveexample{The example shows the construction several valid JSON
+      pointers as well as the exceptional behavior.,json_pointer}
+
+      @since version 2.0.0
+      */
+    explicit json_pointer(const std::string& s = "") : reference_tokens(split(s)) {}
+
+    /*!
+      @brief return a string representation of the JSON pointer
+
+      @invariant For each JSON pointer `ptr`, it holds:
+      @code {.cpp}
+      ptr == json_pointer(ptr.to_string());
+      @endcode
+
+      @return a string representation of the JSON pointer
+
+      @liveexample{The example shows the result of `to_string`.,
+      json_pointer__to_string}
+
+      @since version 2.0.0
+      */
+    std::string to_string() const noexcept
+    {
+        return std::accumulate(reference_tokens.begin(), reference_tokens.end(),
+                               std::string{},
+                               [](const std::string & a, const std::string & b)
+        {
+            return a + "/" + escape(b);
+        });
+    }
+
+    /// @copydoc to_string()
+    operator std::string() const
+    {
+        return to_string();
+    }
+
+  private:
+    /*!
+      @brief remove and return last reference pointer
+      @throw out_of_range.405 if JSON pointer has no parent
+      */
+    std::string pop_back()
+    {
+        if (is_root())
+        {
+            JSON_THROW(
+                detail::out_of_range::create(405, "JSON pointer has no parent"));
+        }
+
+        auto last = reference_tokens.back();
+        reference_tokens.pop_back();
+        return last;
+    }
+
+    /// return whether pointer points to the root document
+    bool is_root() const
+    {
+        return reference_tokens.empty();
+    }
+
+    json_pointer top() const
+    {
+        if (is_root())
+        {
+            JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
+        }
+
+        json_pointer result = *this;
+        result.reference_tokens = {reference_tokens[0]};
+        return result;
+    }
+
+
+    /*!
+      @brief create and return a reference to the pointed to value
+
+      @complexity Linear in the number of reference tokens.
+
+      @throw parse_error.109 if array index is not a number
+      @throw type_error.313 if value cannot be unflattened
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    NLOHMANN_BASIC_JSON_TPL& get_and_create(NLOHMANN_BASIC_JSON_TPL& j) const;
+
+    /*!
+      @brief return a reference to the pointed to value
+
+      @note This version does not throw if a value is not present, but tries
+      to create nested values instead. For instance, calling this function
+      with pointer `"/this/that"` on a null value is equivalent to calling
+      `operator[]("this").operator[]("that")` on that value, effectively
+      changing the null value to an object.
+
+      @param[in] ptr  a JSON value
+
+      @return reference to the JSON value pointed to by the JSON pointer
+
+      @complexity Linear in the length of the JSON pointer.
+
+      @throw parse_error.106   if an array index begins with '0'
+      @throw parse_error.109   if an array index was not a number
+      @throw out_of_range.404  if the JSON pointer can not be resolved
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    NLOHMANN_BASIC_JSON_TPL& get_unchecked(NLOHMANN_BASIC_JSON_TPL* ptr) const;
+
+    /*!
+      @throw parse_error.106   if an array index begins with '0'
+      @throw parse_error.109   if an array index was not a number
+      @throw out_of_range.402  if the array index '-' is used
+      @throw out_of_range.404  if the JSON pointer can not be resolved
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    NLOHMANN_BASIC_JSON_TPL& get_checked(NLOHMANN_BASIC_JSON_TPL* ptr) const;
+
+    /*!
+      @brief return a const reference to the pointed to value
+
+      @param[in] ptr  a JSON value
+
+      @return const reference to the JSON value pointed to by the JSON
+      pointer
+
+      @throw parse_error.106   if an array index begins with '0'
+      @throw parse_error.109   if an array index was not a number
+      @throw out_of_range.402  if the array index '-' is used
+      @throw out_of_range.404  if the JSON pointer can not be resolved
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    const NLOHMANN_BASIC_JSON_TPL& get_unchecked(const NLOHMANN_BASIC_JSON_TPL* ptr) const;
+
+    /*!
+      @throw parse_error.106   if an array index begins with '0'
+      @throw parse_error.109   if an array index was not a number
+      @throw out_of_range.402  if the array index '-' is used
+      @throw out_of_range.404  if the JSON pointer can not be resolved
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    const NLOHMANN_BASIC_JSON_TPL& get_checked(const NLOHMANN_BASIC_JSON_TPL* ptr) const;
+
+    /*!
+      @brief split the string input to reference tokens
+
+      @note This function is only called by the json_pointer constructor.
+      All exceptions below are documented there.
+
+      @throw parse_error.107  if the pointer is not empty or begins with '/'
+      @throw parse_error.108  if character '~' is not followed by '0' or '1'
+      */
+    static std::vector<std::string> split(const std::string& reference_string)
+    {
+        std::vector<std::string> result;
+
+        // special case: empty reference string -> no reference tokens
+        if (reference_string.empty())
+        {
+            return result;
+        }
+
+        // check if nonempty reference string begins with slash
+        if (reference_string[0] != '/')
+        {
+            JSON_THROW(detail::parse_error::create(
+                           107, 1,
+                           "JSON pointer must be empty or begin with '/' - was: '" +
+                           reference_string + "'"));
+        }
+
+        // extract the reference tokens:
+        // - slash: position of the last read slash (or end of string)
+        // - start: position after the previous slash
+        for (
+            // search for the first slash after the first character
+            size_t slash = reference_string.find_first_of('/', 1),
+            // set the beginning of the first reference token
+            start = 1;
+            // we can stop if start == string::npos+1 = 0
+            start != 0;
+            // set the beginning of the next reference token
+            // (will eventually be 0 if slash == std::string::npos)
+            start = slash + 1,
+            // find next slash
+            slash = reference_string.find_first_of('/', start))
+        {
+            // use the text between the beginning of the reference token
+            // (start) and the last slash (slash).
+            auto reference_token = reference_string.substr(start, slash - start);
+
+            // check reference tokens are properly escaped
+            for (size_t pos = reference_token.find_first_of('~');
+                    pos != std::string::npos;
+                    pos = reference_token.find_first_of('~', pos + 1))
+            {
+                assert(reference_token[pos] == '~');
+
+                // ~ must be followed by 0 or 1
+                if (pos == reference_token.size() - 1 or
+                        (reference_token[pos + 1] != '0' and
+                         reference_token[pos + 1] != '1'))
+                {
+                    JSON_THROW(detail::parse_error::create(
+                                   108, 0, "escape character '~' must be followed with '0' or '1'"));
+                }
+            }
+
+            // finally, store the reference token
+            unescape(reference_token);
+            result.push_back(reference_token);
+        }
+
+        return result;
+    }
+
+    /*!
+      @brief replace all occurrences of a substring by another string
+
+      @param[in,out] s  the string to manipulate; changed so that all
+      occurrences of @a f are replaced with @a t
+      @param[in]     f  the substring to replace with @a t
+      @param[in]     t  the string to replace @a f
+
+      @pre The search string @a f must not be empty. **This precondition is
+      enforced with an assertion.**
+
+      @since version 2.0.0
+      */
+    static void replace_substring(std::string& s, const std::string& f,
+                                  const std::string& t)
+    {
+        assert(not f.empty());
+
+        for (size_t pos = s.find(f);         // find first occurrence of f
+                pos != std::string::npos;       // make sure f was found
+                s.replace(pos, f.size(), t),    // replace with t
+                pos = s.find(f, pos + t.size()) // find next occurrence of f
+            )
+            ;
+    }
+
+    /// escape tilde and slash
+    static std::string escape(std::string s)
+    {
+        // escape "~"" to "~0" and "/" to "~1"
+        replace_substring(s, "~", "~0");
+        replace_substring(s, "/", "~1");
+        return s;
+    }
+
+    /// unescape tilde and slash
+    static void unescape(std::string& s)
+    {
+        // first transform any occurrence of the sequence '~1' to '/'
+        replace_substring(s, "~1", "/");
+        // then transform any occurrence of the sequence '~0' to '~'
+        replace_substring(s, "~0", "~");
+    }
+
+    /*!
+      @param[in] reference_string  the reference string to the current value
+      @param[in] value             the value to consider
+      @param[in,out] result        the result object to insert values to
+
+      @note Empty objects or arrays are flattened to `null`.
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    static void flatten(const std::string& reference_string,
+                        const NLOHMANN_BASIC_JSON_TPL& value,
+                        NLOHMANN_BASIC_JSON_TPL& result);
+
+    /*!
+      @param[in] value  flattened JSON
+
+      @return unflattened JSON
+
+      @throw parse_error.109 if array index is not a number
+      @throw type_error.314  if value is not an object
+      @throw type_error.315  if object values are not primitive
+      @throw type_error.313  if value cannot be unflattened
+      */
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    static NLOHMANN_BASIC_JSON_TPL
+    unflatten(const NLOHMANN_BASIC_JSON_TPL& value);
+
+    friend bool operator==(json_pointer const& lhs,
+                           json_pointer const& rhs) noexcept;
+
+    friend bool operator!=(json_pointer const& lhs,
+                           json_pointer const& rhs) noexcept;
+
+    /// the reference tokens
+    std::vector<std::string> reference_tokens;
+};
 
 /*!
 @brief a class to store JSON values
@@ -1409,13 +1737,14 @@ class basic_json
     template<detail::value_t> friend struct detail::external_constructor;
     /// workaround type for MSVC
     using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
+    friend ::nlohmann::json_pointer;
 
   public:
     using value_t = detail::value_t;
     // forward declarations
     template<typename U> class iter_impl;
     template<typename Base> class json_reverse_iterator;
-    class json_pointer;
+    using json_pointer = ::nlohmann::json_pointer;
     template<typename T, typename SFINAE>
     using json_serializer = JSONSerializer<T, SFINAE>;
 
@@ -13031,685 +13360,6 @@ scan_number_done:
     };
 
   public:
-    /*!
-    @brief JSON Pointer
-
-    A JSON pointer defines a string syntax for identifying a specific value
-    within a JSON document. It can be used with functions `at` and
-    `operator[]`. Furthermore, JSON pointers are the base for JSON patches.
-
-    @sa [RFC 6901](https://tools.ietf.org/html/rfc6901)
-
-    @since version 2.0.0
-    */
-    class json_pointer
-    {
-        /// allow basic_json to access private members
-        friend class basic_json;
-
-      public:
-        /*!
-        @brief create JSON pointer
-
-        Create a JSON pointer according to the syntax described in
-        [Section 3 of RFC6901](https://tools.ietf.org/html/rfc6901#section-3).
-
-        @param[in] s  string representing the JSON pointer; if omitted, the
-                      empty string is assumed which references the whole JSON
-                      value
-
-        @throw parse_error.107 if the given JSON pointer @a s is nonempty and
-        does not begin with a slash (`/`); see example below
-
-        @throw parse_error.108 if a tilde (`~`) in the given JSON pointer @a s
-        is not followed by `0` (representing `~`) or `1` (representing `/`);
-        see example below
-
-        @liveexample{The example shows the construction several valid JSON
-        pointers as well as the exceptional behavior.,json_pointer}
-
-        @since version 2.0.0
-        */
-        explicit json_pointer(const std::string& s = "")
-            : reference_tokens(split(s))
-        {}
-
-        /*!
-        @brief return a string representation of the JSON pointer
-
-        @invariant For each JSON pointer `ptr`, it holds:
-        @code {.cpp}
-        ptr == json_pointer(ptr.to_string());
-        @endcode
-
-        @return a string representation of the JSON pointer
-
-        @liveexample{The example shows the result of `to_string`.,
-        json_pointer__to_string}
-
-        @since version 2.0.0
-        */
-        std::string to_string() const noexcept
-        {
-            return std::accumulate(reference_tokens.begin(),
-                                   reference_tokens.end(), std::string{},
-                                   [](const std::string & a, const std::string & b)
-            {
-                return a + "/" + escape(b);
-            });
-        }
-
-        /// @copydoc to_string()
-        operator std::string() const
-        {
-            return to_string();
-        }
-
-      private:
-        /*!
-        @brief remove and return last reference pointer
-        @throw out_of_range.405 if JSON pointer has no parent
-        */
-        std::string pop_back()
-        {
-            if (is_root())
-            {
-                JSON_THROW(out_of_range::create(405, "JSON pointer has no parent"));
-            }
-
-            auto last = reference_tokens.back();
-            reference_tokens.pop_back();
-            return last;
-        }
-
-        /// return whether pointer points to the root document
-        bool is_root() const
-        {
-            return reference_tokens.empty();
-        }
-
-        json_pointer top() const
-        {
-            if (is_root())
-            {
-                JSON_THROW(out_of_range::create(405, "JSON pointer has no parent"));
-            }
-
-            json_pointer result = *this;
-            result.reference_tokens = {reference_tokens[0]};
-            return result;
-        }
-
-        /*!
-        @brief create and return a reference to the pointed to value
-
-        @complexity Linear in the number of reference tokens.
-
-        @throw parse_error.109 if array index is not a number
-        @throw type_error.313 if value cannot be unflattened
-        */
-        reference get_and_create(reference j) const
-        {
-            pointer result = &j;
-
-            // in case no reference tokens exist, return a reference to the
-            // JSON value j which will be overwritten by a primitive value
-            for (const auto& reference_token : reference_tokens)
-            {
-                switch (result->m_type)
-                {
-                    case value_t::null:
-                    {
-                        if (reference_token == "0")
-                        {
-                            // start a new array if reference token is 0
-                            result = &result->operator[](0);
-                        }
-                        else
-                        {
-                            // start a new object otherwise
-                            result = &result->operator[](reference_token);
-                        }
-                        break;
-                    }
-
-                    case value_t::object:
-                    {
-                        // create an entry in the object
-                        result = &result->operator[](reference_token);
-                        break;
-                    }
-
-                    case value_t::array:
-                    {
-                        // create an entry in the array
-                        JSON_TRY
-                        {
-                            result = &result->operator[](static_cast<size_type>(std::stoi(reference_token)));
-                        }
-                        JSON_CATCH (std::invalid_argument&)
-                        {
-                            JSON_THROW(parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                        }
-                        break;
-                    }
-
-                    /*
-                    The following code is only reached if there exists a
-                    reference token _and_ the current value is primitive. In
-                    this case, we have an error situation, because primitive
-                    values may only occur as single value; that is, with an
-                    empty list of reference tokens.
-                    */
-                    default:
-                    {
-                        JSON_THROW(type_error::create(313, "invalid value to unflatten"));
-                    }
-                }
-            }
-
-            return *result;
-        }
-
-        /*!
-        @brief return a reference to the pointed to value
-
-        @note This version does not throw if a value is not present, but tries
-        to create nested values instead. For instance, calling this function
-        with pointer `"/this/that"` on a null value is equivalent to calling
-        `operator[]("this").operator[]("that")` on that value, effectively
-        changing the null value to an object.
-
-        @param[in] ptr  a JSON value
-
-        @return reference to the JSON value pointed to by the JSON pointer
-
-        @complexity Linear in the length of the JSON pointer.
-
-        @throw parse_error.106   if an array index begins with '0'
-        @throw parse_error.109   if an array index was not a number
-        @throw out_of_range.404  if the JSON pointer can not be resolved
-        */
-        reference get_unchecked(pointer ptr) const
-        {
-            for (const auto& reference_token : reference_tokens)
-            {
-                // convert null values to arrays or objects before continuing
-                if (ptr->m_type == value_t::null)
-                {
-                    // check if reference token is a number
-                    const bool nums = std::all_of(reference_token.begin(),
-                                                  reference_token.end(),
-                                                  [](const char x)
-                    {
-                        return (x >= '0' and x <= '9');
-                    });
-
-                    // change value to array for numbers or "-" or to object
-                    // otherwise
-                    if (nums or reference_token == "-")
-                    {
-                        *ptr = value_t::array;
-                    }
-                    else
-                    {
-                        *ptr = value_t::object;
-                    }
-                }
-
-                switch (ptr->m_type)
-                {
-                    case value_t::object:
-                    {
-                        // use unchecked object access
-                        ptr = &ptr->operator[](reference_token);
-                        break;
-                    }
-
-                    case value_t::array:
-                    {
-                        // error condition (cf. RFC 6901, Sect. 4)
-                        if (reference_token.size() > 1 and reference_token[0] == '0')
-                        {
-                            JSON_THROW(parse_error::create(106, 0, "array index '" + reference_token + "' must not begin with '0'"));
-                        }
-
-                        if (reference_token == "-")
-                        {
-                            // explicitly treat "-" as index beyond the end
-                            ptr = &ptr->operator[](ptr->m_value.array->size());
-                        }
-                        else
-                        {
-                            // convert array index to number; unchecked access
-                            JSON_TRY
-                            {
-                                ptr = &ptr->operator[](static_cast<size_type>(std::stoi(reference_token)));
-                            }
-                            JSON_CATCH (std::invalid_argument&)
-                            {
-                                JSON_THROW(parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                            }
-                        }
-                        break;
-                    }
-
-                    default:
-                    {
-                        JSON_THROW(out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-                    }
-                }
-            }
-
-            return *ptr;
-        }
-
-        /*!
-        @throw parse_error.106   if an array index begins with '0'
-        @throw parse_error.109   if an array index was not a number
-        @throw out_of_range.402  if the array index '-' is used
-        @throw out_of_range.404  if the JSON pointer can not be resolved
-        */
-        reference get_checked(pointer ptr) const
-        {
-            for (const auto& reference_token : reference_tokens)
-            {
-                switch (ptr->m_type)
-                {
-                    case value_t::object:
-                    {
-                        // note: at performs range check
-                        ptr = &ptr->at(reference_token);
-                        break;
-                    }
-
-                    case value_t::array:
-                    {
-                        if (reference_token == "-")
-                        {
-                            // "-" always fails the range check
-                            JSON_THROW(out_of_range::create(402, "array index '-' (" +
-                                                            std::to_string(ptr->m_value.array->size()) +
-                                                            ") is out of range"));
-                        }
-
-                        // error condition (cf. RFC 6901, Sect. 4)
-                        if (reference_token.size() > 1 and reference_token[0] == '0')
-                        {
-                            JSON_THROW(parse_error::create(106, 0, "array index '" + reference_token + "' must not begin with '0'"));
-                        }
-
-                        // note: at performs range check
-                        JSON_TRY
-                        {
-                            ptr = &ptr->at(static_cast<size_type>(std::stoi(reference_token)));
-                        }
-                        JSON_CATCH (std::invalid_argument&)
-                        {
-                            JSON_THROW(parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                        }
-                        break;
-                    }
-
-                    default:
-                    {
-                        JSON_THROW(out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-                    }
-                }
-            }
-
-            return *ptr;
-        }
-
-        /*!
-        @brief return a const reference to the pointed to value
-
-        @param[in] ptr  a JSON value
-
-        @return const reference to the JSON value pointed to by the JSON
-                pointer
-
-        @throw parse_error.106   if an array index begins with '0'
-        @throw parse_error.109   if an array index was not a number
-        @throw out_of_range.402  if the array index '-' is used
-        @throw out_of_range.404  if the JSON pointer can not be resolved
-        */
-        const_reference get_unchecked(const_pointer ptr) const
-        {
-            for (const auto& reference_token : reference_tokens)
-            {
-                switch (ptr->m_type)
-                {
-                    case value_t::object:
-                    {
-                        // use unchecked object access
-                        ptr = &ptr->operator[](reference_token);
-                        break;
-                    }
-
-                    case value_t::array:
-                    {
-                        if (reference_token == "-")
-                        {
-                            // "-" cannot be used for const access
-                            JSON_THROW(out_of_range::create(402, "array index '-' (" +
-                                                            std::to_string(ptr->m_value.array->size()) +
-                                                            ") is out of range"));
-                        }
-
-                        // error condition (cf. RFC 6901, Sect. 4)
-                        if (reference_token.size() > 1 and reference_token[0] == '0')
-                        {
-                            JSON_THROW(parse_error::create(106, 0, "array index '" + reference_token + "' must not begin with '0'"));
-                        }
-
-                        // use unchecked array access
-                        JSON_TRY
-                        {
-                            ptr = &ptr->operator[](static_cast<size_type>(std::stoi(reference_token)));
-                        }
-                        JSON_CATCH (std::invalid_argument&)
-                        {
-                            JSON_THROW(parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                        }
-                        break;
-                    }
-
-                    default:
-                    {
-                        JSON_THROW(out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-                    }
-                }
-            }
-
-            return *ptr;
-        }
-
-        /*!
-        @throw parse_error.106   if an array index begins with '0'
-        @throw parse_error.109   if an array index was not a number
-        @throw out_of_range.402  if the array index '-' is used
-        @throw out_of_range.404  if the JSON pointer can not be resolved
-        */
-        const_reference get_checked(const_pointer ptr) const
-        {
-            for (const auto& reference_token : reference_tokens)
-            {
-                switch (ptr->m_type)
-                {
-                    case value_t::object:
-                    {
-                        // note: at performs range check
-                        ptr = &ptr->at(reference_token);
-                        break;
-                    }
-
-                    case value_t::array:
-                    {
-                        if (reference_token == "-")
-                        {
-                            // "-" always fails the range check
-                            JSON_THROW(out_of_range::create(402, "array index '-' (" +
-                                                            std::to_string(ptr->m_value.array->size()) +
-                                                            ") is out of range"));
-                        }
-
-                        // error condition (cf. RFC 6901, Sect. 4)
-                        if (reference_token.size() > 1 and reference_token[0] == '0')
-                        {
-                            JSON_THROW(parse_error::create(106, 0, "array index '" + reference_token + "' must not begin with '0'"));
-                        }
-
-                        // note: at performs range check
-                        JSON_TRY
-                        {
-                            ptr = &ptr->at(static_cast<size_type>(std::stoi(reference_token)));
-                        }
-                        JSON_CATCH (std::invalid_argument&)
-                        {
-                            JSON_THROW(parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                        }
-                        break;
-                    }
-
-                    default:
-                    {
-                        JSON_THROW(out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-                    }
-                }
-            }
-
-            return *ptr;
-        }
-
-        /*!
-        @brief split the string input to reference tokens
-
-        @note This function is only called by the json_pointer constructor.
-              All exceptions below are documented there.
-
-        @throw parse_error.107  if the pointer is not empty or begins with '/'
-        @throw parse_error.108  if character '~' is not followed by '0' or '1'
-        */
-        static std::vector<std::string> split(const std::string& reference_string)
-        {
-            std::vector<std::string> result;
-
-            // special case: empty reference string -> no reference tokens
-            if (reference_string.empty())
-            {
-                return result;
-            }
-
-            // check if nonempty reference string begins with slash
-            if (reference_string[0] != '/')
-            {
-                JSON_THROW(parse_error::create(107, 1, "JSON pointer must be empty or begin with '/' - was: '" + reference_string + "'"));
-            }
-
-            // extract the reference tokens:
-            // - slash: position of the last read slash (or end of string)
-            // - start: position after the previous slash
-            for (
-                // search for the first slash after the first character
-                size_t slash = reference_string.find_first_of('/', 1),
-                // set the beginning of the first reference token
-                start = 1;
-                // we can stop if start == string::npos+1 = 0
-                start != 0;
-                // set the beginning of the next reference token
-                // (will eventually be 0 if slash == std::string::npos)
-                start = slash + 1,
-                // find next slash
-                slash = reference_string.find_first_of('/', start))
-            {
-                // use the text between the beginning of the reference token
-                // (start) and the last slash (slash).
-                auto reference_token = reference_string.substr(start, slash - start);
-
-                // check reference tokens are properly escaped
-                for (size_t pos = reference_token.find_first_of('~');
-                        pos != std::string::npos;
-                        pos = reference_token.find_first_of('~', pos + 1))
-                {
-                    assert(reference_token[pos] == '~');
-
-                    // ~ must be followed by 0 or 1
-                    if (pos == reference_token.size() - 1 or
-                            (reference_token[pos + 1] != '0' and
-                             reference_token[pos + 1] != '1'))
-                    {
-                        JSON_THROW(parse_error::create(108, 0, "escape character '~' must be followed with '0' or '1'"));
-                    }
-                }
-
-                // finally, store the reference token
-                unescape(reference_token);
-                result.push_back(reference_token);
-            }
-
-            return result;
-        }
-
-        /*!
-        @brief replace all occurrences of a substring by another string
-
-        @param[in,out] s  the string to manipulate; changed so that all
-                          occurrences of @a f are replaced with @a t
-        @param[in]     f  the substring to replace with @a t
-        @param[in]     t  the string to replace @a f
-
-        @pre The search string @a f must not be empty. **This precondition is
-             enforced with an assertion.**
-
-        @since version 2.0.0
-        */
-        static void replace_substring(std::string& s,
-                                      const std::string& f,
-                                      const std::string& t)
-        {
-            assert(not f.empty());
-
-            for (
-                size_t pos = s.find(f);         // find first occurrence of f
-                pos != std::string::npos;       // make sure f was found
-                s.replace(pos, f.size(), t),    // replace with t
-                pos = s.find(f, pos + t.size()) // find next occurrence of f
-            );
-        }
-
-        /// escape tilde and slash
-        static std::string escape(std::string s)
-        {
-            // escape "~"" to "~0" and "/" to "~1"
-            replace_substring(s, "~", "~0");
-            replace_substring(s, "/", "~1");
-            return s;
-        }
-
-        /// unescape tilde and slash
-        static void unescape(std::string& s)
-        {
-            // first transform any occurrence of the sequence '~1' to '/'
-            replace_substring(s, "~1", "/");
-            // then transform any occurrence of the sequence '~0' to '~'
-            replace_substring(s, "~0", "~");
-        }
-
-        /*!
-        @param[in] reference_string  the reference string to the current value
-        @param[in] value             the value to consider
-        @param[in,out] result        the result object to insert values to
-
-        @note Empty objects or arrays are flattened to `null`.
-        */
-        static void flatten(const std::string& reference_string,
-                            const basic_json& value,
-                            basic_json& result)
-        {
-            switch (value.m_type)
-            {
-                case value_t::array:
-                {
-                    if (value.m_value.array->empty())
-                    {
-                        // flatten empty array as null
-                        result[reference_string] = nullptr;
-                    }
-                    else
-                    {
-                        // iterate array and use index as reference string
-                        for (size_t i = 0; i < value.m_value.array->size(); ++i)
-                        {
-                            flatten(reference_string + "/" + std::to_string(i),
-                                    value.m_value.array->operator[](i), result);
-                        }
-                    }
-                    break;
-                }
-
-                case value_t::object:
-                {
-                    if (value.m_value.object->empty())
-                    {
-                        // flatten empty object as null
-                        result[reference_string] = nullptr;
-                    }
-                    else
-                    {
-                        // iterate object and use keys as reference string
-                        for (const auto& element : *value.m_value.object)
-                        {
-                            flatten(reference_string + "/" + escape(element.first),
-                                    element.second, result);
-                        }
-                    }
-                    break;
-                }
-
-                default:
-                {
-                    // add primitive value with its reference string
-                    result[reference_string] = value;
-                    break;
-                }
-            }
-        }
-
-        /*!
-        @param[in] value  flattened JSON
-
-        @return unflattened JSON
-
-        @throw parse_error.109 if array index is not a number
-        @throw type_error.314  if value is not an object
-        @throw type_error.315  if object values are not primitive
-        @throw type_error.313  if value cannot be unflattened
-        */
-        static basic_json unflatten(const basic_json& value)
-        {
-            if (not value.is_object())
-            {
-                JSON_THROW(type_error::create(314, "only objects can be unflattened"));
-            }
-
-            basic_json result;
-
-            // iterate the JSON object values
-            for (const auto& element : *value.m_value.object)
-            {
-                if (not element.second.is_primitive())
-                {
-                    JSON_THROW(type_error::create(315, "values in object must be primitive"));
-                }
-
-                // assign value to reference pointed to by JSON pointer; Note
-                // that if the JSON pointer is "" (i.e., points to the whole
-                // value), function get_and_create returns a reference to
-                // result itself. An assignment will then create a primitive
-                // value.
-                json_pointer(element.first).get_and_create(result) = element.second;
-            }
-
-            return result;
-        }
-
-        friend bool operator==(json_pointer const& lhs,
-                               json_pointer const& rhs) noexcept
-        {
-            return lhs.reference_tokens == rhs.reference_tokens;
-        }
-
-        friend bool operator!=(json_pointer const& lhs,
-                               json_pointer const& rhs) noexcept
-        {
-            return !(lhs == rhs);
-        }
-
-        /// the reference tokens
-        std::vector<std::string> reference_tokens {};
-    };
-
     //////////////////////////
     // JSON Pointer support //
     //////////////////////////
@@ -14423,6 +14073,432 @@ uses the standard template types.
 @since version 1.0.0
 */
 using json = basic_json<>;
+
+//////////////////
+// json_pointer //
+//////////////////
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+NLOHMANN_BASIC_JSON_TPL&
+json_pointer::get_and_create(NLOHMANN_BASIC_JSON_TPL& j) const
+{
+    using size_type = typename NLOHMANN_BASIC_JSON_TPL::size_type;
+    auto result = &j;
+
+    // in case no reference tokens exist, return a reference to the
+    // JSON value j which will be overwritten by a primitive value
+    for (const auto& reference_token : reference_tokens)
+    {
+        switch (result->m_type)
+        {
+            case detail::value_t::null:
+            {
+                if (reference_token == "0")
+                {
+                    // start a new array if reference token is 0
+                    result = &result->operator[](0);
+                }
+                else
+                {
+                    // start a new object otherwise
+                    result = &result->operator[](reference_token);
+                }
+                break;
+            }
+
+            case detail::value_t::object:
+            {
+                // create an entry in the object
+                result = &result->operator[](reference_token);
+                break;
+            }
+
+            case detail::value_t::array:
+            {
+                // create an entry in the array
+                JSON_TRY
+                {
+                    result = &result->operator[](
+                        static_cast<size_type>(std::stoi(reference_token)));
+                }
+                JSON_CATCH(std::invalid_argument&)
+                {
+                    JSON_THROW(detail::parse_error::create(
+                                   109, 0, "array index '" + reference_token + "' is not a number"));
+                }
+                break;
+            }
+
+            /*
+            The following code is only reached if there exists a
+            reference token _and_ the current value is primitive. In
+            this case, we have an error situation, because primitive
+            values may only occur as single value; that is, with an
+            empty list of reference tokens.
+            */
+            default:
+            {
+                JSON_THROW(detail::type_error::create(313, "invalid value to unflatten"));
+            }
+        }
+    }
+
+    return *result;
+}
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+NLOHMANN_BASIC_JSON_TPL&
+json_pointer::get_unchecked(NLOHMANN_BASIC_JSON_TPL* ptr) const
+{
+    using size_type = typename NLOHMANN_BASIC_JSON_TPL::size_type;
+    for (const auto& reference_token : reference_tokens)
+    {
+        // convert null values to arrays or objects before continuing
+        if (ptr->m_type == detail::value_t::null)
+        {
+            // check if reference token is a number
+            const bool nums =
+                std::all_of(reference_token.begin(), reference_token.end(),
+                            [](const char x)
+            {
+                return (x >= '0' and x <= '9');
+            });
+
+            // change value to array for numbers or "-" or to object
+            // otherwise
+            if (nums or reference_token == "-")
+            {
+                *ptr = detail::value_t::array;
+            }
+            else
+            {
+                *ptr = detail::value_t::object;
+            }
+        }
+
+        switch (ptr->m_type)
+        {
+            case detail::value_t::object:
+            {
+                // use unchecked object access
+                ptr = &ptr->operator[](reference_token);
+                break;
+            }
+
+            case detail::value_t::array:
+            {
+                // error condition (cf. RFC 6901, Sect. 4)
+                if (reference_token.size() > 1 and reference_token[0] == '0')
+                {
+                    JSON_THROW(detail::parse_error::create(106, 0,
+                                                           "array index '" + reference_token +
+                                                           "' must not begin with '0'"));
+                }
+
+                if (reference_token == "-")
+                {
+                    // explicitly treat "-" as index beyond the end
+                    ptr = &ptr->operator[](ptr->m_value.array->size());
+                }
+                else
+                {
+                    // convert array index to number; unchecked access
+                    JSON_TRY
+                    {
+                        ptr = &ptr->operator[](
+                            static_cast<size_type>(std::stoi(reference_token)));
+                    }
+                    JSON_CATCH(std::invalid_argument&)
+                    {
+                        JSON_THROW(detail::parse_error::create(
+                                       109, 0, "array index '" + reference_token + "' is not a number"));
+                    }
+                }
+                break;
+            }
+
+            default:
+            {
+                JSON_THROW(detail::out_of_range::create(
+                               404, "unresolved reference token '" + reference_token + "'"));
+            }
+        }
+    }
+
+    return *ptr;
+}
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+NLOHMANN_BASIC_JSON_TPL&
+json_pointer::get_checked(NLOHMANN_BASIC_JSON_TPL* ptr) const
+{
+    using size_type = typename NLOHMANN_BASIC_JSON_TPL::size_type;
+    for (const auto& reference_token : reference_tokens)
+    {
+        switch (ptr->m_type)
+        {
+            case detail::value_t::object:
+            {
+                // note: at performs range check
+                ptr = &ptr->at(reference_token);
+                break;
+            }
+
+            case detail::value_t::array:
+            {
+                if (reference_token == "-")
+                {
+                    // "-" always fails the range check
+                    JSON_THROW(detail::out_of_range::create(
+                                   402,
+                                   "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
+                                   ") is out of range"));
+                }
+
+                // error condition (cf. RFC 6901, Sect. 4)
+                if (reference_token.size() > 1 and reference_token[0] == '0')
+                {
+                    JSON_THROW(detail::parse_error::create(106, 0,
+                                                           "array index '" + reference_token +
+                                                           "' must not begin with '0'"));
+                }
+
+                // note: at performs range check
+                JSON_TRY
+                {
+                    ptr = &ptr->at(static_cast<size_type>(std::stoi(reference_token)));
+                }
+                JSON_CATCH(std::invalid_argument&)
+                {
+                    JSON_THROW(detail::parse_error::create(
+                                   109, 0, "array index '" + reference_token + "' is not a number"));
+                }
+                break;
+            }
+
+            default:
+            {
+                JSON_THROW(detail::out_of_range::create(
+                               404, "unresolved reference token '" + reference_token + "'"));
+            }
+        }
+    }
+
+    return *ptr;
+}
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+const NLOHMANN_BASIC_JSON_TPL&
+json_pointer::get_unchecked(const NLOHMANN_BASIC_JSON_TPL* ptr) const
+{
+    using size_type = typename NLOHMANN_BASIC_JSON_TPL::size_type;
+    for (const auto& reference_token : reference_tokens)
+    {
+        switch (ptr->m_type)
+        {
+            case detail::value_t::object:
+            {
+                // use unchecked object access
+                ptr = &ptr->operator[](reference_token);
+                break;
+            }
+
+            case detail::value_t::array:
+            {
+                if (reference_token == "-")
+                {
+                    // "-" cannot be used for const access
+                    JSON_THROW(detail::out_of_range::create(
+                                   402,
+                                   "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
+                                   ") is out of range"));
+                }
+
+                // error condition (cf. RFC 6901, Sect. 4)
+                if (reference_token.size() > 1 and reference_token[0] == '0')
+                {
+                    JSON_THROW(detail::parse_error::create(106, 0,
+                                                           "array index '" + reference_token +
+                                                           "' must not begin with '0'"));
+                }
+
+                // use unchecked array access
+                JSON_TRY
+                {
+                    ptr = &ptr->operator[](
+                        static_cast<size_type>(std::stoi(reference_token)));
+                }
+                JSON_CATCH(std::invalid_argument&)
+                {
+                    JSON_THROW(detail::parse_error::create(
+                                   109, 0, "array index '" + reference_token + "' is not a number"));
+                }
+                break;
+            }
+
+            default:
+            {
+                JSON_THROW(detail::out_of_range::create(
+                               404, "unresolved reference token '" + reference_token + "'"));
+            }
+        }
+    }
+
+    return *ptr;
+}
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+const NLOHMANN_BASIC_JSON_TPL&
+json_pointer::get_checked(const NLOHMANN_BASIC_JSON_TPL* ptr) const
+{
+    using size_type = typename NLOHMANN_BASIC_JSON_TPL::size_type;
+    for (const auto& reference_token : reference_tokens)
+    {
+        switch (ptr->m_type)
+        {
+            case detail::value_t::object:
+            {
+                // note: at performs range check
+                ptr = &ptr->at(reference_token);
+                break;
+            }
+
+            case detail::value_t::array:
+            {
+                if (reference_token == "-")
+                {
+                    // "-" always fails the range check
+                    JSON_THROW(detail::out_of_range::create(
+                                   402,
+                                   "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
+                                   ") is out of range"));
+                }
+
+                // error condition (cf. RFC 6901, Sect. 4)
+                if (reference_token.size() > 1 and reference_token[0] == '0')
+                {
+                    JSON_THROW(detail::parse_error::create(106, 0,
+                                                           "array index '" + reference_token +
+                                                           "' must not begin with '0'"));
+                }
+
+                // note: at performs range check
+                JSON_TRY
+                {
+                    ptr = &ptr->at(static_cast<size_type>(std::stoi(reference_token)));
+                }
+                JSON_CATCH(std::invalid_argument&)
+                {
+                    JSON_THROW(detail::parse_error::create(
+                                   109, 0, "array index '" + reference_token + "' is not a number"));
+                }
+                break;
+            }
+
+            default:
+            {
+                JSON_THROW(detail::out_of_range::create(
+                               404, "unresolved reference token '" + reference_token + "'"));
+            }
+        }
+    }
+
+    return *ptr;
+}
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+void json_pointer::flatten(const std::string& reference_string,
+                           const NLOHMANN_BASIC_JSON_TPL& value,
+                           NLOHMANN_BASIC_JSON_TPL& result)
+{
+    switch (value.m_type)
+    {
+        case detail::value_t::array:
+        {
+            if (value.m_value.array->empty())
+            {
+                // flatten empty array as null
+                result[reference_string] = nullptr;
+            }
+            else
+            {
+                // iterate array and use index as reference string
+                for (size_t i = 0; i < value.m_value.array->size(); ++i)
+                {
+                    flatten(reference_string + "/" + std::to_string(i),
+                            value.m_value.array->operator[](i), result);
+                }
+            }
+            break;
+        }
+
+        case detail::value_t::object:
+        {
+            if (value.m_value.object->empty())
+            {
+                // flatten empty object as null
+                result[reference_string] = nullptr;
+            }
+            else
+            {
+                // iterate object and use keys as reference string
+                for (const auto& element : *value.m_value.object)
+                {
+                    flatten(reference_string + "/" + escape(element.first), element.second,
+                            result);
+                }
+            }
+            break;
+        }
+
+        default:
+        {
+            // add primitive value with its reference string
+            result[reference_string] = value;
+            break;
+        }
+    }
+}
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+NLOHMANN_BASIC_JSON_TPL
+json_pointer::unflatten(const NLOHMANN_BASIC_JSON_TPL& value)
+{
+    if (not value.is_object())
+    {
+        JSON_THROW(detail::type_error::create(314, "only objects can be unflattened"));
+    }
+
+    NLOHMANN_BASIC_JSON_TPL result;
+
+    // iterate the JSON object values
+    for (const auto& element : *value.m_value.object)
+    {
+        if (not element.second.is_primitive())
+        {
+            JSON_THROW(detail::type_error::create(315, "values in object must be primitive"));
+        }
+
+        // assign value to reference pointed to by JSON pointer; Note
+        // that if the JSON pointer is "" (i.e., points to the whole
+        // value), function get_and_create returns a reference to
+        // result itself. An assignment will then create a primitive
+        // value.
+        json_pointer(element.first).get_and_create(result) = element.second;
+    }
+
+    return result;
+}
+
+inline bool operator==(json_pointer const& lhs, json_pointer const& rhs) noexcept
+{
+    return lhs.reference_tokens == rhs.reference_tokens;
+}
+
+inline bool operator!=(json_pointer const& lhs, json_pointer const& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
 } // namespace nlohmann
 
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3569,6 +3569,152 @@ class parser
     /// possible reason for the syntax error
     token_type expected = token_type::uninitialized;
 };
+
+///////////////
+// iterators //
+///////////////
+
+/*!
+@brief an iterator for primitive JSON types
+
+This class models an iterator for primitive JSON types (boolean, number,
+string). It's only purpose is to allow the iterator/const_iterator classes
+to "iterate" over primitive values. Internally, the iterator is modeled by
+a `difference_type` variable. Value begin_value (`0`) models the begin,
+end_value (`1`) models past the end.
+*/
+class primitive_iterator_t
+{
+  public:
+    using difference_type = std::ptrdiff_t;
+
+    difference_type get_value() const noexcept
+    {
+        return m_it;
+    }
+    /// set iterator to a defined beginning
+    void set_begin() noexcept
+    {
+        m_it = begin_value;
+    }
+
+    /// set iterator to a defined past the end
+    void set_end() noexcept
+    {
+        m_it = end_value;
+    }
+
+    /// return whether the iterator can be dereferenced
+    constexpr bool is_begin() const noexcept
+    {
+        return (m_it == begin_value);
+    }
+
+    /// return whether the iterator is at end
+    constexpr bool is_end() const noexcept
+    {
+        return (m_it == end_value);
+    }
+
+    friend constexpr bool operator==(primitive_iterator_t lhs,
+                                     primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it == rhs.m_it;
+    }
+
+    friend constexpr bool operator!=(primitive_iterator_t lhs,
+                                     primitive_iterator_t rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    friend constexpr bool operator<(primitive_iterator_t lhs,
+                                    primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it < rhs.m_it;
+    }
+
+    friend constexpr bool operator<=(primitive_iterator_t lhs,
+                                     primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it <= rhs.m_it;
+    }
+
+    friend constexpr bool operator>(primitive_iterator_t lhs,
+                                    primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it > rhs.m_it;
+    }
+
+    friend constexpr bool operator>=(primitive_iterator_t lhs,
+                                     primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it >= rhs.m_it;
+    }
+
+    primitive_iterator_t operator+(difference_type i)
+    {
+        auto result = *this;
+        result += i;
+        return result;
+    }
+
+    friend constexpr difference_type
+    operator-(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it - rhs.m_it;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, primitive_iterator_t it)
+    {
+        return os << it.m_it;
+    }
+
+    primitive_iterator_t& operator++()
+    {
+        ++m_it;
+        return *this;
+    }
+
+    primitive_iterator_t operator++(int)
+    {
+        auto result = *this;
+        m_it++;
+        return result;
+    }
+
+    primitive_iterator_t& operator--()
+    {
+        --m_it;
+        return *this;
+    }
+
+    primitive_iterator_t operator--(int)
+    {
+        auto result = *this;
+        m_it--;
+        return result;
+    }
+
+    primitive_iterator_t& operator+=(difference_type n)
+    {
+        m_it += n;
+        return *this;
+    }
+
+    primitive_iterator_t& operator-=(difference_type n)
+    {
+        m_it -= n;
+        return *this;
+    }
+
+  private:
+    static constexpr difference_type begin_value = 0;
+    static constexpr difference_type end_value = begin_value + 1;
+
+    /// iterator as signed integer type
+    difference_type m_it = std::numeric_limits<std::ptrdiff_t>::denorm_min();
+};
 } // namespace detail
 
 /// namespace to hold default `to_json` / `from_json` functions
@@ -4046,6 +4192,8 @@ class basic_json
     // convenience aliases for types residing in namespace detail;
     using lexer = ::nlohmann::detail::lexer<basic_json>;
     using parser = ::nlohmann::detail::parser<basic_json>;
+
+    using primitive_iterator_t = ::nlohmann::detail::primitive_iterator_t;
 
   public:
     using value_t = detail::value_t;
@@ -10405,144 +10553,6 @@ class basic_json
 
 
   private:
-    ///////////////
-    // iterators //
-    ///////////////
-
-    /*!
-    @brief an iterator for primitive JSON types
-
-    This class models an iterator for primitive JSON types (boolean, number,
-    string). It's only purpose is to allow the iterator/const_iterator classes
-    to "iterate" over primitive values. Internally, the iterator is modeled by
-    a `difference_type` variable. Value begin_value (`0`) models the begin,
-    end_value (`1`) models past the end.
-    */
-    class primitive_iterator_t
-    {
-      public:
-
-        difference_type get_value() const noexcept
-        {
-            return m_it;
-        }
-        /// set iterator to a defined beginning
-        void set_begin() noexcept
-        {
-            m_it = begin_value;
-        }
-
-        /// set iterator to a defined past the end
-        void set_end() noexcept
-        {
-            m_it = end_value;
-        }
-
-        /// return whether the iterator can be dereferenced
-        constexpr bool is_begin() const noexcept
-        {
-            return (m_it == begin_value);
-        }
-
-        /// return whether the iterator is at end
-        constexpr bool is_end() const noexcept
-        {
-            return (m_it == end_value);
-        }
-
-        friend constexpr bool operator==(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return lhs.m_it == rhs.m_it;
-        }
-
-        friend constexpr bool operator!=(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return !(lhs == rhs);
-        }
-
-        friend constexpr bool operator<(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return lhs.m_it < rhs.m_it;
-        }
-
-        friend constexpr bool operator<=(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return lhs.m_it <= rhs.m_it;
-        }
-
-        friend constexpr bool operator>(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return lhs.m_it > rhs.m_it;
-        }
-
-        friend constexpr bool operator>=(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return lhs.m_it >= rhs.m_it;
-        }
-
-        primitive_iterator_t operator+(difference_type i)
-        {
-            auto result = *this;
-            result += i;
-            return result;
-        }
-
-        friend constexpr difference_type operator-(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-        {
-            return lhs.m_it - rhs.m_it;
-        }
-
-        friend std::ostream& operator<<(std::ostream& os, primitive_iterator_t it)
-        {
-            return os << it.m_it;
-        }
-
-        primitive_iterator_t& operator++()
-        {
-            ++m_it;
-            return *this;
-        }
-
-        primitive_iterator_t operator++(int)
-        {
-            auto result = *this;
-            m_it++;
-            return result;
-        }
-
-        primitive_iterator_t& operator--()
-        {
-            --m_it;
-            return *this;
-        }
-
-        primitive_iterator_t operator--(int)
-        {
-            auto result = *this;
-            m_it--;
-            return result;
-        }
-
-        primitive_iterator_t& operator+=(difference_type n)
-        {
-            m_it += n;
-            return *this;
-        }
-
-        primitive_iterator_t& operator-=(difference_type n)
-        {
-            m_it -= n;
-            return *this;
-        }
-
-      private:
-        static constexpr difference_type begin_value = 0;
-        static constexpr difference_type end_value = begin_value + 1;
-
-        /// iterator as signed integer type
-        difference_type m_it = std::numeric_limits<std::ptrdiff_t>::denorm_min();
-    };
-
     /*!
     @brief an iterator value
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -4564,6 +4564,1820 @@ class json_reverse_iterator : public std::reverse_iterator<Base>
         return it.operator * ();
     }
 };
+
+/////////////////////
+// output adapters //
+/////////////////////
+
+/// abstract output adapter interface
+template <typename CharType> class output_adapter
+{
+  public:
+    virtual void write_character(CharType c) = 0;
+    virtual void write_characters(const CharType* s, size_t length) = 0;
+    virtual ~output_adapter() {}
+};
+
+/// a type to simplify interfaces
+template <typename CharType>
+using output_adapter_t = std::shared_ptr<output_adapter<CharType>>;
+
+/// output adapter for byte vectors
+template <typename CharType>
+class output_vector_adapter : public output_adapter<CharType>
+{
+  public:
+    output_vector_adapter(std::vector<CharType>& vec) : v(vec) {}
+
+    void write_character(CharType c) override
+    {
+        v.push_back(c);
+    }
+
+    void write_characters(const CharType* s, size_t length) override
+    {
+        std::copy(s, s + length, std::back_inserter(v));
+    }
+
+  private:
+    std::vector<CharType>& v;
+};
+
+/// output adapter for output streams
+template <typename CharType>
+class output_stream_adapter : public output_adapter<CharType>
+{
+  public:
+    output_stream_adapter(std::basic_ostream<CharType>& s) : stream(s) {}
+
+    void write_character(CharType c) override
+    {
+        stream.put(c);
+    }
+
+    void write_characters(const CharType* s, size_t length) override
+    {
+        stream.write(s, static_cast<std::streamsize>(length));
+    }
+
+  private:
+    std::basic_ostream<CharType>& stream;
+};
+
+/// output adapter for basic_string
+template <typename CharType>
+class output_string_adapter : public output_adapter<CharType>
+{
+  public:
+    output_string_adapter(std::string& s) : str(s) {}
+
+    void write_character(CharType c) override
+    {
+        str.push_back(c);
+    }
+
+    void write_characters(const CharType* s, size_t length) override
+    {
+        str.append(s, length);
+    }
+
+  private:
+    std::basic_string<CharType>& str;
+};
+
+template <typename CharType> struct output_adapter_factory
+{
+    static std::shared_ptr<output_adapter<CharType>>
+            create(std::vector<CharType>& vec)
+    {
+        return std::make_shared<output_vector_adapter<CharType>>(vec);
+    }
+
+    static std::shared_ptr<output_adapter<CharType>> create(std::ostream& s)
+    {
+        return std::make_shared<output_stream_adapter<CharType>>(s);
+    }
+
+    static std::shared_ptr<output_adapter<CharType>> create(std::string& s)
+    {
+        return std::make_shared<output_string_adapter<CharType>>(s);
+    }
+};
+
+//////////////////////////////
+// binary reader and writer //
+//////////////////////////////
+
+/*!
+@brief deserialization of CBOR and MessagePack values
+*/
+template <typename BasicJsonType>
+class binary_reader
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+
+  public:
+    /*!
+    @brief create a binary reader
+
+    @param[in] adapter  input adapter to read from
+    */
+    explicit binary_reader(input_adapter_t adapter)
+        : ia(adapter), is_little_endian(little_endianess())
+    {
+        assert(ia);
+    }
+
+    /*!
+    @brief create a JSON value from CBOR input
+
+    @param[in] get_char  whether a new character should be retrieved from
+                         the input (true, default) or whether the last
+                         read character should be considered instead
+
+    @return JSON value created from CBOR input
+
+    @throw parse_error.110 if input ended unexpectedly
+    @throw parse_error.112 if unsupported byte was read
+    */
+    BasicJsonType parse_cbor(const bool get_char = true)
+    {
+        switch (get_char ? get() : current)
+        {
+            // EOF
+            case std::char_traits<char>::eof():
+            {
+                JSON_THROW(
+                    parse_error::create(110, chars_read, "unexpected end of input"));
+            }
+
+            // Integer 0x00..0x17 (0..23)
+            case 0x00:
+            case 0x01:
+            case 0x02:
+            case 0x03:
+            case 0x04:
+            case 0x05:
+            case 0x06:
+            case 0x07:
+            case 0x08:
+            case 0x09:
+            case 0x0a:
+            case 0x0b:
+            case 0x0c:
+            case 0x0d:
+            case 0x0e:
+            case 0x0f:
+            case 0x10:
+            case 0x11:
+            case 0x12:
+            case 0x13:
+            case 0x14:
+            case 0x15:
+            case 0x16:
+            case 0x17:
+            {
+                return static_cast<number_unsigned_t>(current);
+            }
+
+            case 0x18: // Unsigned integer (one-byte uint8_t follows)
+            {
+                return get_number<uint8_t>();
+            }
+
+            case 0x19: // Unsigned integer (two-byte uint16_t follows)
+            {
+                return get_number<uint16_t>();
+            }
+
+            case 0x1a: // Unsigned integer (four-byte uint32_t follows)
+            {
+                return get_number<uint32_t>();
+            }
+
+            case 0x1b: // Unsigned integer (eight-byte uint64_t follows)
+            {
+                return get_number<uint64_t>();
+            }
+
+            // Negative integer -1-0x00..-1-0x17 (-1..-24)
+            case 0x20:
+            case 0x21:
+            case 0x22:
+            case 0x23:
+            case 0x24:
+            case 0x25:
+            case 0x26:
+            case 0x27:
+            case 0x28:
+            case 0x29:
+            case 0x2a:
+            case 0x2b:
+            case 0x2c:
+            case 0x2d:
+            case 0x2e:
+            case 0x2f:
+            case 0x30:
+            case 0x31:
+            case 0x32:
+            case 0x33:
+            case 0x34:
+            case 0x35:
+            case 0x36:
+            case 0x37:
+            {
+                return static_cast<int8_t>(0x20 - 1 - current);
+            }
+
+            case 0x38: // Negative integer (one-byte uint8_t follows)
+            {
+                // must be uint8_t !
+                return static_cast<number_integer_t>(-1) - get_number<uint8_t>();
+            }
+
+            case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
+            {
+                return static_cast<number_integer_t>(-1) - get_number<uint16_t>();
+            }
+
+            case 0x3a: // Negative integer -1-n (four-byte uint32_t follows)
+            {
+                return static_cast<number_integer_t>(-1) - get_number<uint32_t>();
+            }
+
+            case 0x3b: // Negative integer -1-n (eight-byte uint64_t follows)
+            {
+                return static_cast<number_integer_t>(-1) -
+                       static_cast<number_integer_t>(get_number<uint64_t>());
+            }
+
+            // UTF-8 string (0x00..0x17 bytes follow)
+            case 0x60:
+            case 0x61:
+            case 0x62:
+            case 0x63:
+            case 0x64:
+            case 0x65:
+            case 0x66:
+            case 0x67:
+            case 0x68:
+            case 0x69:
+            case 0x6a:
+            case 0x6b:
+            case 0x6c:
+            case 0x6d:
+            case 0x6e:
+            case 0x6f:
+            case 0x70:
+            case 0x71:
+            case 0x72:
+            case 0x73:
+            case 0x74:
+            case 0x75:
+            case 0x76:
+            case 0x77:
+            case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
+            case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
+            case 0x7a: // UTF-8 string (four-byte uint32_t for n follow)
+            case 0x7b: // UTF-8 string (eight-byte uint64_t for n follow)
+            case 0x7f: // UTF-8 string (indefinite length)
+            {
+                return get_cbor_string();
+            }
+
+            // array (0x00..0x17 data items follow)
+            case 0x80:
+            case 0x81:
+            case 0x82:
+            case 0x83:
+            case 0x84:
+            case 0x85:
+            case 0x86:
+            case 0x87:
+            case 0x88:
+            case 0x89:
+            case 0x8a:
+            case 0x8b:
+            case 0x8c:
+            case 0x8d:
+            case 0x8e:
+            case 0x8f:
+            case 0x90:
+            case 0x91:
+            case 0x92:
+            case 0x93:
+            case 0x94:
+            case 0x95:
+            case 0x96:
+            case 0x97:
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(current & 0x1f);
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_cbor());
+                }
+                return result;
+            }
+
+            case 0x98: // array (one-byte uint8_t for n follows)
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(get_number<uint8_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_cbor());
+                }
+                return result;
+            }
+
+            case 0x99: // array (two-byte uint16_t for n follow)
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(get_number<uint16_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_cbor());
+                }
+                return result;
+            }
+
+            case 0x9a: // array (four-byte uint32_t for n follow)
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(get_number<uint32_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_cbor());
+                }
+                return result;
+            }
+
+            case 0x9b: // array (eight-byte uint64_t for n follow)
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(get_number<uint64_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_cbor());
+                }
+                return result;
+            }
+
+            case 0x9f: // array (indefinite length)
+            {
+                BasicJsonType result = value_t::array;
+                while (get() != 0xff)
+                {
+                    result.push_back(parse_cbor(false));
+                }
+                return result;
+            }
+
+            // map (0x00..0x17 pairs of data items follow)
+            case 0xa0:
+            case 0xa1:
+            case 0xa2:
+            case 0xa3:
+            case 0xa4:
+            case 0xa5:
+            case 0xa6:
+            case 0xa7:
+            case 0xa8:
+            case 0xa9:
+            case 0xaa:
+            case 0xab:
+            case 0xac:
+            case 0xad:
+            case 0xae:
+            case 0xaf:
+            case 0xb0:
+            case 0xb1:
+            case 0xb2:
+            case 0xb3:
+            case 0xb4:
+            case 0xb5:
+            case 0xb6:
+            case 0xb7:
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(current & 0x1f);
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_cbor_string();
+                    result[key] = parse_cbor();
+                }
+                return result;
+            }
+
+            case 0xb8: // map (one-byte uint8_t for n follows)
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(get_number<uint8_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_cbor_string();
+                    result[key] = parse_cbor();
+                }
+                return result;
+            }
+
+            case 0xb9: // map (two-byte uint16_t for n follow)
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(get_number<uint16_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_cbor_string();
+                    result[key] = parse_cbor();
+                }
+                return result;
+            }
+
+            case 0xba: // map (four-byte uint32_t for n follow)
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(get_number<uint32_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_cbor_string();
+                    result[key] = parse_cbor();
+                }
+                return result;
+            }
+
+            case 0xbb: // map (eight-byte uint64_t for n follow)
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(get_number<uint64_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_cbor_string();
+                    result[key] = parse_cbor();
+                }
+                return result;
+            }
+
+            case 0xbf: // map (indefinite length)
+            {
+                BasicJsonType result = value_t::object;
+                while (get() != 0xff)
+                {
+                    auto key = get_cbor_string();
+                    result[key] = parse_cbor();
+                }
+                return result;
+            }
+
+            case 0xf4: // false
+            {
+                return false;
+            }
+
+            case 0xf5: // true
+            {
+                return true;
+            }
+
+            case 0xf6: // null
+            {
+                return value_t::null;
+            }
+
+            case 0xf9: // Half-Precision Float (two-byte IEEE 754)
+            {
+                const int byte1 = get();
+                check_eof();
+                const int byte2 = get();
+                check_eof();
+
+                // code from RFC 7049, Appendix D, Figure 3:
+                // As half-precision floating-point numbers were only added
+                // to IEEE 754 in 2008, today's programming platforms often
+                // still only have limited support for them. It is very
+                // easy to include at least decoding support for them even
+                // without such support. An example of a small decoder for
+                // half-precision floating-point numbers in the C language
+                // is shown in Fig. 3.
+                const int half = (byte1 << 8) + byte2;
+                const int exp = (half >> 10) & 0x1f;
+                const int mant = half & 0x3ff;
+                double val;
+                if (exp == 0)
+                {
+                    val = std::ldexp(mant, -24);
+                }
+                else if (exp != 31)
+                {
+                    val = std::ldexp(mant + 1024, exp - 25);
+                }
+                else
+                {
+                    val = (mant == 0) ? std::numeric_limits<double>::infinity()
+                          : std::numeric_limits<double>::quiet_NaN();
+                }
+                return (half & 0x8000) != 0 ? -val : val;
+            }
+
+            case 0xfa: // Single-Precision Float (four-byte IEEE 754)
+            {
+                return get_number<float>();
+            }
+
+            case 0xfb: // Double-Precision Float (eight-byte IEEE 754)
+            {
+                return get_number<double>();
+            }
+
+            default: // anything else (0xFF is handled inside the other types)
+            {
+                std::stringstream ss;
+                ss << std::setw(2) << std::setfill('0') << std::hex << current;
+                JSON_THROW(parse_error::create(
+                               112, chars_read, "error reading CBOR; last byte: 0x" + ss.str()));
+            }
+        }
+    }
+
+    /*!
+    @brief create a JSON value from MessagePack input
+
+    @return JSON value created from MessagePack input
+
+    @throw parse_error.110 if input ended unexpectedly
+    @throw parse_error.112 if unsupported byte was read
+    */
+    BasicJsonType parse_msgpack()
+    {
+        switch (get())
+        {
+            // EOF
+            case std::char_traits<char>::eof():
+            {
+                JSON_THROW(
+                    parse_error::create(110, chars_read, "unexpected end of input"));
+            }
+
+            // positive fixint
+            case 0x00:
+            case 0x01:
+            case 0x02:
+            case 0x03:
+            case 0x04:
+            case 0x05:
+            case 0x06:
+            case 0x07:
+            case 0x08:
+            case 0x09:
+            case 0x0a:
+            case 0x0b:
+            case 0x0c:
+            case 0x0d:
+            case 0x0e:
+            case 0x0f:
+            case 0x10:
+            case 0x11:
+            case 0x12:
+            case 0x13:
+            case 0x14:
+            case 0x15:
+            case 0x16:
+            case 0x17:
+            case 0x18:
+            case 0x19:
+            case 0x1a:
+            case 0x1b:
+            case 0x1c:
+            case 0x1d:
+            case 0x1e:
+            case 0x1f:
+            case 0x20:
+            case 0x21:
+            case 0x22:
+            case 0x23:
+            case 0x24:
+            case 0x25:
+            case 0x26:
+            case 0x27:
+            case 0x28:
+            case 0x29:
+            case 0x2a:
+            case 0x2b:
+            case 0x2c:
+            case 0x2d:
+            case 0x2e:
+            case 0x2f:
+            case 0x30:
+            case 0x31:
+            case 0x32:
+            case 0x33:
+            case 0x34:
+            case 0x35:
+            case 0x36:
+            case 0x37:
+            case 0x38:
+            case 0x39:
+            case 0x3a:
+            case 0x3b:
+            case 0x3c:
+            case 0x3d:
+            case 0x3e:
+            case 0x3f:
+            case 0x40:
+            case 0x41:
+            case 0x42:
+            case 0x43:
+            case 0x44:
+            case 0x45:
+            case 0x46:
+            case 0x47:
+            case 0x48:
+            case 0x49:
+            case 0x4a:
+            case 0x4b:
+            case 0x4c:
+            case 0x4d:
+            case 0x4e:
+            case 0x4f:
+            case 0x50:
+            case 0x51:
+            case 0x52:
+            case 0x53:
+            case 0x54:
+            case 0x55:
+            case 0x56:
+            case 0x57:
+            case 0x58:
+            case 0x59:
+            case 0x5a:
+            case 0x5b:
+            case 0x5c:
+            case 0x5d:
+            case 0x5e:
+            case 0x5f:
+            case 0x60:
+            case 0x61:
+            case 0x62:
+            case 0x63:
+            case 0x64:
+            case 0x65:
+            case 0x66:
+            case 0x67:
+            case 0x68:
+            case 0x69:
+            case 0x6a:
+            case 0x6b:
+            case 0x6c:
+            case 0x6d:
+            case 0x6e:
+            case 0x6f:
+            case 0x70:
+            case 0x71:
+            case 0x72:
+            case 0x73:
+            case 0x74:
+            case 0x75:
+            case 0x76:
+            case 0x77:
+            case 0x78:
+            case 0x79:
+            case 0x7a:
+            case 0x7b:
+            case 0x7c:
+            case 0x7d:
+            case 0x7e:
+            case 0x7f:
+            {
+                return static_cast<number_unsigned_t>(current);
+            }
+
+            // fixmap
+            case 0x80:
+            case 0x81:
+            case 0x82:
+            case 0x83:
+            case 0x84:
+            case 0x85:
+            case 0x86:
+            case 0x87:
+            case 0x88:
+            case 0x89:
+            case 0x8a:
+            case 0x8b:
+            case 0x8c:
+            case 0x8d:
+            case 0x8e:
+            case 0x8f:
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(current & 0x0f);
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_msgpack_string();
+                    result[key] = parse_msgpack();
+                }
+                return result;
+            }
+
+            // fixarray
+            case 0x90:
+            case 0x91:
+            case 0x92:
+            case 0x93:
+            case 0x94:
+            case 0x95:
+            case 0x96:
+            case 0x97:
+            case 0x98:
+            case 0x99:
+            case 0x9a:
+            case 0x9b:
+            case 0x9c:
+            case 0x9d:
+            case 0x9e:
+            case 0x9f:
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(current & 0x0f);
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_msgpack());
+                }
+                return result;
+            }
+
+            // fixstr
+            case 0xa0:
+            case 0xa1:
+            case 0xa2:
+            case 0xa3:
+            case 0xa4:
+            case 0xa5:
+            case 0xa6:
+            case 0xa7:
+            case 0xa8:
+            case 0xa9:
+            case 0xaa:
+            case 0xab:
+            case 0xac:
+            case 0xad:
+            case 0xae:
+            case 0xaf:
+            case 0xb0:
+            case 0xb1:
+            case 0xb2:
+            case 0xb3:
+            case 0xb4:
+            case 0xb5:
+            case 0xb6:
+            case 0xb7:
+            case 0xb8:
+            case 0xb9:
+            case 0xba:
+            case 0xbb:
+            case 0xbc:
+            case 0xbd:
+            case 0xbe:
+            case 0xbf:
+            {
+                return get_msgpack_string();
+            }
+
+            case 0xc0: // nil
+            {
+                return value_t::null;
+            }
+
+            case 0xc2: // false
+            {
+                return false;
+            }
+
+            case 0xc3: // true
+            {
+                return true;
+            }
+
+            case 0xca: // float 32
+            {
+                return get_number<float>();
+            }
+
+            case 0xcb: // float 64
+            {
+                return get_number<double>();
+            }
+
+            case 0xcc: // uint 8
+            {
+                return get_number<uint8_t>();
+            }
+
+            case 0xcd: // uint 16
+            {
+                return get_number<uint16_t>();
+            }
+
+            case 0xce: // uint 32
+            {
+                return get_number<uint32_t>();
+            }
+
+            case 0xcf: // uint 64
+            {
+                return get_number<uint64_t>();
+            }
+
+            case 0xd0: // int 8
+            {
+                return get_number<int8_t>();
+            }
+
+            case 0xd1: // int 16
+            {
+                return get_number<int16_t>();
+            }
+
+            case 0xd2: // int 32
+            {
+                return get_number<int32_t>();
+            }
+
+            case 0xd3: // int 64
+            {
+                return get_number<int64_t>();
+            }
+
+            case 0xd9: // str 8
+            case 0xda: // str 16
+            case 0xdb: // str 32
+            {
+                return get_msgpack_string();
+            }
+
+            case 0xdc: // array 16
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(get_number<uint16_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_msgpack());
+                }
+                return result;
+            }
+
+            case 0xdd: // array 32
+            {
+                BasicJsonType result = value_t::array;
+                const auto len = static_cast<size_t>(get_number<uint32_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    result.push_back(parse_msgpack());
+                }
+                return result;
+            }
+
+            case 0xde: // map 16
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(get_number<uint16_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_msgpack_string();
+                    result[key] = parse_msgpack();
+                }
+                return result;
+            }
+
+            case 0xdf: // map 32
+            {
+                BasicJsonType result = value_t::object;
+                const auto len = static_cast<size_t>(get_number<uint32_t>());
+                for (size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    auto key = get_msgpack_string();
+                    result[key] = parse_msgpack();
+                }
+                return result;
+            }
+
+            // positive fixint
+            case 0xe0:
+            case 0xe1:
+            case 0xe2:
+            case 0xe3:
+            case 0xe4:
+            case 0xe5:
+            case 0xe6:
+            case 0xe7:
+            case 0xe8:
+            case 0xe9:
+            case 0xea:
+            case 0xeb:
+            case 0xec:
+            case 0xed:
+            case 0xee:
+            case 0xef:
+            case 0xf0:
+            case 0xf1:
+            case 0xf2:
+            case 0xf3:
+            case 0xf4:
+            case 0xf5:
+            case 0xf6:
+            case 0xf7:
+            case 0xf8:
+            case 0xf9:
+            case 0xfa:
+            case 0xfb:
+            case 0xfc:
+            case 0xfd:
+            case 0xfe:
+            case 0xff:
+            {
+                return static_cast<int8_t>(current);
+            }
+
+            default: // anything else
+            {
+                std::stringstream ss;
+                ss << std::setw(2) << std::setfill('0') << std::hex << current;
+                JSON_THROW(parse_error::create(
+                               112, chars_read,
+                               "error reading MessagePack; last byte: 0x" + ss.str()));
+            }
+        }
+    }
+
+    /*!
+    @brief determine system byte order
+
+    @return true iff system's byte order is little endian
+
+    @note from http://stackoverflow.com/a/1001328/266378
+    */
+    static bool little_endianess() noexcept
+    {
+        int num = 1;
+        return (*reinterpret_cast<char*>(&num) == 1);
+    }
+
+  private:
+    /*!
+    @brief get next character from the input
+
+    This function provides the interface to the used input adapter. It does
+    not throw in case the input reached EOF, but returns
+    `std::char_traits<char>::eof()` in that case.
+
+    @return character read from the input
+    */
+    int get()
+    {
+        ++chars_read;
+        return (current = ia->get_character());
+    }
+
+    /*
+    @brief read a number from the input
+
+    @tparam NumberType the type of the number
+
+    @return number of type @a NumberType
+
+    @note This function needs to respect the system's endianess, because
+          bytes in CBOR and MessagePack are stored in network order (big
+          endian) and therefore need reordering on little endian systems.
+
+    @throw parse_error.110 if input has less than `sizeof(NumberType)`
+                           bytes
+    */
+    template <typename NumberType> NumberType get_number()
+    {
+        // step 1: read input into array with system's byte order
+        std::array<uint8_t, sizeof(NumberType)> vec;
+        for (size_t i = 0; i < sizeof(NumberType); ++i)
+        {
+            get();
+            check_eof();
+
+            // reverse byte order prior to conversion if necessary
+            if (is_little_endian)
+            {
+                vec[sizeof(NumberType) - i - 1] = static_cast<uint8_t>(current);
+            }
+            else
+            {
+                vec[i] = static_cast<uint8_t>(current); // LCOV_EXCL_LINE
+            }
+        }
+
+        // step 2: convert array into number of type T and return
+        NumberType result;
+        std::memcpy(&result, vec.data(), sizeof(NumberType));
+        return result;
+    }
+
+    /*!
+    @brief create a string by reading characters from the input
+
+    @param[in] len number of bytes to read
+
+    @note We can not reserve @a len bytes for the result, because @a len
+          may be too large. Usually, @ref check_eof() detects the end of
+          the input before we run out of string memory.
+
+    @return string created by reading @a len bytes
+
+    @throw parse_error.110 if input has less than @a len bytes
+    */
+    std::string get_string(const size_t len)
+    {
+        std::string result;
+        for (size_t i = 0; i < len; ++i)
+        {
+            get();
+            check_eof();
+            result.append(1, static_cast<char>(current));
+        }
+        return result;
+    }
+
+    /*!
+    @brief reads a CBOR string
+
+    This function first reads starting bytes to determine the expected
+    string length and then copies this number of bytes into a string.
+    Additionally, CBOR's strings with indefinite lengths are supported.
+
+    @return string
+
+    @throw parse_error.110 if input ended
+    @throw parse_error.113 if an unexpected byte is read
+    */
+    std::string get_cbor_string()
+    {
+        check_eof();
+
+        switch (current)
+        {
+            // UTF-8 string (0x00..0x17 bytes follow)
+            case 0x60:
+            case 0x61:
+            case 0x62:
+            case 0x63:
+            case 0x64:
+            case 0x65:
+            case 0x66:
+            case 0x67:
+            case 0x68:
+            case 0x69:
+            case 0x6a:
+            case 0x6b:
+            case 0x6c:
+            case 0x6d:
+            case 0x6e:
+            case 0x6f:
+            case 0x70:
+            case 0x71:
+            case 0x72:
+            case 0x73:
+            case 0x74:
+            case 0x75:
+            case 0x76:
+            case 0x77:
+            {
+                const auto len = static_cast<size_t>(current & 0x1f);
+                return get_string(len);
+            }
+
+            case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
+            {
+                const auto len = static_cast<size_t>(get_number<uint8_t>());
+                return get_string(len);
+            }
+
+            case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
+            {
+                const auto len = static_cast<size_t>(get_number<uint16_t>());
+                return get_string(len);
+            }
+
+            case 0x7a: // UTF-8 string (four-byte uint32_t for n follow)
+            {
+                const auto len = static_cast<size_t>(get_number<uint32_t>());
+                return get_string(len);
+            }
+
+            case 0x7b: // UTF-8 string (eight-byte uint64_t for n follow)
+            {
+                const auto len = static_cast<size_t>(get_number<uint64_t>());
+                return get_string(len);
+            }
+
+            case 0x7f: // UTF-8 string (indefinite length)
+            {
+                std::string result;
+                while (get() != 0xff)
+                {
+                    check_eof();
+                    result.append(1, static_cast<char>(current));
+                }
+                return result;
+            }
+
+            default:
+            {
+                std::stringstream ss;
+                ss << std::setw(2) << std::setfill('0') << std::hex << current;
+                JSON_THROW(parse_error::create(
+                               113, chars_read, "expected a CBOR string; last byte: 0x" + ss.str()));
+            }
+        }
+    }
+
+    /*!
+    @brief reads a MessagePack string
+
+    This function first reads starting bytes to determine the expected
+    string length and then copies this number of bytes into a string.
+
+    @return string
+
+    @throw parse_error.110 if input ended
+    @throw parse_error.113 if an unexpected byte is read
+    */
+    std::string get_msgpack_string()
+    {
+        check_eof();
+
+        switch (current)
+        {
+            // fixstr
+            case 0xa0:
+            case 0xa1:
+            case 0xa2:
+            case 0xa3:
+            case 0xa4:
+            case 0xa5:
+            case 0xa6:
+            case 0xa7:
+            case 0xa8:
+            case 0xa9:
+            case 0xaa:
+            case 0xab:
+            case 0xac:
+            case 0xad:
+            case 0xae:
+            case 0xaf:
+            case 0xb0:
+            case 0xb1:
+            case 0xb2:
+            case 0xb3:
+            case 0xb4:
+            case 0xb5:
+            case 0xb6:
+            case 0xb7:
+            case 0xb8:
+            case 0xb9:
+            case 0xba:
+            case 0xbb:
+            case 0xbc:
+            case 0xbd:
+            case 0xbe:
+            case 0xbf:
+            {
+                const auto len = static_cast<size_t>(current & 0x1f);
+                return get_string(len);
+            }
+
+            case 0xd9: // str 8
+            {
+                const auto len = static_cast<size_t>(get_number<uint8_t>());
+                return get_string(len);
+            }
+
+            case 0xda: // str 16
+            {
+                const auto len = static_cast<size_t>(get_number<uint16_t>());
+                return get_string(len);
+            }
+
+            case 0xdb: // str 32
+            {
+                const auto len = static_cast<size_t>(get_number<uint32_t>());
+                return get_string(len);
+            }
+
+            default:
+            {
+                std::stringstream ss;
+                ss << std::setw(2) << std::setfill('0') << std::hex << current;
+                JSON_THROW(parse_error::create(
+                               113, chars_read,
+                               "expected a MessagePack string; last byte: 0x" + ss.str()));
+            }
+        }
+    }
+
+    /*!
+    @brief check if input ended
+    @throw parse_error.110 if input ended
+    */
+    void check_eof() const
+    {
+        if (JSON_UNLIKELY(current == std::char_traits<char>::eof()))
+        {
+            JSON_THROW(
+                parse_error::create(110, chars_read, "unexpected end of input"));
+        }
+    }
+
+  private:
+    /// input adapter
+    input_adapter_t ia = nullptr;
+
+    /// the current character
+    int current = std::char_traits<char>::eof();
+
+    /// the number of characters read
+    size_t chars_read = 0;
+
+    /// whether we can assume little endianess
+    const bool is_little_endian = true;
+};
+
+/*!
+@brief serialization to CBOR and MessagePack values
+*/
+template <typename BasicJsonType>
+class binary_writer
+{
+  public:
+    /*!
+    @brief create a binary writer
+
+    @param[in] adapter  output adapter to write to
+    */
+    explicit binary_writer(output_adapter_t<uint8_t> adapter)
+        : is_little_endian(binary_reader<BasicJsonType>::little_endianess()), oa(adapter)
+    {
+        assert(oa);
+    }
+
+    /*!
+    @brief[in] j  JSON value to serialize
+    */
+    void write_cbor(const BasicJsonType& j)
+    {
+        switch (j.type())
+        {
+            case value_t::null:
+            {
+                oa->write_character(0xf6);
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                oa->write_character(j.m_value.boolean ? 0xf5 : 0xf4);
+                break;
+            }
+
+            case value_t::number_integer:
+            {
+                if (j.m_value.number_integer >= 0)
+                {
+                    // CBOR does not differentiate between positive signed
+                    // integers and unsigned integers. Therefore, we used the
+                    // code from the value_t::number_unsigned case here.
+                    if (j.m_value.number_integer <= 0x17)
+                    {
+                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer <=
+                             (std::numeric_limits<uint8_t>::max)())
+                    {
+                        oa->write_character(0x18);
+                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer <=
+                             (std::numeric_limits<uint16_t>::max)())
+                    {
+                        oa->write_character(0x19);
+                        write_number(static_cast<uint16_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer <=
+                             (std::numeric_limits<uint32_t>::max)())
+                    {
+                        oa->write_character(0x1a);
+                        write_number(static_cast<uint32_t>(j.m_value.number_integer));
+                    }
+                    else
+                    {
+                        oa->write_character(0x1b);
+                        write_number(static_cast<uint64_t>(j.m_value.number_integer));
+                    }
+                }
+                else
+                {
+                    // The conversions below encode the sign in the first
+                    // byte, and the value is converted to a positive number.
+                    const auto positive_number = -1 - j.m_value.number_integer;
+                    if (j.m_value.number_integer >= -24)
+                    {
+                        write_number(static_cast<uint8_t>(0x20 + positive_number));
+                    }
+                    else if (positive_number <= (std::numeric_limits<uint8_t>::max)())
+                    {
+                        oa->write_character(0x38);
+                        write_number(static_cast<uint8_t>(positive_number));
+                    }
+                    else if (positive_number <= (std::numeric_limits<uint16_t>::max)())
+                    {
+                        oa->write_character(0x39);
+                        write_number(static_cast<uint16_t>(positive_number));
+                    }
+                    else if (positive_number <= (std::numeric_limits<uint32_t>::max)())
+                    {
+                        oa->write_character(0x3a);
+                        write_number(static_cast<uint32_t>(positive_number));
+                    }
+                    else
+                    {
+                        oa->write_character(0x3b);
+                        write_number(static_cast<uint64_t>(positive_number));
+                    }
+                }
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                if (j.m_value.number_unsigned <= 0x17)
+                {
+                    write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint8_t>::max)())
+                {
+                    oa->write_character(0x18);
+                    write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint16_t>::max)())
+                {
+                    oa->write_character(0x19);
+                    write_number(static_cast<uint16_t>(j.m_value.number_unsigned));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint32_t>::max)())
+                {
+                    oa->write_character(0x1a);
+                    write_number(static_cast<uint32_t>(j.m_value.number_unsigned));
+                }
+                else
+                {
+                    oa->write_character(0x1b);
+                    write_number(static_cast<uint64_t>(j.m_value.number_unsigned));
+                }
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                // Double-Precision Float
+                oa->write_character(0xfb);
+                write_number(j.m_value.number_float);
+                break;
+            }
+
+            case value_t::string:
+            {
+                // step 1: write control byte and the string length
+                const auto N = j.m_value.string->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<uint8_t>(0x60 + N));
+                }
+                else if (N <= 0xff)
+                {
+                    oa->write_character(0x78);
+                    write_number(static_cast<uint8_t>(N));
+                }
+                else if (N <= 0xffff)
+                {
+                    oa->write_character(0x79);
+                    write_number(static_cast<uint16_t>(N));
+                }
+                else if (N <= 0xffffffff)
+                {
+                    oa->write_character(0x7a);
+                    write_number(static_cast<uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= 0xffffffffffffffff)
+                {
+                    oa->write_character(0x7b);
+                    write_number(static_cast<uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write the string
+                oa->write_characters(
+                    reinterpret_cast<const uint8_t*>(j.m_value.string->c_str()),
+                    j.m_value.string->size());
+                break;
+            }
+
+            case value_t::array:
+            {
+                // step 1: write control byte and the array size
+                const auto N = j.m_value.array->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<uint8_t>(0x80 + N));
+                }
+                else if (N <= 0xff)
+                {
+                    oa->write_character(0x98);
+                    write_number(static_cast<uint8_t>(N));
+                }
+                else if (N <= 0xffff)
+                {
+                    oa->write_character(0x99);
+                    write_number(static_cast<uint16_t>(N));
+                }
+                else if (N <= 0xffffffff)
+                {
+                    oa->write_character(0x9a);
+                    write_number(static_cast<uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= 0xffffffffffffffff)
+                {
+                    oa->write_character(0x9b);
+                    write_number(static_cast<uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write each element
+                for (const auto& el : *j.m_value.array)
+                {
+                    write_cbor(el);
+                }
+                break;
+            }
+
+            case value_t::object:
+            {
+                // step 1: write control byte and the object size
+                const auto N = j.m_value.object->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<uint8_t>(0xa0 + N));
+                }
+                else if (N <= 0xff)
+                {
+                    oa->write_character(0xb8);
+                    write_number(static_cast<uint8_t>(N));
+                }
+                else if (N <= 0xffff)
+                {
+                    oa->write_character(0xb9);
+                    write_number(static_cast<uint16_t>(N));
+                }
+                else if (N <= 0xffffffff)
+                {
+                    oa->write_character(0xba);
+                    write_number(static_cast<uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= 0xffffffffffffffff)
+                {
+                    oa->write_character(0xbb);
+                    write_number(static_cast<uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write each element
+                for (const auto& el : *j.m_value.object)
+                {
+                    write_cbor(el.first);
+                    write_cbor(el.second);
+                }
+                break;
+            }
+
+            default:
+            {
+                break;
+            }
+        }
+    }
+
+    /*!
+    @brief[in] j  JSON value to serialize
+    */
+    void write_msgpack(const BasicJsonType& j)
+    {
+        switch (j.type())
+        {
+            case value_t::null:
+            {
+                // nil
+                oa->write_character(0xc0);
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                // true and false
+                oa->write_character(j.m_value.boolean ? 0xc3 : 0xc2);
+                break;
+            }
+
+            case value_t::number_integer:
+            {
+                if (j.m_value.number_integer >= 0)
+                {
+                    // MessagePack does not differentiate between positive
+                    // signed integers and unsigned integers. Therefore, we
+                    // used the code from the value_t::number_unsigned case
+                    // here.
+                    if (j.m_value.number_unsigned < 128)
+                    {
+                        // positive fixnum
+                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_unsigned <=
+                             (std::numeric_limits<uint8_t>::max)())
+                    {
+                        // uint 8
+                        oa->write_character(0xcc);
+                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_unsigned <=
+                             (std::numeric_limits<uint16_t>::max)())
+                    {
+                        // uint 16
+                        oa->write_character(0xcd);
+                        write_number(static_cast<uint16_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_unsigned <=
+                             (std::numeric_limits<uint32_t>::max)())
+                    {
+                        // uint 32
+                        oa->write_character(0xce);
+                        write_number(static_cast<uint32_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_unsigned <=
+                             (std::numeric_limits<uint64_t>::max)())
+                    {
+                        // uint 64
+                        oa->write_character(0xcf);
+                        write_number(static_cast<uint64_t>(j.m_value.number_integer));
+                    }
+                }
+                else
+                {
+                    if (j.m_value.number_integer >= -32)
+                    {
+                        // negative fixnum
+                        write_number(static_cast<int8_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer >=
+                             (std::numeric_limits<int8_t>::min)() and
+                             j.m_value.number_integer <=
+                             (std::numeric_limits<int8_t>::max)())
+                    {
+                        // int 8
+                        oa->write_character(0xd0);
+                        write_number(static_cast<int8_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer >=
+                             (std::numeric_limits<int16_t>::min)() and
+                             j.m_value.number_integer <=
+                             (std::numeric_limits<int16_t>::max)())
+                    {
+                        // int 16
+                        oa->write_character(0xd1);
+                        write_number(static_cast<int16_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer >=
+                             (std::numeric_limits<int32_t>::min)() and
+                             j.m_value.number_integer <=
+                             (std::numeric_limits<int32_t>::max)())
+                    {
+                        // int 32
+                        oa->write_character(0xd2);
+                        write_number(static_cast<int32_t>(j.m_value.number_integer));
+                    }
+                    else if (j.m_value.number_integer >=
+                             (std::numeric_limits<int64_t>::min)() and
+                             j.m_value.number_integer <=
+                             (std::numeric_limits<int64_t>::max)())
+                    {
+                        // int 64
+                        oa->write_character(0xd3);
+                        write_number(static_cast<int64_t>(j.m_value.number_integer));
+                    }
+                }
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                if (j.m_value.number_unsigned < 128)
+                {
+                    // positive fixnum
+                    write_number(static_cast<uint8_t>(j.m_value.number_integer));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint8_t>::max)())
+                {
+                    // uint 8
+                    oa->write_character(0xcc);
+                    write_number(static_cast<uint8_t>(j.m_value.number_integer));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint16_t>::max)())
+                {
+                    // uint 16
+                    oa->write_character(0xcd);
+                    write_number(static_cast<uint16_t>(j.m_value.number_integer));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint32_t>::max)())
+                {
+                    // uint 32
+                    oa->write_character(0xce);
+                    write_number(static_cast<uint32_t>(j.m_value.number_integer));
+                }
+                else if (j.m_value.number_unsigned <=
+                         (std::numeric_limits<uint64_t>::max)())
+                {
+                    // uint 64
+                    oa->write_character(0xcf);
+                    write_number(static_cast<uint64_t>(j.m_value.number_integer));
+                }
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                // float 64
+                oa->write_character(0xcb);
+                write_number(j.m_value.number_float);
+                break;
+            }
+
+            case value_t::string:
+            {
+                // step 1: write control byte and the string length
+                const auto N = j.m_value.string->size();
+                if (N <= 31)
+                {
+                    // fixstr
+                    write_number(static_cast<uint8_t>(0xa0 | N));
+                }
+                else if (N <= 255)
+                {
+                    // str 8
+                    oa->write_character(0xd9);
+                    write_number(static_cast<uint8_t>(N));
+                }
+                else if (N <= 65535)
+                {
+                    // str 16
+                    oa->write_character(0xda);
+                    write_number(static_cast<uint16_t>(N));
+                }
+                else if (N <= 4294967295)
+                {
+                    // str 32
+                    oa->write_character(0xdb);
+                    write_number(static_cast<uint32_t>(N));
+                }
+
+                // step 2: write the string
+                oa->write_characters(
+                    reinterpret_cast<const uint8_t*>(j.m_value.string->c_str()),
+                    j.m_value.string->size());
+                break;
+            }
+
+            case value_t::array:
+            {
+                // step 1: write control byte and the array size
+                const auto N = j.m_value.array->size();
+                if (N <= 15)
+                {
+                    // fixarray
+                    write_number(static_cast<uint8_t>(0x90 | N));
+                }
+                else if (N <= 0xffff)
+                {
+                    // array 16
+                    oa->write_character(0xdc);
+                    write_number(static_cast<uint16_t>(N));
+                }
+                else if (N <= 0xffffffff)
+                {
+                    // array 32
+                    oa->write_character(0xdd);
+                    write_number(static_cast<uint32_t>(N));
+                }
+
+                // step 2: write each element
+                for (const auto& el : *j.m_value.array)
+                {
+                    write_msgpack(el);
+                }
+                break;
+            }
+
+            case value_t::object:
+            {
+                // step 1: write control byte and the object size
+                const auto N = j.m_value.object->size();
+                if (N <= 15)
+                {
+                    // fixmap
+                    write_number(static_cast<uint8_t>(0x80 | (N & 0xf)));
+                }
+                else if (N <= 65535)
+                {
+                    // map 16
+                    oa->write_character(0xde);
+                    write_number(static_cast<uint16_t>(N));
+                }
+                else if (N <= 4294967295)
+                {
+                    // map 32
+                    oa->write_character(0xdf);
+                    write_number(static_cast<uint32_t>(N));
+                }
+
+                // step 2: write each element
+                for (const auto& el : *j.m_value.object)
+                {
+                    write_msgpack(el.first);
+                    write_msgpack(el.second);
+                }
+                break;
+            }
+
+            default:
+            {
+                break;
+            }
+        }
+    }
+
+  private:
+    /*
+    @brief write a number to output input
+
+    @param[in] n number of type @a NumberType
+    @tparam NumberType the type of the number
+
+    @note This function needs to respect the system's endianess, because
+          bytes in CBOR and MessagePack are stored in network order (big
+          endian) and therefore need reordering on little endian systems.
+    */
+    template <typename NumberType> void write_number(NumberType n)
+    {
+        // step 1: write number to array of length NumberType
+        std::array<uint8_t, sizeof(NumberType)> vec;
+        std::memcpy(vec.data(), &n, sizeof(NumberType));
+
+        // step 2: write array to output (with possible reordering)
+        if (is_little_endian)
+        {
+            // reverse byte order prior to conversion if necessary
+            std::reverse(vec.begin(), vec.end());
+        }
+
+        oa->write_characters(vec.data(), sizeof(NumberType));
+    }
+
+  private:
+    /// whether we can assume little endianess
+    const bool is_little_endian = true;
+
+    /// the output
+    output_adapter_t<uint8_t> oa = nullptr;
+};
 } // namespace detail
 
 /// namespace to hold default `to_json` / `from_json` functions
@@ -5052,6 +6866,12 @@ class basic_json
     template <typename Iterator>
     using iteration_proxy = ::nlohmann::detail::iteration_proxy<Iterator>;
     template<typename Base> using json_reverse_iterator = ::nlohmann::detail::json_reverse_iterator<Base>;
+
+    template <typename CharType>
+    using output_adapter_t = ::nlohmann::detail::output_adapter_t<CharType>;
+
+    using binary_reader = ::nlohmann::detail::binary_reader<basic_json>;
+    using binary_writer = ::nlohmann::detail::binary_writer<basic_json>;
 
   public:
     using value_t = detail::value_t;
@@ -6621,7 +8441,7 @@ class basic_json
     string_t dump(const int indent = -1, const char indent_char = ' ') const
     {
         string_t result;
-        serializer s(output_adapter<char>::create(result), indent_char);
+        serializer s(detail::output_adapter_factory<char>::create(result), indent_char);
 
         if (indent >= 0)
         {
@@ -10250,110 +12070,6 @@ class basic_json
 
     /// @}
 
-  private:
-    /////////////////////
-    // output adapters //
-    /////////////////////
-
-    /// abstract output adapter interface
-    template<typename CharType>
-    class output_adapter
-    {
-      public:
-        virtual void write_character(CharType c) = 0;
-        virtual void write_characters(const CharType* s, size_t length) = 0;
-        virtual ~output_adapter() {}
-
-        static std::shared_ptr<output_adapter<CharType>> create(std::vector<CharType>& vec)
-        {
-            return std::make_shared<output_vector_adapter<CharType>>(vec);
-        }
-
-        static std::shared_ptr<output_adapter<CharType>> create(std::ostream& s)
-        {
-            return std::make_shared<output_stream_adapter<CharType>>(s);
-        }
-
-        static std::shared_ptr<output_adapter<CharType>> create(std::string& s)
-        {
-            return std::make_shared<output_string_adapter<CharType>>(s);
-        }
-    };
-
-    /// a type to simplify interfaces
-    template<typename CharType>
-    using output_adapter_t = std::shared_ptr<output_adapter<CharType>>;
-
-    /// output adapter for byte vectors
-    template<typename CharType>
-    class output_vector_adapter : public output_adapter<CharType>
-    {
-      public:
-        output_vector_adapter(std::vector<CharType>& vec)
-            : v(vec)
-        {}
-
-        void write_character(CharType c) override
-        {
-            v.push_back(c);
-        }
-
-        void write_characters(const CharType* s, size_t length) override
-        {
-            std::copy(s, s + length, std::back_inserter(v));
-        }
-
-      private:
-        std::vector<CharType>& v;
-    };
-
-    /// output adapter for output streams
-    template<typename CharType>
-    class output_stream_adapter : public output_adapter<CharType>
-    {
-      public:
-        output_stream_adapter(std::basic_ostream<CharType>& s)
-            : stream(s)
-        {}
-
-        void write_character(CharType c) override
-        {
-            stream.put(c);
-        }
-
-        void write_characters(const CharType* s, size_t length) override
-        {
-            stream.write(s, static_cast<std::streamsize>(length));
-        }
-
-      private:
-        std::basic_ostream<CharType>& stream;
-    };
-
-    /// output adapter for basic_string
-    template<typename CharType>
-    class output_string_adapter : public output_adapter<CharType>
-    {
-      public:
-        output_string_adapter(std::string& s)
-            : str(s)
-        {}
-
-        void write_character(CharType c) override
-        {
-            str.push_back(c);
-        }
-
-        void write_characters(const CharType* s, size_t length) override
-        {
-            str.append(s, length);
-        }
-
-      private:
-        std::basic_string<CharType>& str;
-    };
-
-
     ///////////////////
     // serialization //
     ///////////////////
@@ -10991,7 +12707,7 @@ class basic_json
         o.width(0);
 
         // do the actual serialization
-        serializer s(output_adapter<char>::create(o), o.fill());
+        serializer s(detail::output_adapter_factory<char>::create(o), o.fill());
         s.dump(j, pretty_print, static_cast<unsigned int>(indentation));
         return o;
     }
@@ -11410,1677 +13126,6 @@ class basic_json
     /// @name binary serialization/deserialization support
     /// @{
 
-    /*!
-    @brief deserialization of CBOR and MessagePack values
-    */
-    class binary_reader
-    {
-      public:
-        /*!
-        @brief create a binary reader
-
-        @param[in] adapter  input adapter to read from
-        */
-        explicit binary_reader(detail::input_adapter_t adapter)
-            : ia(adapter), is_little_endian(little_endianess())
-        {
-            assert(ia);
-        }
-
-        /*!
-        @brief create a JSON value from CBOR input
-
-        @param[in] get_char  whether a new character should be retrieved from
-                             the input (true, default) or whether the last
-                             read character should be considered instead
-
-        @return JSON value created from CBOR input
-
-        @throw parse_error.110 if input ended unexpectedly
-        @throw parse_error.112 if unsupported byte was read
-        */
-        basic_json parse_cbor(const bool get_char = true)
-        {
-            switch (get_char ? get() : current)
-            {
-                // EOF
-                case std::char_traits<char>::eof():
-                {
-                    JSON_THROW(parse_error::create(110, chars_read, "unexpected end of input"));
-                }
-
-                // Integer 0x00..0x17 (0..23)
-                case 0x00:
-                case 0x01:
-                case 0x02:
-                case 0x03:
-                case 0x04:
-                case 0x05:
-                case 0x06:
-                case 0x07:
-                case 0x08:
-                case 0x09:
-                case 0x0a:
-                case 0x0b:
-                case 0x0c:
-                case 0x0d:
-                case 0x0e:
-                case 0x0f:
-                case 0x10:
-                case 0x11:
-                case 0x12:
-                case 0x13:
-                case 0x14:
-                case 0x15:
-                case 0x16:
-                case 0x17:
-                {
-                    return static_cast<number_unsigned_t>(current);
-                }
-
-                case 0x18: // Unsigned integer (one-byte uint8_t follows)
-                {
-                    return get_number<uint8_t>();
-                }
-
-                case 0x19: // Unsigned integer (two-byte uint16_t follows)
-                {
-                    return get_number<uint16_t>();
-                }
-
-                case 0x1a: // Unsigned integer (four-byte uint32_t follows)
-                {
-                    return get_number<uint32_t>();
-                }
-
-                case 0x1b: // Unsigned integer (eight-byte uint64_t follows)
-                {
-                    return get_number<uint64_t>();
-                }
-
-                // Negative integer -1-0x00..-1-0x17 (-1..-24)
-                case 0x20:
-                case 0x21:
-                case 0x22:
-                case 0x23:
-                case 0x24:
-                case 0x25:
-                case 0x26:
-                case 0x27:
-                case 0x28:
-                case 0x29:
-                case 0x2a:
-                case 0x2b:
-                case 0x2c:
-                case 0x2d:
-                case 0x2e:
-                case 0x2f:
-                case 0x30:
-                case 0x31:
-                case 0x32:
-                case 0x33:
-                case 0x34:
-                case 0x35:
-                case 0x36:
-                case 0x37:
-                {
-                    return static_cast<int8_t>(0x20 - 1 - current);
-                }
-
-                case 0x38: // Negative integer (one-byte uint8_t follows)
-                {
-                    // must be uint8_t !
-                    return static_cast<number_integer_t>(-1) - get_number<uint8_t>();
-                }
-
-                case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
-                {
-                    return static_cast<number_integer_t>(-1) - get_number<uint16_t>();
-                }
-
-                case 0x3a: // Negative integer -1-n (four-byte uint32_t follows)
-                {
-                    return static_cast<number_integer_t>(-1) - get_number<uint32_t>();
-                }
-
-                case 0x3b: // Negative integer -1-n (eight-byte uint64_t follows)
-                {
-                    return static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(get_number<uint64_t>());
-                }
-
-                // UTF-8 string (0x00..0x17 bytes follow)
-                case 0x60:
-                case 0x61:
-                case 0x62:
-                case 0x63:
-                case 0x64:
-                case 0x65:
-                case 0x66:
-                case 0x67:
-                case 0x68:
-                case 0x69:
-                case 0x6a:
-                case 0x6b:
-                case 0x6c:
-                case 0x6d:
-                case 0x6e:
-                case 0x6f:
-                case 0x70:
-                case 0x71:
-                case 0x72:
-                case 0x73:
-                case 0x74:
-                case 0x75:
-                case 0x76:
-                case 0x77:
-                case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
-                case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
-                case 0x7a: // UTF-8 string (four-byte uint32_t for n follow)
-                case 0x7b: // UTF-8 string (eight-byte uint64_t for n follow)
-                case 0x7f: // UTF-8 string (indefinite length)
-                {
-                    return get_cbor_string();
-                }
-
-                // array (0x00..0x17 data items follow)
-                case 0x80:
-                case 0x81:
-                case 0x82:
-                case 0x83:
-                case 0x84:
-                case 0x85:
-                case 0x86:
-                case 0x87:
-                case 0x88:
-                case 0x89:
-                case 0x8a:
-                case 0x8b:
-                case 0x8c:
-                case 0x8d:
-                case 0x8e:
-                case 0x8f:
-                case 0x90:
-                case 0x91:
-                case 0x92:
-                case 0x93:
-                case 0x94:
-                case 0x95:
-                case 0x96:
-                case 0x97:
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(current & 0x1f);
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_cbor());
-                    }
-                    return result;
-                }
-
-                case 0x98: // array (one-byte uint8_t for n follows)
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(get_number<uint8_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_cbor());
-                    }
-                    return result;
-                }
-
-                case 0x99: // array (two-byte uint16_t for n follow)
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(get_number<uint16_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_cbor());
-                    }
-                    return result;
-                }
-
-                case 0x9a: // array (four-byte uint32_t for n follow)
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(get_number<uint32_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_cbor());
-                    }
-                    return result;
-                }
-
-                case 0x9b: // array (eight-byte uint64_t for n follow)
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(get_number<uint64_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_cbor());
-                    }
-                    return result;
-                }
-
-                case 0x9f: // array (indefinite length)
-                {
-                    basic_json result = value_t::array;
-                    while (get() != 0xff)
-                    {
-                        result.push_back(parse_cbor(false));
-                    }
-                    return result;
-                }
-
-                // map (0x00..0x17 pairs of data items follow)
-                case 0xa0:
-                case 0xa1:
-                case 0xa2:
-                case 0xa3:
-                case 0xa4:
-                case 0xa5:
-                case 0xa6:
-                case 0xa7:
-                case 0xa8:
-                case 0xa9:
-                case 0xaa:
-                case 0xab:
-                case 0xac:
-                case 0xad:
-                case 0xae:
-                case 0xaf:
-                case 0xb0:
-                case 0xb1:
-                case 0xb2:
-                case 0xb3:
-                case 0xb4:
-                case 0xb5:
-                case 0xb6:
-                case 0xb7:
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(current & 0x1f);
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_cbor_string();
-                        result[key] = parse_cbor();
-                    }
-                    return result;
-                }
-
-                case 0xb8: // map (one-byte uint8_t for n follows)
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(get_number<uint8_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_cbor_string();
-                        result[key] = parse_cbor();
-                    }
-                    return result;
-                }
-
-                case 0xb9: // map (two-byte uint16_t for n follow)
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(get_number<uint16_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_cbor_string();
-                        result[key] = parse_cbor();
-                    }
-                    return result;
-                }
-
-                case 0xba: // map (four-byte uint32_t for n follow)
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(get_number<uint32_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_cbor_string();
-                        result[key] = parse_cbor();
-                    }
-                    return result;
-                }
-
-                case 0xbb: // map (eight-byte uint64_t for n follow)
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(get_number<uint64_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_cbor_string();
-                        result[key] = parse_cbor();
-                    }
-                    return result;
-                }
-
-                case 0xbf: // map (indefinite length)
-                {
-                    basic_json result = value_t::object;
-                    while (get() != 0xff)
-                    {
-                        auto key = get_cbor_string();
-                        result[key] = parse_cbor();
-                    }
-                    return result;
-                }
-
-                case 0xf4: // false
-                {
-                    return false;
-                }
-
-                case 0xf5: // true
-                {
-                    return true;
-                }
-
-                case 0xf6: // null
-                {
-                    return value_t::null;
-                }
-
-                case 0xf9: // Half-Precision Float (two-byte IEEE 754)
-                {
-                    const int byte1 = get();
-                    check_eof();
-                    const int byte2 = get();
-                    check_eof();
-
-                    // code from RFC 7049, Appendix D, Figure 3:
-                    // As half-precision floating-point numbers were only added
-                    // to IEEE 754 in 2008, today's programming platforms often
-                    // still only have limited support for them. It is very
-                    // easy to include at least decoding support for them even
-                    // without such support. An example of a small decoder for
-                    // half-precision floating-point numbers in the C language
-                    // is shown in Fig. 3.
-                    const int half = (byte1 << 8) + byte2;
-                    const int exp = (half >> 10) & 0x1f;
-                    const int mant = half & 0x3ff;
-                    double val;
-                    if (exp == 0)
-                    {
-                        val = std::ldexp(mant, -24);
-                    }
-                    else if (exp != 31)
-                    {
-                        val = std::ldexp(mant + 1024, exp - 25);
-                    }
-                    else
-                    {
-                        val = (mant == 0)
-                              ? std::numeric_limits<double>::infinity()
-                              : std::numeric_limits<double>::quiet_NaN();
-                    }
-                    return (half & 0x8000) != 0 ? -val : val;
-                }
-
-                case 0xfa: // Single-Precision Float (four-byte IEEE 754)
-                {
-                    return get_number<float>();
-                }
-
-                case 0xfb: // Double-Precision Float (eight-byte IEEE 754)
-                {
-                    return get_number<double>();
-                }
-
-                default: // anything else (0xFF is handled inside the other types)
-                {
-                    std::stringstream ss;
-                    ss << std::setw(2) << std::setfill('0') << std::hex << current;
-                    JSON_THROW(parse_error::create(112, chars_read, "error reading CBOR; last byte: 0x" + ss.str()));
-                }
-            }
-        }
-
-        /*!
-        @brief create a JSON value from MessagePack input
-
-        @return JSON value created from MessagePack input
-
-        @throw parse_error.110 if input ended unexpectedly
-        @throw parse_error.112 if unsupported byte was read
-        */
-        basic_json parse_msgpack()
-        {
-            switch (get())
-            {
-                // EOF
-                case std::char_traits<char>::eof():
-                {
-                    JSON_THROW(parse_error::create(110, chars_read, "unexpected end of input"));
-                }
-
-                // positive fixint
-                case 0x00:
-                case 0x01:
-                case 0x02:
-                case 0x03:
-                case 0x04:
-                case 0x05:
-                case 0x06:
-                case 0x07:
-                case 0x08:
-                case 0x09:
-                case 0x0a:
-                case 0x0b:
-                case 0x0c:
-                case 0x0d:
-                case 0x0e:
-                case 0x0f:
-                case 0x10:
-                case 0x11:
-                case 0x12:
-                case 0x13:
-                case 0x14:
-                case 0x15:
-                case 0x16:
-                case 0x17:
-                case 0x18:
-                case 0x19:
-                case 0x1a:
-                case 0x1b:
-                case 0x1c:
-                case 0x1d:
-                case 0x1e:
-                case 0x1f:
-                case 0x20:
-                case 0x21:
-                case 0x22:
-                case 0x23:
-                case 0x24:
-                case 0x25:
-                case 0x26:
-                case 0x27:
-                case 0x28:
-                case 0x29:
-                case 0x2a:
-                case 0x2b:
-                case 0x2c:
-                case 0x2d:
-                case 0x2e:
-                case 0x2f:
-                case 0x30:
-                case 0x31:
-                case 0x32:
-                case 0x33:
-                case 0x34:
-                case 0x35:
-                case 0x36:
-                case 0x37:
-                case 0x38:
-                case 0x39:
-                case 0x3a:
-                case 0x3b:
-                case 0x3c:
-                case 0x3d:
-                case 0x3e:
-                case 0x3f:
-                case 0x40:
-                case 0x41:
-                case 0x42:
-                case 0x43:
-                case 0x44:
-                case 0x45:
-                case 0x46:
-                case 0x47:
-                case 0x48:
-                case 0x49:
-                case 0x4a:
-                case 0x4b:
-                case 0x4c:
-                case 0x4d:
-                case 0x4e:
-                case 0x4f:
-                case 0x50:
-                case 0x51:
-                case 0x52:
-                case 0x53:
-                case 0x54:
-                case 0x55:
-                case 0x56:
-                case 0x57:
-                case 0x58:
-                case 0x59:
-                case 0x5a:
-                case 0x5b:
-                case 0x5c:
-                case 0x5d:
-                case 0x5e:
-                case 0x5f:
-                case 0x60:
-                case 0x61:
-                case 0x62:
-                case 0x63:
-                case 0x64:
-                case 0x65:
-                case 0x66:
-                case 0x67:
-                case 0x68:
-                case 0x69:
-                case 0x6a:
-                case 0x6b:
-                case 0x6c:
-                case 0x6d:
-                case 0x6e:
-                case 0x6f:
-                case 0x70:
-                case 0x71:
-                case 0x72:
-                case 0x73:
-                case 0x74:
-                case 0x75:
-                case 0x76:
-                case 0x77:
-                case 0x78:
-                case 0x79:
-                case 0x7a:
-                case 0x7b:
-                case 0x7c:
-                case 0x7d:
-                case 0x7e:
-                case 0x7f:
-                {
-                    return static_cast<number_unsigned_t>(current);
-                }
-
-                // fixmap
-                case 0x80:
-                case 0x81:
-                case 0x82:
-                case 0x83:
-                case 0x84:
-                case 0x85:
-                case 0x86:
-                case 0x87:
-                case 0x88:
-                case 0x89:
-                case 0x8a:
-                case 0x8b:
-                case 0x8c:
-                case 0x8d:
-                case 0x8e:
-                case 0x8f:
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(current & 0x0f);
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_msgpack_string();
-                        result[key] = parse_msgpack();
-                    }
-                    return result;
-                }
-
-                // fixarray
-                case 0x90:
-                case 0x91:
-                case 0x92:
-                case 0x93:
-                case 0x94:
-                case 0x95:
-                case 0x96:
-                case 0x97:
-                case 0x98:
-                case 0x99:
-                case 0x9a:
-                case 0x9b:
-                case 0x9c:
-                case 0x9d:
-                case 0x9e:
-                case 0x9f:
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(current & 0x0f);
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_msgpack());
-                    }
-                    return result;
-                }
-
-                // fixstr
-                case 0xa0:
-                case 0xa1:
-                case 0xa2:
-                case 0xa3:
-                case 0xa4:
-                case 0xa5:
-                case 0xa6:
-                case 0xa7:
-                case 0xa8:
-                case 0xa9:
-                case 0xaa:
-                case 0xab:
-                case 0xac:
-                case 0xad:
-                case 0xae:
-                case 0xaf:
-                case 0xb0:
-                case 0xb1:
-                case 0xb2:
-                case 0xb3:
-                case 0xb4:
-                case 0xb5:
-                case 0xb6:
-                case 0xb7:
-                case 0xb8:
-                case 0xb9:
-                case 0xba:
-                case 0xbb:
-                case 0xbc:
-                case 0xbd:
-                case 0xbe:
-                case 0xbf:
-                {
-                    return get_msgpack_string();
-                }
-
-                case 0xc0: // nil
-                {
-                    return value_t::null;
-                }
-
-                case 0xc2: // false
-                {
-                    return false;
-                }
-
-                case 0xc3: // true
-                {
-                    return true;
-                }
-
-                case 0xca: // float 32
-                {
-                    return get_number<float>();
-                }
-
-                case 0xcb: // float 64
-                {
-                    return get_number<double>();
-                }
-
-                case 0xcc: // uint 8
-                {
-                    return get_number<uint8_t>();
-                }
-
-                case 0xcd: // uint 16
-                {
-                    return get_number<uint16_t>();
-                }
-
-                case 0xce: // uint 32
-                {
-                    return get_number<uint32_t>();
-                }
-
-                case 0xcf: // uint 64
-                {
-                    return get_number<uint64_t>();
-                }
-
-                case 0xd0: // int 8
-                {
-                    return get_number<int8_t>();
-                }
-
-                case 0xd1: // int 16
-                {
-                    return get_number<int16_t>();
-                }
-
-                case 0xd2: // int 32
-                {
-                    return get_number<int32_t>();
-                }
-
-                case 0xd3: // int 64
-                {
-                    return get_number<int64_t>();
-                }
-
-                case 0xd9: // str 8
-                case 0xda: // str 16
-                case 0xdb: // str 32
-                {
-                    return get_msgpack_string();
-                }
-
-                case 0xdc: // array 16
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(get_number<uint16_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_msgpack());
-                    }
-                    return result;
-                }
-
-                case 0xdd: // array 32
-                {
-                    basic_json result = value_t::array;
-                    const auto len = static_cast<size_t>(get_number<uint32_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        result.push_back(parse_msgpack());
-                    }
-                    return result;
-                }
-
-                case 0xde: // map 16
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(get_number<uint16_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_msgpack_string();
-                        result[key] = parse_msgpack();
-                    }
-                    return result;
-                }
-
-                case 0xdf: // map 32
-                {
-                    basic_json result = value_t::object;
-                    const auto len = static_cast<size_t>(get_number<uint32_t>());
-                    for (size_t i = 0; i < len; ++i)
-                    {
-                        get();
-                        auto key = get_msgpack_string();
-                        result[key] = parse_msgpack();
-                    }
-                    return result;
-                }
-
-                // positive fixint
-                case 0xe0:
-                case 0xe1:
-                case 0xe2:
-                case 0xe3:
-                case 0xe4:
-                case 0xe5:
-                case 0xe6:
-                case 0xe7:
-                case 0xe8:
-                case 0xe9:
-                case 0xea:
-                case 0xeb:
-                case 0xec:
-                case 0xed:
-                case 0xee:
-                case 0xef:
-                case 0xf0:
-                case 0xf1:
-                case 0xf2:
-                case 0xf3:
-                case 0xf4:
-                case 0xf5:
-                case 0xf6:
-                case 0xf7:
-                case 0xf8:
-                case 0xf9:
-                case 0xfa:
-                case 0xfb:
-                case 0xfc:
-                case 0xfd:
-                case 0xfe:
-                case 0xff:
-                {
-                    return static_cast<int8_t>(current);
-                }
-
-                default: // anything else
-                {
-                    std::stringstream ss;
-                    ss << std::setw(2) << std::setfill('0') << std::hex << current;
-                    JSON_THROW(parse_error::create(112, chars_read, "error reading MessagePack; last byte: 0x" + ss.str()));
-                }
-            }
-        }
-
-        /*!
-        @brief determine system byte order
-
-        @return true iff system's byte order is little endian
-
-        @note from http://stackoverflow.com/a/1001328/266378
-        */
-        static bool little_endianess() noexcept
-        {
-            int num = 1;
-            return (*reinterpret_cast<char*>(&num) == 1);
-        }
-
-      private:
-        /*!
-        @brief get next character from the input
-
-        This function provides the interface to the used input adapter. It does
-        not throw in case the input reached EOF, but returns
-        `std::char_traits<char>::eof()` in that case.
-
-        @return character read from the input
-        */
-        int get()
-        {
-            ++chars_read;
-            return (current = ia->get_character());
-        }
-
-        /*
-        @brief read a number from the input
-
-        @tparam NumberType the type of the number
-
-        @return number of type @a NumberType
-
-        @note This function needs to respect the system's endianess, because
-              bytes in CBOR and MessagePack are stored in network order (big
-              endian) and therefore need reordering on little endian systems.
-
-        @throw parse_error.110 if input has less than `sizeof(NumberType)`
-                               bytes
-        */
-        template<typename NumberType>
-        NumberType get_number()
-        {
-            // step 1: read input into array with system's byte order
-            std::array<uint8_t, sizeof(NumberType)> vec;
-            for (size_t i = 0; i < sizeof(NumberType); ++i)
-            {
-                get();
-                check_eof();
-
-                // reverse byte order prior to conversion if necessary
-                if (is_little_endian)
-                {
-                    vec[sizeof(NumberType) - i - 1] = static_cast<uint8_t>(current);
-                }
-                else
-                {
-                    vec[i] = static_cast<uint8_t>(current);  // LCOV_EXCL_LINE
-                }
-            }
-
-            // step 2: convert array into number of type T and return
-            NumberType result;
-            std::memcpy(&result, vec.data(), sizeof(NumberType));
-            return result;
-        }
-
-        /*!
-        @brief create a string by reading characters from the input
-
-        @param[in] len number of bytes to read
-
-        @note We can not reserve @a len bytes for the result, because @a len
-              may be too large. Usually, @ref check_eof() detects the end of
-              the input before we run out of string memory.
-
-        @return string created by reading @a len bytes
-
-        @throw parse_error.110 if input has less than @a len bytes
-        */
-        std::string get_string(const size_t len)
-        {
-            std::string result;
-            for (size_t i = 0; i < len; ++i)
-            {
-                get();
-                check_eof();
-                result.append(1, static_cast<char>(current));
-            }
-            return result;
-        }
-
-        /*!
-        @brief reads a CBOR string
-
-        This function first reads starting bytes to determine the expected
-        string length and then copies this number of bytes into a string.
-        Additionally, CBOR's strings with indefinite lengths are supported.
-
-        @return string
-
-        @throw parse_error.110 if input ended
-        @throw parse_error.113 if an unexpected byte is read
-        */
-        std::string get_cbor_string()
-        {
-            check_eof();
-
-            switch (current)
-            {
-                // UTF-8 string (0x00..0x17 bytes follow)
-                case 0x60:
-                case 0x61:
-                case 0x62:
-                case 0x63:
-                case 0x64:
-                case 0x65:
-                case 0x66:
-                case 0x67:
-                case 0x68:
-                case 0x69:
-                case 0x6a:
-                case 0x6b:
-                case 0x6c:
-                case 0x6d:
-                case 0x6e:
-                case 0x6f:
-                case 0x70:
-                case 0x71:
-                case 0x72:
-                case 0x73:
-                case 0x74:
-                case 0x75:
-                case 0x76:
-                case 0x77:
-                {
-                    const auto len = static_cast<size_t>(current & 0x1f);
-                    return get_string(len);
-                }
-
-                case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
-                {
-                    const auto len = static_cast<size_t>(get_number<uint8_t>());
-                    return get_string(len);
-                }
-
-                case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
-                {
-                    const auto len = static_cast<size_t>(get_number<uint16_t>());
-                    return get_string(len);
-                }
-
-                case 0x7a: // UTF-8 string (four-byte uint32_t for n follow)
-                {
-                    const auto len = static_cast<size_t>(get_number<uint32_t>());
-                    return get_string(len);
-                }
-
-                case 0x7b: // UTF-8 string (eight-byte uint64_t for n follow)
-                {
-                    const auto len = static_cast<size_t>(get_number<uint64_t>());
-                    return get_string(len);
-                }
-
-                case 0x7f: // UTF-8 string (indefinite length)
-                {
-                    std::string result;
-                    while (get() != 0xff)
-                    {
-                        check_eof();
-                        result.append(1, static_cast<char>(current));
-                    }
-                    return result;
-                }
-
-                default:
-                {
-                    std::stringstream ss;
-                    ss << std::setw(2) << std::setfill('0') << std::hex << current;
-                    JSON_THROW(parse_error::create(113, chars_read, "expected a CBOR string; last byte: 0x" + ss.str()));
-                }
-            }
-        }
-
-        /*!
-        @brief reads a MessagePack string
-
-        This function first reads starting bytes to determine the expected
-        string length and then copies this number of bytes into a string.
-
-        @return string
-
-        @throw parse_error.110 if input ended
-        @throw parse_error.113 if an unexpected byte is read
-        */
-        std::string get_msgpack_string()
-        {
-            check_eof();
-
-            switch (current)
-            {
-                // fixstr
-                case 0xa0:
-                case 0xa1:
-                case 0xa2:
-                case 0xa3:
-                case 0xa4:
-                case 0xa5:
-                case 0xa6:
-                case 0xa7:
-                case 0xa8:
-                case 0xa9:
-                case 0xaa:
-                case 0xab:
-                case 0xac:
-                case 0xad:
-                case 0xae:
-                case 0xaf:
-                case 0xb0:
-                case 0xb1:
-                case 0xb2:
-                case 0xb3:
-                case 0xb4:
-                case 0xb5:
-                case 0xb6:
-                case 0xb7:
-                case 0xb8:
-                case 0xb9:
-                case 0xba:
-                case 0xbb:
-                case 0xbc:
-                case 0xbd:
-                case 0xbe:
-                case 0xbf:
-                {
-                    const auto len = static_cast<size_t>(current & 0x1f);
-                    return get_string(len);
-                }
-
-                case 0xd9: // str 8
-                {
-                    const auto len = static_cast<size_t>(get_number<uint8_t>());
-                    return get_string(len);
-                }
-
-                case 0xda: // str 16
-                {
-                    const auto len = static_cast<size_t>(get_number<uint16_t>());
-                    return get_string(len);
-                }
-
-                case 0xdb: // str 32
-                {
-                    const auto len = static_cast<size_t>(get_number<uint32_t>());
-                    return get_string(len);
-                }
-
-                default:
-                {
-                    std::stringstream ss;
-                    ss << std::setw(2) << std::setfill('0') << std::hex << current;
-                    JSON_THROW(parse_error::create(113, chars_read, "expected a MessagePack string; last byte: 0x" + ss.str()));
-                }
-            }
-        }
-
-        /*!
-        @brief check if input ended
-        @throw parse_error.110 if input ended
-        */
-        void check_eof() const
-        {
-            if (JSON_UNLIKELY(current == std::char_traits<char>::eof()))
-            {
-                JSON_THROW(parse_error::create(110, chars_read, "unexpected end of input"));
-            }
-        }
-
-      private:
-        /// input adapter
-        detail::input_adapter_t ia = nullptr;
-
-        /// the current character
-        int current = std::char_traits<char>::eof();
-
-        /// the number of characters read
-        size_t chars_read = 0;
-
-        /// whether we can assume little endianess
-        const bool is_little_endian = true;
-    };
-
-    /*!
-    @brief serialization to CBOR and MessagePack values
-    */
-    class binary_writer
-    {
-      public:
-        /*!
-        @brief create a binary writer
-
-        @param[in] adapter  output adapter to write to
-        */
-        explicit binary_writer(output_adapter_t<uint8_t> adapter)
-            : is_little_endian(binary_reader::little_endianess()), oa(adapter)
-        {
-            assert(oa);
-        }
-
-        /*!
-        @brief[in] j  JSON value to serialize
-        */
-        void write_cbor(const basic_json& j)
-        {
-            switch (j.type())
-            {
-                case value_t::null:
-                {
-                    oa->write_character(0xf6);
-                    break;
-                }
-
-                case value_t::boolean:
-                {
-                    oa->write_character(j.m_value.boolean ? 0xf5 : 0xf4);
-                    break;
-                }
-
-                case value_t::number_integer:
-                {
-                    if (j.m_value.number_integer >= 0)
-                    {
-                        // CBOR does not differentiate between positive signed
-                        // integers and unsigned integers. Therefore, we used the
-                        // code from the value_t::number_unsigned case here.
-                        if (j.m_value.number_integer <= 0x17)
-                        {
-                            write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer <= (std::numeric_limits<uint8_t>::max)())
-                        {
-                            oa->write_character(0x18);
-                            write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer <= (std::numeric_limits<uint16_t>::max)())
-                        {
-                            oa->write_character(0x19);
-                            write_number(static_cast<uint16_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer <= (std::numeric_limits<uint32_t>::max)())
-                        {
-                            oa->write_character(0x1a);
-                            write_number(static_cast<uint32_t>(j.m_value.number_integer));
-                        }
-                        else
-                        {
-                            oa->write_character(0x1b);
-                            write_number(static_cast<uint64_t>(j.m_value.number_integer));
-                        }
-                    }
-                    else
-                    {
-                        // The conversions below encode the sign in the first
-                        // byte, and the value is converted to a positive number.
-                        const auto positive_number = -1 - j.m_value.number_integer;
-                        if (j.m_value.number_integer >= -24)
-                        {
-                            write_number(static_cast<uint8_t>(0x20 + positive_number));
-                        }
-                        else if (positive_number <= (std::numeric_limits<uint8_t>::max)())
-                        {
-                            oa->write_character(0x38);
-                            write_number(static_cast<uint8_t>(positive_number));
-                        }
-                        else if (positive_number <= (std::numeric_limits<uint16_t>::max)())
-                        {
-                            oa->write_character(0x39);
-                            write_number(static_cast<uint16_t>(positive_number));
-                        }
-                        else if (positive_number <= (std::numeric_limits<uint32_t>::max)())
-                        {
-                            oa->write_character(0x3a);
-                            write_number(static_cast<uint32_t>(positive_number));
-                        }
-                        else
-                        {
-                            oa->write_character(0x3b);
-                            write_number(static_cast<uint64_t>(positive_number));
-                        }
-                    }
-                    break;
-                }
-
-                case value_t::number_unsigned:
-                {
-                    if (j.m_value.number_unsigned <= 0x17)
-                    {
-                        write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                    {
-                        oa->write_character(0x18);
-                        write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)())
-                    {
-                        oa->write_character(0x19);
-                        write_number(static_cast<uint16_t>(j.m_value.number_unsigned));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)())
-                    {
-                        oa->write_character(0x1a);
-                        write_number(static_cast<uint32_t>(j.m_value.number_unsigned));
-                    }
-                    else
-                    {
-                        oa->write_character(0x1b);
-                        write_number(static_cast<uint64_t>(j.m_value.number_unsigned));
-                    }
-                    break;
-                }
-
-                case value_t::number_float:
-                {
-                    // Double-Precision Float
-                    oa->write_character(0xfb);
-                    write_number(j.m_value.number_float);
-                    break;
-                }
-
-                case value_t::string:
-                {
-                    // step 1: write control byte and the string length
-                    const auto N = j.m_value.string->size();
-                    if (N <= 0x17)
-                    {
-                        write_number(static_cast<uint8_t>(0x60 + N));
-                    }
-                    else if (N <= 0xff)
-                    {
-                        oa->write_character(0x78);
-                        write_number(static_cast<uint8_t>(N));
-                    }
-                    else if (N <= 0xffff)
-                    {
-                        oa->write_character(0x79);
-                        write_number(static_cast<uint16_t>(N));
-                    }
-                    else if (N <= 0xffffffff)
-                    {
-                        oa->write_character(0x7a);
-                        write_number(static_cast<uint32_t>(N));
-                    }
-                    // LCOV_EXCL_START
-                    else if (N <= 0xffffffffffffffff)
-                    {
-                        oa->write_character(0x7b);
-                        write_number(static_cast<uint64_t>(N));
-                    }
-                    // LCOV_EXCL_STOP
-
-                    // step 2: write the string
-                    oa->write_characters(reinterpret_cast<const uint8_t*>(j.m_value.string->c_str()),
-                                         j.m_value.string->size());
-                    break;
-                }
-
-                case value_t::array:
-                {
-                    // step 1: write control byte and the array size
-                    const auto N = j.m_value.array->size();
-                    if (N <= 0x17)
-                    {
-                        write_number(static_cast<uint8_t>(0x80 + N));
-                    }
-                    else if (N <= 0xff)
-                    {
-                        oa->write_character(0x98);
-                        write_number(static_cast<uint8_t>(N));
-                    }
-                    else if (N <= 0xffff)
-                    {
-                        oa->write_character(0x99);
-                        write_number(static_cast<uint16_t>(N));
-                    }
-                    else if (N <= 0xffffffff)
-                    {
-                        oa->write_character(0x9a);
-                        write_number(static_cast<uint32_t>(N));
-                    }
-                    // LCOV_EXCL_START
-                    else if (N <= 0xffffffffffffffff)
-                    {
-                        oa->write_character(0x9b);
-                        write_number(static_cast<uint64_t>(N));
-                    }
-                    // LCOV_EXCL_STOP
-
-                    // step 2: write each element
-                    for (const auto& el : *j.m_value.array)
-                    {
-                        write_cbor(el);
-                    }
-                    break;
-                }
-
-                case value_t::object:
-                {
-                    // step 1: write control byte and the object size
-                    const auto N = j.m_value.object->size();
-                    if (N <= 0x17)
-                    {
-                        write_number(static_cast<uint8_t>(0xa0 + N));
-                    }
-                    else if (N <= 0xff)
-                    {
-                        oa->write_character(0xb8);
-                        write_number(static_cast<uint8_t>(N));
-                    }
-                    else if (N <= 0xffff)
-                    {
-                        oa->write_character(0xb9);
-                        write_number(static_cast<uint16_t>(N));
-                    }
-                    else if (N <= 0xffffffff)
-                    {
-                        oa->write_character(0xba);
-                        write_number(static_cast<uint32_t>(N));
-                    }
-                    // LCOV_EXCL_START
-                    else if (N <= 0xffffffffffffffff)
-                    {
-                        oa->write_character(0xbb);
-                        write_number(static_cast<uint64_t>(N));
-                    }
-                    // LCOV_EXCL_STOP
-
-                    // step 2: write each element
-                    for (const auto& el : *j.m_value.object)
-                    {
-                        write_cbor(el.first);
-                        write_cbor(el.second);
-                    }
-                    break;
-                }
-
-                default:
-                {
-                    break;
-                }
-            }
-        }
-
-        /*!
-        @brief[in] j  JSON value to serialize
-        */
-        void write_msgpack(const basic_json& j)
-        {
-            switch (j.type())
-            {
-                case value_t::null:
-                {
-                    // nil
-                    oa->write_character(0xc0);
-                    break;
-                }
-
-                case value_t::boolean:
-                {
-                    // true and false
-                    oa->write_character(j.m_value.boolean ? 0xc3 : 0xc2);
-                    break;
-                }
-
-                case value_t::number_integer:
-                {
-                    if (j.m_value.number_integer >= 0)
-                    {
-                        // MessagePack does not differentiate between positive
-                        // signed integers and unsigned integers. Therefore, we
-                        // used the code from the value_t::number_unsigned case
-                        // here.
-                        if (j.m_value.number_unsigned < 128)
-                        {
-                            // positive fixnum
-                            write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                        {
-                            // uint 8
-                            oa->write_character(0xcc);
-                            write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)())
-                        {
-                            // uint 16
-                            oa->write_character(0xcd);
-                            write_number(static_cast<uint16_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)())
-                        {
-                            // uint 32
-                            oa->write_character(0xce);
-                            write_number(static_cast<uint32_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_unsigned <= (std::numeric_limits<uint64_t>::max)())
-                        {
-                            // uint 64
-                            oa->write_character(0xcf);
-                            write_number(static_cast<uint64_t>(j.m_value.number_integer));
-                        }
-                    }
-                    else
-                    {
-                        if (j.m_value.number_integer >= -32)
-                        {
-                            // negative fixnum
-                            write_number(static_cast<int8_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer >= (std::numeric_limits<int8_t>::min)() and j.m_value.number_integer <= (std::numeric_limits<int8_t>::max)())
-                        {
-                            // int 8
-                            oa->write_character(0xd0);
-                            write_number(static_cast<int8_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer >= (std::numeric_limits<int16_t>::min)() and j.m_value.number_integer <= (std::numeric_limits<int16_t>::max)())
-                        {
-                            // int 16
-                            oa->write_character(0xd1);
-                            write_number(static_cast<int16_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer >= (std::numeric_limits<int32_t>::min)() and j.m_value.number_integer <= (std::numeric_limits<int32_t>::max)())
-                        {
-                            // int 32
-                            oa->write_character(0xd2);
-                            write_number(static_cast<int32_t>(j.m_value.number_integer));
-                        }
-                        else if (j.m_value.number_integer >= (std::numeric_limits<int64_t>::min)() and j.m_value.number_integer <= (std::numeric_limits<int64_t>::max)())
-                        {
-                            // int 64
-                            oa->write_character(0xd3);
-                            write_number(static_cast<int64_t>(j.m_value.number_integer));
-                        }
-                    }
-                    break;
-                }
-
-                case value_t::number_unsigned:
-                {
-                    if (j.m_value.number_unsigned < 128)
-                    {
-                        // positive fixnum
-                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                    {
-                        // uint 8
-                        oa->write_character(0xcc);
-                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)())
-                    {
-                        // uint 16
-                        oa->write_character(0xcd);
-                        write_number(static_cast<uint16_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)())
-                    {
-                        // uint 32
-                        oa->write_character(0xce);
-                        write_number(static_cast<uint32_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint64_t>::max)())
-                    {
-                        // uint 64
-                        oa->write_character(0xcf);
-                        write_number(static_cast<uint64_t>(j.m_value.number_integer));
-                    }
-                    break;
-                }
-
-                case value_t::number_float:
-                {
-                    // float 64
-                    oa->write_character(0xcb);
-                    write_number(j.m_value.number_float);
-                    break;
-                }
-
-                case value_t::string:
-                {
-                    // step 1: write control byte and the string length
-                    const auto N = j.m_value.string->size();
-                    if (N <= 31)
-                    {
-                        // fixstr
-                        write_number(static_cast<uint8_t>(0xa0 | N));
-                    }
-                    else if (N <= 255)
-                    {
-                        // str 8
-                        oa->write_character(0xd9);
-                        write_number(static_cast<uint8_t>(N));
-                    }
-                    else if (N <= 65535)
-                    {
-                        // str 16
-                        oa->write_character(0xda);
-                        write_number(static_cast<uint16_t>(N));
-                    }
-                    else if (N <= 4294967295)
-                    {
-                        // str 32
-                        oa->write_character(0xdb);
-                        write_number(static_cast<uint32_t>(N));
-                    }
-
-                    // step 2: write the string
-                    oa->write_characters(reinterpret_cast<const uint8_t*>(j.m_value.string->c_str()),
-                                         j.m_value.string->size());
-                    break;
-                }
-
-                case value_t::array:
-                {
-                    // step 1: write control byte and the array size
-                    const auto N = j.m_value.array->size();
-                    if (N <= 15)
-                    {
-                        // fixarray
-                        write_number(static_cast<uint8_t>(0x90 | N));
-                    }
-                    else if (N <= 0xffff)
-                    {
-                        // array 16
-                        oa->write_character(0xdc);
-                        write_number(static_cast<uint16_t>(N));
-                    }
-                    else if (N <= 0xffffffff)
-                    {
-                        // array 32
-                        oa->write_character(0xdd);
-                        write_number(static_cast<uint32_t>(N));
-                    }
-
-                    // step 2: write each element
-                    for (const auto& el : *j.m_value.array)
-                    {
-                        write_msgpack(el);
-                    }
-                    break;
-                }
-
-                case value_t::object:
-                {
-                    // step 1: write control byte and the object size
-                    const auto N = j.m_value.object->size();
-                    if (N <= 15)
-                    {
-                        // fixmap
-                        write_number(static_cast<uint8_t>(0x80 | (N & 0xf)));
-                    }
-                    else if (N <= 65535)
-                    {
-                        // map 16
-                        oa->write_character(0xde);
-                        write_number(static_cast<uint16_t>(N));
-                    }
-                    else if (N <= 4294967295)
-                    {
-                        // map 32
-                        oa->write_character(0xdf);
-                        write_number(static_cast<uint32_t>(N));
-                    }
-
-                    // step 2: write each element
-                    for (const auto& el : *j.m_value.object)
-                    {
-                        write_msgpack(el.first);
-                        write_msgpack(el.second);
-                    }
-                    break;
-                }
-
-                default:
-                {
-                    break;
-                }
-            }
-        }
-
-      private:
-        /*
-        @brief write a number to output input
-
-        @param[in] n number of type @a NumberType
-        @tparam NumberType the type of the number
-
-        @note This function needs to respect the system's endianess, because
-              bytes in CBOR and MessagePack are stored in network order (big
-              endian) and therefore need reordering on little endian systems.
-        */
-        template<typename NumberType>
-        void write_number(NumberType n)
-        {
-            // step 1: write number to array of length NumberType
-            std::array<uint8_t, sizeof(NumberType)> vec;
-            std::memcpy(vec.data(), &n, sizeof(NumberType));
-
-            // step 2: write array to output (with possible reordering)
-            if (is_little_endian)
-            {
-                // reverse byte order prior to conversion if necessary
-                std::reverse(vec.begin(), vec.end());
-            }
-
-            oa->write_characters(vec.data(), sizeof(NumberType));
-        }
-
-      private:
-        /// whether we can assume little endianess
-        const bool is_little_endian = true;
-
-        /// the output
-        output_adapter_t<uint8_t> oa = nullptr;
-    };
-
   public:
     /*!
     @brief create a CBOR serialization of a given JSON value
@@ -13167,7 +13212,7 @@ class basic_json
     static std::vector<uint8_t> to_cbor(const basic_json& j)
     {
         std::vector<uint8_t> result;
-        binary_writer bw(output_adapter<uint8_t>::create(result));
+        binary_writer bw(detail::output_adapter_factory<uint8_t>::create(result));
         bw.write_cbor(j);
         return result;
     }
@@ -13249,7 +13294,7 @@ class basic_json
     static std::vector<uint8_t> to_msgpack(const basic_json& j)
     {
         std::vector<uint8_t> result;
-        binary_writer bw(output_adapter<uint8_t>::create(result));
+        binary_writer bw(detail::output_adapter_factory<uint8_t>::create(result));
         bw.write_msgpack(j);
         return result;
     }

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -4459,6 +4459,111 @@ template <typename IteratorType> class iteration_proxy
         return iteration_proxy_internal(container.end());
     }
 };
+
+/*!
+@brief a template for a reverse iterator class
+
+@tparam Base the base iterator type to reverse. Valid types are @ref
+iterator (to create @ref reverse_iterator) and @ref const_iterator (to
+create @ref const_reverse_iterator).
+
+@requirement The class satisfies the following concept requirements:
+-
+[RandomAccessIterator](http://en.cppreference.com/w/cpp/concept/RandomAccessIterator):
+  The iterator that can be moved to point (forward and backward) to any
+  element in constant time.
+- [OutputIterator](http://en.cppreference.com/w/cpp/concept/OutputIterator):
+  It is possible to write to the pointed-to element (only if @a Base is
+  @ref iterator).
+
+@since version 1.0.0
+*/
+template <typename Base>
+class json_reverse_iterator : public std::reverse_iterator<Base>
+{
+  public:
+    using difference_type = std::ptrdiff_t;
+    /// shortcut to the reverse iterator adaptor
+    using base_iterator = std::reverse_iterator<Base>;
+    /// the reference type for the pointed-to element
+    using reference = typename Base::reference;
+
+    /// create reverse iterator from iterator
+    json_reverse_iterator(
+        const typename base_iterator::iterator_type& it) noexcept
+        : base_iterator(it) {}
+
+    /// create reverse iterator from base class
+    json_reverse_iterator(const base_iterator& it) noexcept : base_iterator(it) {}
+
+    /// post-increment (it++)
+    json_reverse_iterator operator++(int)
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator++(1));
+    }
+
+    /// pre-increment (++it)
+    json_reverse_iterator& operator++()
+    {
+        return static_cast<json_reverse_iterator&>(base_iterator::operator++());
+    }
+
+    /// post-decrement (it--)
+    json_reverse_iterator operator--(int)
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator--(1));
+    }
+
+    /// pre-decrement (--it)
+    json_reverse_iterator& operator--()
+    {
+        return static_cast<json_reverse_iterator&>(base_iterator::operator--());
+    }
+
+    /// add to iterator
+    json_reverse_iterator& operator+=(difference_type i)
+    {
+        return static_cast<json_reverse_iterator&>(base_iterator::operator+=(i));
+    }
+
+    /// add to iterator
+    json_reverse_iterator operator+(difference_type i) const
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator+(i));
+    }
+
+    /// subtract from iterator
+    json_reverse_iterator operator-(difference_type i) const
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator-(i));
+    }
+
+    /// return difference
+    difference_type operator-(const json_reverse_iterator& other) const
+    {
+        return base_iterator(*this) - base_iterator(other);
+    }
+
+    /// access to successor
+    reference operator[](difference_type n) const
+    {
+        return *(this->operator+(n));
+    }
+
+    /// return the key of an object iterator
+    auto key() const -> decltype(std::declval<Base>().key())
+    {
+        auto it = --this->base();
+        return it.key();
+    }
+
+    /// return the value of an iterator
+    reference value() const
+    {
+        auto it = --this->base();
+        return it.operator * ();
+    }
+};
 } // namespace detail
 
 /// namespace to hold default `to_json` / `from_json` functions
@@ -4946,11 +5051,11 @@ class basic_json
     using iter_impl = ::nlohmann::detail::iter_impl<BasicJsonType>;
     template <typename Iterator>
     using iteration_proxy = ::nlohmann::detail::iteration_proxy<Iterator>;
+    template<typename Base> using json_reverse_iterator = ::nlohmann::detail::json_reverse_iterator<Base>;
 
   public:
     using value_t = detail::value_t;
     // forward declarations
-    template<typename Base> class json_reverse_iterator;
     using json_pointer = ::nlohmann::json_pointer;
     template<typename T, typename SFINAE>
     using json_serializer = JSONSerializer<T, SFINAE>;
@@ -11298,114 +11403,6 @@ class basic_json
     /// the value of the current element
     json_value m_value = {};
 
-  public:
-    /*!
-    @brief a template for a reverse iterator class
-
-    @tparam Base the base iterator type to reverse. Valid types are @ref
-    iterator (to create @ref reverse_iterator) and @ref const_iterator (to
-    create @ref const_reverse_iterator).
-
-    @requirement The class satisfies the following concept requirements:
-    - [RandomAccessIterator](http://en.cppreference.com/w/cpp/concept/RandomAccessIterator):
-      The iterator that can be moved to point (forward and backward) to any
-      element in constant time.
-    - [OutputIterator](http://en.cppreference.com/w/cpp/concept/OutputIterator):
-      It is possible to write to the pointed-to element (only if @a Base is
-      @ref iterator).
-
-    @since version 1.0.0
-    */
-    template<typename Base>
-    class json_reverse_iterator : public std::reverse_iterator<Base>
-    {
-      public:
-        /// shortcut to the reverse iterator adaptor
-        using base_iterator = std::reverse_iterator<Base>;
-        /// the reference type for the pointed-to element
-        using reference = typename Base::reference;
-
-        /// create reverse iterator from iterator
-        json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
-            : base_iterator(it)
-        {}
-
-        /// create reverse iterator from base class
-        json_reverse_iterator(const base_iterator& it) noexcept
-            : base_iterator(it)
-        {}
-
-        /// post-increment (it++)
-        json_reverse_iterator operator++(int)
-        {
-            return static_cast<json_reverse_iterator>(base_iterator::operator++(1));
-        }
-
-        /// pre-increment (++it)
-        json_reverse_iterator& operator++()
-        {
-            return static_cast<json_reverse_iterator&>(base_iterator::operator++());
-        }
-
-        /// post-decrement (it--)
-        json_reverse_iterator operator--(int)
-        {
-            return static_cast<json_reverse_iterator>(base_iterator::operator--(1));
-        }
-
-        /// pre-decrement (--it)
-        json_reverse_iterator& operator--()
-        {
-            return static_cast<json_reverse_iterator&>(base_iterator::operator--());
-        }
-
-        /// add to iterator
-        json_reverse_iterator& operator+=(difference_type i)
-        {
-            return static_cast<json_reverse_iterator&>(base_iterator::operator+=(i));
-        }
-
-        /// add to iterator
-        json_reverse_iterator operator+(difference_type i) const
-        {
-            return static_cast<json_reverse_iterator>(base_iterator::operator+(i));
-        }
-
-        /// subtract from iterator
-        json_reverse_iterator operator-(difference_type i) const
-        {
-            return static_cast<json_reverse_iterator>(base_iterator::operator-(i));
-        }
-
-        /// return difference
-        difference_type operator-(const json_reverse_iterator& other) const
-        {
-            return base_iterator(*this) - base_iterator(other);
-        }
-
-        /// access to successor
-        reference operator[](difference_type n) const
-        {
-            return *(this->operator+(n));
-        }
-
-        /// return the key of an object iterator
-        typename object_t::key_type key() const
-        {
-            auto it = --this->base();
-            return it.key();
-        }
-
-        /// return the value of an iterator
-        reference value() const
-        {
-            auto it = --this->base();
-            return it.operator * ();
-        }
-    };
-
-
-  private:
     //////////////////////////////////////////
     // binary serialization/deserialization //
     //////////////////////////////////////////

--- a/test/src/unit-class_lexer.cpp
+++ b/test/src/unit-class_lexer.cpp
@@ -36,7 +36,7 @@ using nlohmann::json;
 json::lexer::token_type scan_string(const char* s);
 json::lexer::token_type scan_string(const char* s)
 {
-    return json::lexer(json::input_adapter::create(s)).scan();
+    return json::lexer(nlohmann::detail::input_adapter_factory::create(s)).scan();
 }
 
 TEST_CASE("lexer class")

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -40,30 +40,30 @@ TEST_CASE("parser class")
     {
         SECTION("null")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("null"))).parse() == json(nullptr));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("null"))).parse() == json(nullptr));
         }
 
         SECTION("true")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("true"))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("true"))).parse() == json(true));
         }
 
         SECTION("false")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("false"))).parse() == json(false));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("false"))).parse() == json(false));
         }
 
         SECTION("array")
         {
             SECTION("empty array")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("[]"))).parse() == json(json::value_t::array));
-                CHECK(json::parser(json::input_adapter::create(std::string("[ ]"))).parse() == json(json::value_t::array));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[]"))).parse() == json(json::value_t::array));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[ ]"))).parse() == json(json::value_t::array));
             }
 
             SECTION("nonempty array")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("[true, false, null]"))).parse() == json({true, false, nullptr}));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[true, false, null]"))).parse() == json({true, false, nullptr}));
             }
         }
 
@@ -71,113 +71,113 @@ TEST_CASE("parser class")
         {
             SECTION("empty object")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("{}"))).parse() == json(json::value_t::object));
-                CHECK(json::parser(json::input_adapter::create(std::string("{ }"))).parse() == json(json::value_t::object));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{}"))).parse() == json(json::value_t::object));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{ }"))).parse() == json(json::value_t::object));
             }
 
             SECTION("nonempty object")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("{\"\": true, \"one\": 1, \"two\": null}"))).parse() == json({{"", true}, {"one", 1}, {"two", nullptr}}));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"\": true, \"one\": 1, \"two\": null}"))).parse() == json({{"", true}, {"one", 1}, {"two", nullptr}}));
             }
         }
 
         SECTION("string")
         {
             // empty string
-            CHECK(json::parser(json::input_adapter::create(std::string("\"\""))).parse() == json(json::value_t::string));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\""))).parse() == json(json::value_t::string));
 
             SECTION("errors")
             {
                 // error: tab in string
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\t\""))).parse(), json::parse_error&);
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\t\""))).parse(),
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\t\""))).parse(), json::parse_error&);
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\t\""))).parse(),
                                   "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: control character must be escaped; last read: '\"<U+0009>'");
                 // error: newline in string
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\n\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\r\""))).parse(), json::parse_error&);
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\n\""))).parse(),
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\n\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\r\""))).parse(), json::parse_error&);
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\n\""))).parse(),
                                   "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: control character must be escaped; last read: '\"<U+000A>'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\r\""))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\r\""))).parse(),
                                   "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: control character must be escaped; last read: '\"<U+000D>'");
                 // error: backspace in string
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\b\""))).parse(), json::parse_error&);
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\b\""))).parse(),
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\b\""))).parse(), json::parse_error&);
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\b\""))).parse(),
                                   "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: control character must be escaped; last read: '\"<U+0008>'");
                 // improve code coverage
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\uFF01"))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("[-4:1,]"))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\uFF01"))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[-4:1,]"))).parse(), json::parse_error&);
                 // unescaped control characters
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x00\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x01\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x02\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x03\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x04\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x05\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x06\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x07\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x08\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x09\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x0a\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x0b\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x0c\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x0d\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x0e\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x0f\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x10\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x11\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x12\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x13\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x14\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x15\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x16\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x17\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x18\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x19\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x1a\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x1b\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x1c\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x1d\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x1e\""))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\x1f\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x00\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x01\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x02\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x03\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x04\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x05\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x06\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x07\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x08\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x09\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0a\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0b\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0c\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0d\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0e\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0f\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x10\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x11\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x12\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x13\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x14\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x15\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x16\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x17\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x18\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x19\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1a\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1b\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1c\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1d\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1e\""))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1f\""))).parse(), json::parse_error&);
             }
 
             SECTION("escaped")
             {
                 // quotation mark "\""
                 auto r1 = R"("\"")"_json;
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\\"\""))).parse() == r1);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\"\""))).parse() == r1);
                 // reverse solidus "\\"
                 auto r2 = R"("\\")"_json;
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\\\\""))).parse() == r2);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\\\""))).parse() == r2);
                 // solidus
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\/\""))).parse() == R"("/")"_json);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\/\""))).parse() == R"("/")"_json);
                 // backspace
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\b\""))).parse() == json("\b"));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\b\""))).parse() == json("\b"));
                 // formfeed
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\f\""))).parse() == json("\f"));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\f\""))).parse() == json("\f"));
                 // newline
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\n\""))).parse() == json("\n"));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\n\""))).parse() == json("\n"));
                 // carriage return
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\r\""))).parse() == json("\r"));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\r\""))).parse() == json("\r"));
                 // horizontal tab
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\t\""))).parse() == json("\t"));
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\t\""))).parse() == json("\t"));
 
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0001\""))).parse().get<json::string_t>() == "\x01");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u000a\""))).parse().get<json::string_t>() == "\n");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u00b0\""))).parse().get<json::string_t>() == "°");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0c00\""))).parse().get<json::string_t>() == "ఀ");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\ud000\""))).parse().get<json::string_t>() == "퀀");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u000E\""))).parse().get<json::string_t>() == "\x0E");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u00F0\""))).parse().get<json::string_t>() == "ð");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0100\""))).parse().get<json::string_t>() == "Ā");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u2000\""))).parse().get<json::string_t>() == " ");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\uFFFF\""))).parse().get<json::string_t>() == "￿");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u20AC\""))).parse().get<json::string_t>() == "€");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"€\""))).parse().get<json::string_t>() == "€");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"🎈\""))).parse().get<json::string_t>() == "🎈");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0001\""))).parse().get<json::string_t>() == "\x01");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u000a\""))).parse().get<json::string_t>() == "\n");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u00b0\""))).parse().get<json::string_t>() == "°");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0c00\""))).parse().get<json::string_t>() == "ఀ");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\ud000\""))).parse().get<json::string_t>() == "퀀");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u000E\""))).parse().get<json::string_t>() == "\x0E");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u00F0\""))).parse().get<json::string_t>() == "ð");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0100\""))).parse().get<json::string_t>() == "Ā");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u2000\""))).parse().get<json::string_t>() == " ");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\uFFFF\""))).parse().get<json::string_t>() == "￿");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u20AC\""))).parse().get<json::string_t>() == "€");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"€\""))).parse().get<json::string_t>() == "€");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"🎈\""))).parse().get<json::string_t>() == "🎈");
 
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\ud80c\\udc60\""))).parse().get<json::string_t>() == u8"\U00013060");
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\ud83c\\udf1e\""))).parse().get<json::string_t>() == "🌞");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\ud80c\\udc60\""))).parse().get<json::string_t>() == u8"\U00013060");
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\ud83c\\udf1e\""))).parse().get<json::string_t>() == "🌞");
             }
         }
 
@@ -187,40 +187,40 @@ TEST_CASE("parser class")
             {
                 SECTION("without exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128"))).parse() == json(-128));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0"))).parse() == json(-0));
-                    CHECK(json::parser(json::input_adapter::create(std::string("0"))).parse() == json(0));
-                    CHECK(json::parser(json::input_adapter::create(std::string("128"))).parse() == json(128));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128"))).parse() == json(-128));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0"))).parse() == json(-0));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0"))).parse() == json(0));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("128"))).parse() == json(128));
                 }
 
                 SECTION("with exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("0e1"))).parse() == json(0e1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("0E1"))).parse() == json(0e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0e1"))).parse() == json(0e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0E1"))).parse() == json(0e1));
 
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-4"))).parse() == json(10000e-4));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-3"))).parse() == json(10000e-3));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-2"))).parse() == json(10000e-2));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-1"))).parse() == json(10000e-1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E0"))).parse() == json(10000e0));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E1"))).parse() == json(10000e1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E2"))).parse() == json(10000e2));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E3"))).parse() == json(10000e3));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E4"))).parse() == json(10000e4));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-4"))).parse() == json(10000e-4));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-3"))).parse() == json(10000e-3));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-2"))).parse() == json(10000e-2));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-1"))).parse() == json(10000e-1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E0"))).parse() == json(10000e0));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E1"))).parse() == json(10000e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E2"))).parse() == json(10000e2));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E3"))).parse() == json(10000e3));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E4"))).parse() == json(10000e4));
 
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-4"))).parse() == json(10000e-4));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-3"))).parse() == json(10000e-3));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-2"))).parse() == json(10000e-2));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-1"))).parse() == json(10000e-1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e0"))).parse() == json(10000e0));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e1"))).parse() == json(10000e1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e2"))).parse() == json(10000e2));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e3"))).parse() == json(10000e3));
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e4"))).parse() == json(10000e4));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-4"))).parse() == json(10000e-4));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-3"))).parse() == json(10000e-3));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-2"))).parse() == json(10000e-2));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-1"))).parse() == json(10000e-1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e0"))).parse() == json(10000e0));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e1"))).parse() == json(10000e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e2"))).parse() == json(10000e2));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e3"))).parse() == json(10000e3));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e4"))).parse() == json(10000e4));
 
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0e1"))).parse() == json(-0e1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0E1"))).parse() == json(-0e1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0E123"))).parse() == json(-0e123));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e1"))).parse() == json(-0e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E1"))).parse() == json(-0e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E123"))).parse() == json(-0e123));
                 }
 
                 SECTION("edge cases")
@@ -232,9 +232,9 @@ TEST_CASE("parser class")
                     // agree exactly on their numeric values.
 
                     // -(2**53)+1
-                    CHECK(json::parser(json::input_adapter::create(std::string("-9007199254740991"))).parse().get<int64_t>() == -9007199254740991);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-9007199254740991"))).parse().get<int64_t>() == -9007199254740991);
                     // (2**53)-1
-                    CHECK(json::parser(json::input_adapter::create(std::string("9007199254740991"))).parse().get<int64_t>() == 9007199254740991);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("9007199254740991"))).parse().get<int64_t>() == 9007199254740991);
                 }
 
                 SECTION("over the edge cases")  // issue #178 - Integer conversion to unsigned (incorrect handling of 64 bit integers)
@@ -247,11 +247,11 @@ TEST_CASE("parser class")
                     // i.e. -(2**63) -> (2**64)-1.
 
                     // -(2**63)    ** Note: compilers see negative literals as negated positive numbers (hence the -1))
-                    CHECK(json::parser(json::input_adapter::create(std::string("-9223372036854775808"))).parse().get<int64_t>() == -9223372036854775807 - 1);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-9223372036854775808"))).parse().get<int64_t>() == -9223372036854775807 - 1);
                     // (2**63)-1
-                    CHECK(json::parser(json::input_adapter::create(std::string("9223372036854775807"))).parse().get<int64_t>() == 9223372036854775807);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("9223372036854775807"))).parse().get<int64_t>() == 9223372036854775807);
                     // (2**64)-1
-                    CHECK(json::parser(json::input_adapter::create(std::string("18446744073709551615"))).parse().get<uint64_t>() == 18446744073709551615u);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("18446744073709551615"))).parse().get<uint64_t>() == 18446744073709551615u);
                 }
             }
 
@@ -259,85 +259,85 @@ TEST_CASE("parser class")
             {
                 SECTION("without exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128.5"))).parse() == json(-128.5));
-                    CHECK(json::parser(json::input_adapter::create(std::string("0.999"))).parse() == json(0.999));
-                    CHECK(json::parser(json::input_adapter::create(std::string("128.5"))).parse() == json(128.5));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0.0"))).parse() == json(-0.0));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128.5"))).parse() == json(-128.5));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0.999"))).parse() == json(0.999));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("128.5"))).parse() == json(128.5));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0"))).parse() == json(-0.0));
                 }
 
                 SECTION("with exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128.5E3"))).parse() == json(-128.5E3));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128.5E-3"))).parse() == json(-128.5E-3));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0.0e1"))).parse() == json(-0.0e1));
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0.0E1"))).parse() == json(-0.0e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128.5E3"))).parse() == json(-128.5E3));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128.5E-3"))).parse() == json(-128.5E-3));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0e1"))).parse() == json(-0.0e1));
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0E1"))).parse() == json(-0.0e1));
                 }
             }
 
             SECTION("overflow")
             {
                 // overflows during parsing yield an exception
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1.18973e+4932"))).parse() == json(), json::out_of_range&);
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1.18973e+4932"))).parse() == json(),
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1.18973e+4932"))).parse() == json(), json::out_of_range&);
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1.18973e+4932"))).parse() == json(),
                                   "[json.exception.out_of_range.406] number overflow parsing '1.18973e+4932'");
             }
 
             SECTION("invalid numbers")
             {
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("01"))).parse(),      json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("--1"))).parse(),     json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1."))).parse(),      json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1E"))).parse(),      json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1E-"))).parse(),     json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1.E1"))).parse(),    json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-1E"))).parse(),     json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0E#"))).parse(),    json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0E-#"))).parse(),   json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0#"))).parse(),     json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0.0:"))).parse(),   json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0.0Z"))).parse(),   json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0E123:"))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0e0-:"))).parse(),  json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0e-:"))).parse(),   json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0f"))).parse(),     json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("01"))).parse(),      json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("--1"))).parse(),     json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1."))).parse(),      json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E"))).parse(),      json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E-"))).parse(),     json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1.E1"))).parse(),    json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-1E"))).parse(),     json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E#"))).parse(),    json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E-#"))).parse(),   json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0#"))).parse(),     json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0:"))).parse(),   json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0Z"))).parse(),   json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E123:"))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e0-:"))).parse(),  json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e-:"))).parse(),   json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0f"))).parse(),     json::parse_error&);
 
                 // numbers must not begin with "+"
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("+1"))).parse(), json::parse_error&);
-                CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("+0"))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("+1"))).parse(), json::parse_error&);
+                CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("+0"))).parse(), json::parse_error&);
 
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("01"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("01"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 2: syntax error - unexpected number literal; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-01"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-01"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 3: syntax error - unexpected number literal; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("--1"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("--1"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 2: syntax error - invalid number; expected digit after '-'; last read: '--'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1."))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1."))).parse(),
                                   "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected digit after '.'; last read: '1.'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1E"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1E'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1E-"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E-"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 4: syntax error - invalid number; expected digit after exponent sign; last read: '1E-'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1.E1"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1.E1"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected digit after '.'; last read: '1.E'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-1E"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-1E"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 4: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '-1E'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0E#"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E#"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 4: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '-0E#'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0E-#"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E-#"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 5: syntax error - invalid number; expected digit after exponent sign; last read: '-0E-#'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0#"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0#"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 3: syntax error - invalid literal; last read: '-0#'; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0.0:"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0:"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 5: syntax error - unexpected ':'; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0.0Z"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0Z"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 5: syntax error - invalid literal; last read: '-0.0Z'; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0E123:"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E123:"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 7: syntax error - unexpected ':'; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0e0-:"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e0-:"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 6: syntax error - invalid number; expected digit after '-'; last read: '-:'; expected end of input");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0e-:"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e-:"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 5: syntax error - invalid number; expected digit after exponent sign; last read: '-0e-:'");
-                CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0f"))).parse(),
+                CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0f"))).parse(),
                                   "[json.exception.parse_error.101] parse error at 4: syntax error - invalid literal; last read: '-0f'; expected end of input");
             }
         }
@@ -347,30 +347,30 @@ TEST_CASE("parser class")
     {
         SECTION("null")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("null"))).accept());
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("null"))).accept());
         }
 
         SECTION("true")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("true"))).accept());
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("true"))).accept());
         }
 
         SECTION("false")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("false"))).accept());
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("false"))).accept());
         }
 
         SECTION("array")
         {
             SECTION("empty array")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("[]"))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("[ ]"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[]"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[ ]"))).accept());
             }
 
             SECTION("nonempty array")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("[true, false, null]"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[true, false, null]"))).accept());
             }
         }
 
@@ -378,105 +378,105 @@ TEST_CASE("parser class")
         {
             SECTION("empty object")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("{}"))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("{ }"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{}"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{ }"))).accept());
             }
 
             SECTION("nonempty object")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("{\"\": true, \"one\": 1, \"two\": null}"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"\": true, \"one\": 1, \"two\": null}"))).accept());
             }
         }
 
         SECTION("string")
         {
             // empty string
-            CHECK(json::parser(json::input_adapter::create(std::string("\"\""))).accept());
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\""))).accept());
 
             SECTION("errors")
             {
                 // error: tab in string
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\t\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\t\""))).accept() == false);
                 // error: newline in string
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\n\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\r\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\n\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\r\""))).accept() == false);
                 // error: backspace in string
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\b\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\b\""))).accept() == false);
                 // improve code coverage
-                CHECK(json::parser(json::input_adapter::create(std::string("\uFF01"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("[-4:1,]"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\uFF01"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[-4:1,]"))).accept() == false);
                 // unescaped control characters
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x00\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x01\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x02\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x03\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x04\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x05\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x06\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x07\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x08\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x09\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x0a\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x0b\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x0c\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x0d\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x0e\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x0f\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x10\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x11\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x12\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x13\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x14\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x15\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x16\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x17\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x18\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x19\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x1a\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x1b\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x1c\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x1d\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x1e\""))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\x1f\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x00\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x01\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x02\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x03\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x04\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x05\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x06\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x07\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x08\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x09\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0a\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0b\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0c\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0d\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0e\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x0f\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x10\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x11\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x12\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x13\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x14\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x15\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x16\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x17\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x18\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x19\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1a\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1b\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1c\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1d\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1e\""))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\x1f\""))).accept() == false);
             }
 
             SECTION("escaped")
             {
                 // quotation mark "\""
                 auto r1 = R"("\"")"_json;
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\\"\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\"\""))).accept());
                 // reverse solidus "\\"
                 auto r2 = R"("\\")"_json;
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\\\\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\\\""))).accept());
                 // solidus
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\/\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\/\""))).accept());
                 // backspace
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\b\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\b\""))).accept());
                 // formfeed
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\f\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\f\""))).accept());
                 // newline
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\n\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\n\""))).accept());
                 // carriage return
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\r\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\r\""))).accept());
                 // horizontal tab
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\t\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\t\""))).accept());
 
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0001\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u000a\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u00b0\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0c00\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\ud000\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u000E\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u00F0\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0100\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u2000\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\uFFFF\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\u20AC\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"€\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"🎈\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0001\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u000a\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u00b0\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0c00\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\ud000\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u000E\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u00F0\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0100\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u2000\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\uFFFF\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u20AC\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"€\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"🎈\""))).accept());
 
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\ud80c\\udc60\""))).accept());
-                CHECK(json::parser(json::input_adapter::create(std::string("\"\\ud83c\\udf1e\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\ud80c\\udc60\""))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\ud83c\\udf1e\""))).accept());
             }
         }
 
@@ -486,40 +486,40 @@ TEST_CASE("parser class")
             {
                 SECTION("without exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("0"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("128"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("128"))).accept());
                 }
 
                 SECTION("with exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("0e1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("0E1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0e1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0E1"))).accept());
 
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-4"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-3"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-2"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E-1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E0"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E2"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E3"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000E4"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-4"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-3"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-2"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E-1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E0"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E2"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E3"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000E4"))).accept());
 
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-4"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-3"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-2"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e-1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e0"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e2"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e3"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("10000e4"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-4"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-3"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-2"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e-1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e0"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e2"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e3"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("10000e4"))).accept());
 
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0e1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0E1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0E123"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E123"))).accept());
                 }
 
                 SECTION("edge cases")
@@ -531,9 +531,9 @@ TEST_CASE("parser class")
                     // agree exactly on their numeric values.
 
                     // -(2**53)+1
-                    CHECK(json::parser(json::input_adapter::create(std::string("-9007199254740991"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-9007199254740991"))).accept());
                     // (2**53)-1
-                    CHECK(json::parser(json::input_adapter::create(std::string("9007199254740991"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("9007199254740991"))).accept());
                 }
 
                 SECTION("over the edge cases")  // issue #178 - Integer conversion to unsigned (incorrect handling of 64 bit integers)
@@ -546,11 +546,11 @@ TEST_CASE("parser class")
                     // i.e. -(2**63) -> (2**64)-1.
 
                     // -(2**63)    ** Note: compilers see negative literals as negated positive numbers (hence the -1))
-                    CHECK(json::parser(json::input_adapter::create(std::string("-9223372036854775808"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-9223372036854775808"))).accept());
                     // (2**63)-1
-                    CHECK(json::parser(json::input_adapter::create(std::string("9223372036854775807"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("9223372036854775807"))).accept());
                     // (2**64)-1
-                    CHECK(json::parser(json::input_adapter::create(std::string("18446744073709551615"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("18446744073709551615"))).accept());
                 }
             }
 
@@ -558,49 +558,49 @@ TEST_CASE("parser class")
             {
                 SECTION("without exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128.5"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("0.999"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("128.5"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0.0"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128.5"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0.999"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("128.5"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0"))).accept());
                 }
 
                 SECTION("with exponent")
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128.5E3"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-128.5E-3"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0.0e1"))).accept());
-                    CHECK(json::parser(json::input_adapter::create(std::string("-0.0E1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128.5E3"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-128.5E-3"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0e1"))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0E1"))).accept());
                 }
             }
 
             SECTION("overflow")
             {
                 // overflows during parsing yield an exception, but is accepted anyway
-                CHECK(json::parser(json::input_adapter::create(std::string("1.18973e+4932"))).accept());
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1.18973e+4932"))).accept());
             }
 
             SECTION("invalid numbers")
             {
-                CHECK(json::parser(json::input_adapter::create(std::string("01"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("--1"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("1."))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("1E"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("1E-"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("1.E1"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-1E"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0E#"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0E-#"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0#"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0.0:"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0.0Z"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0E123:"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0e0-:"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0e-:"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("-0f"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("01"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("--1"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1."))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E-"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1.E1"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-1E"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E#"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E-#"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0#"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0:"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0.0Z"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0E123:"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e0-:"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0e-:"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0f"))).accept() == false);
 
                 // numbers must not begin with "+"
-                CHECK(json::parser(json::input_adapter::create(std::string("+1"))).accept() == false);
-                CHECK(json::parser(json::input_adapter::create(std::string("+0"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("+1"))).accept() == false);
+                CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("+0"))).accept() == false);
             }
         }
     }
@@ -608,152 +608,152 @@ TEST_CASE("parser class")
     SECTION("parse errors")
     {
         // unexpected end of number
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("0."))).parse(),  json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-"))).parse(),   json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("--"))).parse(),  json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-0."))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-."))).parse(),  json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("-:"))).parse(),  json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("0.:"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("e."))).parse(),  json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1e."))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1e/"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1e:"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1E."))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1E/"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("1E:"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("0."))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0."))).parse(),  json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-"))).parse(),   json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("--"))).parse(),  json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0."))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-."))).parse(),  json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-:"))).parse(),  json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0.:"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("e."))).parse(),  json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e."))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e/"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e:"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E."))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E/"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E:"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0."))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected digit after '.'; last read: '0.'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid number; expected digit after '-'; last read: '-'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("--"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("--"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid number; expected digit after '-'; last read: '--'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-0."))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0."))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid number; expected digit after '.'; last read: '-0.'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-."))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-."))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid number; expected digit after '-'; last read: '-.'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("-:"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-:"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid number; expected digit after '-'; last read: '-:'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("0.:"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0.:"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected digit after '.'; last read: '0.:'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("e."))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("e."))).parse(),
                           "[json.exception.parse_error.101] parse error at 1: syntax error - invalid literal; last read: 'e'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1e."))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e."))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1e.'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1e/"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e/"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1e/'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1e:"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e:"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1e:'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1E."))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E."))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1E.'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1E/"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E/"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1E/'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("1E:"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E:"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid number; expected '+', '-', or digit after exponent; last read: '1E:'");
 
         // unexpected end of null
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("n"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("nu"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("nul"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("n"))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("n"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("nu"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("nul"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("n"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid literal; last read: 'n'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("nu"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("nu"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid literal; last read: 'nu'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("nul"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("nul"))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid literal; last read: 'nul'");
 
         // unexpected end of true
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("t"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("tr"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("tru"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("t"))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("t"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("tr"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("tru"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("t"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid literal; last read: 't'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("tr"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("tr"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid literal; last read: 'tr'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("tru"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("tru"))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid literal; last read: 'tru'");
 
         // unexpected end of false
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("f"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("fa"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("fal"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("fals"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("f"))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("f"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fa"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fal"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fals"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("f"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid literal; last read: 'f'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("fa"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fa"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid literal; last read: 'fa'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("fal"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fal"))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid literal; last read: 'fal'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("fals"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fals"))).parse(),
                           "[json.exception.parse_error.101] parse error at 5: syntax error - invalid literal; last read: 'fals'");
 
         // missing/unexpected end of array
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("["))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("[1"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("[1,"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("[1,]"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("]"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("["))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("["))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1,"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1,]"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("]"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("["))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - unexpected end of input; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("[1"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1"))).parse(),
                           "[json.exception.parse_error.101] parse error at 3: syntax error - unexpected end of input; expected ']'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("[1,"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1,"))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - unexpected end of input; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("[1,]"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1,]"))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - unexpected ']'; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("]"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("]"))).parse(),
                           "[json.exception.parse_error.101] parse error at 1: syntax error - unexpected ']'; expected '[', '{', or a literal");
 
         // missing/unexpected end of object
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("{"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("{\"foo\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("{\"foo\":"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("{\"foo\":}"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("{\"foo\":1,}"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("}"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("{"))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":}"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":1,}"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("}"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - unexpected end of input; expected string literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("{\"foo\""))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 7: syntax error - unexpected end of input; expected ':'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("{\"foo\":"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":"))).parse(),
                           "[json.exception.parse_error.101] parse error at 8: syntax error - unexpected end of input; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("{\"foo\":}"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":}"))).parse(),
                           "[json.exception.parse_error.101] parse error at 8: syntax error - unexpected '}'; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("{\"foo\":1,}"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":1,}"))).parse(),
                           "[json.exception.parse_error.101] parse error at 10: syntax error - unexpected '}'; expected string literal");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("}"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("}"))).parse(),
                           "[json.exception.parse_error.101] parse error at 1: syntax error - unexpected '}'; expected '[', '{', or a literal");
 
         // missing/unexpected end of string
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u0\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u01\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u012\""))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u0"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u01"))).parse(), json::parse_error&);
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("\"\\u012"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\""))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u01\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u012\""))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u01"))).parse(), json::parse_error&);
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u012"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: missing closing quote; last read: '\"'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\\""))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid string: missing closing quote; last read: '\"\\\"'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u\""))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u\"'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u0\""))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 5: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0\"'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u01\""))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u01\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 6: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01\"'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u012\""))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u012\""))).parse(),
                           "[json.exception.parse_error.101] parse error at 7: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012\"'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u"))).parse(),
                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u0"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0"))).parse(),
                           "[json.exception.parse_error.101] parse error at 5: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u01"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u01"))).parse(),
                           "[json.exception.parse_error.101] parse error at 6: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01'");
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("\"\\u012"))).parse(),
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u012"))).parse(),
                           "[json.exception.parse_error.101] parse error at 7: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012'");
 
         // invalid escapes
@@ -773,7 +773,7 @@ TEST_CASE("parser class")
                 case ('r'):
                 case ('t'):
                 {
-                    CHECK_NOTHROW(json::parser(json::input_adapter::create(std::string(s.c_str()))).parse());
+                    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s.c_str()))).parse());
                     break;
                 }
 
@@ -786,11 +786,11 @@ TEST_CASE("parser class")
                 // any other combination of backslash and character is invalid
                 default:
                 {
-                    CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string(s.c_str()))).parse(), json::parse_error&);
+                    CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s.c_str()))).parse(), json::parse_error&);
                     // only check error message if c is not a control character
                     if (c > 0x1f)
                     {
-                        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string(s.c_str()))).parse(),
+                        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s.c_str()))).parse(),
                                           "[json.exception.parse_error.101] parse error at 3: syntax error - invalid string: forbidden character after backslash; last read: '\"\\" + std::string(1, static_cast<char>(c)) + "'");
                     }
                     break;
@@ -851,49 +851,49 @@ TEST_CASE("parser class")
                 if (valid(c))
                 {
                     CAPTURE(s1);
-                    CHECK_NOTHROW(json::parser(json::input_adapter::create(std::string(s1.c_str()))).parse());
+                    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s1.c_str()))).parse());
                     CAPTURE(s2);
-                    CHECK_NOTHROW(json::parser(json::input_adapter::create(std::string(s2.c_str()))).parse());
+                    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s2.c_str()))).parse());
                     CAPTURE(s3);
-                    CHECK_NOTHROW(json::parser(json::input_adapter::create(std::string(s3.c_str()))).parse());
+                    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s3.c_str()))).parse());
                     CAPTURE(s4);
-                    CHECK_NOTHROW(json::parser(json::input_adapter::create(std::string(s4.c_str()))).parse());
+                    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s4.c_str()))).parse());
                 }
                 else
                 {
                     CAPTURE(s1);
-                    CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string(s1.c_str()))).parse(), json::parse_error&);
+                    CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s1.c_str()))).parse(), json::parse_error&);
                     // only check error message if c is not a control character
                     if (c > 0x1f)
                     {
-                        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string(s1.c_str()))).parse(),
+                        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s1.c_str()))).parse(),
                                           "[json.exception.parse_error.101] parse error at 7: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '" + s1.substr(0, 7) + "'");
                     }
 
                     CAPTURE(s2);
-                    CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string(s2.c_str()))).parse(), json::parse_error&);
+                    CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s2.c_str()))).parse(), json::parse_error&);
                     // only check error message if c is not a control character
                     if (c > 0x1f)
                     {
-                        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string(s2.c_str()))).parse(),
+                        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s2.c_str()))).parse(),
                                           "[json.exception.parse_error.101] parse error at 6: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '" + s2.substr(0, 6) + "'");
                     }
 
                     CAPTURE(s3);
-                    CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string(s3.c_str()))).parse(), json::parse_error&);
+                    CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s3.c_str()))).parse(), json::parse_error&);
                     // only check error message if c is not a control character
                     if (c > 0x1f)
                     {
-                        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string(s3.c_str()))).parse(),
+                        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s3.c_str()))).parse(),
                                           "[json.exception.parse_error.101] parse error at 5: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '" + s3.substr(0, 5) + "'");
                     }
 
                     CAPTURE(s4);
-                    CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string(s4.c_str()))).parse(), json::parse_error&);
+                    CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s4.c_str()))).parse(), json::parse_error&);
                     // only check error message if c is not a control character
                     if (c > 0x1f)
                     {
-                        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string(s4.c_str()))).parse(),
+                        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s4.c_str()))).parse(),
                                           "[json.exception.parse_error.101] parse error at 4: syntax error - invalid string: '\\u' must be followed by 4 hex digits; last read: '" + s4.substr(0, 4) + "'");
                     }
                 }
@@ -919,63 +919,63 @@ TEST_CASE("parser class")
     SECTION("parse errors (accept)")
     {
         // unexpected end of number
-        CHECK(json::parser(json::input_adapter::create(std::string("0."))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("-"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("--"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("-0."))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("-."))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("-:"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("0.:"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("e."))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("1e."))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("1e/"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("1e:"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("1E."))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("1E/"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("1E:"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0."))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("--"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-0."))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-."))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("-:"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("0.:"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("e."))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e."))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e/"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1e:"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E."))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E/"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("1E:"))).accept() == false);
 
         // unexpected end of null
-        CHECK(json::parser(json::input_adapter::create(std::string("n"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("nu"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("nul"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("n"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("nu"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("nul"))).accept() == false);
 
         // unexpected end of true
-        CHECK(json::parser(json::input_adapter::create(std::string("t"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("tr"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("tru"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("t"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("tr"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("tru"))).accept() == false);
 
         // unexpected end of false
-        CHECK(json::parser(json::input_adapter::create(std::string("f"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("fa"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("fal"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("fals"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("f"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fa"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fal"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("fals"))).accept() == false);
 
         // missing/unexpected end of array
-        CHECK(json::parser(json::input_adapter::create(std::string("["))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("[1"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("[1,"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("[1,]"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("]"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("["))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1,"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[1,]"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("]"))).accept() == false);
 
         // missing/unexpected end of object
-        CHECK(json::parser(json::input_adapter::create(std::string("{"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("{\"foo\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("{\"foo\":"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("{\"foo\":}"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("{\"foo\":1,}"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("}"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":}"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{\"foo\":1,}"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("}"))).accept() == false);
 
         // missing/unexpected end of string
-        CHECK(json::parser(json::input_adapter::create(std::string("\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u01\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u012\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u0"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u01"))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\u012"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u01\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u012\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u0"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u01"))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\u012"))).accept() == false);
 
         // invalid escapes
         for (int c = 1; c < 128; ++c)
@@ -994,7 +994,7 @@ TEST_CASE("parser class")
                 case ('r'):
                 case ('t'):
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string(s.c_str()))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s.c_str()))).accept());
                     break;
                 }
 
@@ -1007,7 +1007,7 @@ TEST_CASE("parser class")
                 // any other combination of backslash and character is invalid
                 default:
                 {
-                    CHECK(json::parser(json::input_adapter::create(std::string(s.c_str()))).accept() == false);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s.c_str()))).accept() == false);
                     break;
                 }
             }
@@ -1066,48 +1066,48 @@ TEST_CASE("parser class")
                 if (valid(c))
                 {
                     CAPTURE(s1);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s1.c_str()))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s1.c_str()))).accept());
                     CAPTURE(s2);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s2.c_str()))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s2.c_str()))).accept());
                     CAPTURE(s3);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s3.c_str()))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s3.c_str()))).accept());
                     CAPTURE(s4);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s4.c_str()))).accept());
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s4.c_str()))).accept());
                 }
                 else
                 {
                     CAPTURE(s1);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s1.c_str()))).accept() == false);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s1.c_str()))).accept() == false);
 
                     CAPTURE(s2);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s2.c_str()))).accept() == false);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s2.c_str()))).accept() == false);
 
                     CAPTURE(s3);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s3.c_str()))).accept() == false);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s3.c_str()))).accept() == false);
 
                     CAPTURE(s4);
-                    CHECK(json::parser(json::input_adapter::create(std::string(s4.c_str()))).accept() == false);
+                    CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string(s4.c_str()))).accept() == false);
                 }
             }
         }
 
         // missing part of a surrogate pair
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\uD80C\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\uD80C\""))).accept() == false);
         // invalid surrogate pair
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\uD80C\\uD80C\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\uD80C\\u0000\""))).accept() == false);
-        CHECK(json::parser(json::input_adapter::create(std::string("\"\\uD80C\\uFFFF\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\uD80C\\uD80C\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\uD80C\\u0000\""))).accept() == false);
+        CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("\"\\uD80C\\uFFFF\""))).accept() == false);
     }
 
     SECTION("tests found by mutate++")
     {
         // test case to make sure no comma preceeds the first key
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("{,\"key\": false}"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("{,\"key\": false}"))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{,\"key\": false}"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("{,\"key\": false}"))).parse(),
                           "[json.exception.parse_error.101] parse error at 2: syntax error - unexpected ','; expected string literal");
         // test case to make sure an object is properly closed
-        CHECK_THROWS_AS(json::parser(json::input_adapter::create(std::string("[{\"key\": false true]"))).parse(), json::parse_error&);
-        CHECK_THROWS_WITH(json::parser(json::input_adapter::create(std::string("[{\"key\": false true]"))).parse(),
+        CHECK_THROWS_AS(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[{\"key\": false true]"))).parse(), json::parse_error&);
+        CHECK_THROWS_WITH(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("[{\"key\": false true]"))).parse(),
                           "[json.exception.parse_error.101] parse error at 19: syntax error - unexpected true literal; expected '}'");
 
         // test case to make sure the callback is properly evaluated after reading a key
@@ -1295,42 +1295,42 @@ TEST_CASE("parser class")
         SECTION("from std::vector")
         {
             std::vector<uint8_t> v = {'t', 'r', 'u', 'e'};
-            CHECK(json::parser(json::input_adapter::create(std::begin(v), std::end(v))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::begin(v), std::end(v))).parse() == json(true));
         }
 
         SECTION("from std::array")
         {
             std::array<uint8_t, 5> v { {'t', 'r', 'u', 'e'} };
-            CHECK(json::parser(json::input_adapter::create(std::begin(v), std::end(v))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::begin(v), std::end(v))).parse() == json(true));
         }
 
         SECTION("from array")
         {
             uint8_t v[] = {'t', 'r', 'u', 'e'};
-            CHECK(json::parser(json::input_adapter::create(std::begin(v), std::end(v))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::begin(v), std::end(v))).parse() == json(true));
         }
 
         SECTION("from char literal")
         {
-            CHECK(json::parser(json::input_adapter::create(std::string("true"))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::string("true"))).parse() == json(true));
         }
 
         SECTION("from std::string")
         {
             std::string v = {'t', 'r', 'u', 'e'};
-            CHECK(json::parser(json::input_adapter::create(std::begin(v), std::end(v))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::begin(v), std::end(v))).parse() == json(true));
         }
 
         SECTION("from std::initializer_list")
         {
             std::initializer_list<uint8_t> v = {'t', 'r', 'u', 'e'};
-            CHECK(json::parser(json::input_adapter::create(std::begin(v), std::end(v))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::begin(v), std::end(v))).parse() == json(true));
         }
 
         SECTION("from std::valarray")
         {
             std::valarray<uint8_t> v = {'t', 'r', 'u', 'e'};
-            CHECK(json::parser(json::input_adapter::create(std::begin(v), std::end(v))).parse() == json(true));
+            CHECK(json::parser(nlohmann::detail::input_adapter_factory::create(std::begin(v), std::end(v))).parse() == json(true));
         }
     }
 }

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -53,7 +53,7 @@ TEST_CASE("convenience functions")
                                       const char* escaped)
         {
             std::stringstream ss;
-            json::serializer s(json::output_adapter<char>::create(ss), ' ');
+            json::serializer s(nlohmann::detail::output_adapter_factory<char>::create(ss), ' ');
             s.dump_escaped(original);
             CHECK(ss.str() == escaped);
         };


### PR DESCRIPTION
Hi, I managed to move every nested struct/class present in `basic_json` to the `detail` namespace.

Excepted `json_pointer` which is now in `nlohmann`, I don't know if input/output adapters are exposed, if so, I will move them there too.

This is an intermediate refactoring, needed before splitting the library into multiple files, and before changing classes and namespace names.

I'm afraid the review will not be very interesting... I advise reviewers to look at each commit separately, it is not readable otherwise.