### PR TITLE
Fix warning C4127: conditional expression is constant

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -115,51 +115,6 @@ class input_buffer_adapter : public input_adapter_protocol
     const char* const limit;
 };
 
-template<typename WideStringType>
-class wide_string_input_adapter : public input_adapter_protocol
-{
-  public:
-    explicit wide_string_input_adapter(const WideStringType& w) : str(w) {}
-
-    std::char_traits<char>::int_type get_character() noexcept override
-    {
-        // check if buffer needs to be filled
-        if (utf8_bytes_index == utf8_bytes_filled)
-        {
-            fill_buffer<sizeof(typename WideStringType::value_type)>();
-
-            assert(utf8_bytes_filled > 0);
-            assert(utf8_bytes_index == 0);
-        }
-
-        // use buffer
-        assert(utf8_bytes_filled > 0);
-        assert(utf8_bytes_index < utf8_bytes_filled);
-        return utf8_bytes[utf8_bytes_index++];
-    }
-
-  private:
-    template<size_t T>
-    void fill_buffer()
-    {
-        wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
-    }
-    
-    /// the wstring to process
-    const WideStringType& str;
-
-    /// index of the current wchar in str
-    std::size_t current_wchar = 0;
-
-    /// a buffer for UTF-8 bytes
-    std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
-
-    /// index to the utf8_codes array for the next valid byte
-    std::size_t utf8_bytes_index = 0;
-    /// number of valid bytes in the utf8_codes array
-    std::size_t utf8_bytes_filled = 0;
-};
-
 namespace
 {
     template<typename WideStringType, size_t T>
@@ -278,6 +233,51 @@ namespace
         }
     };
 }
