### PR TITLE
meson: fix include directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('nlohmann_json', 'cpp')
 
-nlohmann_json_inc = include_directories('single_include/nlohmann')
+nlohmann_json_inc = include_directories('single_include')
 
 nlohmann_json_dep = declare_dependency(
   include_directories : nlohmann_json_inc

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,9 @@
 project('nlohmann_json', 'cpp')
 
-nlohmann_json_inc = include_directories('single_include')
-
 nlohmann_json_dep = declare_dependency(
-  include_directories : nlohmann_json_inc
+  include_directories: include_directories('single_include')
+)
+
+nlohmann_json_multiple_headers = declare_dependency(
+  include_directories: include_directories('include')
 )


### PR DESCRIPTION
Currently Meson exports `single_include/nlohmann` as include directory.
The compiler flag `-I…/nlohmann_json/single_include/nlohmann` is generated.
According to the documentation, this is how you should include it:
```c++
#include <nlohmann/json.hpp>
```
This does not work currently, but `#include <json.hpp>` does.

The correct flag directory is `-I…/nlohmann_json/single_include` and this commit fixes the Meson file.
