### PR TITLE
Fix Compile warning in Visual Studio

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -120,16 +120,14 @@ SOFTWARE.
 In Visual Studio 2017 there are warnings on min
 and max in this header having not enough args.
 This is because in C min and max take args and
-wll are not needed anyway so we undefine them
+well are not needed anyway so we undefine them
 first to silence these annoying warnings!!!
 */
-#if (_MSC_VER >= 1911)
 #ifdef min
 #undef min
 #endif
 #ifdef max
 #undef max
-#endif
 #endif
 
 /*!

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -116,6 +116,21 @@ SOFTWARE.
 #elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
     #define JSON_HAS_CPP_14
 #endif
+/*
+In Visual Studio 2017 there are warnings on min
+and max in this header having not enough args.
+This is because in C min and max take args and
+wll are not needed anyway so we undefine them
+first to silence these annoying warnings!!!
+*/
+#if (_MSC_VER >= 1911)
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+#endif
 
 /*!
 @brief namespace for Niels Lohmann


### PR DESCRIPTION
In issue #821 I found that on the latest (since version 2.0.7) there are now min and max warnings. This PR now removes those warnings on the source and hopefully should work on all platforms without degrading anything. This only disables the min and max macros if defined.

* * *

## Pull request checklist

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
