### PR TITLE
Added support for string_view in C++17

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -70,6 +70,25 @@ void from_json(const BasicJsonType& j, typename BasicJsonType::string_t& s)
     s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
 }
 
+template <
+    typename BasicJsonType, typename CompatibleStringType,
+    enable_if_t <
+        is_compatible_string_type<BasicJsonType, CompatibleStringType>::value and
+        not std::is_same<typename BasicJsonType::string_t,
+                         CompatibleStringType>::value and
+        std::is_constructible <
+            BasicJsonType, typename CompatibleStringType::value_type >::value,
+        int > = 0 >
+void from_json(const BasicJsonType& j, CompatibleStringType& s)
+{
+    if (JSON_UNLIKELY(not j.is_string()))
+    {
+        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
+    }
+
+    s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+}
+
 template<typename BasicJsonType>
 void from_json(const BasicJsonType& j, typename BasicJsonType::number_float_t& val)
 {

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -75,9 +75,7 @@ template <
     enable_if_t <
         is_compatible_string_type<BasicJsonType, CompatibleStringType>::value and
         not std::is_same<typename BasicJsonType::string_t,
-                         CompatibleStringType>::value and
-        std::is_constructible <
-            BasicJsonType, typename CompatibleStringType::value_type >::value,
+                         CompatibleStringType>::value,
         int > = 0 >
 void from_json(const BasicJsonType& j, CompatibleStringType& s)
 {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -51,6 +51,16 @@ struct external_constructor<value_t::string>
         j.m_value = std::move(s);
         j.assert_invariant();
     }
+
+	template<typename BasicJsonType, typename CompatibleStringType,
+		 enable_if_t<not std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
+		             int> = 0>
+		static void construct(BasicJsonType& j, const CompatibleStringType& str)
+	{
+		j.m_type = value_t::string;
+		j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
+		j.assert_invariant();
+	}
 };
 
 template<>

--- a/include/nlohmann/detail/meta.hpp
+++ b/include/nlohmann/detail/meta.hpp
@@ -120,6 +120,16 @@ struct is_compatible_object_type_impl<true, RealType, CompatibleObjectType>
         std::is_constructible<typename RealType::mapped_type, typename CompatibleObjectType::mapped_type>::value;
 };
 
+template<bool B, class RealType, class CompatibleStringType>
+struct is_compatible_string_type_impl : std::false_type {};
+
+template<class RealType, class CompatibleStringType>
+struct is_compatible_string_type_impl<true, RealType, CompatibleStringType>
+{
+    static constexpr auto value =
+        std::is_same<typename RealType::value_type, typename CompatibleStringType::value_type>::value;
+};
+
 template<class BasicJsonType, class CompatibleObjectType>
 struct is_compatible_object_type
 {
@@ -128,6 +138,15 @@ struct is_compatible_object_type
                                   has_mapped_type<CompatibleObjectType>,
                                   has_key_type<CompatibleObjectType>>::value,
                                   typename BasicJsonType::object_t, CompatibleObjectType >::value;
+};
+
+template<class BasicJsonType, class CompatibleStringType>
+struct is_compatible_string_type
+{
+    static auto constexpr value = is_compatible_string_type_impl <
+                                  conjunction<negation<std::is_same<void, CompatibleStringType>>,
+                                  has_value_type<CompatibleStringType>>::value,
+                                  typename BasicJsonType::string_t, CompatibleStringType >::value;
 };
 
 template<typename BasicJsonType, typename T>

--- a/include/nlohmann/detail/meta.hpp
+++ b/include/nlohmann/detail/meta.hpp
@@ -127,7 +127,8 @@ template<class RealType, class CompatibleStringType>
 struct is_compatible_string_type_impl<true, RealType, CompatibleStringType>
 {
     static constexpr auto value =
-        std::is_same<typename RealType::value_type, typename CompatibleStringType::value_type>::value;
+        std::is_same<typename RealType::value_type, typename CompatibleStringType::value_type>::value and
+        std::is_constructible<RealType, CompatibleStringType>::value;
 };
 
 template<class BasicJsonType, class CompatibleObjectType>

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -2821,9 +2821,9 @@ class basic_json
                    not detail::is_basic_json<ValueType>::value
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
-#endif
-#if defined(JSON_HAS_CPP_17)
+#if defined(JSON_HAS_CPP_17) && _MSC_VER <= 1913
                    and not std::is_same<ValueType, typename std::string_view>::value
