### PR TITLE
Howto installation of json_fwd.hpp (fixes #923)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ using json = nlohmann::json;
 
 to the files you want to use JSON objects. That's it. Do not forget to set the necessary switches to enable C++11 (e.g., `-std=c++11` for GCC and Clang).
 
-You can further use file [`develop/json_fwd.hpp`](https://github.com/nlohmann/json/blob/develop/develop/json_fwd.hpp) for forward-declarations.
+You can further use file [`develop/json_fwd.hpp`](https://github.com/nlohmann/json/blob/develop/develop/json_fwd.hpp) for forward-declarations. The installation of json_fwd.hpp (as part of cmake's install step), can be achieved by setting `-DJSON_MultipleHeaders=ON`:
 
 ### Package Managers
 


### PR DESCRIPTION
Updated README.md to indicate how installation of json_fwd.hpp can be achieved as part of install step. I'm hoping that will save developers a few minutes.

