### PR TITLE
Add no thrown exception support to parse

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -10884,7 +10884,7 @@ class basic_json
     @note This method always returns @ref end() when executed on a JSON type
           that is not an object.
 
-    @param[in] key key value of the element to search for
+    @param[in] key key value of the element to search for.
 
     @return Iterator to an element with key equivalent to @a key. If no such
     element is found or the JSON value is not an object, past-the-end (see
@@ -10895,39 +10895,6 @@ class basic_json
     @liveexample{The example shows how `find()` is used.,find__key_type}
 
     @since version 1.0.0
-    */
-    iterator find(typename object_t::key_type key)
-    {
-        auto result = end();
-
-        if (is_object())
-        {
-            result.m_it.object_iterator = m_value.object->find(key);
-        }
-
-        return result;
-    }
-
-    /*!
-    @brief find an element in a JSON object
-    @copydoc find(typename object_t::key_type)
-    */
-    const_iterator find(typename object_t::key_type key) const
-    {
-        auto result = cend();
-
-        if (is_object())
-        {
-            result.m_it.object_iterator = m_value.object->find(key);
-        }
-
-        return result;
-    }
-
-#ifdef JSON_HAS_CPP_14
-    /*!
-    @brief find an element in a JSON object
-    @copydoc find(typename object_t::key_type)
     */
     template<typename KeyT>
     iterator find(KeyT&& key)
@@ -10944,7 +10911,7 @@ class basic_json
 
     /*!
     @brief find an element in a JSON object
-    @copydoc find(typename object_t::key_type)
+    @copydoc find(KeyT&&)
     */
     template<typename KeyT>
     const_iterator find(KeyT&& key) const
@@ -10958,7 +10925,6 @@ class basic_json
 
         return result;
     }
-#endif
 
     /*!
     @brief returns the number of occurrences of a key in a JSON object
@@ -10981,24 +10947,13 @@ class basic_json
 
     @since version 1.0.0
     */
-    size_type count(typename object_t::key_type key) const
-    {
-        // return 0 for all nonobject types
-        return is_object() ? m_value.object->count(key) : 0;
-    }
-
-#ifdef JSON_HAS_CPP_14
-    /*!
-    @brief returns the number of occurrences of a key in a JSON object
-    @copydoc count(typename object_t::key_type)
-    */
     template<typename KeyT>
     size_type count(KeyT&& key) const
     {
         // return 0 for all nonobject types
         return is_object() ? m_value.object->count(std::forward<KeyT>(key)) : 0;
     }
-#endif
+
     /// @}
 
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -110,7 +110,7 @@ SOFTWARE.
 #endif
 
 // string_view support
-#if defined(_MSC_VER) && defined(_HAS_CXX17)
+#if defined(_MSC_VER) && defined(_HAS_CXX17) && _HAS_CXX17 == 1
 	#define JSON_USE_STRING_VIEW
 #endif
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -111,10 +111,10 @@ SOFTWARE.
 
 // cpp language standard detection
 #if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
-	#define JSON_HAS_CPP_17
-	#define JSON_HAS_CPP_14
+    #define JSON_HAS_CPP_17
+    #define JSON_HAS_CPP_14
 #elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
-	#define JSON_HAS_CPP_14
+    #define JSON_HAS_CPP_14
 #endif
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7606,10 +7606,10 @@ class basic_json
     using object_comparator_t = std::less<StringType>;
 #endif
     using object_t = ObjectType<StringType,
-        basic_json,
-        object_comparator_t,
-        AllocatorType<std::pair<const StringType,
-        basic_json>>>;
+      basic_json,
+      object_comparator_t,
+      AllocatorType<std::pair<const StringType,
+      basic_json>>>;
 
     /*!
     @brief a type for an array

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -110,11 +110,11 @@ SOFTWARE.
 #endif
 
 // string_view support
-#if defined(_MSC_VER) && defined(_HAS_CXX17) && _HAS_CXX17 == 1
-	#define JSON_USE_STRING_VIEW
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+	#define JSON_HAS_STRING_VIEW
 #endif
 
-#if defined(JSON_USE_STRING_VIEW)
+#if defined(JSON_HAS_STRING_VIEW)
 	#include <string_view>
 #endif
 
@@ -7600,7 +7600,7 @@ class basic_json
     specified "unordered" nature of JSON objects.
     */
 
