### PR TITLE
[Iterator] Adding the methods is_begin() and is_end() to the iter_impl

### DIFF
--- a/include/nlohmann/detail/iterators/iter_impl.hpp
+++ b/include/nlohmann/detail/iterators/iter_impl.hpp
@@ -209,6 +209,54 @@ class iter_impl
     }
 
   public:
+    /// return whether the iterator can be dereferenced
+    constexpr bool is_begin() const noexcept
+    {
+        assert(m_object != nullptr);
+
+        switch (m_object->m_type)
+        {
+            case value_t::object:
+            {
+                return m_it.object_iterator == m_object->m_value.object->begin();
+            }
+            case value_t::array:
+            {
+                return m_it.array_iterator == m_object->m_value.array->begin();
+            }
+            case value_t::null:
+                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+            default:
+            {
+                return m_it.primitive_iterator.is_begin();
+            }
+        }
+    }
+
+    /// return whether the iterator is at end
+    constexpr bool is_end() const noexcept
+    {
+        assert(m_object != nullptr);
+
+        switch (m_object->m_type)
+        {
+            case value_t::object:
+            {
+                return m_it.object_iterator == m_object->m_value.object->end();
+            }
+            case value_t::array:
+            {
+                return m_it.array_iterator == m_object->m_value.array->end();
+            }
+            case value_t::null:
+                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+            default:
+            {
+                return m_it.primitive_iterator.is_end();
+            }
+        }
+    }
+
     /*!
     @brief return a reference to the value pointed to by the iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5647,7 +5647,6 @@ class iter_impl
     }
 
   public:
-
     /// return whether the iterator can be dereferenced
     constexpr bool is_begin() const noexcept
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5647,6 +5647,55 @@ class iter_impl
     }
 
   public:
+
+    /// return whether the iterator can be dereferenced
+    constexpr bool is_begin() const noexcept
+    {
+        assert(m_object != nullptr);
+
+        switch (m_object->m_type)
+        {
+            case value_t::object:
+            {
+                return m_it.object_iterator == m_object->m_value.object->begin();
+            }
+            case value_t::array:
+            {
+                return m_it.array_iterator == m_object->m_value.array->begin();
+            }
+            case value_t::null:
+                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+            default:
+            {
+                return m_it.primitive_iterator.is_begin();
+            }
+        }
+    }
+
+    /// return whether the iterator is at end
+    constexpr bool is_end() const noexcept
+    {
+        assert(m_object != nullptr);
+
+        switch (m_object->m_type)
+        {
+            case value_t::object:
+            {
+                return m_it.object_iterator == m_object->m_value.object->end();
+            }
+            case value_t::array:
+            {
+                return m_it.array_iterator == m_object->m_value.array->end();
+            }
+            case value_t::null:
+                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+            default:
+            {
+                return m_it.primitive_iterator.is_end();
+            }
+        }
+    }
+
     /*!
     @brief return a reference to the value pointed to by the iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.


### PR DESCRIPTION
Hi,

I don't know if this is the proper way to proceed with a PR. Maybe I should create an issue first. I already created one some time ago https://github.com/nlohmann/json/issues/1242

After that I tried several things, the point is we create a iterator adaptor and we need to skip the end iterators during that creation process to avoid the assert.

 But after trying many things the only thing I could do to avoid the assert was creating this is_end() method.

Tell me if tis is not a proper solution to the problem or if you want me to implement a test for this methods that I added.