### PR TITLE
Fix operator== overload ambiguity

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5533,8 +5533,10 @@ class basic_json
     @brief comparison: equal
     @copydoc operator==(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    template < typename ScalarType, typename std::enable_if <
+                   std::is_scalar<ScalarType>::value, int >::type = 0,
+               typename std::enable_if <
+                   std::is_same<std::nullptr_t, std::remove_cv<ScalarType>>::value, int >::type = 0 >
     friend bool operator==(const_reference lhs, const ScalarType rhs) noexcept
     {
         return (lhs == basic_json(rhs));
@@ -5544,8 +5546,10 @@ class basic_json
     @brief comparison: equal
     @copydoc operator==(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    template < typename ScalarType, typename std::enable_if <
+                   std::is_scalar<ScalarType>::value, int >::type = 0,
+               typename std::enable_if <
+                   std::is_same<std::nullptr_t, std::remove_cv<ScalarType>>::value, int >::type = 0 >
     friend bool operator==(const ScalarType lhs, const_reference rhs) noexcept
     {
         return (basic_json(lhs) == rhs);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15174,8 +15174,10 @@ class basic_json
     @brief comparison: equal
     @copydoc operator==(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    template < typename ScalarType, typename std::enable_if <
+                   std::is_scalar<ScalarType>::value, int >::type = 0,
+               typename std::enable_if <
+                   !std::is_same<std::nullptr_t, std::remove_cv<ScalarType>>::value, int >::type = 0 >
     friend bool operator==(const_reference lhs, const ScalarType rhs) noexcept
     {
         return (lhs == basic_json(rhs));
@@ -15185,8 +15187,10 @@ class basic_json
     @brief comparison: equal
     @copydoc operator==(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    template < typename ScalarType, typename std::enable_if <
+                   std::is_scalar<ScalarType>::value, int >::type = 0,
+               typename std::enable_if <
+                   !std::is_same<std::nullptr_t, std::remove_cv<ScalarType>>::value, int >::type = 0 >
     friend bool operator==(const ScalarType lhs, const_reference rhs) noexcept
     {
         return (basic_json(lhs) == rhs);


### PR DESCRIPTION
Currently, `json` does not work well together with GoogleMock.
(e.g. `MOCK_METHOD0(sample, nlohmann::json(void));`)

This is because of an ambiguous overload which this PR fixes by disabling one of the two.
As `std::is_null_pointer` is only available from C++14, this uses the possible implementation from http://en.cppreference.com/w/cpp/types/is_null_pointer

Example error:
```
In file included from external/com_google_googletest/googlemock/include/gmock/gmock.h:58:
external/com_google_googletest/googlemock/include/gmock/gmock-actions.h:388:18: error: use of overloaded operator '==' is ambiguous (with operand types 'const internal::linked_ptr<ActionInterface<const basic_json<std::map, std::vector, basic_string<char, char_traits<char>, allocator<char> >, bool, long, unsigned long, double, std::allocator, adl_serializer> ()> >' and 'nullptr_t')
    return impl_ == nullptr && fun_ == nullptr;
           ~~~~~ ^  ~~~~~~~
SNIP

external/com_google_googletest/googletest/include/gtest/internal/gtest-linked_ptr.h:186:8: note: candidate function
  bool operator==(T* p) const { return value_ == p; }
       ^
json.h:15149:17: note: candidate function [with ScalarType = nullptr_t, $1 = 0]
    friend bool operator==(const_reference lhs, const ScalarType rhs) noexcept
                ^
json.h:15078:17: note: candidate function
    friend bool operator==(const_reference lhs, const_reference rhs) noexcept
```