### PR TITLE
Don't include <iostream>, use std::make_shared

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -6634,17 +6634,17 @@ class basic_json
 
         static std::shared_ptr<output_adapter<CharType>> create(std::vector<CharType>& vec)
         {
-            return std::shared_ptr<output_adapter>(new output_vector_adapter<CharType>(vec));
+            return std::make_shared<output_vector_adapter<CharType>>(vec);
         }
 
         static std::shared_ptr<output_adapter<CharType>> create(std::ostream& s)
         {
-            return std::shared_ptr<output_adapter>(new output_stream_adapter<CharType>(s));
+            return std::make_shared<output_stream_adapter<CharType>>(s);
         }
 
         static std::shared_ptr<output_adapter<CharType>> create(std::string& s)
         {
-            return std::shared_ptr<output_adapter>(new output_string_adapter<CharType>(s));
+            return std::make_shared<output_string_adapter<CharType>>(s);
         }
     };
 
@@ -8767,19 +8767,19 @@ class basic_json
         /// input adapter for input stream
         static std::shared_ptr<input_adapter> create(std::istream& i)
         {
-            return std::shared_ptr<input_adapter>(new cached_input_stream_adapter<16384>(i));
+            return std::make_shared<cached_input_stream_adapter<16384>> (i);
         }
 
         /// input adapter for input stream
         static std::shared_ptr<input_adapter> create(std::istream&& i)
         {
-            return std::shared_ptr<input_adapter>(new cached_input_stream_adapter<16384>(i));
+            return std::make_shared<cached_input_stream_adapter<16384>>(i);
         }
 
         /// input adapter for buffer
         static std::shared_ptr<input_adapter> create(const char* b, size_t l)
         {
-            return std::shared_ptr<input_adapter>(new input_buffer_adapter(b, l));
+            return std::make_shared<input_buffer_adapter>(b, l);
         }
 
         // derived support

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -6675,7 +6675,7 @@ class basic_json
         std::vector<CharType>& v;
     };
 
-    /// putput adapter for output streams
+    /// output adapter for output streams
     template<typename CharType>
     class output_stream_adapter : public output_adapter<CharType>
     {

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -43,7 +43,7 @@ SOFTWARE.
 #include <functional> // function, hash, less
 #include <initializer_list> // initializer_list
 #include <iomanip> // hex
-#include <iostream> // istream, ostream
+#include <iosfwd>   // istream, ostream
 #include <iterator> // advance, begin, back_inserter, bidirectional_iterator_tag, distance, end, inserter, iterator, iterator_traits, next, random_access_iterator_tag, reverse_iterator
 #include <limits> // numeric_limits
 #include <locale> // locale

--- a/test/src/unit-readme.cpp
+++ b/test/src/unit-readme.cpp
@@ -36,6 +36,7 @@ using nlohmann::json;
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
+#include <iostream>
 
 TEST_CASE("README", "[hide]")
 {

--- a/test/src/unit-unicode.cpp
+++ b/test/src/unit-unicode.cpp
@@ -33,6 +33,7 @@ SOFTWARE.
 using nlohmann::json;
 
 #include <fstream>
+#include <iostream>
 
 extern size_t calls;
 size_t calls = 0;


### PR DESCRIPTION
I've been evaluating this library for usage in an embedded software that runs on an MCU with on-chip flash.  Memory on these devices is a premium.  Just including the \<iostream> file, makes the ROM image grow by about 200 KByte, and I've got only about 768 KByte in total.  This is a known problem of \<iostream>.  One workaround is not to include it in (library) header files, but only in source files where it is actually needed.  Header files should include \<iosfwd> instead.

While skimming over the code, I've also spotted some opportunities to use std::make_shared.

Tested with 'make' and 'make test' on GCC 5.4.0 x86_64-linux-gnu.
Also briefly checked that the library can be used without including \<iostream> on GCC 6.4.1 rx-elf.