-#if defined(JSON_USE_STRING_VIEW)
+#if defined(JSON_HAS_STRING_VIEW)
 	// if std::string_view is to be used the object_t must
 	// be declared with a transparent comparator
 	// https://stackoverflow.com/questions/35525777/use-of-string-view-for-map-lookup
@@ -9868,7 +9868,7 @@ class basic_json
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
 #endif
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER >1900 && defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+#if defined(JSON_HAS_STRING_VIEW)
                    and not std::is_same<ValueType, typename std::string_view>::value
 #endif
                    , int >::type = 0 >

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -7606,10 +7606,10 @@ class basic_json
     using object_comparator_t = std::less<StringType>;
 #endif
     using object_t = ObjectType<StringType,
-      basic_json,
-      object_comparator_t,
-      AllocatorType<std::pair<const StringType,
-      basic_json>>>;
+          basic_json,
+          object_comparator_t,
+          AllocatorType<std::pair<const StringType,
+          basic_json>>>;
 
     /*!
     @brief a type for an array

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -501,24 +501,27 @@ class other_error : public exception
 };
 
 /*!
-@brief helper function to throw the a downcasted exception.
+@brief helper function to throw a downcasted exception.
 */
+#ifdef JSON_EXCEPTIONS_ENABLED
 template<class Exception>
 void try_throw_exception(exception* ex)
 {
-#ifdef JSON_EXCEPTIONS_ENABLED
-    // Only use RTTI if necessary (exceptions are enabled). This way
-    // can be compiled with no RTTI.
+	// Only use RTTI if necessary (exceptions are enabled). This way
+	// can be compiled with no RTTI.
     Exception* down = dynamic_cast<Exception*>(ex);
     if(down != nullptr)
     {
         JSON_THROW(*down);
     }
-#else
-    ex = ex; // suppress unreferenced formal parameter warnings
-    std::abort();
-#endif
 }
