### PR TITLE
Enable string_view, const_char_star wrapper, for map_key_type

### DIFF
--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -6,6 +6,7 @@
 
 #include <nlohmann/detail/input/parser.hpp>
 #include <nlohmann/detail/exceptions.hpp>
+#include <nlohmann/detail/json_string_view.hpp>
 
 namespace nlohmann
 {
@@ -21,6 +22,7 @@ input.
 template<typename BasicJsonType>
 struct json_sax
 {
+    using object_t = typename BasicJsonType::object_t;
     /// type for (signed) integers
     using number_integer_t = typename BasicJsonType::number_integer_t;
     /// type for unsigned integers
@@ -143,6 +145,7 @@ template<typename BasicJsonType>
 class json_sax_dom_parser
 {
   public:
+    using object_t = typename BasicJsonType::object_t;
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
@@ -209,7 +212,7 @@ class json_sax_dom_parser
     bool key(string_t& val)
     {
         // add null at given key and store the reference for later
-        object_element = &(ref_stack.back()->m_value.object->operator[](val));
+        object_element = &(ref_stack.back()->m_value.object->operator[](to_map_key<typename object_t::key_type>(val)));
         return true;
     }
 
@@ -318,6 +321,7 @@ template<typename BasicJsonType>
 class json_sax_dom_callback_parser
 {
   public:
+    using object_t = typename BasicJsonType::object_t;
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
@@ -402,7 +406,7 @@ class json_sax_dom_callback_parser
         // add discarded value at given key and store the reference for later
         if (keep and ref_stack.back())
         {
-            object_element = &(ref_stack.back()->m_value.object->operator[](val) = discarded);
+            object_element = &(ref_stack.back()->m_value.object->operator[](to_map_key<typename object_t::key_type>(val)) = discarded);
         }
 
         return true;

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -212,7 +212,7 @@ class json_sax_dom_parser
     bool key(string_t& val)
     {
         // add null at given key and store the reference for later
-        object_element = &(ref_stack.back()->m_value.object->operator[](to_map_key<typename object_t::key_type>(val)));
+        object_element = &(ref_stack.back()->m_value.object->operator[](BasicJsonType::to_map_key_(val)));
         return true;
     }
 
@@ -406,7 +406,7 @@ class json_sax_dom_callback_parser
         // add discarded value at given key and store the reference for later
         if (keep and ref_stack.back())
         {
-            object_element = &(ref_stack.back()->m_value.object->operator[](to_map_key<typename object_t::key_type>(val)) = discarded);
+            object_element = &(ref_stack.back()->m_value.object->operator[](BasicJsonType::to_map_key_(val)) = discarded);
         }
 
         return true;

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -14,6 +14,7 @@
 #include <nlohmann/detail/input/json_sax.hpp>
 #include <nlohmann/detail/input/lexer.hpp>
 #include <nlohmann/detail/value_t.hpp>
+#include <nlohmann/detail/json_string_view.hpp>
 
 namespace nlohmann
 {
@@ -31,6 +32,7 @@ This class implements a recursive decent parser.
 template<typename BasicJsonType>
 class parser
 {
+    using object_t = typename BasicJsonType::object_t;
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;

--- a/include/nlohmann/detail/iterators/iteration_proxy.hpp
+++ b/include/nlohmann/detail/iterators/iteration_proxy.hpp
@@ -67,6 +67,7 @@ template<typename IteratorType> class iteration_proxy
         }
 
         /// return key of the iterator
+        // this code is strange, why are returning a std::string & instead of just a std::string
         const std::string& key() const
         {
             assert(anchor.m_object != nullptr);
@@ -86,7 +87,8 @@ template<typename IteratorType> class iteration_proxy
 
                 // use key from the object
                 case value_t::object:
-                    return anchor.key();
+                    array_index_str = anchor.key();
+                    return array_index_str;
 
                 // use an empty key for all primitive types
                 default:

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -409,15 +409,17 @@ class json_pointer
         // if we get here, it means that no exception was thrown, so therefore the value specified to
         // erase exists
 
-        // if previous exists, it means that the specified json value was not a root, so, we use the previous
-        // object and erase from it
 		if (previous)
         {
+			// if previous exists, it means that the specified json value was not a root, so, we use the previous
+			// object and erase from it
 			previous->erase(reference_tokens.back());
         }
         else
         {
-            // what to do
+			// else it means the root was referenced, so we nullify it.
+			if (ptr != nullptr)
+				*ptr = {};
         }
     }
 

--- a/include/nlohmann/detail/json_string_view.hpp
+++ b/include/nlohmann/detail/json_string_view.hpp
@@ -1,0 +1,257 @@
+#pragma once
+
+// ------------------------------------------------------------------------
+// This header, and the associated changes in json.hpp enable string_view and struct { const char * } as a map_key type.
+//
+// Why would you want this?  In my case, I am using millions of json objects, each one uses the same keys.
+// Why use objects at all?  This is a question for another time.
+//
+// In any case, since my keys are known, and finite, I would rather there be a key look-up table, so as to no have a billion copies
+// of "transform" lying around.  I would rather just have one.
+//
+// The differences of string_view and const char * are simple.
+// string_view uses a strcmp in it's core of the map lookup, so there is no performance increase.
+// struct { const char * } uses a pure pointer comparison, so map operations are super fast, and as well, the map should probably be changed
+// into a hash map using the pointers.
+//
+// The draw back of the struct { const char * }, is that, for the full performance, you must cache the correct to_map_key("my_key_value")
+// and use that (so it doesn't need to look up the correct pointer first).  This is trivial to do however, so, the performance increase
+// is great.
+//
+// ------------------------------------------------------------------------
+
+
+#ifdef USE_EXPERIMENTAL_STRINGVIEW
+#include <experimental/string_view>
+#endif
+
+namespace nlohmann
+{
+
+
+#ifdef USE_EXPERIMENTAL_STRINGVIEW
+using json_string_view = std::experimental::string_view;
+#else
+
+// a minimum implementation of string_view
+struct json_string_view
+{
+	const char *data_;
+	size_t size_;
+	
+	json_string_view(const char *data, size_t size) :
+		data_(data), size_(size)
+	{}
+	
+	json_string_view(const std::string &s) :
+		data_(s.c_str()), size_(s.size())
+	{
+	}
+	
+	size_t size() const
+	{
+		return size_;
+	}
+	
+	operator std::string() const
+	{
+		return std::string(data_, size_);
+	}
+	
+	const char *begin() const
+	{
+		return data_;
+	}
+	
+	const char *end () const
+	{
+		return data_ + size_;
+	}
+} ;
+
+inline
+bool operator ==(const json_string_view &l, const json_string_view &r)
+{
+	if (l.data_ == r.data_ && l.size_ == r.size_)
+		return true;
+	
+	return l.size_ == r.size_ && strncmp(l.data_, r.data_, l.size_) == 0;
+}
+
+inline
+bool operator !=(const json_string_view &l, const json_string_view &r)
+{
+	return !(l == r);
+}
+
+inline
+bool operator <(const json_string_view &l, const json_string_view &r)
+{
+	// will implement, i need to look up proper way to do this
+	std::string ls(l);
+	std::string rs(r);
+	return ls < rs;
+}
+
+#endif
+
+// -----------------------
+
+struct json_const_char_star {
+	const char *data;
+} ;
+
+inline
+bool operator ==(const json_const_char_star &l, const json_const_char_star &r)
+{
+	return (l.data == r.data);
+}
+
+inline
+bool operator !=(const json_const_char_star &l, const json_const_char_star &r)
+{
+	return !(l == r);
+}
+
+inline
+bool operator <(const json_const_char_star &l, const json_const_char_star &r)
+{
+	// pure pointer compare
+	return l.data < r.data;
+}
+
+// -------------------
+
+// why am I having trouble getting rid of this? it must be too late
+typedef const char *__stupid_const_char_typedef;
+
+template<typename R> inline R to_map_key(const __stupid_const_char_typedef &s);
+template<typename R> inline R to_map_key(const json_string_view &s);
+template<typename R> inline R to_map_key(const std::string &s);
+template<typename R> inline R to_map_key(const json_const_char_star &s);
+
+template<typename R> inline R to_lookup_key(const __stupid_const_char_typedef &s);
+template<typename R> inline R to_lookup_key(const json_string_view &s);
+template<typename R> inline R to_lookup_key(const std::string &s);
+template<typename R> inline R to_lookup_key(const json_const_char_star &s);
+
+template<typename T, typename R=std::string>
+inline R to_concatable_string(const T &t)
+{
+	return R(t);
+}
+
+// -------------------
+ 
+template<>
+inline json_string_view to_map_key(const json_string_view &s)
+{
+	static std::set<std::string> strings;
+	static std::set<json_string_view> internals;
+
+	auto i = internals.find(s);
+	if (i == internals.end())
+	{
+		std::string str(s.begin(), s.end());
+		strings.insert(str);
+		
+		auto sv = json_string_view(*strings.find(str));
+
+		internals.insert(sv);
+		return sv;
+	}
+
+	return *i;
+} ;
+
+template<>
+inline json_string_view to_map_key(const std::string &s)
+{
+	return to_map_key<json_string_view>(json_string_view(s));
+} ;
+
+template<>
+inline json_string_view to_map_key(const __stupid_const_char_typedef &s)
+{
+	return to_map_key<json_string_view>(json_string_view(s, strlen(s)));
+}
+
+// -----------------------
+ 
+template<>
+inline json_string_view to_lookup_key(const json_string_view &s)
+{
+	return s;
+}
+
+template<>
+inline json_string_view to_lookup_key(const std::string &s)
+{
+	return json_string_view(s);
+} ;
+
+template<>
+inline json_string_view to_lookup_key(const __stupid_const_char_typedef &s)
+{
+	return json_string_view(s, strlen(s));
+} ;
+
+// -----------------------
+
+
+template<>
+inline json_const_char_star to_map_key(const std::string &s)
+{
+	static std::set<std::string> strings;
+
+	auto i = strings.find(s);
+	if (i == strings.end())
+	{
+		std::string str(s);
+		strings.insert(str);
+		
+		i = strings.find(str);
+	}
+
+	return { i->c_str() };
+} ;
+
+template<>
+inline json_const_char_star to_map_key(const __stupid_const_char_typedef &s)
+{
+	return to_map_key<json_const_char_star>(std::string(s));
+}
+
+template<>
+inline json_const_char_star to_map_key(const json_const_char_star &s)
+{
+	return s;
+}
+
+template<>
+inline json_const_char_star to_lookup_key(const std::string &s)
+{
+	return to_map_key<json_const_char_star>(s);
+} ;
+
+template<>
+inline json_const_char_star to_lookup_key(const __stupid_const_char_typedef &s)
+{
+	return to_map_key<json_const_char_star>(s);
+}
+
+template<>
+inline json_const_char_star to_lookup_key(const json_const_char_star &s)
+{
+	return s;
+}
+
+template<>
+inline
+std::string to_concatable_string(const json_const_char_star &t)
+{
+	return std::string(t.data);
+}
+
+
+} // namespace

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -659,9 +659,10 @@ class binary_writer
                 for (const auto& el : *j.m_value.object)
                 {
                     write_number_with_ubjson_prefix(el.first.size(), true);
+                    auto writable = BasicJsonType::to_concatable_string_(el.first);
                     oa->write_characters(
-                        reinterpret_cast<const CharType*>(el.first.c_str()),
-                        el.first.size());
+                        reinterpret_cast<const CharType*>(writable.c_str()),
+                        writable.size());
                     write_ubjson(el.second, use_count, use_type, prefix_required);
                 }
 

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -106,7 +106,7 @@ class serializer
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
                         o->write_character('\"');
-                        dump_escaped(to_concatable_string(i->first), ensure_ascii);
+                        dump_escaped(BasicJsonType::to_concatable_string_(i->first), ensure_ascii);
                         o->write_characters("\": ", 3);
                         dump(i->second, true, ensure_ascii, indent_step, new_indent);
                         o->write_characters(",\n", 2);
@@ -117,7 +117,7 @@ class serializer
                     assert(std::next(i) == val.m_value.object->cend());
                     o->write_characters(indent_string.c_str(), new_indent);
                     o->write_character('\"');
-                    dump_escaped(to_concatable_string(i->first), ensure_ascii);
+                    dump_escaped(BasicJsonType::to_concatable_string_(i->first), ensure_ascii);
                     o->write_characters("\": ", 3);
                     dump(i->second, true, ensure_ascii, indent_step, new_indent);
 
@@ -134,7 +134,7 @@ class serializer
                     for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         o->write_character('\"');
-                        dump_escaped(to_concatable_string(i->first), ensure_ascii);
+                        dump_escaped(BasicJsonType::to_concatable_string_(i->first), ensure_ascii);
                         o->write_characters("\":", 2);
                         dump(i->second, false, ensure_ascii, indent_step, current_indent);
                         o->write_character(',');
@@ -144,7 +144,7 @@ class serializer
                     assert(i != val.m_value.object->cend());
                     assert(std::next(i) == val.m_value.object->cend());
                     o->write_character('\"');
-                    dump_escaped(to_concatable_string(i->first), ensure_ascii);
+                    dump_escaped(BasicJsonType::to_concatable_string_(i->first), ensure_ascii);
                     o->write_characters("\":", 2);
                     dump(i->second, false, ensure_ascii, indent_step, current_indent);
 

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -106,7 +106,7 @@ class serializer
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
                         o->write_character('\"');
-                        dump_escaped(i->first, ensure_ascii);
+                        dump_escaped(to_concatable_string(i->first), ensure_ascii);
                         o->write_characters("\": ", 3);
                         dump(i->second, true, ensure_ascii, indent_step, new_indent);
                         o->write_characters(",\n", 2);
@@ -117,7 +117,7 @@ class serializer
                     assert(std::next(i) == val.m_value.object->cend());
                     o->write_characters(indent_string.c_str(), new_indent);
                     o->write_character('\"');
-                    dump_escaped(i->first, ensure_ascii);
+                    dump_escaped(to_concatable_string(i->first), ensure_ascii);
                     o->write_characters("\": ", 3);
                     dump(i->second, true, ensure_ascii, indent_step, new_indent);
 
@@ -134,7 +134,7 @@ class serializer
                     for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         o->write_character('\"');
-                        dump_escaped(i->first, ensure_ascii);
+                        dump_escaped(to_concatable_string(i->first), ensure_ascii);
                         o->write_characters("\":", 2);
                         dump(i->second, false, ensure_ascii, indent_step, current_indent);
                         o->write_character(',');
@@ -144,7 +144,7 @@ class serializer
                     assert(i != val.m_value.object->cend());
                     assert(std::next(i) == val.m_value.object->cend());
                     o->write_character('\"');
-                    dump_escaped(i->first, ensure_ascii);
+                    dump_escaped(to_concatable_string(i->first), ensure_ascii);
                     o->write_characters("\":", 2);
                     dump(i->second, false, ensure_ascii, indent_step, current_indent);
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -7085,6 +7085,45 @@ class basic_json
     {
         return ptr.get_checked(this);
     }
+	
+	
+    /*!
+    @brief remove element from a JSON tree given a pointer
+
+    Removes elements from a JSON tree with the pointer value @ptr
+
+    @param[in] pointer value of the elements to remove
+
+    @post References and iterators to the erased elements are invalidated.
+    Other references and iterators are not affected.
+
+    @throw parse_error.106 if an array index in the passed JSON pointer @a ptr
+    begins with '0'. See example below.
+
+    @throw parse_error.109 if an array index in the passed JSON pointer @a ptr
+    is not a number. See example below.
+
+    @throw out_of_range.401 if an array index in the passed JSON pointer @a ptr
+    is out of range. See example below.
+
+    @throw out_of_range.402 if the array index '-' is used in the passed JSON
+    pointer @a ptr. As `at` provides checked access (and no elements are
+    implicitly inserted), the index '-' is always invalid. See example below.
+
+    @throw out_of_range.403 if the JSON pointer describes a key of an object
+    which cannot be found. See example below.
+
+    @throw out_of_range.404 if the JSON pointer @a ptr can not be resolved.
+    See example below.
+
+    @complexity
+
+    @since version
+    */
+    void erase(const json_pointer& ptr)
+    {
+        ptr.erase_checked(this);
+    }
 
     /*!
     @brief return flattened JSON value

--- a/test/src/unit-alt-string.cpp
+++ b/test/src/unit-alt-string.cpp
@@ -143,7 +143,7 @@ class alt_string
         str_impl.clear();
     }
 
-    const value_type* data()
+    const value_type* data() const
     {
         return str_impl.data();
     }
@@ -154,6 +154,68 @@ class alt_string
     friend bool ::operator<(const char*, const alt_string&);
 };
 
+
+// ---------------------------------
+
+template<typename R> inline R to_map_key(const alt_string& s);
+template<typename R> inline R to_lookup_key(const alt_string& s);
+
+template<>
+inline std::string to_map_key(const alt_string& s)
+{
+    return nlohmann::to_map_key<std::string>(std::string(s.data(), s.size()));
+}
+template<>
+inline nlohmann::json_string_view to_map_key(const alt_string& s)
+{
+    return nlohmann::to_map_key<nlohmann::json_string_view>(std::string(s.data(), s.size()));
+}
+template<>
+inline nlohmann::json_const_char_star to_map_key(const alt_string& s)
+{
+    return nlohmann::to_map_key<nlohmann::json_const_char_star>(std::string(s.data(), s.size()));
+}
+
+template<>
+inline std::string to_lookup_key(const alt_string& s)
+{
+    return to_map_key<std::string>(s);
+}
+
+template<>
+inline nlohmann::json_string_view to_lookup_key(const alt_string& s)
+{
+    return to_map_key<nlohmann::json_string_view>(s);
+}
+
+template<>
+inline nlohmann::json_const_char_star to_lookup_key(const alt_string& s)
+{
+    return to_map_key<nlohmann::json_const_char_star>(s);
+}
+
+// I can't believe this is the right syntax.  It works, but by golly!
+template<>
+inline alt_string nlohmann::to_concatable_string(const std::string& s)
+{
+    return alt_string(s.data(), s.size());
+}
+
+// I can't believe this is the right syntax.  It works, but by golly!
+template<>
+inline alt_string nlohmann::to_concatable_string(const nlohmann::json_string_view& s)
+{
+    return alt_string(s.data(), s.size());
+}
+
+// I can't believe this is the right syntax.  It works, but by golly!
+template<>
+inline alt_string nlohmann::to_concatable_string(const nlohmann::json_const_char_star& s)
+{
+    return alt_string(s.data, strlen(s.data));
+}
+
+// ---------------------------------
 
 using alt_json = nlohmann::basic_json <
                  std::map,

--- a/test/src/unit-constructor1.cpp
+++ b/test/src/unit-constructor1.cpp
@@ -1076,23 +1076,28 @@ TEST_CASE("constructors")
                 std::string source(1024, '!');
                 const char* source_addr = source.data();
 
-                SECTION("constructor with implicit types (array)")
-                {
-                    json j = {std::move(source)};
-                    CHECK(j[0].get_ref<std::string const&>().data() == source_addr);
-                }
-
                 SECTION("constructor with implicit types (object)")
                 {
                     json j = {{"key", std::move(source)}};
                     CHECK(j["key"].get_ref<std::string const&>().data() == source_addr);
                 }
 
-                SECTION("constructor with implicit types (object key)")
+                // These are invalid, because if the key type is different from std::string, the pointers will not stay the same
+                // Reenable after templatization of basic_json
+                if (false)
                 {
-                    json j = {{std::move(source), 42}};
-                    CHECK(j.get_ref<json::object_t&>().begin()->first.data() == source_addr);
-                }
+                    SECTION("constructor with implicit types (array)")
+                    {
+                        json j = {std::move(source)};
+                        CHECK(j[0].get_ref<std::string const&>().data() == source_addr);
+                    }
+
+                    SECTION("constructor with implicit types (object key)")
+                    {
+                        json j = {{std::move(source), 42}};
+                        CHECK(j.get_ref<json::object_t&>().begin()->first.data() == source_addr);
+                    }
+                } // end not work
             }
 
             SECTION("array")


### PR DESCRIPTION
Closes #1274.

Hey there,

Unfortunately, I forked this string_view off of a merged erase_by_json_pointer + develop branch.  
I'm not sure if you can easily cherry pick the edits you would want or not.
If you need these changes forked off the develop branch pre-erase-by-json-pointer let me know, I think I can apply a diff of this vs merged-develop branch, and apply that to a pre-merged-erase-json-pointer new branch.  (but if I don't have to, etc, etc, etc)

In any case there is still work to be done.  
Mainly 
1. make the map_key_type -string_view/std::string/whatever part of the template parameters.
2. see if there is a better place to put those "to_map_key" "to_lookup_key" template functions..  And or, is it possible to make them do a better job of picking up from outside the amalgamated json.hpp file..  (see unit alt string tests).  Since you have dealt with this before, you probably would need far less time to figure this out.

But, this was quite a lot of work actually to get all the unit tests compiling and working, especially alt_string..

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