+
+template<typename WideStringType>
+class wide_string_input_adapter : public input_adapter_protocol
+{
+  public:
+    explicit wide_string_input_adapter(const WideStringType& w) : str(w) {}
+
+    std::char_traits<char>::int_type get_character() noexcept override
+    {
+        // check if buffer needs to be filled
+        if (utf8_bytes_index == utf8_bytes_filled)
+        {
+            fill_buffer<sizeof(typename WideStringType::value_type)>();
+
+            assert(utf8_bytes_filled > 0);
+            assert(utf8_bytes_index == 0);
+        }
+
+        // use buffer
+        assert(utf8_bytes_filled > 0);
+        assert(utf8_bytes_index < utf8_bytes_filled);
+        return utf8_bytes[utf8_bytes_index++];
+    }
+
+  private:
+    template<size_t T>
+    void fill_buffer()
+    {
+        wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
+    }
+    
+    /// the wstring to process
+    const WideStringType& str;
+
+    /// index of the current wchar in str
+    std::size_t current_wchar = 0;
+
+    /// a buffer for UTF-8 bytes
+    std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
+
+    /// index to the utf8_codes array for the next valid byte
+    std::size_t utf8_bytes_index = 0;
+    /// number of valid bytes in the utf8_codes array
+    std::size_t utf8_bytes_filled = 0;
+};
 
 class input_adapter
 {

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -126,7 +126,7 @@ class wide_string_input_adapter : public input_adapter_protocol
         // check if buffer needs to be filled
         if (utf8_bytes_index == utf8_bytes_filled)
         {
-            fill_buffer(sizeof(typename WideStringType::value_type));
+            fill_buffer<sizeof(typename WideStringType::value_type)>();
 
             assert(utf8_bytes_filled > 0);
             assert(utf8_bytes_index == 0);
@@ -139,16 +139,16 @@ class wide_string_input_adapter : public input_adapter_protocol
     }
 
   private:
-    void fill_buffer(size_t size)
+    template<size_t T>
+    void fill_buffer()
     {
-        if (2 == size)
-        {
-            fill_buffer_utf16();
-        }
-        else
-        {
-            fill_buffer_utf32();
-        }
+        fill_buffer_utf32();
+    }
+
+    template<>
+    void fill_buffer<2>()
+    {
+        fill_buffer_utf16();
     }
     
     void fill_buffer_utf16()

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -126,14 +126,7 @@ class wide_string_input_adapter : public input_adapter_protocol
         // check if buffer needs to be filled
         if (utf8_bytes_index == utf8_bytes_filled)
         {
-            if (sizeof(typename WideStringType::value_type) == 2)
-            {
-                fill_buffer_utf16();
-            }
-            else
-            {
-                fill_buffer_utf32();
-            }
+            fill_buffer(sizeof(typename WideStringType::value_type));
 
             assert(utf8_bytes_filled > 0);
             assert(utf8_bytes_index == 0);
@@ -146,6 +139,18 @@ class wide_string_input_adapter : public input_adapter_protocol
     }
 
   private:
+    void fill_buffer(size_t size)
+    {
+        if (2 == size)
+        {
+            fill_buffer_utf16();
+        }
+        else
+        {
+            fill_buffer_utf32();
+        }
+    }
+    
     void fill_buffer_utf16()
     {
         utf8_bytes_index = 0;

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -115,124 +115,121 @@ class input_buffer_adapter : public input_adapter_protocol
     const char* const limit;
 };
 
-namespace
+template<typename WideStringType, size_t T>
+struct wide_string_input_helper
 {
-    template<typename WideStringType, size_t T>
-    struct wide_string_input_helper
+    // UTF-32
+    static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
     {
-        // UTF-32
-        static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
-        {
-            utf8_bytes_index = 0;
+        utf8_bytes_index = 0;
 
-            if (current_wchar == str.size())
+        if (current_wchar == str.size())
+        {
+            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes_filled = 1;
+        }
+        else
+        {
+            // get the current character
+            const int wc = static_cast<int>(str[current_wchar++]);
+
+            // UTF-32 to UTF-8 encoding
+            if (wc < 0x80)
             {
-                utf8_bytes[0] = std::char_traits<char>::eof();
+                utf8_bytes[0] = wc;
                 utf8_bytes_filled = 1;
+            }
+            else if (wc <= 0x7FF)
+            {
+                utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
+                utf8_bytes[1] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 2;
+            }
+            else if (wc <= 0xFFFF)
+            {
+                utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
+                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
+                utf8_bytes[2] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 3;
+            }
+            else if (wc <= 0x10FFFF)
+            {
+                utf8_bytes[0] = 0xF0 | ((wc >> 18) & 0x07);
+                utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
+                utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
+                utf8_bytes[3] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 4;
             }
             else
             {
-                // get the current character
-                const int wc = static_cast<int>(str[current_wchar++]);
+                // unknown character
+                utf8_bytes[0] = wc;
+                utf8_bytes_filled = 1;
+            }
+        }
+    }
+};
 
-                // UTF-32 to UTF-8 encoding
-                if (wc < 0x80)
+template<typename WideStringType>
+struct wide_string_input_helper<WideStringType, 2>
+{
+    // UTF-16
+    static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
+    {
+        utf8_bytes_index = 0;
+
+        if (current_wchar == str.size())
+        {
+            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes_filled = 1;
+        }
+        else
+        {
+            // get the current character
+            const int wc = static_cast<int>(str[current_wchar++]);
+
+            // UTF-16 to UTF-8 encoding
+            if (wc < 0x80)
+            {
+                utf8_bytes[0] = wc;
+                utf8_bytes_filled = 1;
+            }
+            else if (wc <= 0x7FF)
+            {
+                utf8_bytes[0] = 0xC0 | ((wc >> 6));
+                utf8_bytes[1] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 2;
+            }
+            else if (0xD800 > wc or wc >= 0xE000)
+            {
+                utf8_bytes[0] = 0xE0 | ((wc >> 12));
+                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
+                utf8_bytes[2] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 3;
+            }
+            else
+            {
+                if (current_wchar < str.size())
                 {
-                    utf8_bytes[0] = wc;
-                    utf8_bytes_filled = 1;
-                }
-                else if (wc <= 0x7FF)
-                {
-                    utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
-                    utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 2;
-                }
-                else if (wc <= 0xFFFF)
-                {
-                    utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
-                    utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                    utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 3;
-                }
-                else if (wc <= 0x10FFFF)
-                {
-                    utf8_bytes[0] = 0xF0 | ((wc >> 18) & 0x07);
-                    utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
-                    utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
-                    utf8_bytes[3] = 0x80 | (wc & 0x3F);
+                    const int wc2 = static_cast<int>(str[current_wchar++]);
+                    const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
+                    utf8_bytes[0] = 0xf0 | (charcode >> 18);
+                    utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
+                    utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
+                    utf8_bytes[3] = 0x80 | (charcode & 0x3F);
                     utf8_bytes_filled = 4;
                 }
                 else
                 {
                     // unknown character
+                    ++current_wchar;
                     utf8_bytes[0] = wc;
                     utf8_bytes_filled = 1;
                 }
             }
         }
-    };
-
-    template<typename WideStringType>
-    struct wide_string_input_helper<WideStringType, 2>
-    {
-        // UTF-16
-        static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
-        {
-            utf8_bytes_index = 0;
-
-            if (current_wchar == str.size())
-            {
-                utf8_bytes[0] = std::char_traits<char>::eof();
-                utf8_bytes_filled = 1;
-            }
-            else
-            {
-                // get the current character
-                const int wc = static_cast<int>(str[current_wchar++]);
-
-                // UTF-16 to UTF-8 encoding
-                if (wc < 0x80)
-                {
-                    utf8_bytes[0] = wc;
-                    utf8_bytes_filled = 1;
-                }
-                else if (wc <= 0x7FF)
-                {
-                    utf8_bytes[0] = 0xC0 | ((wc >> 6));
-                    utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 2;
-                }
-                else if (0xD800 > wc or wc >= 0xE000)
-                {
-                    utf8_bytes[0] = 0xE0 | ((wc >> 12));
-                    utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                    utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 3;
-                }
-                else
-                {
-                    if (current_wchar < str.size())
-                    {
-                        const int wc2 = static_cast<int>(str[current_wchar++]);
-                        const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
-                        utf8_bytes[0] = 0xf0 | (charcode >> 18);
-                        utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
-                        utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
-                        utf8_bytes[3] = 0x80 | (charcode & 0x3F);
-                        utf8_bytes_filled = 4;
-                    }
-                    else
-                    {
-                        // unknown character
-                        ++current_wchar;
-                        utf8_bytes[0] = wc;
-                        utf8_bytes_filled = 1;
-                    }
-                }
-            }
-        }
-    };
-}
+    }
+};
 
 template<typename WideStringType>
 class wide_string_input_adapter : public input_adapter_protocol

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -142,122 +142,9 @@ class wide_string_input_adapter : public input_adapter_protocol
     template<size_t T>
     void fill_buffer()
     {
-        fill_buffer_utf32();
-    }
-
-    template<>
-    void fill_buffer<2>()
-    {
-        fill_buffer_utf16();
+        wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
     }
     
