### PR TITLE
dump to alternative string type, as defined in basic_json template

### DIFF
--- a/include/nlohmann/detail/output/output_adapters.hpp
+++ b/include/nlohmann/detail/output/output_adapters.hpp
@@ -68,11 +68,11 @@ class output_stream_adapter : public output_adapter_protocol<CharType>
 };
 
 /// output adapter for basic_string
-template<typename CharType>
+template<typename CharType, typename StringType = std::basic_string<CharType>>
 class output_string_adapter : public output_adapter_protocol<CharType>
 {
   public:
-    explicit output_string_adapter(std::basic_string<CharType>& s) : str(s) {}
+    explicit output_string_adapter(StringType& s) : str(s) {}
 
     void write_character(CharType c) override
     {
@@ -85,10 +85,10 @@ class output_string_adapter : public output_adapter_protocol<CharType>
     }
 
   private:
-    std::basic_string<CharType>& str;
+    StringType& str;
 };
 
-template<typename CharType>
+template<typename CharType, typename StringType = std::basic_string<CharType>>
 class output_adapter
 {
   public:
@@ -98,7 +98,7 @@ class output_adapter
     output_adapter(std::basic_ostream<CharType>& s)
         : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
-    output_adapter(std::basic_string<CharType>& s)
+    output_adapter(StringType& s)
         : oa(std::make_shared<output_string_adapter<CharType>>(s)) {}
 
     operator output_adapter_t<CharType>()

--- a/include/nlohmann/detail/output/output_adapters.hpp
+++ b/include/nlohmann/detail/output/output_adapters.hpp
@@ -99,7 +99,7 @@ class output_adapter
         : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
     output_adapter(StringType& s)
-        : oa(std::make_shared<output_string_adapter<CharType>>(s)) {}
+        : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
 
     operator output_adapter_t<CharType>()
     {

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1947,7 +1947,7 @@ class basic_json
                   const bool ensure_ascii = false) const
     {
         string_t result;
-        serializer s(detail::output_adapter<char>(result), indent_char);
+        serializer s(detail::output_adapter<char, string_t>(result), indent_char);
 
         if (indent >= 0)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4808,7 +4808,7 @@ class output_adapter
         : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
     output_adapter(StringType& s)
-        : oa(std::make_shared<output_string_adapter<CharType>>(s)) {}
+        : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
 
     operator output_adapter_t<CharType>()
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4777,11 +4777,11 @@ class output_stream_adapter : public output_adapter_protocol<CharType>
 };
 
 /// output adapter for basic_string
-template<typename CharType>
+template<typename CharType, typename StringType = std::basic_string<CharType>>
 class output_string_adapter : public output_adapter_protocol<CharType>
 {
   public:
-    explicit output_string_adapter(std::basic_string<CharType>& s) : str(s) {}
+    explicit output_string_adapter(StringType& s) : str(s) {}
 
     void write_character(CharType c) override
     {
@@ -4794,10 +4794,10 @@ class output_string_adapter : public output_adapter_protocol<CharType>
     }
 
   private:
-    std::basic_string<CharType>& str;
+    StringType& str;
 };
 
-template<typename CharType>
+template<typename CharType, typename StringType = std::basic_string<CharType>>
 class output_adapter
 {
   public:
@@ -4807,7 +4807,7 @@ class output_adapter
     output_adapter(std::basic_ostream<CharType>& s)
         : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
-    output_adapter(std::basic_string<CharType>& s)
+    output_adapter(StringType& s)
         : oa(std::make_shared<output_string_adapter<CharType>>(s)) {}
 
     operator output_adapter_t<CharType>()
@@ -11556,7 +11556,7 @@ class basic_json
                   const bool ensure_ascii = false) const
     {
         string_t result;
-        serializer s(detail::output_adapter<char>(result), indent_char);
+        serializer s(detail::output_adapter<char, string_t>(result), indent_char);
 
         if (indent >= 0)
         {

--- a/test/src/unit-alt-string.cpp
+++ b/test/src/unit-alt-string.cpp
@@ -143,23 +143,53 @@ TEST_CASE("alternative string type")
 {
     SECTION("dump")
     {
-        alt_json doc;
-        doc["pi"] = 3.141;
-        doc["happy"] = true;
-        doc["name"] = "I'm Batman";
-        doc["nothing"] = nullptr;
-        doc["answer"]["everything"] = 42;
-        doc["list"] = { 1, 0, 2 };
-        doc["object"] = { {"currency", "USD"}, {"value", 42.99} };
+        {
+            alt_json doc;
+            doc["pi"] = 3.141;
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"pi":3.141})");
+        }
 
-        alt_string dump = doc.dump();
+        {
+            alt_json doc;
+            doc["happy"] = true;
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"happy":true})");
+        }
 
-        const char* const expect_str =
-            R"({"answer":{"everything":42},)"
-            R"("happy":true,"list":[1,0,2],)"
-            R"("name":"I'm Batman","nothing":null,)"
-            R"("object":{"currency":"USD","value":42.99},)"
-            R"("pi":3.141})";
-        CHECK(dump == expect_str);
+        {
+            alt_json doc;
+            doc["name"] = "I'm Batman";
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"name":"I'm Batman"})");
+        }
+
+        {
+            alt_json doc;
+            doc["nothing"] = nullptr;
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"nothing":null})");
+        }
+
+        {
+            alt_json doc;
+            doc["answer"]["everything"] = 42;
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"answer":{"everything":42}})");
+        }
+
+        {
+            alt_json doc;
+            doc["list"] = { 1, 0, 2 };
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"list":[1,0,2]})");
+        }
+
+        {
+            alt_json doc;
+            doc["list"] = { 1, 0, 2 };
+            alt_string dump = doc.dump();
+            CHECK(dump == R"({"list":[1,0,2]})");
+        }
     }
 }

