### PR TITLE
:boom: throwing an exception in case dump encounters a non-UTF-8 string #838

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,9 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+* * *
+
+The class contains the UTF-8 Decoder from Bjoern Hoehrmann which is licensed under the [MIT License](http://opensource.org/licenses/MIT) (see above). Copyright &copy; 2008-2009 [Bjoern Hoehrmann](http://bjoern.hoehrmann.de/) <bjoern@hoehrmann.de>
 
 ## Contact
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -6415,12 +6415,8 @@ class serializer
                     if (ensure_ascii and (s[i] & 0x80 or s[i] == 0x7F))
                     {
                         const auto bytes = bytes_following(static_cast<uint8_t>(s[i]));
-                        if (bytes == std::string::npos)
-                        {
-                            // invalid characters are treated as is, so no
-                            // additional space will be used
-                            break;
-                        }
+                        // invalid characters will be detected by throw_if_invalid_utf8
+                        assert (bytes != std::string::npos);
 
                         if (bytes == 3)
                         {
@@ -6588,12 +6584,8 @@ class serializer
                             (ensure_ascii and (s[i] & 0x80 or s[i] == 0x7F)))
                     {
                         const auto bytes = bytes_following(static_cast<uint8_t>(s[i]));
-                        if (bytes == std::string::npos)
-                        {
-                            // copy invalid character as is
-                            result[pos++] = s[i];
-                            break;
-                        }
+                        // invalid characters will be detected by throw_if_invalid_utf8
+                        assert (bytes != std::string::npos);
 
                         // check that the additional bytes are present
                         assert(i + bytes < s.size());

--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -1287,10 +1287,10 @@ TEST_CASE("CBOR")
             {
                 CHECK_THROWS_AS(json::from_cbor(std::vector<uint8_t>({0x1c})), json::parse_error&);
                 CHECK_THROWS_WITH(json::from_cbor(std::vector<uint8_t>({0x1c})),
-                                  "[json.exception.parse_error.112] parse error at 1: error reading CBOR; last byte: 0x1c");
+                                  "[json.exception.parse_error.112] parse error at 1: error reading CBOR; last byte: 0x1C");
                 CHECK_THROWS_AS(json::from_cbor(std::vector<uint8_t>({0xf8})), json::parse_error&);
                 CHECK_THROWS_WITH(json::from_cbor(std::vector<uint8_t>({0xf8})),
-                                  "[json.exception.parse_error.112] parse error at 1: error reading CBOR; last byte: 0xf8");
+                                  "[json.exception.parse_error.112] parse error at 1: error reading CBOR; last byte: 0xF8");
             }
 
             SECTION("all unsupported bytes")
@@ -1348,7 +1348,7 @@ TEST_CASE("CBOR")
         {
             CHECK_THROWS_AS(json::from_cbor(std::vector<uint8_t>({0xa1, 0xff, 0x01})), json::parse_error&);
             CHECK_THROWS_WITH(json::from_cbor(std::vector<uint8_t>({0xa1, 0xff, 0x01})),
-                              "[json.exception.parse_error.113] parse error at 2: expected a CBOR string; last byte: 0xff");
+                              "[json.exception.parse_error.113] parse error at 2: expected a CBOR string; last byte: 0xFF");
         }
 
         SECTION("strict mode")

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include "json.hpp"
 using nlohmann::json;
 
-void check_escaped(const char* original, const char* escaped, const bool ensure_ascii = false);
+void check_escaped(const char* original, const char* escaped = "", const bool ensure_ascii = false);
 void check_escaped(const char* original, const char* escaped, const bool ensure_ascii)
 {
     std::stringstream ss;
@@ -99,7 +99,12 @@ TEST_CASE("convenience functions")
         check_escaped("\x1f", "\\u001f");
 
         // invalid UTF-8 characters
-        check_escaped("ä\xA9ü", "ä\xA9ü");
-        check_escaped("ä\xA9ü", "\\u00e4\xA9\\u00fc", true);
+        CHECK_THROWS_AS(check_escaped("ä\xA9ü"), json::type_error);
+        CHECK_THROWS_WITH(check_escaped("ä\xA9ü"),
+            "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9");
+
+        CHECK_THROWS_AS(check_escaped("\xC2"), json::type_error);
+        CHECK_THROWS_WITH(check_escaped("\xC2"),
+            "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2");
     }
 }

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -101,10 +101,10 @@ TEST_CASE("convenience functions")
         // invalid UTF-8 characters
         CHECK_THROWS_AS(check_escaped("ä\xA9ü"), json::type_error);
         CHECK_THROWS_WITH(check_escaped("ä\xA9ü"),
-            "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9");
+                          "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9");
 
         CHECK_THROWS_AS(check_escaped("\xC2"), json::type_error);
         CHECK_THROWS_WITH(check_escaped("\xC2"),
-            "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2");
+                          "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2");
     }
 }

