### PR TITLE
Set GENERATE_TAGFILE in Doxyfile

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -281,7 +281,7 @@ SKIP_FUNCTION_MACROS   = YES
 # Configuration options related to external references
 #---------------------------------------------------------------------------
 TAGFILES               =
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = html/nlohmann_json.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES


### PR DESCRIPTION
Allows documentation to be linked from other projects to https://nlohmann.github.io/json using Doxygen with the tag:
TAGFILES = $(SOME_PATH)/nlohmann_json.tag=https://nlohmann.github.io/json

This change does not affect code or compilation in any way.