-    void fill_buffer_utf16()
-    {
-        utf8_bytes_index = 0;
-
-        if (current_wchar == str.size())
-        {
-            utf8_bytes[0] = std::char_traits<char>::eof();
-            utf8_bytes_filled = 1;
-        }
-        else
-        {
-            // get the current character
-            const int wc = static_cast<int>(str[current_wchar++]);
-
-            // UTF-16 to UTF-8 encoding
-            if (wc < 0x80)
-            {
-                utf8_bytes[0] = wc;
-                utf8_bytes_filled = 1;
-            }
-            else if (wc <= 0x7FF)
-            {
-                utf8_bytes[0] = 0xC0 | ((wc >> 6));
-                utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 2;
-            }
-            else if (0xD800 > wc or wc >= 0xE000)
-            {
-                utf8_bytes[0] = 0xE0 | ((wc >> 12));
-                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 3;
-            }
-            else
-            {
-                if (current_wchar < str.size())
-                {
-                    const int wc2 = static_cast<int>(str[current_wchar++]);
-                    const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
-                    utf8_bytes[0] = 0xf0 | (charcode >> 18);
-                    utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
-                    utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
-                    utf8_bytes[3] = 0x80 | (charcode & 0x3F);
-                    utf8_bytes_filled = 4;
-                }
-                else
-                {
-                    // unknown character
-                    ++current_wchar;
-                    utf8_bytes[0] = wc;
-                    utf8_bytes_filled = 1;
-                }
-            }
-        }
-    }
-
-    void fill_buffer_utf32()
-    {
-        utf8_bytes_index = 0;
-
-        if (current_wchar == str.size())
-        {
-            utf8_bytes[0] = std::char_traits<char>::eof();
-            utf8_bytes_filled = 1;
-        }
-        else
-        {
-            // get the current character
-            const int wc = static_cast<int>(str[current_wchar++]);
-
-            // UTF-32 to UTF-8 encoding
-            if (wc < 0x80)
-            {
-                utf8_bytes[0] = wc;
-                utf8_bytes_filled = 1;
-            }
-            else if (wc <= 0x7FF)
-            {
-                utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
-                utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 2;
-            }
-            else if (wc <= 0xFFFF)
-            {
-                utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
-                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 3;
-            }
-            else if (wc <= 0x10FFFF)
-            {
-                utf8_bytes[0] = 0xF0 | ((wc >> 18 ) & 0x07);
-                utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
-                utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
-                utf8_bytes[3] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 4;
-            }
-            else
-            {
-                // unknown character
-                utf8_bytes[0] = wc;
-                utf8_bytes_filled = 1;
-            }
-        }
-    }
-
-  private:
     /// the wstring to process
     const WideStringType& str;
 
