### PR TITLE
Fix unit tests that were silently skipped or crashed (depending on the compiler)

### DIFF
--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -1660,6 +1660,21 @@ TEST_CASE("CBOR roundtrips", "[hide]")
 {
     SECTION("input from flynn")
     {
+        // most of these are exluded due to differences in key order (not a real problem)
+        auto exclude_packed = std::set<std::string>{
+                    "test/data/json.org/1.json",
+                    "test/data/json.org/2.json",
+                    "test/data/json.org/3.json",
+                    "test/data/json.org/4.json",
+                    "test/data/json.org/5.json",
+                    "test/data/json_testsuite/sample.json", // kills AppVeyor
+                    "test/data/json_tests/pass1.json",
+                    "test/data/regression/working_file.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_duplicated_key.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_long_strings.json",
+        };
+
         for (std::string filename :
                 {
                     "test/data/json_nlohmann_tests/all_unicode.json",
@@ -1811,12 +1826,12 @@ TEST_CASE("CBOR roundtrips", "[hide]")
         {
             CAPTURE(filename);
 
-            // parse JSON file
-            std::ifstream f_json(filename);
-            json j1 = json::parse(f_json);
-
             SECTION(filename + ": std::vector<uint8_t>")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
                 std::vector<uint8_t> packed(
@@ -1831,6 +1846,10 @@ TEST_CASE("CBOR roundtrips", "[hide]")
 
             SECTION(filename + ": std::ifstream")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
                 json j2;
@@ -1842,6 +1861,10 @@ TEST_CASE("CBOR roundtrips", "[hide]")
 
             SECTION(filename + ": uint8_t* and size")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
                 std::vector<uint8_t> packed(
@@ -1856,17 +1879,24 @@ TEST_CASE("CBOR roundtrips", "[hide]")
 
             SECTION(filename + ": output to output adapters")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
                 std::vector<uint8_t> packed(
                     (std::istreambuf_iterator<char>(f_cbor)),
                     std::istreambuf_iterator<char>());
 
-                SECTION(filename + ": output adapters: std::vector<uint8_t>")
+                if (!exclude_packed.count(filename))
                 {
-                    std::vector<uint8_t> vec;
-                    json::to_cbor(j1, vec);
-                    CHECK(vec == packed);
+                    SECTION(filename + ": output adapters: std::vector<uint8_t>")
+                    {
+                        std::vector<uint8_t> vec;
+                        json::to_cbor(j1, vec);
+                        CHECK(vec == packed);
+                    }
                 }
             }
         }

--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -1815,7 +1815,7 @@ TEST_CASE("CBOR roundtrips", "[hide]")
             std::ifstream f_json(filename);
             json j1 = json::parse(f_json);
 
-            SECTION("std::vector<uint8_t>")
+            SECTION(filename + ": std::vector<uint8_t>")
             {
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
@@ -1829,7 +1829,7 @@ TEST_CASE("CBOR roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("std::ifstream")
+            SECTION(filename + ": std::ifstream")
             {
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
@@ -1840,7 +1840,7 @@ TEST_CASE("CBOR roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("uint8_t* and size")
+            SECTION(filename + ": uint8_t* and size")
             {
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
@@ -1854,7 +1854,7 @@ TEST_CASE("CBOR roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("output to output adapters")
+            SECTION(filename + ": output to output adapters")
             {
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
@@ -1862,7 +1862,7 @@ TEST_CASE("CBOR roundtrips", "[hide]")
                     (std::istreambuf_iterator<char>(f_cbor)),
                     std::istreambuf_iterator<char>());
 
-                SECTION("std::vector<uint8_t>")
+                SECTION(filename + ": output adapters: std::vector<uint8_t>")
                 {
                     std::vector<uint8_t> vec;
                     json::to_cbor(j1, vec);

--- a/test/src/unit-msgpack.cpp
+++ b/test/src/unit-msgpack.cpp
@@ -1349,6 +1349,24 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
 {
     SECTION("input from msgpack-python")
     {
+        // most of these are exluded due to differences in key order (not a real problem)
+        auto exclude_packed = std::set<std::string>{
+                    "test/data/json.org/1.json",
+                    "test/data/json.org/2.json",
+                    "test/data/json.org/3.json",
+                    "test/data/json.org/4.json",
+                    "test/data/json.org/5.json",
+                    "test/data/json_testsuite/sample.json", // kills AppVeyor
+                    "test/data/json_tests/pass1.json",
+                    "test/data/regression/working_file.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_basic.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_duplicated_key.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_long_strings.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_simple.json",
+                    "test/data/nst_json_testsuite/test_parsing/y_object_string_unicode.json",
+        };
+
         for (std::string filename :
                 {
                     "test/data/json_nlohmann_tests/all_unicode.json",
@@ -1500,12 +1518,12 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
         {
             CAPTURE(filename);
 
-            // parse JSON file
-            std::ifstream f_json(filename);
-            json j1 = json::parse(f_json);
-
             SECTION(filename + ": std::vector<uint8_t>")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
                 std::vector<uint8_t> packed(
@@ -1520,6 +1538,10 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
 
             SECTION(filename + ": std::ifstream")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
                 json j2;
@@ -1531,6 +1553,10 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
 
             SECTION(filename + ": uint8_t* and size")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
                 std::vector<uint8_t> packed(
@@ -1545,17 +1571,24 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
 
             SECTION(filename + ": output to output adapters")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
                 std::vector<uint8_t> packed(
                     (std::istreambuf_iterator<char>(f_msgpack)),
                     std::istreambuf_iterator<char>());
 
-                SECTION(filename + ": output adapters: std::vector<uint8_t>")
+                if (!exclude_packed.count(filename))
                 {
-                    std::vector<uint8_t> vec;
-                    json::to_msgpack(j1, vec);
-                    CHECK(vec == packed);
+                    SECTION(filename + ": output adapters: std::vector<uint8_t>")
+                    {
+                        std::vector<uint8_t> vec;
+                        json::to_msgpack(j1, vec);
+                        CHECK(vec == packed);
+                    }
                 }
             }
         }

--- a/test/src/unit-msgpack.cpp
+++ b/test/src/unit-msgpack.cpp
@@ -1504,7 +1504,7 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
             std::ifstream f_json(filename);
             json j1 = json::parse(f_json);
 
-            SECTION("std::vector<uint8_t>")
+            SECTION(filename + ": std::vector<uint8_t>")
             {
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
@@ -1518,7 +1518,7 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("std::ifstream")
+            SECTION(filename + ": std::ifstream")
             {
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
@@ -1529,7 +1529,7 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("uint8_t* and size")
+            SECTION(filename + ": uint8_t* and size")
             {
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
@@ -1543,7 +1543,7 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("output to output adapters")
+            SECTION(filename + ": output to output adapters")
             {
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
@@ -1551,7 +1551,7 @@ TEST_CASE("MessagePack roundtrips", "[hide]")
                     (std::istreambuf_iterator<char>(f_msgpack)),
                     std::istreambuf_iterator<char>());
 
-                SECTION("std::vector<uint8_t>")
+                SECTION(filename + ": output adapters: std::vector<uint8_t>")
                 {
                     std::vector<uint8_t> vec;
                     json::to_msgpack(j1, vec);

--- a/test/src/unit-ubjson.cpp
+++ b/test/src/unit-ubjson.cpp
@@ -2203,7 +2203,7 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
             std::ifstream f_json(filename);
             json j1 = json::parse(f_json);
 
-            SECTION("std::vector<uint8_t>")
+            SECTION(filename + ": std::vector<uint8_t>")
             {
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
@@ -2217,7 +2217,7 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("std::ifstream")
+            SECTION(filename + ": std::ifstream")
             {
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
@@ -2228,7 +2228,7 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("uint8_t* and size")
+            SECTION(filename + ": uint8_t* and size")
             {
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
@@ -2242,7 +2242,7 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
                 CHECK(j1 == j2);
             }
 
-            SECTION("output to output adapters")
+            SECTION(filename + ": output to output adapters")
             {
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
@@ -2250,7 +2250,7 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
                     (std::istreambuf_iterator<char>(f_ubjson)),
                     std::istreambuf_iterator<char>());
 
-                SECTION("std::vector<uint8_t>")
+                SECTION(filename + ": output adapters: std::vector<uint8_t>")
                 {
                     std::vector<uint8_t> vec;
                     json::to_ubjson(j1, vec);

--- a/test/src/unit-ubjson.cpp
+++ b/test/src/unit-ubjson.cpp
@@ -2199,12 +2199,12 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
         {
             CAPTURE(filename);
 
-            // parse JSON file
-            std::ifstream f_json(filename);
-            json j1 = json::parse(f_json);
-
             SECTION(filename + ": std::vector<uint8_t>")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
                 std::vector<uint8_t> packed(
@@ -2219,6 +2219,10 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
 
             SECTION(filename + ": std::ifstream")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
                 json j2;
@@ -2230,6 +2234,10 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
 
             SECTION(filename + ": uint8_t* and size")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
                 std::vector<uint8_t> packed(
@@ -2244,6 +2252,10 @@ TEST_CASE("UBJSON roundtrips", "[hide]")
 
             SECTION(filename + ": output to output adapters")
             {
+                // parse JSON file
+                std::ifstream f_json(filename);
+                json j1 = json::parse(f_json);
+
                 // parse MessagePack file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
                 std::vector<uint8_t> packed(


### PR DESCRIPTION
Make section names unique in loops, as catch doesn't support duplicate sections, see also https://github.com/catchorg/Catch2/issues/816#issuecomment-278268122

As a result, when built with gcc, loop iterations were skipped. When
built with clang, the test aborted with an assertion in catch.hpp
line 6222.

This also addresses the issues discussed here:
https://github.com/nlohmann/json/issues/1032#issuecomment-378707696

and here:
https://github.com/catchorg/Catch2/issues/1241

As some of the unit tests which never ran before failed now, I added an exclude list for one of the tests (this is due to nlohmann-json ordering dictionaries by key, while the output files it compares against kept the key order of the json files).

Also, the way the tests were written, they would now take a long time, therefore I moved parsing the source into individual sections (more code, but 99% less parsing operations for the same tests).

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
