### PR TITLE
Fix MSVC warning C4819

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -6564,7 +6564,7 @@ class serializer
                         // check that the additional bytes are present
                         assert(i + bytes < s.size());
 
-                        // to use \uxxxx escaping, we first need to caluclate
+                        // to use \uxxxx escaping, we first need to calculate
                         // the codepoint from the UTF-8 bytes
                         int codepoint = 0;
 


### PR DESCRIPTION
I get the following warning when I compile v3.0.0 with Visual Studio 2017 15.5.2 on a Windows machine with Japanese system locale:

> warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss

MSDN [explains](https://msdn.microsoft.com/en-us/library/ms173715.aspx):

> C4819 occurs when an ANSI source file is compiled on a system with a codepage that cannot represent all characters in the file.

This happens due to a [U+00A0](http://www.fileformat.info/info/unicode/char/00a0/index.htm) character, introduced in 21d23982cafe826cae088b2bb37cb40c8e7a81fe.

Assuming that it was unintentional, this PR replaces the UTF-8 byte sequence (`0xC2 0xA0`) with a regular space character (`0x20`), rather than saving the file in Unicode format.