### PR TITLE
Fix warning C4706 on Visual Studio 2017

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3035,19 +3035,19 @@ class parser
             case token_type::begin_object:
             {
                 if (keep)
-				{
-					if (callback)
-					{
-						keep = callback(depth++, parse_event_t::object_start, result);
-					}
+                {
+                    if (callback)
+                    {
+                        keep = callback(depth++, parse_event_t::object_start, result);
+                    }
 
-					if (not callback or keep)
-					{
-						// explicitly set result to object to cope with {}
-						result.m_type = value_t::object;
-						result.m_value = value_t::object;
-	                }
-				}
+                    if (not callback or keep)
+                    {
+                        // explicitly set result to object to cope with {}
+                        result.m_type = value_t::object;
+                        result.m_value = value_t::object;
+                    }
+                }
 
                 // read next token
                 get_token();
@@ -3140,17 +3140,17 @@ class parser
             {
                 if (keep)
                 {
-					if (callback)
-					{
-						keep = callback(depth++, parse_event_t::array_start, result);
-					}
+                    if (callback)
+                    {
+                        keep = callback(depth++, parse_event_t::array_start, result);
+                    }
 
-					if (not callback or keep)
-					{
-						// explicitly set result to object to cope with []
-						result.m_type = value_t::array;
-						result.m_value = value_t::array;
-					}
+                    if (not callback or keep)
+                    {
+                        // explicitly set result to array to cope with []
+                        result.m_type = value_t::array;
+                        result.m_value = value_t::array;
+                    }
                 }
 
                 // read next token

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3034,12 +3034,20 @@ class parser
         {
             case token_type::begin_object:
             {
-                if (keep and (not callback or ((keep = callback(depth++, parse_event_t::object_start, result)))))
-                {
-                    // explicitly set result to object to cope with {}
-                    result.m_type = value_t::object;
-                    result.m_value = value_t::object;
-                }
+                if (keep)
+				{
+					if (callback)
+					{
+						keep = callback(depth++, parse_event_t::object_start, result);
+					}
+
+					if (not callback or keep)
+					{
+						// explicitly set result to object to cope with {}
+						result.m_type = value_t::object;
+						result.m_value = value_t::object;
+	                }
+				}
 
                 // read next token
                 get_token();
@@ -3130,11 +3138,19 @@ class parser
 
             case token_type::begin_array:
             {
-                if (keep and (not callback or ((keep = callback(depth++, parse_event_t::array_start, result)))))
+                if (keep)
                 {
-                    // explicitly set result to object to cope with []
-                    result.m_type = value_t::array;
-                    result.m_value = value_t::array;
+					if (callback)
+					{
+						keep = callback(depth++, parse_event_t::array_start, result);
+					}
+
+					if (not callback or keep)
+					{
+						// explicitly set result to object to cope with []
+						result.m_type = value_t::array;
+						result.m_value = value_t::array;
+					}
                 }
 
                 // read next token

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,16 @@ foreach(file ${files})
         set_target_properties(${testcase} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-float-equal")
     endif()
 
+    # https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake
+    if(MSVC)
+        # Force to always compile with W4
+        if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+            string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        else()
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+        endif()
+    endif()
+
     add_test(NAME "${testcase}_default"
       COMMAND ${testcase} ${CATCH_TEST_FILTER}
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,19 @@ set_target_properties(catch_main PROPERTIES
 )
 target_include_directories(catch_main PRIVATE "thirdparty/catch")
 
+# https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake
+if(MSVC)
+    # Force to always compile with W4
+    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    endif()
+
+    # Disable warning C4389: '==': signed/unsigned mismatch
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389")
+endif()
+
 #############################################################################
 # one executable for each unit test file
 #############################################################################
@@ -89,16 +102,6 @@ foreach(file ${files})
 
     if(NOT MSVC)
         set_target_properties(${testcase} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-float-equal")
-    endif()
-
-    # https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake
-    if(MSVC)
-        # Force to always compile with W4
-        if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-            string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-        else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-        endif()
     endif()
 
     add_test(NAME "${testcase}_default"

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -201,7 +201,7 @@ void from_json(const BasicJsonType& j, country& c)
     {
         {u8"中华人民共和国", country::china},
         {"France", country::france},
-        {"Российская Федерация", country::russia}
+        {u8"Российская Федерация", country::russia}
     };
 
     const auto it = m.find(str);


### PR DESCRIPTION
I'm pretty sure the logic is the same, just moves out the updating of variable `keep`. All tests pass at least.

This also fixes a bug in `unit-udt` which has a missing `u8` causing crashes on windows (due to iterator assert)
