### PR TITLE
:white_check_mark: re-added tests for algorithms

### DIFF
--- a/test/src/unit-algorithms.cpp
+++ b/test/src/unit-algorithms.cpp
@@ -256,7 +256,6 @@ TEST_CASE("algorithms")
 
     SECTION("set operations")
     {
-        /*
         SECTION("std::merge")
         {
             {
@@ -268,7 +267,6 @@ TEST_CASE("algorithms")
                 CHECK(j3 == json({1, 2, 2, 3, 4, 5, 6, 7, 8}));
             }
         }
-        */
 
         SECTION("std::set_difference")
         {
@@ -290,7 +288,6 @@ TEST_CASE("algorithms")
             CHECK(j3 == json({1, 2, 3, 5, 7}));
         }
 
-        /*
         SECTION("std::set_union")
         {
             json j1 = {2, 4, 6, 8};
@@ -310,7 +307,6 @@ TEST_CASE("algorithms")
             std::set_symmetric_difference(j1.begin(), j1.end(), j2.begin(), j2.end(), std::back_inserter(j3));
             CHECK(j3 == json({1, 3, 4, 5, 6, 7, 8}));
         }
-        */
     }
 
     SECTION("heap operations")


### PR DESCRIPTION
These tests were commented out, and I want to know whether there was a reason for it.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
