### PR TITLE
Add transparent comparator and perfect forwarding support to find() and count()

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -10884,7 +10884,7 @@ class basic_json
     @note This method always returns @ref end() when executed on a JSON type
           that is not an object.
 
-    @param[in] key key value of the element to search for
+    @param[in] key key value of the element to search for.
 
     @return Iterator to an element with key equivalent to @a key. If no such
     element is found or the JSON value is not an object, past-the-end (see
@@ -10895,39 +10895,6 @@ class basic_json
     @liveexample{The example shows how `find()` is used.,find__key_type}
 
     @since version 1.0.0
-    */
-    iterator find(typename object_t::key_type key)
-    {
-        auto result = end();
-
-        if (is_object())
-        {
-            result.m_it.object_iterator = m_value.object->find(key);
-        }
-
-        return result;
-    }
-
-    /*!
-    @brief find an element in a JSON object
-    @copydoc find(typename object_t::key_type)
-    */
-    const_iterator find(typename object_t::key_type key) const
-    {
-        auto result = cend();
-
-        if (is_object())
-        {
-            result.m_it.object_iterator = m_value.object->find(key);
-        }
-
-        return result;
-    }
-
-#ifdef JSON_HAS_CPP_14
-    /*!
-    @brief find an element in a JSON object
-    @copydoc find(typename object_t::key_type)
     */
     template<typename KeyT>
     iterator find(KeyT&& key)
@@ -10944,7 +10911,7 @@ class basic_json
 
     /*!
     @brief find an element in a JSON object
-    @copydoc find(typename object_t::key_type)
+    @copydoc find(KeyT&&)
     */
     template<typename KeyT>
     const_iterator find(KeyT&& key) const
@@ -10958,7 +10925,6 @@ class basic_json
 
         return result;
     }
-#endif
 
     /*!
     @brief returns the number of occurrences of a key in a JSON object
@@ -10981,24 +10947,13 @@ class basic_json
 
     @since version 1.0.0
     */
-    size_type count(typename object_t::key_type key) const
-    {
-        // return 0 for all nonobject types
-        return is_object() ? m_value.object->count(key) : 0;
-    }
-
-#ifdef JSON_HAS_CPP_14
-    /*!
-    @brief returns the number of occurrences of a key in a JSON object
-    @copydoc count(typename object_t::key_type)
-    */
     template<typename KeyT>
     size_type count(KeyT&& key) const
     {
         // return 0 for all nonobject types
         return is_object() ? m_value.object->count(std::forward<KeyT>(key)) : 0;
     }
-#endif
+
     /// @}
 
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -110,7 +110,7 @@ SOFTWARE.
 #endif
 
 // string_view support
-#if defined(_MSC_VER) && defined(_HAS_CXX17)
+#if defined(_MSC_VER) && defined(_HAS_CXX17) && _HAS_CXX17 == 1
 	#define JSON_USE_STRING_VIEW
 #endif
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -111,10 +111,10 @@ SOFTWARE.
 
 // cpp language standard detection
 #if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
-	#define JSON_HAS_CPP_17
-	#define JSON_HAS_CPP_14
+    #define JSON_HAS_CPP_17
+    #define JSON_HAS_CPP_14
 #elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
-	#define JSON_HAS_CPP_14
+    #define JSON_HAS_CPP_14
 #endif
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7606,10 +7606,10 @@ class basic_json
     using object_comparator_t = std::less<StringType>;
 #endif
     using object_t = ObjectType<StringType,
-        basic_json,
-        object_comparator_t,
-        AllocatorType<std::pair<const StringType,
-        basic_json>>>;
+      basic_json,
+      object_comparator_t,
+      AllocatorType<std::pair<const StringType,
+      basic_json>>>;
 
     /*!
     @brief a type for an array

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -110,11 +110,11 @@ SOFTWARE.
 #endif
 
 // string_view support
-#if defined(_MSC_VER) && defined(_HAS_CXX17) && _HAS_CXX17 == 1
-	#define JSON_USE_STRING_VIEW
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+	#define JSON_HAS_STRING_VIEW
 #endif
 
-#if defined(JSON_USE_STRING_VIEW)
+#if defined(JSON_HAS_STRING_VIEW)
 	#include <string_view>
 #endif
 
@@ -7600,7 +7600,7 @@ class basic_json
     specified "unordered" nature of JSON objects.
     */
 
-#if defined(JSON_USE_STRING_VIEW)
+#if defined(JSON_HAS_STRING_VIEW)
 	// if std::string_view is to be used the object_t must
 	// be declared with a transparent comparator
 	// https://stackoverflow.com/questions/35525777/use-of-string-view-for-map-lookup
@@ -9868,7 +9868,7 @@ class basic_json
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
 #endif
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER >1900 && defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+#if defined(JSON_HAS_STRING_VIEW)
                    and not std::is_same<ValueType, typename std::string_view>::value
 #endif
                    , int >::type = 0 >

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7606,10 +7606,10 @@ class basic_json
     using object_comparator_t = std::less<StringType>;
 #endif
     using object_t = ObjectType<StringType,
-      basic_json,
-      object_comparator_t,
-      AllocatorType<std::pair<const StringType,
-      basic_json>>>;
+          basic_json,
+          object_comparator_t,
+          AllocatorType<std::pair<const StringType,
+          basic_json>>>;
 
     /*!
     @brief a type for an array

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,11 +80,6 @@ if(MSVC)
 	# Disable warning C4566: character represented by universal-character-name '\uFF01' cannot be represented in the current code page (1252)
 	# Disable warning C4996: 'nlohmann::basic_json<std::map,std::vector,std::string,bool,int64_t,uint64_t,double,std::allocator,nlohmann::adl_serializer>::operator <<': was declared deprecated
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389 /wd4309 /wd4566 /wd4996")
-
-    if(MSVC_VERSION GREATER_EQUAL 1910)
-        # Enable c++17 support in Visual Studio 2017 (for testing perfect forwarding and transparent comparator in find() / count())
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
-    endif()
 endif()
 
 #############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,11 @@ if(MSVC)
 	# Disable warning C4566: character represented by universal-character-name '\uFF01' cannot be represented in the current code page (1252)
 	# Disable warning C4996: 'nlohmann::basic_json<std::map,std::vector,std::string,bool,int64_t,uint64_t,double,std::allocator,nlohmann::adl_serializer>::operator <<': was declared deprecated
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389 /wd4309 /wd4566 /wd4996")
+
+    if(MSVC_VERSION GREATER_EQUAL 1910)
+        # Enable c++17 support in Visual Studio 2017 (for testing string_view support)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
+    endif()
 endif()
 
 #############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389 /wd4309 /wd4566 /wd4996")
 
     if(MSVC_VERSION GREATER_EQUAL 1910)
-        # Enable c++17 support in Visual Studio 2017 (for testing string_view support)
+        # Enable c++17 support in Visual Studio 2017 (for testing perfect forwarding and transparent comparator in find() / count())
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
     endif()
 endif()


### PR DESCRIPTION
This avoids unnecessary string copies and allocation on often used `find()` if `std::string_view` is supported.

NOTE: currently only implemented for MSVS 2017, should be easily enabled for other compilers as well but don't have them available.