@@ -272,6 +159,125 @@ class wide_string_input_adapter : public input_adapter_protocol
     /// number of valid bytes in the utf8_codes array
     std::size_t utf8_bytes_filled = 0;
 };
+
+namespace
+{
+    template<typename WideStringType, size_t T>
+    struct wide_string_input_helper
+    {
+        // UTF-32
+        static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
+        {
+            utf8_bytes_index = 0;
+
+            if (current_wchar == str.size())
+            {
+                utf8_bytes[0] = std::char_traits<char>::eof();
+                utf8_bytes_filled = 1;
+            }
+            else
+            {
+                // get the current character
+                const int wc = static_cast<int>(str[current_wchar++]);
+
+                // UTF-32 to UTF-8 encoding
+                if (wc < 0x80)
+                {
+                    utf8_bytes[0] = wc;
+                    utf8_bytes_filled = 1;
+                }
+                else if (wc <= 0x7FF)
+                {
+                    utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
+                    utf8_bytes[1] = 0x80 | (wc & 0x3F);
+                    utf8_bytes_filled = 2;
+                }
+                else if (wc <= 0xFFFF)
+                {
+                    utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
+                    utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
+                    utf8_bytes[2] = 0x80 | (wc & 0x3F);
+                    utf8_bytes_filled = 3;
+                }
+                else if (wc <= 0x10FFFF)
+                {
+                    utf8_bytes[0] = 0xF0 | ((wc >> 18) & 0x07);
+                    utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
+                    utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
+                    utf8_bytes[3] = 0x80 | (wc & 0x3F);
+                    utf8_bytes_filled = 4;
+                }
+                else
+                {
+                    // unknown character
+                    utf8_bytes[0] = wc;
+                    utf8_bytes_filled = 1;
+                }
+            }
+        }
+    };
+
+    template<typename WideStringType>
+    struct wide_string_input_helper<WideStringType, 2>
+    {
+        // UTF-16
+        static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
+        {
+            utf8_bytes_index = 0;
+
+            if (current_wchar == str.size())
+            {
+                utf8_bytes[0] = std::char_traits<char>::eof();
+                utf8_bytes_filled = 1;
+            }
+            else
+            {
+                // get the current character
+                const int wc = static_cast<int>(str[current_wchar++]);
+
+                // UTF-16 to UTF-8 encoding
+                if (wc < 0x80)
+                {
+                    utf8_bytes[0] = wc;
+                    utf8_bytes_filled = 1;
+                }
+                else if (wc <= 0x7FF)
+                {
+                    utf8_bytes[0] = 0xC0 | ((wc >> 6));
+                    utf8_bytes[1] = 0x80 | (wc & 0x3F);
+                    utf8_bytes_filled = 2;
+                }
+                else if (0xD800 > wc or wc >= 0xE000)
+                {
+                    utf8_bytes[0] = 0xE0 | ((wc >> 12));
+                    utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
+                    utf8_bytes[2] = 0x80 | (wc & 0x3F);
+                    utf8_bytes_filled = 3;
+                }
+                else
+                {
+                    if (current_wchar < str.size())
+                    {
+                        const int wc2 = static_cast<int>(str[current_wchar++]);
+                        const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
+                        utf8_bytes[0] = 0xf0 | (charcode >> 18);
+                        utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
+                        utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
+                        utf8_bytes[3] = 0x80 | (charcode & 0x3F);
+                        utf8_bytes_filled = 4;
+                    }
+                    else
+                    {
+                        // unknown character
+                        ++current_wchar;
+                        utf8_bytes[0] = wc;
+                        utf8_bytes_filled = 1;
+                    }
+                }
+            }
+        }
+    };
+}
 
 class input_adapter
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2004,14 +2004,7 @@ class wide_string_input_adapter : public input_adapter_protocol
         // check if buffer needs to be filled
         if (utf8_bytes_index == utf8_bytes_filled)
         {
-            if (sizeof(typename WideStringType::value_type) == 2)
-            {
-                fill_buffer_utf16();
-            }
-            else
-            {
-                fill_buffer_utf32();
-            }
+            fill_buffer(sizeof(typename WideStringType::value_type));
 
             assert(utf8_bytes_filled > 0);
             assert(utf8_bytes_index == 0);
@@ -2024,6 +2017,18 @@ class wide_string_input_adapter : public input_adapter_protocol
     }
 
   private:
