### PR TITLE
make release: Generate a lightweight buildable zip file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,8 +340,12 @@ release:
 	zip -9 -r include.zip include/*
 	gpg --armor --detach-sig include.zip
 	mv include.zip include.zip.asc release_files
+	zip -9 -r buildable_meson.zip meson.build single_include/* include/*
+	gpg --armor --detach-sig buildable_meson.zip
+	mv buildable_meson.zip buildable_meson.zip.asc release_files
 	gpg --armor --detach-sig single_include/nlohmann/json.hpp
 	cp single_include/nlohmann/json.hpp release_files
 	mv single_include/nlohmann/json.hpp.asc release_files
 	cd release_files ; shasum -a 256 json.hpp > hashes.txt
 	cd release_files ; shasum -a 256 include.zip >> hashes.txt
+	cd release_files ; shasum -a 256 buildable_meson.zip >> hashes.txt


### PR DESCRIPTION
This commit adds the generation of a ``buildable-meson.zip`` file when calling ``make release``.
The generated zip file contains ``meson.build`` and the ``include`` and ``single_include`` directories.

The goal is to allow both package managers and Meson users to get a lightweight (~250 KB) buildable/installable source tree for each release — as the tarballs of the latest release were heavy (~110 MB).