### PR TITLE
Std allocator conformance cpp17

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -8115,37 +8115,37 @@ class basic_json
 
         void destroy(value_t t)
         {
-            switch (t)
-            {
-                case value_t::object:
-                {
-                    AllocatorType<object_t> alloc;
-                    alloc.destroy(object);
-                    alloc.deallocate(object, 1);
-                    break;
-                }
+			switch (t)
+			{
+				case value_t::object:
+				{
+					AllocatorType<object_t> alloc;
+					std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
+					std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
+					break;
+				}
 
-                case value_t::array:
-                {
-                    AllocatorType<array_t> alloc;
-                    alloc.destroy(array);
-                    alloc.deallocate(array, 1);
-                    break;
-                }
+				case value_t::array:
+				{
+					AllocatorType<array_t> alloc;
+					std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
+					std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
+					break;
+				}
 
-                case value_t::string:
-                {
-                    AllocatorType<string_t> alloc;
-                    alloc.destroy(string);
-                    alloc.deallocate(string, 1);
-                    break;
-                }
+				case value_t::string:
+				{
+					AllocatorType<string_t> alloc;
+					std::allocator_traits<decltype(alloc)>::destroy(alloc, string);
+					std::allocator_traits<decltype(alloc)>::deallocate(alloc, string, 1);
+					break;
+				}
 
-                default:
-                {
-                    break;
-                }
-            }
+				default:
+				{
+					break;
+				}
+			}
         }
     };
 
@@ -8940,39 +8940,6 @@ class basic_json
     ~basic_json()
     {
         assert_invariant();
-
-        switch (m_type)
-        {
-            case value_t::object:
-            {
-                AllocatorType<object_t> alloc;
-				std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.object);
-				std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.object, 1);
-                break;
-            }
-
-            case value_t::array:
-            {
-                AllocatorType<array_t> alloc;
-				std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.array);
-				std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.array, 1);
-                break;
-            }
-
-            case value_t::string:
-            {
-                AllocatorType<string_t> alloc;
-				std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
-				std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
-                break;
-            }
-
-            default:
-            {
-                // all other types need no specific destructor
-                break;
-            }
-        }
         m_value.destroy(m_type);
     }
 


### PR DESCRIPTION
improved conformance with C++17, some members of std::allocator are deprecated and should be used via std::allocator_traits

* * *

## Pull request checklist

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
