### PR TITLE
Allowing for user-defined string type in lexer/parser

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -32,6 +32,7 @@ class lexer
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
 
   public:
     /// token types for the parser
@@ -1130,7 +1131,7 @@ scan_number_done:
     }
 
     /// return current string value (implicitly resets the token; useful only once)
-    std::string&& move_string()
+    string_t&& move_string()
     {
         return std::move(token_buffer);
     }
@@ -1260,7 +1261,7 @@ scan_number_done:
     std::vector<char> token_string {};
 
     /// buffer for variable-length tokens (numbers, strings)
-    std::string token_buffer {};
+    string_t token_buffer {};
 
     /// a description of occurred lexer errors
     const char* error_message = "";

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -32,6 +32,7 @@ class parser
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
     using lexer_t = lexer<BasicJsonType>;
     using token_type = typename lexer_t::token_type;
 
@@ -175,7 +176,7 @@ class parser
                 }
 
                 // parse values
-                std::string key;
+                string_t key;
                 BasicJsonType value;
                 while (true)
                 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -1871,6 +1871,7 @@ class lexer
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
 
   public:
     /// token types for the parser
@@ -2969,7 +2970,7 @@ scan_number_done:
     }
 
     /// return current string value (implicitly resets the token; useful only once)
-    std::string&& move_string()
+    string_t&& move_string()
     {
         return std::move(token_buffer);
     }
@@ -3099,7 +3100,7 @@ scan_number_done:
     std::vector<char> token_string {};
 
     /// buffer for variable-length tokens (numbers, strings)
-    std::string token_buffer {};
+    string_t token_buffer {};
 
     /// a description of occurred lexer errors
     const char* error_message = "";
@@ -3155,6 +3156,7 @@ class parser
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
     using lexer_t = lexer<BasicJsonType>;
     using token_type = typename lexer_t::token_type;
 
@@ -3298,7 +3300,7 @@ class parser
                 }
 
                 // parse values
-                std::string key;
+                string_t key;
                 BasicJsonType value;
                 while (true)
                 {

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,6 +9,7 @@ CPPFLAGS += -I ../single_include -I . -I thirdparty/catch -I thirdparty/fifo_map
 SOURCES = src/unit.cpp \
           src/unit-algorithms.cpp \
           src/unit-allocator.cpp \
+          src/unit-alt-string.cpp \
           src/unit-capacity.cpp \
           src/unit-cbor.cpp \
           src/unit-class_const_iterator.cpp \

--- a/test/src/unit-alt-string.cpp
+++ b/test/src/unit-alt-string.cpp
@@ -42,7 +42,7 @@ class alt_string
     using value_type = std::string::value_type;
 
     alt_string(const char* str): str_impl(str) {}
-    alt_string(const char* str, size_t count): str_impl(str, count) {}
+    alt_string(const char* str, std::size_t count): str_impl(str, count) {}
     alt_string(size_t count, char chr): str_impl(count, chr) {}
     alt_string() = default;
 
@@ -70,17 +70,17 @@ class alt_string
         return str_impl != op;
     }
 
-    size_t size() const noexcept
+    std::size_t size() const noexcept
     {
         return str_impl.size();
     }
 
-    void resize (size_t n)
+    void resize (std::size_t n)
     {
         str_impl.resize(n);
     }
 
-    void resize (size_t n, char c)
+    void resize (std::size_t n, char c)
     {
         str_impl.resize(n, c);
     }
@@ -101,12 +101,12 @@ class alt_string
         return str_impl.c_str();
     }
 
-    char& operator[](int index)
+    char& operator[](std::size_t index)
     {
         return str_impl[index];
     }
 
-    const char& operator[](int index) const
+    const char& operator[](std::size_t index) const
     {
         return str_impl[index];
     }
@@ -119,6 +119,16 @@ class alt_string
     const char& back() const
     {
         return str_impl.back();
+    }
+
+    void clear()
+    {
+        str_impl.clear();
+    }
+
+    const value_type* data()
+    {
+        return str_impl.data();
     }
 
   private:
@@ -191,5 +201,12 @@ TEST_CASE("alternative string type")
             alt_string dump = doc.dump();
             CHECK(dump == R"({"list":[1,0,2]})");
         }
+    }
+
+    SECTION("parse")
+    {
+        auto doc = alt_json::parse("{\"foo\": \"bar\"}");
+        alt_string dump = doc.dump();
+        CHECK(dump == R"({"foo":"bar"})");
     }
 }


### PR DESCRIPTION
With #1006 we allowed for user-defined string types in the serializer. This PR also adds support for user-defined string types in the lexer and parser.

Thanks to @ralfbielig for noting.