### PR TITLE
Added public target_compile_features for auto and constexpr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -277,6 +277,7 @@ script:
      if [[ (-x $(which brew)) ]]; then
        brew update
        brew install cmake ninja
+       brew upgrade cmake
        cmake --version
      fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 
 ##
 ## PROJECT
@@ -43,6 +43,8 @@ endif()
 ## create target and add include path
 ##
 add_library(${NLOHMANN_JSON_TARGET_NAME} INTERFACE)
+
+target_compile_features(${NLOHMANN_JSON_TARGET_NAME} INTERFACE cxx_std_11)
 
 target_include_directories(
     ${NLOHMANN_JSON_TARGET_NAME}

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 project(JSON_Benchmarks LANGUAGES CXX)
 
 # set compiler flags
 if((CMAKE_CXX_COMPILER_ID MATCHES GNU) OR (CMAKE_CXX_COMPILER_ID MATCHES Clang))
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -flto -DNDEBUG -O3")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -DNDEBUG -O3")
 endif()
 
 # configure Google Benchmarks
@@ -23,4 +23,5 @@ file(COPY ${CMAKE_SOURCE_DIR}/../test/data/regression/floats.json
 
 # benchmark binary
 add_executable(json_benchmarks src/benchmarks.cpp)
+target_compile_features(json_benchmarks PRIVATE cxx_std_11)
 target_link_libraries(json_benchmarks benchmark ${CMAKE_THREAD_LIBS_INIT})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ option(JSON_Coverage "Build test suite with coverage information" OFF)
 if(JSON_Sanitizer)
     message(STATUS "Building test suite with Clang sanitizer")
     if(NOT MSVC)
-        set(CMAKE_CXX_FLAGS "-std=c++11 -g -O2 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
+        set(CMAKE_CXX_FLAGS "-g -O2 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
     endif()
 endif()
 
@@ -62,11 +62,10 @@ add_library(catch_main OBJECT
     "src/unit.cpp"
 )
 set_target_properties(catch_main PROPERTIES
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED ON
     COMPILE_DEFINITIONS "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
     COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>"
 )
+target_compile_features(catch_main PUBLIC cxx_std_11)
 target_include_directories(catch_main PRIVATE "thirdparty/catch")
 
 # https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake
@@ -96,13 +95,12 @@ foreach(file ${files})
 
     add_executable(${testcase} $<TARGET_OBJECTS:catch_main> ${file})
     set_target_properties(${testcase} PROPERTIES
-        CXX_STANDARD 11
-        CXX_STANDARD_REQUIRED ON
         COMPILE_DEFINITIONS "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
         COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>"
     )
 
     target_compile_definitions(${testcase} PRIVATE CATCH_CONFIG_FAST_COMPILE)
+    target_compile_features(${testcase} PRIVATE cxx_std_11)
     target_include_directories(${testcase} PRIVATE "thirdparty/catch")
     target_include_directories(${testcase} PRIVATE "thirdparty/fifo_map")
     target_include_directories(${testcase} PRIVATE ${NLOHMANN_JSON_INCLUDE_BUILD_DIR})


### PR DESCRIPTION
For projects which consume this header-only library using CMake, this adds public dependencies on C++ features to the library target. Requires an update to CMake 3.1.0, as `target_compile_features` was not available before that version.

Also, I'm not sure that the list of features is exhaustive. I only notice the use of `auto` and `constexpr`, and including these two was sufficient to get my example building without having to manually specify C++ 11.
