### PR TITLE
Optional comment stripping.

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1185,12 +1185,46 @@ scan_number_done:
 
     token_type scan()
     {
+#ifndef JSON_STRIP_COMMENTS
         // read next character and ignore whitespace
         do
         {
             get();
         }
         while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+#else
+        // skip white space and comments if comment stripping enabled
+        while(true) {
+          // first skip any whitespace
+          do {
+            get();
+          }
+          while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
+
+          // next, skip any comment
+          if(current == '/') {
+            get();
+            // really a comment?
+            if (current == '/') {
+              // skip to the end of line/file
+              do {
+                get();
+              } while (! (current == '\n' ||
+                          current == '\r' ||
+                          current == std::char_traits<char>::eof()));
+            }
+            else {
+              // not a comment, leave it up to the rest of the code to deal with the '/'
+              unget();
+              break;
+            }
+          }
+          else {
+            // not a comment at all, break out of the loop
+            break;
+          }
+        }
+#endif
 
         switch (current)
         {

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1194,35 +1194,43 @@ scan_number_done:
         while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
 #else
         // skip white space and comments if comment stripping enabled
-        while(true) {
-          // first skip any whitespace
-          do {
-            get();
-          }
-          while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
-
-          // next, skip any comment
-          if(current == '/') {
-            get();
-            // really a comment?
-            if (current == '/') {
-              // skip to the end of line/file
-              do {
+        while (true)
+        {
+            // first skip any whitespace
+            do
+            {
                 get();
-              } while (! (current == '\n' ||
-                          current == '\r' ||
-                          current == std::char_traits<char>::eof()));
             }
-            else {
-              // not a comment, leave it up to the rest of the code to deal with the '/'
-              unget();
-              break;
+            while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
+
+            // next, skip any comment
+            if (current == '/')
+            {
+                get();
+                // really a comment?
+                if (current == '/')
+                {
+                    // skip to the end of line/file
+                    do
+                    {
+                        get();
+                    }
+                    while (! (current == '\n' ||
+                              current == '\r' ||
+                              current == std::char_traits<char>::eof()));
+                }
+                else
+                {
+                    // not a comment, leave it up to the rest of the code to deal with the '/'
+                    unget();
+                    break;
+                }
             }
-          }
-          else {
-            // not a comment at all, break out of the loop
-            break;
-          }
+            else
+            {
+                // not a comment at all, break out of the loop
+                break;
+            }
         }
 #endif
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3024,12 +3024,54 @@ scan_number_done:
 
     token_type scan()
     {
+#ifndef JSON_STRIP_COMMENTS
         // read next character and ignore whitespace
         do
         {
             get();
         }
         while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+#else
+        // skip white space and comments if comment stripping enabled
+        while (true)
+        {
+            // first skip any whitespace
+            do
+            {
+                get();
+            }
+            while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
+
+            // next, skip any comment
+            if (current == '/')
+            {
+                get();
+                // really a comment?
+                if (current == '/')
+                {
+                    // skip to the end of line/file
+                    do
+                    {
+                        get();
+                    }
+                    while (! (current == '\n' ||
+                              current == '\r' ||
+                              current == std::char_traits<char>::eof()));
+                }
+                else
+                {
+                    // not a comment, leave it up to the rest of the code to deal with the '/'
+                    unget();
+                    break;
+                }
+            }
+            else
+            {
+                // not a comment at all, break out of the loop
+                break;
+            }
+        }
+#endif
 
         switch (current)
         {


### PR DESCRIPTION
I've added optional code to strip javascript '//' style comments from a json file. This is only enabled if the JSON_STRIP_COMMENTS C++ macro is defined. By default this does not break conformance with the JSON standard, but allows cases where comment stripping is needed to be enabled on an ad-hoc basis without having to introduce pre-parsing phases with any associated extra code.