+#else
+template<class Exception>
+void try_throw_exception(exception* /*unused*/)
+{
+	std::abort();
+}
+#endif
 
 /*!
 @brief helper function to throw the correct downcasted exception.

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -507,8 +507,8 @@ template<class Exception>
 void try_throw_exception(exception* ex)
 {
 #ifdef JSON_EXCEPTIONS_ENABLED
-	// Only use RTTI if necessary (exceptions are enabled). This way
-	// can be compiled with no RTTI.
+    // Only use RTTI if necessary (exceptions are enabled). This way
+    // can be compiled with no RTTI.
     Exception* down = dynamic_cast<Exception*>(ex);
     if(down != nullptr)
     {
@@ -516,7 +516,7 @@ void try_throw_exception(exception* ex)
     }
 #else
     ex = ex; // suppress unreferenced formal parameter warnings
-	std::abort();
+    std::abort();
 #endif
 }
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -534,7 +534,7 @@ void try_throw_any_exception(exception* ex)
         try_throw_exception<invalid_iterator>(ex);
         try_throw_exception<type_error>(ex);
         try_throw_exception<out_of_range>(ex);
-        try_throw_exception<other_error>(ex);
+        try_throw_exception<other_error>(ex); // LCOV_EXCL_LINE
         assert(false); // LCOV_EXCL_LINE
     }
 }

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -94,6 +94,7 @@ SOFTWARE.
     #define JSON_THROW(exception) throw exception
     #define JSON_TRY try
     #define JSON_CATCH(exception) catch(exception)
+    #define JSON_USE_RUNTIME_ERROR_STORAGE
 #else
     #define JSON_THROW(exception) std::abort()
     #define JSON_TRY if(true)
@@ -203,10 +204,17 @@ class exception : public std::exception
 {
   public:
     /// returns the explanatory string
+#if defined(JSON_USE_RUNTIME_ERROR_STORAGE)
     const char* what() const noexcept override
     {
         return m.what();
     }
+#else
+    const char* what() const noexcept override
+    {
+        return m.c_str();
+    }
+#endif
 
     /// the id of the exception
     const int id;
@@ -221,7 +229,11 @@ class exception : public std::exception
 
   private:
     /// an exception object as storage for error messages
+#if defined(JSON_USE_RUNTIME_ERROR_STORAGE)
     std::runtime_error m;
+#else
+    std::string m;
+#endif
 };
 
 /*!
@@ -14800,6 +14812,7 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 #undef JSON_CATCH
 #undef JSON_THROW
 #undef JSON_TRY
+#undef JSON_USE_RUNTIME_ERROR_STORAGE
 #undef JSON_LIKELY
 #undef JSON_UNLIKELY
 #undef JSON_DEPRECATED

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3019,7 +3019,7 @@ class parser
         result.assert_invariant();
 
         // in strict mode, input must be completely read
-        if (strict)
+        if (!errored && strict)
         {
             get_token();
             expect(token_type::end_of_input, ex);
@@ -3309,6 +3309,7 @@ class parser
                 if (JSON_UNLIKELY(not std::isfinite(result.m_value.number_float)))
                 {
                     ex = std::make_unique<out_of_range>(406, "number overflow parsing '" + m_lexer.get_token_string() + "'");
+                    errored = true;
                     return;
                 }
                 break;

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -506,11 +506,18 @@ class other_error : public exception
 template<class Exception>
 void try_throw_exception(exception* ex)
 {
+#ifdef JSON_EXCEPTIONS_ENABLED
+	// Only use RTTI if necessary (exceptions are enabled). This way
+	// can be compiled with no RTTI.
     Exception* down = dynamic_cast<Exception*>(ex);
     if(down != nullptr)
     {
         JSON_THROW(*down);
     }
+#else
+    ex = ex; // suppress unreferenced formal parameter warnings
+	std::abort();
+#endif
 }
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3334,7 +3334,7 @@ class parser
                 // throw in case of infinity or NAN
                 if (JSON_UNLIKELY(not std::isfinite(result.m_value.number_float)))
                 {
-                    ex = std::make_unique<out_of_range>(406, "number overflow parsing '" + m_lexer.get_token_string() + "'");
+                    ex = std::unique_ptr<exception>(new out_of_range(406, "number overflow parsing '" + m_lexer.get_token_string() + "'"));
                     errored = true;
                     return;
                 }
@@ -3521,7 +3521,7 @@ class parser
             error_msg += "; expected " + std::string(lexer_t::token_type_name(expected));
         }
 
-        return std::make_unique<parse_error>(101, m_lexer.get_position(), error_msg);
+        return std::unique_ptr<exception>(new parse_error(101, m_lexer.get_position(), error_msg));
     }
 
   private:

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -91,10 +91,10 @@ SOFTWARE.
 
 // allow to disable exceptions
 #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && not defined(JSON_NOEXCEPTION)
+    #define JSON_EXCEPTIONS_ENABLED
     #define JSON_THROW(exception) throw exception
     #define JSON_TRY try
     #define JSON_CATCH(exception) catch(exception)
-    #define JSON_USE_RUNTIME_ERROR_STORAGE
 #else
     #define JSON_THROW(exception) std::abort()
     #define JSON_TRY if(true)
@@ -203,8 +203,8 @@ caught.,exception}
 class exception : public std::exception
 {
   public:
-    /// returns the explanatory string
-#if defined(JSON_USE_RUNTIME_ERROR_STORAGE)
+    /// returns the explanatory string.
+#if defined(JSON_EXCEPTIONS_ENABLED)
     const char* what() const noexcept override
     {
         return m.what();
@@ -228,10 +228,14 @@ class exception : public std::exception
     }
 
   private:
+#if defined(JSON_EXCEPTIONS_ENABLED)
     /// an exception object as storage for error messages
-#if defined(JSON_USE_RUNTIME_ERROR_STORAGE)
     std::runtime_error m;
 #else
+    /// if exceptions are disabled then std::runtime_error is not
+    /// guaranteed to contain storage for the string. Use std::string
+    /// instead because we aren't actually throwing this object. Just
+    /// passing it back as an out param.
     std::string m;
 #endif
 };
@@ -14809,10 +14813,10 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 #endif
 
 // clean up
+#undef JSON_EXCEPTIONS_DISABLED
 #undef JSON_CATCH
 #undef JSON_THROW
 #undef JSON_TRY
-#undef JSON_USE_RUNTIME_ERROR_STORAGE
 #undef JSON_LIKELY
 #undef JSON_UNLIKELY
 #undef JSON_DEPRECATED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,11 +80,6 @@ if(MSVC)
 	# Disable warning C4566: character represented by universal-character-name '\uFF01' cannot be represented in the current code page (1252)
 	# Disable warning C4996: 'nlohmann::basic_json<std::map,std::vector,std::string,bool,int64_t,uint64_t,double,std::allocator,nlohmann::adl_serializer>::operator <<': was declared deprecated
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389 /wd4309 /wd4566 /wd4996")
-
-    if(MSVC_VERSION GREATER_EQUAL 1910)
-        # Enable c++17 support in Visual Studio 2017 (for testing perfect forwarding and transparent comparator in find() / count())
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
-    endif()
 endif()
 
 #############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,11 @@ if(MSVC)
 	# Disable warning C4566: character represented by universal-character-name '\uFF01' cannot be represented in the current code page (1252)
 	# Disable warning C4996: 'nlohmann::basic_json<std::map,std::vector,std::string,bool,int64_t,uint64_t,double,std::allocator,nlohmann::adl_serializer>::operator <<': was declared deprecated
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389 /wd4309 /wd4566 /wd4996")
+
+    if(MSVC_VERSION GREATER_EQUAL 1910)
+        # Enable c++17 support in Visual Studio 2017 (for testing string_view support)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
+    endif()
 endif()
 
 #############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4389 /wd4309 /wd4566 /wd4996")
 
     if(MSVC_VERSION GREATER_EQUAL 1910)
-        # Enable c++17 support in Visual Studio 2017 (for testing string_view support)
+        # Enable c++17 support in Visual Studio 2017 (for testing perfect forwarding and transparent comparator in find() / count())
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
     endif()
 endif()

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -45,7 +45,8 @@ json parser_helper(const std::string& s)
     // if this line was reached, no exception ocurred
     // -> check if result is the same without exceptions
     json j_nothrow;
-    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter(s), nullptr, false).parse(true, j_nothrow));
+    std::unique_ptr<json::exception> ex;
+    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter(s), nullptr).parse(true, j_nothrow, ex));
     CHECK(j_nothrow == j);
 
     return j;
@@ -55,7 +56,8 @@ bool accept_helper(const std::string& s)
 {
     // 1. parse s without exceptions
     json j;
-    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter(s), nullptr, false).parse(true, j));
+    std::unique_ptr<json::exception> ex;
+    CHECK_NOTHROW(json::parser(nlohmann::detail::input_adapter(s)).parse(true, j, ex));
     const bool ok_noexcept = not j.is_discarded();
 
     // 2. accept s

--- a/test/src/unit-deserialization.cpp
+++ b/test/src/unit-deserialization.cpp
@@ -103,7 +103,8 @@ TEST_CASE("deserialization")
             CHECK(not json::accept(ss3));
 
             json j_error;
-            CHECK_NOTHROW(j_error = json::parse(ss1, nullptr, false));
+            std::unique_ptr<json::exception> ex;
+            CHECK_NOTHROW(j_error = json::parse(ss1, ex));
             CHECK(j_error.is_discarded());
         }
 
@@ -116,7 +117,8 @@ TEST_CASE("deserialization")
             CHECK(not json::accept(s));
 
             json j_error;
-            CHECK_NOTHROW(j_error = json::parse(s, nullptr, false));
+            std::unique_ptr<json::exception> ex;
+            CHECK_NOTHROW(j_error = json::parse(s, ex));
             CHECK(j_error.is_discarded());
         }
 
@@ -272,7 +274,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -283,7 +286,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -294,7 +298,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -305,7 +310,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -316,7 +322,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -329,7 +336,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -340,7 +348,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -351,7 +360,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -362,7 +372,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -373,7 +384,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -384,7 +396,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -395,7 +408,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -406,7 +420,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -417,7 +432,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -428,7 +444,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
 
@@ -439,7 +456,8 @@ TEST_CASE("deserialization")
                 CHECK(not json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
-                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), nullptr, false));
+                std::unique_ptr<json::exception> ex;
+                CHECK_NOTHROW(j_error = json::parse(std::begin(v), std::end(v), ex));
                 CHECK(j_error.is_discarded());
             }
         }


### PR DESCRIPTION
This PR adds support for parse to not throw exceptions.  Use similar pattern as `std::experimental::filesystem` where overload that takes in `std::error_code&` does not throw an exception.

Did not add new tests as changes to existing tests provide full coverage of new codepath.

NOTE: accidentally branched from https://github.com/nlohmann/json/pull/795, ignore that for now.