+#endif
 #endif
                    , int >::type = 0 >
     operator ValueType() const

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -2821,7 +2821,7 @@ class basic_json
                    not detail::is_basic_json<ValueType>::value
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
-#if defined(JSON_HAS_CPP_17) && _MSC_VER <= 1913
+#if defined(JSON_HAS_CPP_17) && _MSC_VER <= 1914
                    and not std::is_same<ValueType, typename std::string_view>::value
 #endif
 #endif

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -353,6 +353,16 @@ struct is_compatible_object_type_impl<true, RealType, CompatibleObjectType>
         std::is_constructible<typename RealType::mapped_type, typename CompatibleObjectType::mapped_type>::value;
 };
 
+template<bool B, class RealType, class CompatibleStringType>
+struct is_compatible_string_type_impl : std::false_type {};
+
+template<class RealType, class CompatibleStringType>
+struct is_compatible_string_type_impl<true, RealType, CompatibleStringType>
+{
+    static constexpr auto value =
+        std::is_same<typename RealType::value_type, typename CompatibleStringType::value_type>::value;
+};
+
 template<class BasicJsonType, class CompatibleObjectType>
 struct is_compatible_object_type
 {
@@ -361,6 +371,15 @@ struct is_compatible_object_type
                                   has_mapped_type<CompatibleObjectType>,
                                   has_key_type<CompatibleObjectType>>::value,
                                   typename BasicJsonType::object_t, CompatibleObjectType >::value;
+};
+
+template<class BasicJsonType, class CompatibleStringType>
+struct is_compatible_string_type
+{
+    static auto constexpr value = is_compatible_string_type_impl <
+                                  conjunction<negation<std::is_same<void, CompatibleStringType>>,
+                                  has_value_type<CompatibleStringType>>::value,
+                                  typename BasicJsonType::string_t, CompatibleStringType >::value;
 };
 
 template<typename BasicJsonType, typename T>
@@ -974,6 +993,25 @@ void from_json(const BasicJsonType& j, typename BasicJsonType::string_t& s)
     {
         JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
     }
+    s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+}
+
+template <
+    typename BasicJsonType, typename CompatibleStringType,
+    enable_if_t <
+        is_compatible_string_type<BasicJsonType, CompatibleStringType>::value and
+        not std::is_same<typename BasicJsonType::string_t,
+                         CompatibleStringType>::value and
+        std::is_constructible <
+            BasicJsonType, typename CompatibleStringType::value_type >::value,
+        int > = 0 >
+void from_json(const BasicJsonType& j, CompatibleStringType& s)
+{
+    if (JSON_UNLIKELY(not j.is_string()))
+    {
+        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
+    }
+
     s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
 }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -1321,16 +1321,6 @@ struct external_constructor<value_t::string>
         j.m_value = std::move(s);
         j.assert_invariant();
     }
-
-    template<typename BasicJsonType, typename CompatibleStringType,
-             enable_if_t<not std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
-                         int> = 0>
-    static void construct(BasicJsonType& j, const CompatibleStringType& str)
-    {
-        j.m_type = value_t::string;
-        j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
-        j.assert_invariant();
-    }
 };
 
 template<>
@@ -12480,6 +12470,9 @@ class basic_json
                    not detail::is_basic_json<ValueType>::value
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
+#if defined(JSON_HAS_CPP_17) && _MSC_VER <= 1913
+                   and not std::is_same<ValueType, typename std::string_view>::value
+#endif
 #endif
                    , int >::type = 0 >
     operator ValueType() const

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -1321,6 +1321,16 @@ struct external_constructor<value_t::string>
         j.m_value = std::move(s);
         j.assert_invariant();
     }
+
+    template<typename BasicJsonType, typename CompatibleStringType,
+             enable_if_t<not std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
+                         int> = 0>
+    static void construct(BasicJsonType& j, const CompatibleStringType& str)
+    {
+        j.m_type = value_t::string;
+        j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
+        j.assert_invariant();
+    }
 };
 
 template<>
@@ -12470,9 +12480,6 @@ class basic_json
                    not detail::is_basic_json<ValueType>::value
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
-#endif
-#if defined(JSON_HAS_CPP_17)
-                   and not std::is_same<ValueType, typename std::string_view>::value
 #endif
                    , int >::type = 0 >
     operator ValueType() const

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12470,7 +12470,7 @@ class basic_json
                    not detail::is_basic_json<ValueType>::value
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
-#if defined(JSON_HAS_CPP_17) && _MSC_VER <= 1913
+#if defined(JSON_HAS_CPP_17) && _MSC_VER <= 1914
                    and not std::is_same<ValueType, typename std::string_view>::value
 #endif
 #endif

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -360,7 +360,8 @@ template<class RealType, class CompatibleStringType>
 struct is_compatible_string_type_impl<true, RealType, CompatibleStringType>
 {
     static constexpr auto value =
-        std::is_same<typename RealType::value_type, typename CompatibleStringType::value_type>::value;
+        std::is_same<typename RealType::value_type, typename CompatibleStringType::value_type>::value and
+        std::is_constructible<RealType, CompatibleStringType>::value;
 };
 
 template<class BasicJsonType, class CompatibleObjectType>
