### PR TITLE
add constraints for variadic json_ref constructors

### DIFF
--- a/include/nlohmann/detail/json_ref.hpp
+++ b/include/nlohmann/detail/json_ref.hpp
@@ -3,6 +3,8 @@
 #include <initializer_list>
 #include <utility>
 
+#include <nlohmann/detail/meta/type_traits.hpp>
+
 namespace nlohmann
 {
 namespace detail
@@ -25,10 +27,12 @@ class json_ref
         : owned_value(init), value_ref(&owned_value), is_rvalue(true)
     {}
 
-    template<class... Args>
-    json_ref(Args&& ... args)
-        : owned_value(std::forward<Args>(args)...), value_ref(&owned_value), is_rvalue(true)
-    {}
+    template <
+        class... Args,
+        enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0 >
+    json_ref(Args && ... args)
+        : owned_value(std::forward<Args>(args)...), value_ref(&owned_value),
+          is_rvalue(true) {}
 
     // class should be movable only
     json_ref(json_ref&&) = default;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10591,6 +10591,9 @@ class serializer
 #include <initializer_list>
 #include <utility>
 
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+
 namespace nlohmann
 {
 namespace detail
@@ -10613,10 +10616,12 @@ class json_ref
         : owned_value(init), value_ref(&owned_value), is_rvalue(true)
     {}
 
-    template<class... Args>
-    json_ref(Args&& ... args)
-        : owned_value(std::forward<Args>(args)...), value_ref(&owned_value), is_rvalue(true)
-    {}
+    template <
+        class... Args,
+        enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0 >
+    json_ref(Args && ... args)
+        : owned_value(std::forward<Args>(args)...), value_ref(&owned_value),
+          is_rvalue(true) {}
 
     // class should be movable only
     json_ref(json_ref&&) = default;

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -33,6 +33,14 @@ SOFTWARE.
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+    #define JSON_HAS_CPP_17
+#endif
+
+#ifdef JSON_HAS_CPP_17
+    #include <variant>
+#endif
+
 #include "fifo_map.hpp"
 
 #include <fstream>
@@ -1649,4 +1657,12 @@ TEST_CASE("regression tests")
 
         CHECK(diffs.size() == 1); // Note the change here, was 2
     }
+
+#ifdef JSON_HAS_CPP_17
+    SECTION("issue #1292 - Serializing std::variant causes stack overflow")
+    {
+        static_assert(
+            not std::is_constructible<json, std::variant<int, float>>::value, "");
+    }
+#endif
 }


### PR DESCRIPTION
Fixes #1292

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).