### PR TITLE
add forwarding references to json_ref constructor

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -6789,7 +6789,7 @@ class json_ref
     {}
 
     template <class... Args>
-    json_ref(Args... args)
+    json_ref(Args&&... args)
         : owned_value(std::forward<Args>(args)...),
           value_ref(&owned_value),
           is_rvalue(true)

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -36,6 +36,22 @@ using nlohmann::json;
 #include <list>
 #include <cstdio>
 
+namespace
+{
+  struct nocopy
+  {
+    nocopy() = default;
+    nocopy(const nocopy &) = delete;
+
+    int val = 0;
+
+    friend void to_json(json& j, const nocopy& n)
+    {
+      j = {{"val", n.val}};
+    }
+  };
+}
+
 TEST_CASE("regression tests")
 {
     SECTION("issue #60 - Double quotation mark is not parsed correctly")
@@ -1282,4 +1298,12 @@ TEST_CASE("regression tests")
             }
         }
     */
+
+    SECTION("issue #805 - copy constructor is used with std::initializer_list constructor.")
+    {
+      nocopy n;
+      json j;
+      j = {{"nocopy", n}};
+      CHECK(j["nocopy"]["val"] == 0);
+    }
 }


### PR DESCRIPTION
fixes #805

One funny thing I've discovered: You cannot use `friend void to_json()` with a local class (class/struct defined inside a function). I'll investigate later, I remember seeing something in the standard about that.

Anyway it's not a very asked feature :) 