+    void fill_buffer(size_t size)
+    {
+        if (2 == size)
+        {
+            fill_buffer_utf16();
+        }
+        else
+        {
+            fill_buffer_utf32();
+        }
+    }
+
     void fill_buffer_utf16()
     {
         utf8_bytes_index = 0;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -1993,124 +1993,121 @@ class input_buffer_adapter : public input_adapter_protocol
     const char* const limit;
 };
 
-namespace
+template<typename WideStringType, size_t T>
+struct wide_string_input_helper
 {
-    template<typename WideStringType, size_t T>
-    struct wide_string_input_helper
+    // UTF-32
+    static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
     {
-        // UTF-32
-        static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
-        {
-            utf8_bytes_index = 0;
+        utf8_bytes_index = 0;
 
-            if (current_wchar == str.size())
+        if (current_wchar == str.size())
+        {
+            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes_filled = 1;
+        }
+        else
+        {
+            // get the current character
+            const int wc = static_cast<int>(str[current_wchar++]);
+
+            // UTF-32 to UTF-8 encoding
+            if (wc < 0x80)
             {
-                utf8_bytes[0] = std::char_traits<char>::eof();
+                utf8_bytes[0] = wc;
                 utf8_bytes_filled = 1;
+            }
+            else if (wc <= 0x7FF)
+            {
+                utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
+                utf8_bytes[1] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 2;
+            }
+            else if (wc <= 0xFFFF)
+            {
+                utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
+                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
+                utf8_bytes[2] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 3;
+            }
+            else if (wc <= 0x10FFFF)
+            {
+                utf8_bytes[0] = 0xF0 | ((wc >> 18) & 0x07);
+                utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
+                utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
+                utf8_bytes[3] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 4;
             }
             else
             {
-                // get the current character
-                const int wc = static_cast<int>(str[current_wchar++]);
+                // unknown character
+                utf8_bytes[0] = wc;
+                utf8_bytes_filled = 1;
+            }
+        }
+    }
+};
 
-                // UTF-32 to UTF-8 encoding
-                if (wc < 0x80)
+template<typename WideStringType>
+struct wide_string_input_helper<WideStringType, 2>
+{
+    // UTF-16
+    static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
+    {
+        utf8_bytes_index = 0;
+
+        if (current_wchar == str.size())
+        {
+            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes_filled = 1;
+        }
+        else
+        {
+            // get the current character
+            const int wc = static_cast<int>(str[current_wchar++]);
+
+            // UTF-16 to UTF-8 encoding
+            if (wc < 0x80)
+            {
+                utf8_bytes[0] = wc;
+                utf8_bytes_filled = 1;
+            }
+            else if (wc <= 0x7FF)
+            {
+                utf8_bytes[0] = 0xC0 | ((wc >> 6));
+                utf8_bytes[1] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 2;
+            }
+            else if (0xD800 > wc or wc >= 0xE000)
+            {
+                utf8_bytes[0] = 0xE0 | ((wc >> 12));
+                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
+                utf8_bytes[2] = 0x80 | (wc & 0x3F);
+                utf8_bytes_filled = 3;
+            }
+            else
+            {
+                if (current_wchar < str.size())
                 {
-                    utf8_bytes[0] = wc;
-                    utf8_bytes_filled = 1;
-                }
-                else if (wc <= 0x7FF)
-                {
-                    utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
-                    utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 2;
-                }
-                else if (wc <= 0xFFFF)
-                {
-                    utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
-                    utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                    utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 3;
-                }
-                else if (wc <= 0x10FFFF)
-                {
-                    utf8_bytes[0] = 0xF0 | ((wc >> 18) & 0x07);
-                    utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
-                    utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
-                    utf8_bytes[3] = 0x80 | (wc & 0x3F);
+                    const int wc2 = static_cast<int>(str[current_wchar++]);
+                    const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
+                    utf8_bytes[0] = 0xf0 | (charcode >> 18);
+                    utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
+                    utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
+                    utf8_bytes[3] = 0x80 | (charcode & 0x3F);
                     utf8_bytes_filled = 4;
                 }
                 else
                 {
                     // unknown character
+                    ++current_wchar;
                     utf8_bytes[0] = wc;
                     utf8_bytes_filled = 1;
                 }
             }
         }
-    };
-
-    template<typename WideStringType>
-    struct wide_string_input_helper<WideStringType, 2>
-    {
-        // UTF-16
-        static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
-        {
-            utf8_bytes_index = 0;
-
-            if (current_wchar == str.size())
-            {
-                utf8_bytes[0] = std::char_traits<char>::eof();
-                utf8_bytes_filled = 1;
-            }
-            else
-            {
-                // get the current character
-                const int wc = static_cast<int>(str[current_wchar++]);
-
-                // UTF-16 to UTF-8 encoding
-                if (wc < 0x80)
-                {
-                    utf8_bytes[0] = wc;
-                    utf8_bytes_filled = 1;
-                }
-                else if (wc <= 0x7FF)
-                {
-                    utf8_bytes[0] = 0xC0 | ((wc >> 6));
-                    utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 2;
-                }
-                else if (0xD800 > wc or wc >= 0xE000)
-                {
-                    utf8_bytes[0] = 0xE0 | ((wc >> 12));
-                    utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                    utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                    utf8_bytes_filled = 3;
-                }
-                else
-                {
-                    if (current_wchar < str.size())
-                    {
-                        const int wc2 = static_cast<int>(str[current_wchar++]);
-                        const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
-                        utf8_bytes[0] = 0xf0 | (charcode >> 18);
-                        utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
-                        utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
-                        utf8_bytes[3] = 0x80 | (charcode & 0x3F);
-                        utf8_bytes_filled = 4;
-                    }
-                    else
-                    {
-                        // unknown character
-                        ++current_wchar;
-                        utf8_bytes[0] = wc;
-                        utf8_bytes_filled = 1;
-                    }
-                }
-            }
-        }
-    };
-}
+    }
+};
 
 template<typename WideStringType>
 class wide_string_input_adapter : public input_adapter_protocol

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -1993,51 +1993,6 @@ class input_buffer_adapter : public input_adapter_protocol
     const char* const limit;
 };
 