@@ -1001,9 +1002,7 @@ template <
     enable_if_t <
         is_compatible_string_type<BasicJsonType, CompatibleStringType>::value and
         not std::is_same<typename BasicJsonType::string_t,
-                         CompatibleStringType>::value and
-        std::is_constructible <
-            BasicJsonType, typename CompatibleStringType::value_type >::value,
+                         CompatibleStringType>::value,
         int > = 0 >
 void from_json(const BasicJsonType& j, CompatibleStringType& s)
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -1320,6 +1320,16 @@ struct external_constructor<value_t::string>
         j.m_value = std::move(s);
         j.assert_invariant();
     }
+
+    template<typename BasicJsonType, typename CompatibleStringType,
+             enable_if_t<not std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
+                         int> = 0>
+    static void construct(BasicJsonType& j, const CompatibleStringType& str)
+    {
+        j.m_type = value_t::string;
+        j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
+        j.assert_invariant();
+    }
 };
 
 template<>

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -39,6 +39,13 @@ using nlohmann::json;
 #include <unordered_set>
 #include <valarray>
 
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+    #define JSON_HAS_CPP_17
+    #define JSON_HAS_CPP_14
+#elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
+    #define JSON_HAS_CPP_14
+#endif
+
 #if defined(JSON_HAS_CPP_17)
 #include <string_view>
 #endif

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -329,6 +329,34 @@ TEST_CASE("value conversion")
             CHECK_THROWS_WITH(json(json::value_t::number_float).get<json::string_t>(),
                               "[json.exception.type_error.302] type must be string, but is number");
         }
+
+#if defined(JSON_HAS_CPP_17)
+        SECTION("exception in case of a non-string type using string_view")
+        {
+            CHECK_THROWS_AS(json(json::value_t::null).get<std::string_view>(), json::type_error&);
+            CHECK_THROWS_AS(json(json::value_t::object).get<std::string_view>(), json::type_error&);
+            CHECK_THROWS_AS(json(json::value_t::array).get<std::string_view>(), json::type_error&);
+            CHECK_THROWS_AS(json(json::value_t::boolean).get<std::string_view>(), json::type_error&);
+            CHECK_THROWS_AS(json(json::value_t::number_integer).get<std::string_view>(), json::type_error&);
+            CHECK_THROWS_AS(json(json::value_t::number_unsigned).get<std::string_view>(), json::type_error&);
+            CHECK_THROWS_AS(json(json::value_t::number_float).get<std::string_view>(), json::type_error&);
+
+            CHECK_THROWS_WITH(json(json::value_t::null).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is null");
+            CHECK_THROWS_WITH(json(json::value_t::object).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is object");
+            CHECK_THROWS_WITH(json(json::value_t::array).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is array");
+            CHECK_THROWS_WITH(json(json::value_t::boolean).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is boolean");
+            CHECK_THROWS_WITH(json(json::value_t::number_integer).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is number");
+            CHECK_THROWS_WITH(json(json::value_t::number_unsigned).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is number");
+            CHECK_THROWS_WITH(json(json::value_t::number_float).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is number");
+        }
+#endif
     }
 
     SECTION("get a string (implicit)")

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -39,6 +39,10 @@ using nlohmann::json;
 #include <unordered_set>
 #include <valarray>
 
+#if defined(JSON_HAS_CPP_17)
+#include <string_view>
+#endif
+
 TEST_CASE("value conversion")
 {
     SECTION("get an object (explicit)")
@@ -292,6 +296,13 @@ TEST_CASE("value conversion")
             std::string s = j.get<std::string>();
             CHECK(json(s) == j);
         }
+#if defined(JSON_HAS_CPP_17)
+        SECTION("std::string_view")
+        {
+            std::string_view s = j.get<std::string_view>();
+            CHECK(json(s) == j);
+        }
+#endif
 
         SECTION("exception in case of a non-string type")
         {
@@ -330,6 +341,14 @@ TEST_CASE("value conversion")
             json::string_t s = j;
             CHECK(json(s) == j);
         }
+
+#if defined(JSON_HAS_CPP_17)
+        SECTION("std::string_view")
+        {
+            std::string_view s = j;
+            CHECK(json(s) == j);
+        }
+#endif
 
         SECTION("std::string")
         {


### PR DESCRIPTION
This patch adds support for `std::string_view` conversion (explicit and implicit). It also added construction from `std::string_view`.

I did that by following how many compatible array types were handled and adding a type trait that checks for compatible string types.

However, I fear the trait is kinda loose in which type is allows (see `is_compatible_string_type`). Tell me if it needs to be fixed!