### PR TITLE
Added forward declaration header json_forward.hpp. Minimise build times.

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -29,6 +29,10 @@ SOFTWARE.
 #ifndef NLOHMANN_JSON_HPP
 #define NLOHMANN_JSON_HPP
 
+
+#include "json_forward.hpp" // Some forward declarations are re-used here.
+
+
 #include <algorithm> // all_of, copy, fill, find, for_each, generate_n, none_of, remove, reverse, transform
 #include <array> // array
 #include <cassert> // assert
@@ -124,21 +128,6 @@ SOFTWARE.
 */
 namespace nlohmann
 {
-template<typename = void, typename = void>
-struct adl_serializer;
-
-// forward declaration of basic_json (required to split the class)
-template<template<typename U, typename V, typename... Args> class ObjectType =
-         std::map,
-         template<typename U, typename... Args> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
-         class NumberIntegerType = std::int64_t,
-         class NumberUnsignedType = std::uint64_t,
-         class NumberFloatType = double,
-         template<typename U> class AllocatorType = std::allocator,
-         template<typename T, typename SFINAE = void> class JSONSerializer =
-         adl_serializer>
-class basic_json;
 
 // Ugly macros to avoid uglier copy-paste when specializing basic_json
 // This is only temporary and will be removed in 3.0

--- a/src/json_forward.hpp
+++ b/src/json_forward.hpp
@@ -1,0 +1,65 @@
+/*
+    __ _____ _____ _____
+ __|  |   __|     |   | |  JSON for Modern C++
+|  |  |__   |  |  | | | |  version 2.1.1
+|_____|_____|_____|_|___|  https://github.com/nlohmann/json
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+Copyright (c) 2013-2017 Niels Lohmann <http://nlohmann.me>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef NLOHMANN_JSON_FORWARD_HPP
+#define NLOHMANN_JSON_FORWARD_HPP
+
+#include <cstdint> // std::int64_t, std::uint64_t ...
+#include <iosfwd> // std::allocator
+#include <map> // map
+#include <string> // std::string
+#include <vector> // std::vector
+
+
+namespace nlohmann
+{
+
+template<typename = void, typename = void>
+struct adl_serializer;
+
+// forward declaration of basic_json
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer>
+class basic_json;
+
+
+// nlohmann::json uses defaults of args of basic_json<>.
+using json = basic_json<>;
+
+} // End namespace 'nlohmann'
+
+
+#endif // End NLOHMANN_JSON_FORWARD_HPP


### PR DESCRIPTION

This pull request aims to reduce compile time by the introduction of a header dedicated to providing forward declaration of nlohmann::json.

One of the great merits of the this library is that it is header only.  Unfortunately, that does also come with some disadvantages, namely the compile times are often higher with such code dependencies.

This pull request introduces a 'json_forward.hpp' header file (similar to how Boost offer forward header files) in an attempt to try reduce build times.  

Things to note (and some of these come down to personal preference):
- json.hpp includes json_forward.hpp to minimise code replication
- json.hpp includes some of same std library headers as json_forward.hpp (technically these could be removed) but with #include guards, I don't feel this is much of an issue. Discuss.

Points to consider:
- Code change is small.
- It reduces build times (at least what I've seen).

So I tried integrating these code changes with my own project and ran a comparison test.

Build time without forward declaration header:
> real	10m7.981s
> user	36m40.768s
> sys	2m1.432s


Build time making extensive use of forward declaration header (where possible):
> real	9m21.282s
> user	33m53.744s
> sys	1m52.880s

Please note that this test was _not_ wholly scientific. I imagine mileage will vary across environments/compilers and the level of use of this library in the said project.


Tested with cmake and gcc 6.3 running on Ubuntu's 17.04 (Zesty).

