### PR TITLE
Package Manager: Spack

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ If you are using the [Meson Build System](http://mesonbuild.com), then you can w
 
 If you are using [Conan](https://www.conan.io/) to manage your dependencies, merely add `jsonformoderncpp/x.y.z@vthiery/stable` to your `conanfile.py`'s requires, where `x.y.z` is the release version you want to use. Please file issues [here](https://github.com/vthiery/conan-jsonformoderncpp/issues) if you experience problems with the packages.
 
+If you are using [Spack](https://www.spack.io/) to manage your dependencies, you can use the `nlohmann_json` package. Please see the [spack project](https://github.com/spack/spack) for any issues regarding the packaging.
+
 If you are using [hunter](https://github.com/ruslo/hunter/) on your project for external dependencies, then you can use the [nlohmann_json package](https://docs.hunter.sh/en/latest/packages/pkg/nlohmann_json.html). Please see the hunter project for any issues regarding the packaging.
 
 If you are using [Buckaroo](https://buckaroo.pm), you can install this library's module with `buckaroo install nlohmann/json`. Please file issues [here](https://github.com/LoopPerfect/buckaroo-recipes/issues/new?title=nlohmann/nlohmann/json).


### PR DESCRIPTION
I [contributed a package](https://github.com/spack/spack/pull/7690) to the [Spack package manager](https://spack.io/).

Spack is a flexible package manager that supports multiple versions, configurations, platforms, and compilers. It is popular in high-performance computing.

## Usage

### CLI

```bash
spack install nlohmann-json
spack load    nlohmann-json
#             |-- "spec" -|
```

| Variant: add to spec               | Description                   |
|-------------------------------------|-------------------------------|
| `+test`/`~test`                     |   Build tests                 |
| `+single_header` / `~single_header` | Use amalgamated single-header |

Example with a variant:
```bash
spack install nlohmann-json ~test ~single_header
#             |------------ "spec" ------------|
```

Example with a variant of a specific version with a specific compiler:
```bash
spack install nlohmann-json@3.1.2 ~test %clang
#             |----------- "spec" -----------|
```

### Depending on the Library
```python
from spack import *


class MyProject(CMakePackage):
    # ...
    depends_on('nlohmann-json')
```

## To Do

- [x] wait for the PR in https://github.com/spack/spack/pull/7690 to be reviewed & merged
