### PR TITLE
Convert unit testing to use new APIs instead of deprecated ones.

### DIFF
--- a/test/src/unit-deserialization.cpp
+++ b/test/src/unit-deserialization.cpp
@@ -236,7 +236,7 @@ TEST_CASE("deserialization")
             std::stringstream ss;
             ss << "[\"foo\",1,2,3,false,{\"one\":1}]";
             json j;
-            j << ss;
+            ss >> j;
             CHECK(j == json({"foo", 1, 2, 3, false, {{"one", 1}}}));
         }
 
@@ -316,8 +316,8 @@ TEST_CASE("deserialization")
             ss1 << "[\"foo\",1,2,3,false,{\"one\":1}";
             ss2 << "[\"foo\",1,2,3,false,{\"one\":1}";
             json j;
-            CHECK_THROWS_AS(j << ss1, json::parse_error&);
-            CHECK_THROWS_WITH(j << ss2,
+            CHECK_THROWS_AS(ss1 >> j, json::parse_error&);
+            CHECK_THROWS_WITH(ss2 >> j,
                               "[json.exception.parse_error.101] parse error at 29: syntax error - unexpected end of input; expected ']'");
         }
 
@@ -959,9 +959,9 @@ TEST_CASE("deserialization")
         {
             std::istringstream s(bom + "123 456");
             json j;
-            j << s;
+            s >> j;
             CHECK(j == 123);
-            j << s;
+            s >> j;
             CHECK(j == 456);
         }
     }

--- a/test/src/unit-items.cpp
+++ b/test/src/unit-items.cpp
@@ -41,7 +41,7 @@ TEST_CASE("iterator_wrapper")
             json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (auto i : json::iterator_wrapper(j))
+            for (auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -74,7 +74,7 @@ TEST_CASE("iterator_wrapper")
             json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (auto& i : json::iterator_wrapper(j))
+            for (auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -118,7 +118,7 @@ TEST_CASE("iterator_wrapper")
             json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (const auto i : json::iterator_wrapper(j))
+            for (const auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -151,7 +151,7 @@ TEST_CASE("iterator_wrapper")
             json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (const auto& i : json::iterator_wrapper(j))
+            for (const auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -187,7 +187,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (auto i : json::iterator_wrapper(j))
+            for (auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -220,7 +220,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (auto& i : json::iterator_wrapper(j))
+            for (auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -253,7 +253,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (const auto i : json::iterator_wrapper(j))
+            for (const auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -286,7 +286,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {{"A", 1}, {"B", 2}};
             int counter = 1;
 
-            for (const auto& i : json::iterator_wrapper(j))
+            for (const auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -322,7 +322,7 @@ TEST_CASE("iterator_wrapper")
             json j = {"A", "B"};
             int counter = 1;
 
-            for (auto i : json::iterator_wrapper(j))
+            for (auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -355,7 +355,7 @@ TEST_CASE("iterator_wrapper")
             json j = {"A", "B"};
             int counter = 1;
 
-            for (auto& i : json::iterator_wrapper(j))
+            for (auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -399,7 +399,7 @@ TEST_CASE("iterator_wrapper")
             json j = {"A", "B"};
             int counter = 1;
 
-            for (const auto i : json::iterator_wrapper(j))
+            for (const auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -432,7 +432,7 @@ TEST_CASE("iterator_wrapper")
             json j = {"A", "B"};
             int counter = 1;
 
-            for (const auto& i : json::iterator_wrapper(j))
+            for (const auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -468,7 +468,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {"A", "B"};
             int counter = 1;
 
-            for (auto i : json::iterator_wrapper(j))
+            for (auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -501,7 +501,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {"A", "B"};
             int counter = 1;
 
-            for (auto& i : json::iterator_wrapper(j))
+            for (auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -534,7 +534,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {"A", "B"};
             int counter = 1;
 
-            for (const auto i : json::iterator_wrapper(j))
+            for (const auto i : j.items())
             {
                 switch (counter++)
                 {
@@ -567,7 +567,7 @@ TEST_CASE("iterator_wrapper")
             const json j = {"A", "B"};
             int counter = 1;
 
-            for (const auto& i : json::iterator_wrapper(j))
+            for (const auto& i : j.items())
             {
                 switch (counter++)
                 {
@@ -603,7 +603,7 @@ TEST_CASE("iterator_wrapper")
             json j = 1;
             int counter = 1;
 
-            for (auto i : json::iterator_wrapper(j))
+            for (auto i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -618,7 +618,7 @@ TEST_CASE("iterator_wrapper")
             json j = 1;
             int counter = 1;
 
-            for (auto& i : json::iterator_wrapper(j))
+            for (auto& i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -639,7 +639,7 @@ TEST_CASE("iterator_wrapper")
             json j = 1;
             int counter = 1;
 
-            for (const auto i : json::iterator_wrapper(j))
+            for (const auto i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -654,7 +654,7 @@ TEST_CASE("iterator_wrapper")
             json j = 1;
             int counter = 1;
 
-            for (const auto& i : json::iterator_wrapper(j))
+            for (const auto& i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -672,7 +672,7 @@ TEST_CASE("iterator_wrapper")
             const json j = 1;
             int counter = 1;
 
-            for (auto i : json::iterator_wrapper(j))
+            for (auto i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -687,7 +687,7 @@ TEST_CASE("iterator_wrapper")
             const json j = 1;
             int counter = 1;
 
-            for (auto& i : json::iterator_wrapper(j))
+            for (auto& i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -702,7 +702,7 @@ TEST_CASE("iterator_wrapper")
             const json j = 1;
             int counter = 1;
 
-            for (const auto i : json::iterator_wrapper(j))
+            for (const auto i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");
@@ -717,7 +717,7 @@ TEST_CASE("iterator_wrapper")
             const json j = 1;
             int counter = 1;
 
-            for (const auto& i : json::iterator_wrapper(j))
+            for (const auto& i : j.items())
             {
                 ++counter;
                 CHECK(i.key() == "");

--- a/test/src/unit-serialization.cpp
+++ b/test/src/unit-serialization.cpp
@@ -69,7 +69,7 @@ TEST_CASE("serialization")
         {
             std::stringstream ss;
             json j = {"foo", 1, 2, 3, false, {{"one", 1}}};
-            j >> ss;
+            ss << j;
             CHECK(ss.str() == "[\"foo\",1,2,3,false,{\"one\":1}]");
         }
 
@@ -78,7 +78,7 @@ TEST_CASE("serialization")
             std::stringstream ss;
             json j = {"foo", 1, 2, 3, false, {{"one", 1}}};
             ss.width(4);
-            j >> ss;
+            ss << j;
             CHECK(ss.str() ==
                   "[\n    \"foo\",\n    1,\n    2,\n    3,\n    false,\n    {\n        \"one\": 1\n    }\n]");
         }
@@ -89,7 +89,7 @@ TEST_CASE("serialization")
             json j = {"foo", 1, 2, 3, false, {{"one", 1}}};
             ss.width(1);
             ss.fill('\t');
-            j >> ss;
+            ss << j;
             CHECK(ss.str() ==
                   "[\n\t\"foo\",\n\t1,\n\t2,\n\t3,\n\tfalse,\n\t{\n\t\t\"one\": 1\n\t}\n]");
         }


### PR DESCRIPTION
Unit tests were still using deprecated APIs causing a lot of noise during compilation.  This converts the unit tets to use the new APIs for iterators and stream operators.
