### PR TITLE
Allow installation via Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,3 +11,11 @@ nlohmann_json_dep = declare_dependency(
 nlohmann_json_multiple_headers = declare_dependency(
     include_directories: include_directories('include')
 )
+
+install_headers('single_include/nlohmann/json.hpp', subdir: 'nlohmann')
+
+pkgc = import('pkgconfig')
+pkgc.generate(name: 'nlohmann_json',
+    version: meson.project_version(),
+    description: 'JSON for Modern C++'
+)


### PR DESCRIPTION
Hello and thanks for your work!

This commit allows to install the library via [meson].
- The `single_include` header file is installed into `lib/include/nlohmann/json.hpp`.
- A [pkg-config] file `nlohmann_json.pc` is generated into the default directory `lib/pkgconfig`.

### Usage example
``` bash
meson build # [--prefix=/desired/installation/path]
cd build
ninja install
```

### Example of generated `nlohmann_json.pc`
``` pkg-config
prefix=/usr/local
libdir=${prefix}/lib
includedir=${prefix}/include

Name: nlohmann_json
Description: JSON for Modern C++
Version: 3.4.0
Cflags: -I${includedir}
```

[meson]: https://mesonbuild.com/
[pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/