### PR TITLE
Add support for workarounds for non-compliant C++11 compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ fuzzing-stop:
 ##########################################################################
 
 # call cppcheck on the main header file
-cppcheck:
+cppcheck: $(AMALGAMATED_FILE)
 	cppcheck --enable=warning --inconclusive --force --std=c++11 $(AMALGAMATED_FILE) --error-exitcode=1
 
 # compile and check with Clang Static Analyzer

--- a/doc/examples/meta.output
+++ b/doc/examples/meta.output
@@ -4,7 +4,7 @@
         "family": "clang",
         "version": "9.0.0 (clang-900.0.39.2)"
     },
-    "copyright": "(C) 2013-2017 Niels Lohmann",
+    "copyright": "(C) 2013-2018 Niels Lohmann",
     "name": "JSON for Modern C++",
     "platform": "apple",
     "url": "https://github.com/nlohmann/json",

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -93,7 +93,7 @@ class binary_reader
                 get();
             }
 
-            if (JSON_UNLIKELY(current != std::char_traits<char>::eof()))
+            if (JSON_UNLIKELY(current != end_of_file))
             {
                 return sax->parse_error(chars_read, get_token_string(), parse_error::create(110, chars_read, "expected end of input"));
             }
@@ -126,8 +126,7 @@ class binary_reader
     {
         switch (get_char ? get() : current)
         {
-            // EOF
-            case std::char_traits<char>::eof():
+            case end_of_file:
                 return unexpect_eof();
 
             // Integer 0x00..0x17 (0..23)
@@ -453,8 +452,7 @@ class binary_reader
     {
         switch (get())
         {
-            // EOF
-            case std::char_traits<char>::eof():
+            case end_of_file:
                 return unexpect_eof();
 
             // positive fixint
@@ -1420,7 +1418,7 @@ class binary_reader
     {
         switch (prefix)
         {
-            case std::char_traits<char>::eof():  // EOF
+            case end_of_file:
                 return unexpect_eof();
 
             case 'T':  // true
@@ -1651,7 +1649,7 @@ class binary_reader
     */
     bool unexpect_eof() const
     {
-        if (JSON_UNLIKELY(current == std::char_traits<char>::eof()))
+        if (JSON_UNLIKELY(current == end_of_file))
         {
             return sax->parse_error(chars_read, "<end of file>", parse_error::create(110, chars_read, "unexpected end of input"));
         }
@@ -1673,7 +1671,7 @@ class binary_reader
     input_adapter_t ia = nullptr;
 
     /// the current character
-    int current = std::char_traits<char>::eof();
+    int current = end_of_file;
 
     /// the number of characters read
     std::size_t chars_read = 0;

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -105,7 +105,7 @@ class input_buffer_adapter : public input_adapter_protocol
             return std::char_traits<char>::to_int_type(*(cursor++));
         }
 
-        return std::char_traits<char>::eof();
+        return end_of_file;
     }
 
   private:
@@ -152,7 +152,7 @@ class wide_string_input_adapter : public input_adapter_protocol
 
         if (current_wchar == str.size())
         {
-            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes[0] = end_of_file;
             utf8_bytes_filled = 1;
         }
         else
@@ -208,7 +208,7 @@ class wide_string_input_adapter : public input_adapter_protocol
 
         if (current_wchar == str.size())
         {
-            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes[0] = end_of_file;
             utf8_bytes_filled = 1;
         }
         else

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -235,7 +235,7 @@ class lexer
             switch (get())
             {
                 // end of file while parsing string
-                case std::char_traits<char>::eof():
+                case end_of_file:
                 {
                     error_message = "invalid string: missing closing quote";
                     return token_type::parse_error;
@@ -1089,7 +1089,7 @@ scan_number_done:
             current = ia->get_character();
         }
 
-        if (JSON_LIKELY(current != std::char_traits<char>::eof()))
+        if (JSON_LIKELY(current != end_of_file))
         {
             token_string.push_back(std::char_traits<char>::to_char_type(current));
         }
@@ -1108,7 +1108,7 @@ scan_number_done:
     {
         next_unget = true;
         --chars_read;
-        if (JSON_LIKELY(current != std::char_traits<char>::eof()))
+        if (JSON_LIKELY(current != end_of_file))
         {
             assert(token_string.size() != 0);
             token_string.pop_back();
@@ -1285,7 +1285,7 @@ scan_number_done:
             // end of input (the null byte is needed when parsing from
             // string literals)
             case '\0':
-            case std::char_traits<char>::eof():
+            case end_of_file:
                 return token_type::end_of_input;
 
             // error
@@ -1300,7 +1300,7 @@ scan_number_done:
     detail::input_adapter_t ia = nullptr;
 
     /// the current character
-    std::char_traits<char>::int_type current = std::char_traits<char>::eof();
+    std::char_traits<char>::int_type current = end_of_file;
 
     /// whether the next get() call should just return current
     bool next_unget = false;

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -4,13 +4,15 @@
 // You MUST include macro_unscope.hpp at the end of json.hpp to undef all of them
 
 // exclude unsupported compilers
-#if defined(__clang__)
-    #if (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) < 30400
-        #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
-    #endif
-#elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
-    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
-        #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
+#ifndef NLOHMANN_JSON_SKIP_COMPILER_CHECK
+    #if defined(__clang__)
+        #if (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) < 30400
+            #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
+        #endif
+    #elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
+        #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+            #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
+        #endif
     #endif
 #endif
 

--- a/include/nlohmann/detail/meta.hpp
+++ b/include/nlohmann/detail/meta.hpp
@@ -25,6 +25,8 @@ namespace detail
 // helpers //
 /////////////
 
+static constexpr std::char_traits<char>::int_type end_of_file = std::char_traits<char>::eof();
+
 template<typename> struct is_basic_json : std::false_type {};
 
 NLOHMANN_BASIC_JSON_TPL_DECLARATION

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -414,7 +414,7 @@ class serializer
         else
         {
             // we finish reading, but do not accept: string was incomplete
-            std::string sn(3,'\0');
+            std::string sn(3, '\0');
             snprintf(&sn[0], sn.size(), "%.2X", static_cast<uint8_t>(s.back()));
             JSON_THROW(type_error::create(316, "incomplete UTF-8 string; last byte: 0x" + sn));
         }

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -316,7 +316,7 @@ class basic_json
     {
         basic_json result;
 
-        result["copyright"] = "(C) 2013-2017 Niels Lohmann";
+        result["copyright"] = "(C) 2013-2018 Niels Lohmann";
         result["name"] = "JSON for Modern C++";
         result["url"] = "https://github.com/nlohmann/json";
         result["version"]["string"] =

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -1093,9 +1093,9 @@ TEST_CASE("value conversion")
 
                 SECTION("superfluous entries")
                 {
-                  json j8 = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
-                  m2 = j8.get<std::map<int, int>>();
-                  CHECK(m == m2);
+                    json j8 = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
+                    m2 = j8.get<std::map<int, int>>();
+                    CHECK(m == m2);
                 }
             }
 

--- a/test/src/unit-inspection.cpp
+++ b/test/src/unit-inspection.cpp
@@ -317,8 +317,8 @@ TEST_CASE("object inspection")
     SECTION("round trips")
     {
         for (const auto& s :
-                {"3.141592653589793", "1000000000000000010E5"
-                })
+    {"3.141592653589793", "1000000000000000010E5"
+    })
         {
             json j1 = json::parse(s);
             std::string s1 = j1.dump();

--- a/test/src/unit-meta.cpp
+++ b/test/src/unit-meta.cpp
@@ -39,7 +39,7 @@ TEST_CASE("version information")
         json j = json::meta();
 
         CHECK(j["name"] == "JSON for Modern C++");
-        CHECK(j["copyright"] == "(C) 2013-2017 Niels Lohmann");
+        CHECK(j["copyright"] == "(C) 2013-2018 Niels Lohmann");
         CHECK(j["url"] == "https://github.com/nlohmann/json");
         CHECK(j["version"] == json(
         {


### PR DESCRIPTION
Include example for Borland C++ Builder (RAD Studio)'s clang (3.3.1) based compiler (bcc32c).

I know this goes against the Contribution Guidelines and I will keep my fork rebased separately if this is unacceptable. I would nevertheless like your input please.

What I've done is to add a macro (_NLOHMANN_JSON_SKIP_COMPILER_CHECK_) to be able override the compiler check and one macro (_NLOHMANN_JSON_FIX_CONSTEXPR_FOR_CHAR_TRAITS_EOF_) to let a porter define a constexpr instead of using std::char_traits<char>::eof(). I couldn't find a way to override the built in definition unfortunately. If you know of a way that this could be done, I'd be glad to use that way instead.

The file "include/nlohmann/detail/workarounds/borland.hpp" will not be included in the amalgamated json.hpp - so any user will have to manually include it before json.hpp. I'll happily remove this file if the other changes would be acceptable.