### PR TITLE
REFACTOR: rewrite CMakeLists.txt for better inlcude and reuse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,56 +1,78 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0.0)
 
-# define the project
-project(nlohmann_json VERSION 2.1.1 LANGUAGES CXX)
+##
+## PROJECT
+## name and version
+##
+project(nlohmann_json VERSION 2.1.1)
 
+##
+## OPTIONS
+##
 option(JSON_BuildTests "Build the unit tests" ON)
 
-# define project variables
-set(JSON_TARGET_NAME ${PROJECT_NAME})
-set(JSON_PACKAGE_NAME ${JSON_TARGET_NAME})
-set(JSON_TARGETS_FILENAME "${JSON_PACKAGE_NAME}Targets.cmake")
-set(JSON_CONFIG_FILENAME "${JSON_PACKAGE_NAME}Config.cmake")
-set(JSON_CONFIGVERSION_FILENAME "${JSON_PACKAGE_NAME}ConfigVersion.cmake")
-set(JSON_CONFIG_DESTINATION "cmake")
-set(JSON_INCLUDE_DESTINATION "include/nlohmann")
+##
+## CONFIGURATION
+##
+set(NLOHMANN_JSON_TARGET_NAME               ${PROJECT_NAME})
+set(NLOHMANN_JSON_SOURCE_DIR                "src/")
+set(NLOHMANN_JSON_CONFIG_INSTALL_DIR        "lib/cmake/${PROJECT_NAME}")
+set(NLOHMANN_JSON_INCLUDE_INSTALL_DIR       "include")
+set(NLOHMANN_JSON_HEADER_INSTALL_DIR        "${NLOHMANN_JSON_INCLUDE_INSTALL_DIR}/nlohmann")
+set(NLOHMANN_JSON_TARGETS_EXPORT_NAME       "${PROJECT_NAME}Targets")
+set(NLOHMANN_JSON_CMAKE_CONFIG_TEMPLATE     "cmake/config.cmake.in")
+set(NLOHMANN_JSON_CMAKE_CONFIG_DIR          "${CMAKE_CURRENT_BINARY_DIR}/cmake_config")
+set(NLOHMANN_JSON_CMAKE_VERSION_CONFIG_FILE "${NLOHMANN_JSON_CMAKE_CONFIG_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(NLOHMANN_JSON_CMAKE_PROJECT_CONFIG_FILE "${NLOHMANN_JSON_CMAKE_CONFIG_DIR}/${PROJECT_NAME}Config.cmake")
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+##
+## TARGET
+## create target and add include path
+##
+add_library(${NLOHMANN_JSON_TARGET_NAME} INTERFACE)
 
-# create and configure the library target
-add_library(${JSON_TARGET_NAME} INTERFACE)
-target_include_directories(${JSON_TARGET_NAME} INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-  $<INSTALL_INTERFACE:${JSON_INCLUDE_DESTINATION}>)
-
-# create and configure the unit test target
+target_include_directories(
+    ${NLOHMANN_JSON_TARGET_NAME}
+    INTERFACE $<INSTALL_INTERFACE:include/>
+)
+            
+##
+## TESTS
+## create and configure the unit test target
+##
 if(JSON_BuildTests)
     enable_testing()
+    include_directories(${NLOHMANN_JSON_SOURCE_DIR})
     add_subdirectory(test)
 endif()
 
-# generate a config and config version file for the package
+##
+## INSTALL
+## install header files, generate and install cmake config files for find_package()
+##
 include(CMakePackageConfigHelpers)
-configure_package_config_file("cmake/config.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
-    INSTALL_DESTINATION ${JSON_CONFIG_DESTINATION}
-    PATH_VARS JSON_INCLUDE_DESTINATION)
-write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion)
-
-# export the library target and store build directory in package registry
-export(TARGETS ${JSON_TARGET_NAME}
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/${JSON_TARGETS_FILENAME}")
-export(PACKAGE ${JSON_PACKAGE_NAME})
-
-# install library target and config files
-install(TARGETS ${JSON_TARGET_NAME}
-    EXPORT ${JSON_PACKAGE_NAME})
-install(FILES "src/json.hpp"
-    DESTINATION ${JSON_INCLUDE_DESTINATION})
-install(EXPORT ${JSON_PACKAGE_NAME}
-    FILE ${JSON_TARGETS_FILENAME}
-    DESTINATION ${JSON_CONFIG_DESTINATION})
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIG_FILENAME}"
-    "${CMAKE_CURRENT_BINARY_DIR}/${JSON_CONFIGVERSION_FILENAME}"
-    DESTINATION ${JSON_CONFIG_DESTINATION})
+write_basic_package_version_file(
+    ${NLOHMANN_JSON_CMAKE_VERSION_CONFIG_FILE} COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(
+    ${NLOHMANN_JSON_CMAKE_CONFIG_TEMPLATE}
+    ${NLOHMANN_JSON_CMAKE_PROJECT_CONFIG_FILE}
+    INSTALL_DESTINATION ${NLOHMANN_JSON_CONFIG_INSTALL_DIR}
+)
+install(
+    DIRECTORY ${NLOHMANN_JSON_SOURCE_DIR}
+    DESTINATION ${NLOHMANN_JSON_HEADER_INSTALL_DIR}
+)
+install(
+    FILES ${NLOHMANN_JSON_CMAKE_PROJECT_CONFIG_FILE} ${NLOHMANN_JSON_CMAKE_VERSION_CONFIG_FILE}
+    DESTINATION ${NLOHMANN_JSON_CONFIG_INSTALL_DIR}
+)
+install(
+    TARGETS ${NLOHMANN_JSON_TARGET_NAME}
+    EXPORT ${NLOHMANN_JSON_TARGETS_EXPORT_NAME}
+    INCLUDES DESTINATION ${NLOHMANN_JSON_INCLUDE_INSTALL_DIR}
+)
+install(
+    EXPORT ${NLOHMANN_JSON_TARGETS_EXPORT_NAME}
+    DESTINATION ${NLOHMANN_JSON_CONFIG_INSTALL_DIR}
+)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,7 +1,3 @@
 @PACKAGE_INIT@
-set_and_check(JSON_INCLUDE_DIR "@PACKAGE_JSON_INCLUDE_DESTINATION@")
-
-cmake_policy(PUSH)
-cmake_policy(SET CMP0024 OLD)
-include(${CMAKE_CURRENT_LIST_DIR}/@JSON_TARGETS_FILENAME@)
-cmake_policy(POP)
+include("${CMAKE_CURRENT_LIST_DIR}/@NLOHMANN_JSON_TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
The rewrite uses more cmake build-in functions and build-in automaticly generated
variables to allow better generic reuse.
This is based on the cmake example project [package-example](https://github.com/forexample/package-example)
* cmake  files are installed to
``` <install_prefix>/lib/cmake/nlohmann_json/ ``` for best support on
most systems
* include path is set to ``` include ```  for usage as ``` #include
<nlohmann/json.hpp> ```

## Motivation
The motivation is the reintegration of ``` nlohmann_json ``` into the cmake package-manager [hunter](https://github.com/ruslo/hunter/pull/907) 
and to avoid possible naming collissions with other packages( e.g. jsoncpp, etc)

## compile install and run with unit tests
```sh
dan@kay ~/git/json/build (git)-[change_installed_cmake_include_path] % rm -rf ./* && rm -rf ../test_install/* && cmake ..  -DCMAKE_INSTALL_PREFIX=../test_install -DJSON_BuildTests=ON && make -j8  && make install
zsh: sure you want to delete all 8 files in /home/dan/git/json/build/. [yn]? y
zsh: sure you want to delete all 2 files in /home/dan/git/json/build/../test_install [yn]? y
-- The C compiler identification is GNU 7.1.1
-- The CXX compiler identification is GNU 7.1.1
[....]
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dan/git/json/build
Scanning dependencies of target catch_main
[  2%] Building CXX object test/CMakeFiles/catch_main.dir/src/unit.cpp.o
[...]
[100%] Built target json_unit
make -j8  157.98s user 5.96s system 580% cpu 28.240 total
[  2%] Built target catch_main
[100%] Built target json_unit
Install the project...
-- Install configuration: ""
-- Installing: /home/dan/git/json/test_install/include/nlohmann
-- Installing: /home/dan/git/json/test_install/include/nlohmann/json.hpp
-- Installing: /home/dan/git/json/test_install/lib/cmake/nlohmann_json/nlohmann_jsonConfig.cmake
-- Installing: /home/dan/git/json/test_install/lib/cmake/nlohmann_json/nlohmann_jsonConfigVersion.cmake
-- Installing: /home/dan/git/json/test_install/lib/cmake/nlohmann_json/nlohmann_jsonTargets.cmake
dan@kay ~/git/json/build (git)-[change_installed_cmake_include_path] % ctest -j2
Test project /home/dan/git/json/build
    Start 1: json_unit_default
    Start 2: json_unit_all
1/2 Test #1: json_unit_default ................   Passed   12.12 sec
2/2 Test #2: json_unit_all ....................   Passed  223.00 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) = 223.01 sec
ctest -j2  234.59s user 0.52s system 105% cpu 3:43.01 total
```

## Usage on an external project after installation
#### CMakeLists.txt
``` cmake
cmake_minimum_required (VERSION 3.0)
project(test_json)
find_package(nlohmann_json CONFIG REQUIRED PATHS /home/dan/git/json/test_install/)
add_executable(main main.cpp)
target_link_libraries(main nlohmann_json)
```
#### main.cpp
```cpp
#include <iostream>
#include <nlohmann/json.hpp>
int main (int argc, char** argv) {
  nlohmann::json j2 = {
    {"pi", 3.141},    
  };
  std::cout << j2 << std::endl;
  return 0;
}
```


I'm looking forward on comments and thoughts about the changes.
Many thanks in advance