--- a/test/src/unit-msgpack.cpp
+++ b/test/src/unit-msgpack.cpp
@@ -1077,10 +1077,10 @@ TEST_CASE("MessagePack")
             {
                 CHECK_THROWS_AS(json::from_msgpack(std::vector<uint8_t>({0xc1})), json::parse_error&);
                 CHECK_THROWS_WITH(json::from_msgpack(std::vector<uint8_t>({0xc1})),
-                                  "[json.exception.parse_error.112] parse error at 1: error reading MessagePack; last byte: 0xc1");
+                                  "[json.exception.parse_error.112] parse error at 1: error reading MessagePack; last byte: 0xC1");
                 CHECK_THROWS_AS(json::from_msgpack(std::vector<uint8_t>({0xc6})), json::parse_error&);
                 CHECK_THROWS_WITH(json::from_msgpack(std::vector<uint8_t>({0xc6})),
-                                  "[json.exception.parse_error.112] parse error at 1: error reading MessagePack; last byte: 0xc6");
+                                  "[json.exception.parse_error.112] parse error at 1: error reading MessagePack; last byte: 0xC6");
             }
 
             SECTION("all unsupported bytes")
@@ -1106,7 +1106,7 @@ TEST_CASE("MessagePack")
         {
             CHECK_THROWS_AS(json::from_msgpack(std::vector<uint8_t>({0x81, 0xff, 0x01})), json::parse_error&);
             CHECK_THROWS_WITH(json::from_msgpack(std::vector<uint8_t>({0x81, 0xff, 0x01})),
-                              "[json.exception.parse_error.113] parse error at 2: expected a MessagePack string; last byte: 0xff");
+                              "[json.exception.parse_error.113] parse error at 2: expected a MessagePack string; last byte: 0xFF");
         }
 
         SECTION("strict mode")

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -1309,7 +1309,7 @@ TEST_CASE("regression tests")
     SECTION("issue #838 - incorrect parse error with binary data in keys")
     {
         uint8_t key1[] = { 103, 92, 117, 48, 48, 48, 55, 92, 114, 215, 126, 214, 95, 92, 34, 174, 40, 71, 38, 174, 40, 71, 38, 223, 134, 247, 127 };
-        std::string key1_str(key1, key1 + sizeof(key1)/sizeof(key1[0]));
+        std::string key1_str(key1, key1 + sizeof(key1) / sizeof(key1[0]));
         json j = key1_str;
         CHECK_THROWS_AS(j.dump(), json::type_error);
         CHECK_THROWS_WITH(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 10: 0x7E");

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -975,7 +975,7 @@ TEST_CASE("regression tests")
         };
         CHECK_THROWS_AS(json::from_cbor(vec1), json::parse_error&);
         CHECK_THROWS_WITH(json::from_cbor(vec1),
-                          "[json.exception.parse_error.113] parse error at 13: expected a CBOR string; last byte: 0xb4");
+                          "[json.exception.parse_error.113] parse error at 13: expected a CBOR string; last byte: 0xB4");
 
         // related test case: double-precision
         std::vector<uint8_t> vec2
@@ -989,7 +989,7 @@ TEST_CASE("regression tests")
         };
         CHECK_THROWS_AS(json::from_cbor(vec2), json::parse_error&);
         CHECK_THROWS_WITH(json::from_cbor(vec2),
-                          "[json.exception.parse_error.113] parse error at 13: expected a CBOR string; last byte: 0xb4");
+                          "[json.exception.parse_error.113] parse error at 13: expected a CBOR string; last byte: 0xB4");
     }
 
     SECTION("issue #452 - Heap-buffer-overflow (OSS-Fuzz issue 585)")
@@ -1304,6 +1304,15 @@ TEST_CASE("regression tests")
         json j;
         j = {{"nocopy", n}};
         CHECK(j["nocopy"]["val"] == 0);
+    }
+
+    SECTION("issue #838 - incorrect parse error with binary data in keys")
+    {
+        uint8_t key1[] = { 103, 92, 117, 48, 48, 48, 55, 92, 114, 215, 126, 214, 95, 92, 34, 174, 40, 71, 38, 174, 40, 71, 38, 223, 134, 247, 127 };
+        std::string key1_str(key1, key1 + sizeof(key1)/sizeof(key1[0]));
+        json j = key1_str;
+        CHECK_THROWS_AS(j.dump(), json::type_error);
+        CHECK_THROWS_WITH(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 10: 0x7E");
     }
 
     SECTION("issue #843 - converting to array not working")


### PR DESCRIPTION
We had a lot of issues with failing roundtrips (i.e., parse errors from serializations) in case string were stored in the library that were not UTF-8 encoded. This PR adds an exception in this case.

Addresses #838

* * *

## Pull request checklist

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
