### PR TITLE
to/from_json: add a MSVC-specific static_assert to force a stacktrace

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1351,6 +1351,13 @@ struct to_json_fn
     {
         static_assert(sizeof(BasicJsonType) == 0,
                       "could not find to_json() method in T's namespace");
+
+#ifdef _MSC_VER
+	// Visual Studio does not show a stacktrace for the above assert.
+	using decayed = uncvref_t<T>;
+        static_assert(sizeof(typename decayed::force_msvc_stacktrace) == 0,
+                      "forcing msvc stacktrace to show which T we're talking about.");
+#endif
     }
 
   public:
@@ -1378,6 +1385,12 @@ struct from_json_fn
     {
         static_assert(sizeof(BasicJsonType) == 0,
                       "could not find from_json() method in T's namespace");
+#ifdef _MSC_VER
+	// Visual Studio does not show a stacktrace for the above assert.
+	using decayed = uncvref_t<T>;
+        static_assert(sizeof(typename decayed::force_msvc_stacktrace) == 0,
+                      "forcing msvc stacktrace to show which T we're talking about.");
+#endif
     }
 
   public:


### PR DESCRIPTION
Hi,

This PR add a `static_assert` inside `from_json_fn/to_json_fn` to help users understand the following message:

> could not find to_json in T's namespace

Sometimes Visual Studio does not show the stacktrace, thus making it tricky to know which type is `T`.

## Pull request checklist

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
