### PR TITLE
Experimental support for binary type and CBOR (de)serialization

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -127,10 +127,15 @@ namespace nlohmann
 template<typename = void, typename = void>
 struct adl_serializer;
 
+// TODO: Probably some wrapper around std::string
+class SomeBinaryType;
+
 // forward declaration of basic_json (required to split the class)
 template<template<typename, typename, typename...> class ObjectType = std::map,
          template<typename, typename...> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
+         class StringType = std::string,
+         class BinaryType = SomeBinaryType,
+         class BooleanType = bool,
          class NumberIntegerType = std::int64_t,
          class NumberUnsignedType = std::uint64_t,
          class NumberFloatType = double,
@@ -144,13 +149,14 @@ class basic_json;
 #define NLOHMANN_BASIC_JSON_TPL_DECLARATION                                \
     template<template<typename, typename, typename...> class ObjectType,   \
              template<typename, typename...> class ArrayType,              \
-             class StringType, class BooleanType, class NumberIntegerType, \
-             class NumberUnsignedType, class NumberFloatType,              \
+             class StringType, class BinaryType, class BooleanType,        \
+             class NumberIntegerType, class NumberUnsignedType,            \
+             class NumberFloatType,                                        \
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
-    basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
+    basic_json<ObjectType, ArrayType, StringType, BinaryType, BooleanType, \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
     AllocatorType, JSONSerializer>
 
@@ -519,6 +525,7 @@ enum class value_t : uint8_t
     object,           ///< object (unordered set of name/value pairs)
     array,            ///< array (ordered collection of values)
     string,           ///< string value
+    binary,           ///< binary value
     boolean,          ///< boolean value
     number_integer,   ///< number value (signed integer)
     number_unsigned,  ///< number value (unsigned integer)
@@ -8022,6 +8029,7 @@ class basic_json
     object    | object          | pointer to @ref object_t
     array     | array           | pointer to @ref array_t
     string    | string          | pointer to @ref string_t
+    binary    | binary          | pointer to @ref binary_t
     boolean   | boolean         | @ref boolean_t
     number    | number_integer  | @ref number_integer_t
     number    | number_unsigned | @ref number_unsigned_t
@@ -8042,6 +8050,8 @@ class basic_json
         array_t* array;
         /// string (stored with pointer to save storage)
         string_t* string;
+        /// binary (stored with pointer to save storage)
+        binary_t* binary;
         /// boolean
         boolean_t boolean;
         /// number (integer)

--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -1967,3 +1967,28 @@ TEST_CASE("examples from RFC 7049 Appendix A")
         CHECK(json::parse("{\"Fun\": true, \"Amt\": -2}") == json::from_cbor(std::vector<uint8_t>({0xbf, 0x63, 0x46, 0x75, 0x6e, 0xf5, 0x63, 0x41, 0x6d, 0x74, 0x21, 0xff})));
     }
 }
+
+TEST_CASE("binary_data") {
+    json obj;
+    obj.emplace("age", 12);
+    obj.emplace("name", "Bob");
+    obj.emplace("secret", json::binary_t{'h', 'e', 'l', 'l', 'o'});
+
+    std::vector<uint8_t> cbor_value = json::to_cbor(obj);
+
+    std::vector<uint8_t> expected_value{
+            0b10100011, // map with 3 pairs
+            0b01100011, 'a', 'g', 'e', // "age" key
+            0b00001100, // 12 value
+            0b01100100, 'n', 'a', 'm', 'e', // "name" key
+            0b01100011, 'B', 'o', 'b', // "Bob" value
+            0b01100110, 's', 'e', 'c', 'r', 'e', 't', // "secret" key
+            0b01000101, 'h', 'e', 'l', 'l', 'o' // binary value
+    };
+
+    CHECK(cbor_value == expected_value);
+
+    json obj_parsed = json::from_cbor(cbor_value);
+
+    CHECK(obj == obj_parsed);
+}


### PR DESCRIPTION
First of all huge thanks for creating this library.

I saw a few issues https://github.com/nlohmann/json/issues/757, https://github.com/nlohmann/json/issues/601 and https://github.com/nlohmann/json/issues/483 where people discuss if this library can support `CBOR`'s binary data type. Motivation for this pull request is to discuss how easy it would be to add support for such data type.

Binary data type is not natural for `JSON`, but many people have to deal with it, especially, when converting from `CBOR` to `JSON`.

In `C++`, though, we can represent contiguous binary arrays using `std::string`, `std::vector<uint8_t>`, `std::list<uint8_t>`, `char*` and whatnot. It could be up to the user how to represent and convert this type into `JSON`.

Right now the change is mostly about the API aspect (e.g. adding binary type), without actual implementation.

Comments are very welcome! Thanks!