### PR TITLE
Simplified istream handing #367

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 json_unit
 json_benchmarks
+json_benchmarks_simple
 fuzz-testing
 
 *.dSYM

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,11 +1,21 @@
-all: json_benchmarks
-	./json_benchmarks
 
-json_benchmarks: src/benchmarks.cpp ../src/json.hpp number_jsons
+#
+# Build/run json.hpp benchmarks, eg. CXX=g++-7 make
+# 
+# The existing json_benchmarks did not allow optimization under some compilers
+# 
+all: json_benchmarks json_benchmarks_simple number_jsons
+	bash -c 'time ./json_benchmarks'
+	bash -c 'time ./json_benchmarks_simple'
+
+json_benchmarks: src/benchmarks.cpp ../src/json.hpp
 	$(CXX) -std=c++11 -pthread $(CXXFLAGS) -DNDEBUG -O3 -flto -I thirdparty/benchpress -I thirdparty/cxxopts -I../src src/benchmarks.cpp $(LDFLAGS) -o $@
+
+json_benchmarks_simple: src/benchmarks_simple.cpp ../src/json.hpp
+	$(CXX) -std=c++11 $(CXXFLAGS) -DNDEBUG -O3 -flto -I../src $(<) $(LDFLAGS) -o $@
 
 number_jsons:
 	(test -e files/numbers/floats.json -a -e files/numbers/signed_ints.json -a -e files/numbers/unsigned_ints.json) || (cd files/numbers ; python generate.py)
 
 clean:
-	rm -f json_benchmarks files/numbers/*.json
+	rm -f json_benchmarks json_benchmarks_simple files/numbers/*.json

--- a/benchmarks/src/benchmarks.cpp
+++ b/benchmarks/src/benchmarks.cpp
@@ -34,6 +34,19 @@ static void bench(benchpress::context& ctx,
 {
     // using string streams for benchmarking to factor-out cold-cache disk
     // access.
+#if defined( FROMFILE )
+    std::ifstream istr;
+    {
+        istr.open( in_path, std::ifstream::in );
+
+        // read the stream once
+        json j;
+        istr >> j;
+        // clear flags and rewind
+        istr.clear();
+        istr.seekg(0);
+    }
+#else
     std::stringstream istr;
     {
         // read file into string stream
@@ -43,11 +56,12 @@ static void bench(benchpress::context& ctx,
 
         // read the stream once
         json j;
-        j << istr;
+        istr >> j;
         // clear flags and rewind
         istr.clear();
         istr.seekg(0);
     }
+#endif
 
     switch (mode)
     {
@@ -62,7 +76,7 @@ static void bench(benchpress::context& ctx,
                 istr.clear();
                 istr.seekg(0);
                 json j;
-                j << istr;
+                istr >> j;
             }
 
             break;
@@ -74,7 +88,7 @@ static void bench(benchpress::context& ctx,
         {
             // create JSON value from input
             json j;
-            j << istr;
+            istr >> j;
             std::stringstream ostr;
 
             ctx.reset_timer();

--- a/benchmarks/src/benchmarks_simple.cpp
+++ b/benchmarks/src/benchmarks_simple.cpp
@@ -1,0 +1,158 @@
+// 
+// benchmarks_simple.cpp -- a less complex version of benchmarks.cpp, that better reflects actual performance
+// 
+//     For some reason, the complexity of benchmarks.cpp doesn't allow
+// the compiler to optimize code using json.hpp effectively.  The
+// exact same tests, with the use of benchpress and cxxopts produces
+// much faster code, at least under g++.
+// 
+#include <fstream>
+#include <iostream>
+#include <chrono>
+#include <list>
+#include <tuple>
+
+#include <json.hpp>
+
+using json = nlohmann::json;
+
+enum class EMode { input, output, indent };
+
+static double bench(const EMode mode, size_t iters, const std::string& in_path )
+{
+    // using string streams for benchmarking to factor-out cold-cache disk
+    // access.  Define FROMFILE to use file I/O instead.
+#if defined( FROMFILE )
+    std::ifstream istr;
+    {
+        istr.open( in_path, std::ifstream::in );
+
+        // read the stream once
+        json j;
+        istr >> j;
+        // clear flags and rewind
+        istr.clear();
+        istr.seekg(0);
+    }
+#else
+    std::stringstream istr;
+    {
+        // read file into string stream
+        std::ifstream input_file(in_path);
+        istr << input_file.rdbuf();
+        input_file.close();
+
+        // read the stream once
+        json j;
+        istr >> j;
+        // clear flags and rewind
+        istr.clear();
+        istr.seekg(0);
+    }
+#endif
+    double tps = 0;
+    switch (mode)
+    {
+        // benchmarking input
+        case EMode::input:
+        {
+	    auto start = std::chrono::system_clock::now();
+            for (size_t i = 0; i < iters; ++i)
+            {
+                // clear flags and rewind
+                istr.clear();
+                istr.seekg(0);
+                json j;
+                istr >> j;
+            }
+	    auto ended = std::chrono::system_clock::now();
+	    tps = 1.0 / std::chrono::duration<double>( ended - start ).count();
+            break;
+        }
+
+        // benchmarking output
+        case EMode::output:
+        case EMode::indent:
+        {
+            // create JSON value from input
+            json j;
+            istr >> j;
+            std::stringstream ostr;
+
+	    auto start = std::chrono::system_clock::now();
+            for (size_t i = 0; i < iters; ++i)
+            {
+                if (mode == EMode::indent)
+                {
+                    ostr << j;
+                }
+                else
+                {
+                    ostr << std::setw(4) << j;
+                }
+
+                // reset data
+                ostr.str(std::string());
+            }
+	    auto ended = std::chrono::system_clock::now();
+	    tps = 1.0 / std::chrono::duration<double>( ended - start ).count();
+
+            break;
+        }
+    }
+    return tps;
+}
+
+template <typename T>
+struct average {
+    T _sum { 0 };
+    size_t _count { 0 };
+    T operator+=( const T &val_ ) { _sum += val_; +_count++; return val_; }
+    operator T() { return _sum / _count; }
+};
+
+// Execute each test approximately enough times to get near 1
+// transaction per second, and compute the average; a single aggregate
+// number that gives a performance metric representing both parsing
+// and output.
+
+int main( int, char ** )
+{
+    std::list<std::tuple<std::string, EMode, size_t, std::string>> tests {
+	{ "parse jeopardy.json",	EMode::input,   2, "files/jeopardy/jeopardy.json" },
+	{ "parse canada.json",		EMode::input,  30, "files/nativejson-benchmark/canada.json" },
+	{ "parse citm_catalog.json",	EMode::input, 120, "files/nativejson-benchmark/citm_catalog.json" },
+	{ "parse twitter.json",		EMode::input, 225, "files/nativejson-benchmark/twitter.json" },
+	{ "parse floats.json",		EMode::input,   5, "files/numbers/floats.json" },
+	{ "parse signed_ints.json",	EMode::input,   6, "files/numbers/signed_ints.json" },
+	{ "parse unsigned_ints.json",	EMode::input,   6, "files/numbers/unsigned_ints.json" },
+	{ "dump jeopardy.json",		EMode::output,  5, "files/jeopardy/jeopardy.json" },
+	{ "dump jeopardy.json w/ind.",	EMode::indent,  5, "files/jeopardy/jeopardy.json" },
+	{ "dump floats.json",		EMode::output,  2, "files/numbers/floats.json" },
+	{ "dump signed_ints.json",	EMode::output, 20, "files/numbers/signed_ints.json" },
+    };
+    
+    average<double> avg;
+    for ( auto t : tests ) {
+	std::string name, path;
+	EMode mode;
+	size_t iters;
+	std::tie(name, mode, iters, path) = t;
+	auto tps = bench( mode, iters, path );
+	avg += tps;
+	std::cout
+	    << std::left 
+	    << std::setw( 30 ) << name
+	    << std::right	    
+	    << " x " 	<< std::setw(  3 ) << iters
+	    << std::left
+	    << " == " 	<< std::setw( 10 ) << tps
+	    << std::right
+	    << " TPS, "	<< std::setw(  8 ) << std::round( tps * 1e6 / iters )
+	    << " ms/op"
+	    << std::endl;
+    }
+    std::cout << std::setw( 40 ) << "" << std::string( 10, '-' ) << std::endl;
+    std::cout << std::setw( 40 ) << "" << std::setw( 10 ) << std::left << avg << " TPS Average" << std::endl;
+    return 0;
+}

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1451,9 +1451,12 @@ class input_stream_adapter : public input_adapter_protocol
     input_stream_adapter(const input_stream_adapter&) = delete;
     input_stream_adapter& operator=(input_stream_adapter&) = delete;
 
+    // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
+    // ensure that std::char_traits<char>::eof() and the character 0xff do not
+    // end up as the same value, eg. 0xffffffff.
     int get_character() override
     {
-        return reinterpret_cast<int>( sb->sbumpc() );
+        return sb->sbumpc();
     }
 
     void unget_character() override
@@ -1489,10 +1492,10 @@ class input_buffer_adapter : public input_adapter_protocol
     {
         if (JSON_LIKELY(cursor < limit))
         {
-            return reinterpret_cast<int>(std::char_traits<char>::to_int_type(*(cursor++)));
+            return std::char_traits<char>::to_int_type(*(cursor++));
         }
 
-        return reinterpret_cast<int>(std::char_traits<char>::eof());
+        return std::char_traits<char>::eof();
     }
 
     void unget_character() noexcept override

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -2656,9 +2656,9 @@ scan_number_done:
     int get()
     {
         ++chars_read;
-        int c = current = ia->get_character();
-        token_string.push_back(static_cast<char>(c));
-        return c;
+        current = ia->get_character();
+        token_string.push_back(static_cast<char>(current));
+        return current;
     }
 
     /// unget current character (return it again on next get)
@@ -2703,7 +2703,7 @@ scan_number_done:
     }
 
     /// return string value
-    const std::string get_string()
+    std::string get_string()
     {
         return std::move( yytext );
     }

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -2674,7 +2674,7 @@ scan_number_done:
     {
         yytext.clear();
         token_string.clear();
-        token_string.push_back(static_cast<char>(current));
+        token_string.push_back(std::char_traits<char>::to_char_type(current));
     }
 
     /*

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -2702,8 +2702,8 @@ scan_number_done:
         return value_float;
     }
 
-    /// return string value
-    std::string get_string()
+    /// return current string value (implicitly resets the token; useful only once)
+    std::string move_string()
     {
         return std::move( yytext );
     }
@@ -3004,7 +3004,7 @@ class parser
                     {
                         return;
                     }
-                    key = m_lexer.get_string();
+                    key = m_lexer.move_string();
 
                     bool keep_tag = false;
                     if (keep)
@@ -3142,7 +3142,7 @@ class parser
             case token_type::value_string:
             {
                 result.m_type = value_t::string;
-                result.m_value = m_lexer.get_string();
+                result.m_value = m_lexer.move_string();
                 break;
             }
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -2833,29 +2833,30 @@ scan_number_done:
 
   private:
     /// input adapter
-    detail::input_adapter_t ia = nullptr;
+    detail::input_adapter_t ia { nullptr };
 
     /// the current character
-    int current = std::char_traits<char>::eof();
+    int current { std::char_traits<char>::eof() };
 
     /// the number of characters read
-    std::size_t chars_read = 0;
+    std::size_t chars_read { 0 };
+
     /// raw input token string (for error messages)
-    std::vector<char> token_string = std::vector<char>();
+    std::vector<char> token_string { };
 
     /// buffer for variable-length tokens (numbers, strings)
-    std::string yytext = "";
+    std::string yytext { };
 
     /// a description of occurred lexer errors
-    const char* error_message = "";
+    const char* error_message { "" };
 
     // number values
-    number_integer_t value_integer = 0;
-    number_unsigned_t value_unsigned = 0;
-    number_float_t value_float = 0;
+    number_integer_t value_integer { 0 };
+    number_unsigned_t value_unsigned { 0 };
+    number_float_t value_float { 0 };
 
     /// the decimal point
-    const char decimal_point_char = '.';
+    const char decimal_point_char { '.' };
 };
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -2841,13 +2841,13 @@ scan_number_done:
 
   private:
     /// input adapter
-    detail::input_adapter_t ia { nullptr };
+    detail::input_adapter_t ia = nullptr;
 
     /// the current character
-    int current { std::char_traits<char>::eof() };
+    int current = std::char_traits<char>::eof();
 
     /// the number of characters read
-    std::size_t chars_read { 0 };
+    std::size_t chars_read = 0;
 
     /// raw input token string (for error messages)
     std::vector<char> token_string { };
@@ -2856,15 +2856,15 @@ scan_number_done:
     std::string yytext { };
 
     /// a description of occurred lexer errors
-    const char* error_message { "" };
+    const char* error_message = "";
 
     // number values
-    number_integer_t value_integer { 0 };
-    number_unsigned_t value_unsigned { 0 };
-    number_float_t value_float { 0 };
+    number_integer_t value_integer = 0;
+    number_unsigned_t value_unsigned = 0;
+    number_float_t value_float = 0;
 
     /// the decimal point
-    const char decimal_point_char { '.' };
+    const char decimal_point_char = '.';
 };
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1417,6 +1417,7 @@ class input_stream_adapter : public input_adapter_protocol
     }
     explicit input_stream_adapter(std::istream& i)
         : is(i)
+        , sb(i.rdbuf())
     {
         // Ignore Byte Order Mark at start of input
         int c;
@@ -1448,18 +1449,19 @@ class input_stream_adapter : public input_adapter_protocol
 
     int get_character() override
     {
-        int c = is.rdbuf()->sbumpc(); // Avoided for performance: int c = is.get();
+        int c = sb->sbumpc(); // Avoided for performance: int c = is.get();
         return c < 0 ? c : ( c & 0xFF ); // faster than == std::char_traits<char>::eof()
     }
 
     void unget_character() override
     {
-        is.rdbuf()->sungetc(); // Avoided for performance: is.unget();
+        sb->sungetc(); // Avoided for performance: is.unget();
     }
   private:
 
     /// the associated input stream
     std::istream& is;
+    std::streambuf *sb;
 };
 
 /// input adapter for buffer input

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1828,9 +1828,6 @@ class lexer
                 // closing quote
                 case '\"':
                 {
-                    // terminate yytext
-                    add('\0');
-                    --yylen;
                     return token_type::value_string;
                 }
 
@@ -2575,10 +2572,6 @@ scan_number_done:
         // unget the character after the number (we only read it to know that
         // we are done scanning a number)
         unget();
-
-        // terminate token
-        add('\0');
-        --yylen;
 
         char* endptr = nullptr;
         errno = 0;

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -215,7 +215,7 @@ TEST_CASE("parser class")
                     std::string s = "\"1\"";
                     s[1] = '\0';
                     CHECK_THROWS_AS(json::parse(s.begin(), s.end()), json::parse_error&);
-                    CHECK_THROWS_WITH(json::parse(s.begin(), s.end()), "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: control character must be escaped; last read: '\"'");
+                    CHECK_THROWS_WITH(json::parse(s.begin(), s.end()), "[json.exception.parse_error.101] parse error at 2: syntax error - invalid string: control character must be escaped; last read: '\"<U+0000>'");
                 }
             }
 

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -1233,4 +1233,24 @@ TEST_CASE("regression tests")
                               "[json.exception.type_error.302] type must be array, but is null");
         }
     }
+
+    SECTION("issue #367 - Behavior of operator>> should more closely resemble that of built-in overloads.")
+    {
+	SECTION("example 1")
+	{
+	    std::istringstream i1_2_3( "{\"first\": \"one\" }{\"second\": \"two\"}3" );
+	    json j1, j2, j3;
+	    i1_2_3 >> j1;
+	    i1_2_3 >> j2;
+	    i1_2_3 >> j3;
+
+	    std::map<std::string,std::string> m1 = j1;
+	    std::map<std::string,std::string> m2 = j2;
+	    int i3 = j3;
+
+	    CHECK( m1 == ( std::map<std::string,std::string> {{ "first",  "one" }} ));
+	    CHECK( m2 == ( std::map<std::string,std::string> {{ "second", "two" }} ));
+	    CHECK( i3 == 3 );
+	}
+    }
 }


### PR DESCRIPTION
Simplified cached_input_stream_adapter<> to input_stream_adapter, to avoid redundant buffering (already buffered in underlying std::streambuf), and thus to not pre-load (and discard) a large buffer of input from the istream when parsing a smaller JSON record.  Handles a leading Byte Order Mark using standard istream putback/unget.

Also, instead of trying to re-read the previous token on error (which involved seeking, which may or may not be available on an istream), simply collects the developing token into a std::string.  The space underlying this string is preserved between tokens, so this collection devolves into simple copying, and is therefore quite efficient.

This also opens the door to further simplifications in the future.

Added a simple unit test to confirm operation.  Did not test effect on json::parse.  I feel that the approach suggested by @nlohmann (std::parse demands that the entire buffer be a single JSON object, but operator>> scans just a single upcoming JSON object) is correct...  Perhaps this pull request may help move in that direction.