### PR TITLE
Add documentation for integration with CMake and hunter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0.0)
 ## PROJECT
 ## name and version
 ##
-project(nlohmann_json VERSION 2.1.1)
+project(nlohmann_json VERSION 2.1.1 LANGUAGES CXX)
 
 ##
 ## OPTIONS

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ If you are using the [Meson Build System](http://mesonbuild.com), then you can w
 
 If you are using [Conan](https://www.conan.io/) to manage your dependencies, merely add `jsonformoderncpp/x.y.z@vthiery/stable` to your `conanfile.py`'s requires, where `x.y.z` is the release version you want to use. Please file issues [here](https://github.com/vthiery/conan-jsonformoderncpp/issues) if you experience problems with the packages.
 
+If you are using [hunter](https://github.com/ruslo/hunter/) on your project for external dependencies, then you can use the [nlohman_json package](https://github.com/ruslo/hunter/wiki/pkg.nlohmann_json). Please see the hunter project for any issues regarding the packaging.
+
 :warning: [Version 3.0.0](https://github.com/nlohmann/json/wiki/Road-toward-3.0.0) is currently under development. Branch `develop` is used for the ongoing work and is probably **unstable**. Please use the `master` branch for the last stable version 2.1.1.
 
 


### PR DESCRIPTION
here you go, as requested. I added again the ``` LANGUAGES CXX ``` and also added the documenation about using it with CMake and CMake with hunter.
Hunter just released his latest version with supporting the version v2.1.1 of ``` nlohman_json ``` 👍 