-template<typename WideStringType>
-class wide_string_input_adapter : public input_adapter_protocol
-{
-  public:
-    explicit wide_string_input_adapter(const WideStringType& w) : str(w) {}
-
-    std::char_traits<char>::int_type get_character() noexcept override
-    {
-        // check if buffer needs to be filled
-        if (utf8_bytes_index == utf8_bytes_filled)
-        {
-            fill_buffer<sizeof(typename WideStringType::value_type)>();
-
-            assert(utf8_bytes_filled > 0);
-            assert(utf8_bytes_index == 0);
-        }
-
-        // use buffer
-        assert(utf8_bytes_filled > 0);
-        assert(utf8_bytes_index < utf8_bytes_filled);
-        return utf8_bytes[utf8_bytes_index++];
-    }
-
-  private:
-    template<size_t T>
-    void fill_buffer()
-    {
-        wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
-    }
-    
-    /// the wstring to process
-    const WideStringType& str;
-
-    /// index of the current wchar in str
-    std::size_t current_wchar = 0;
-
-    /// a buffer for UTF-8 bytes
-    std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
-
-    /// index to the utf8_codes array for the next valid byte
-    std::size_t utf8_bytes_index = 0;
-    /// number of valid bytes in the utf8_codes array
-    std::size_t utf8_bytes_filled = 0;
-};
-
 namespace
 {
     template<typename WideStringType, size_t T>
@@ -2156,6 +2111,53 @@ namespace
         }
     };
 }