--- a/test/src/unit-alt-string.cpp
+++ b/test/src/unit-alt-string.cpp
@@ -1,0 +1,165 @@
+/*
+    __ _____ _____ _____
+ __|  |   __|     |   | |  JSON for Modern C++ (test suite)
+|  |  |__   |  |  | | | |  version 3.1.1
+|_____|_____|_____|_|___|  https://github.com/nlohmann/json
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+Copyright (c) 2018 Vitaliy Manushkin <agri@akamo.info>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "catch.hpp"
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
+
+/*
+ * This is virtually a string class.
+ * It covers std::string under the hood.
+ */
+class alt_string
+{
+  public:
+    using value_type = std::string::value_type;
+
+    alt_string(const char* str): str_impl(str) {}
+    alt_string(const char* str, size_t count): str_impl(str, count) {}
+    alt_string(size_t count, char chr): str_impl(count, chr) {}
+    alt_string() = default;
+
+    template <typename...TParams>
+    alt_string& append(TParams&& ...params)
+    {
+        str_impl.append(std::forward<TParams>(params)...);
+        return *this;
+    }
+
+    void push_back(char c)
+    {
+        str_impl.push_back(c);
+    }
+
+    template <typename op_type>
+    bool operator==(op_type&& op) const
+    {
+        return str_impl == op;
+    }
+
+    template <typename op_type>
+    bool operator!=(op_type&& op) const
+    {
+        return str_impl != op;
+    }
+
+    size_t size() const noexcept
+    {
+        return str_impl.size();
+    }
+
+    void resize (size_t n)
+    {
+        str_impl.resize(n);
+    }
+
+    void resize (size_t n, char c)
+    {
+        str_impl.resize(n, c);
+    }
+
+    template <typename op_type>
+    bool operator<(op_type&& op) const
+    {
+        return str_impl < op;
+    }
+
+    bool operator<(const alt_string& op) const
+    {
+        return str_impl < op.str_impl;
+    }
+
+    const char* c_str() const
+    {
+        return str_impl.c_str();
+    }
+
+    char& operator[](int index)
+    {
+        return str_impl[index];
+    }
+
+    const char& operator[](int index) const
+    {
+        return str_impl[index];
+    }
+
+    char& back()
+    {
+        return str_impl.back();
+    }
+
+    const char& back() const
+    {
+        return str_impl.back();
+    }
+
+  private:
+    std::string str_impl;
+};
+
+
+using alt_json = nlohmann::basic_json <
+                 std::map,
+                 std::vector,
+                 alt_string,
+                 bool,
+                 std::int64_t,
+                 std::uint64_t,
+                 double,
+                 std::allocator,
+                 nlohmann::adl_serializer >;
+
+
+
+TEST_CASE("alternative string type")
+{
+    SECTION("dump")
+    {
+        alt_json doc;
+        doc["pi"] = 3.141;
+        doc["happy"] = true;
+        doc["name"] = "I'm Batman";
+        doc["nothing"] = nullptr;
+        doc["answer"]["everything"] = 42;
+        doc["list"] = { 1, 0, 2 };
+        doc["object"] = { {"currency", "USD"}, {"value", 42.99} };
+
+        alt_string dump = doc.dump();
+
+        const char* const expect_str =
+            R"({"answer":{"everything":42},)"
+            R"("happy":true,"list":[1,0,2],)"
+            R"("name":"I'm Batman","nothing":null,)"
+            R"("object":{"currency":"USD","value":42.99},)"
+            R"("pi":3.141})";
+        CHECK(dump == expect_str);
+    }
+}


### PR DESCRIPTION
An alternative string implementation can be defined in basic_json template. These changes allow json::dump to work with the alternative string type.