+
+template<typename WideStringType>
+class wide_string_input_adapter : public input_adapter_protocol
+{
+  public:
+    explicit wide_string_input_adapter(const WideStringType& w) : str(w) {}
+
+    std::char_traits<char>::int_type get_character() noexcept override
+    {
+        // check if buffer needs to be filled
+        if (utf8_bytes_index == utf8_bytes_filled)
+        {
+            fill_buffer<sizeof(typename WideStringType::value_type)>();
+
+            assert(utf8_bytes_filled > 0);
+            assert(utf8_bytes_index == 0);
+        }
+
+        // use buffer
+        assert(utf8_bytes_filled > 0);
+        assert(utf8_bytes_index < utf8_bytes_filled);
+        return utf8_bytes[utf8_bytes_index++];
+    }
+
+  private:
+    template<size_t T>
+    void fill_buffer()
+    {
+        wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
+    }
+    
+    /// the wstring to process
+    const WideStringType& str;
+
+    /// index of the current wchar in str
+    std::size_t current_wchar = 0;
+
+    /// a buffer for UTF-8 bytes
+    std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
+
+    /// index to the utf8_codes array for the next valid byte
+    std::size_t utf8_bytes_index = 0;
+    /// number of valid bytes in the utf8_codes array
+    std::size_t utf8_bytes_filled = 0;
+};
+
+
 
 class input_adapter
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2004,7 +2004,7 @@ class wide_string_input_adapter : public input_adapter_protocol
         // check if buffer needs to be filled
         if (utf8_bytes_index == utf8_bytes_filled)
         {
-            fill_buffer(sizeof(typename WideStringType::value_type));
+            fill_buffer<sizeof(typename WideStringType::value_type)>();
 
             assert(utf8_bytes_filled > 0);
             assert(utf8_bytes_index == 0);
@@ -2017,18 +2017,18 @@ class wide_string_input_adapter : public input_adapter_protocol
     }
 
   private:
-    void fill_buffer(size_t size)
+    template<size_t T>
+    void fill_buffer()
     {
-        if (2 == size)
-        {
-            fill_buffer_utf16();
-        }
-        else
-        {
-            fill_buffer_utf32();
-        }
+        fill_buffer_utf32();
     }
 
+    template<>
+    void fill_buffer<2>()
+    {
+        fill_buffer_utf16();
+    }
+    
     void fill_buffer_utf16()
     {
         utf8_bytes_index = 0;


### PR DESCRIPTION
https://github.com/nlohmann/json/issues/1268

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
