### PR TITLE
Feature/add file input adapter

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -46,6 +46,10 @@ struct input_adapter_protocol
 /// a type to simplify interfaces
 using input_adapter_t = std::shared_ptr<input_adapter_protocol>;
 
+/*!
+Input adapter for stdio file access. This adapter read only 1 byte and do not use any
+ buffer. This adapter is a very low level adapter. This adapter
+*/
 class file_input_adapter : public input_adapter_protocol
 {
 public:
@@ -55,11 +59,7 @@ public:
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        auto res = fgetc(const_cast<FILE *>(file));
-        if(res == EOF)
-            return std::char_traits<char>::eof();
-        else
-            return static_cast<std::char_traits<char>::int_type>(res);
+        return fgetc(const_cast<FILE *>(file));
     }
 private:
     /// the file pointer to read from

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -52,18 +52,18 @@ Input adapter for stdio file access. This adapter read only 1 byte and do not us
 */
 class file_input_adapter : public input_adapter_protocol
 {
-public:
-    explicit file_input_adapter(const FILE *file)  noexcept
-            : file(file)
+  public:
+    explicit file_input_adapter(const FILE* file)  noexcept
+        : file(file)
     {}
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        return fgetc(const_cast<FILE *>(file));
+        return fgetc(const_cast<FILE*>(file));
     }
-private:
+  private:
     /// the file pointer to read from
-    const FILE * file;
+    const FILE* file;
 };
 
 
@@ -309,8 +309,8 @@ class input_adapter
 {
   public:
     // native support
-    input_adapter(FILE * file)
-            : ia(std::make_shared<file_input_adapter>(file)) {}
+    input_adapter(FILE* file)
+        : ia(std::make_shared<file_input_adapter>(file)) {}
     /// input adapter for input stream
     input_adapter(std::istream& i)
         : ia(std::make_shared<input_stream_adapter>(i)) {}

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -53,17 +53,17 @@ Input adapter for stdio file access. This adapter read only 1 byte and do not us
 class file_input_adapter : public input_adapter_protocol
 {
   public:
-    explicit file_input_adapter(const FILE* file)  noexcept
+    explicit file_input_adapter(FILE* file)  noexcept
         : file(file)
     {}
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        return fgetc(const_cast<FILE*>(file));
+        return fgetc(file);
     }
   private:
     /// the file pointer to read from
-    const FILE* file;
+    FILE* file;
 };
 
 

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -48,7 +48,7 @@ using input_adapter_t = std::shared_ptr<input_adapter_protocol>;
 
 /*!
 Input adapter for stdio file access. This adapter read only 1 byte and do not use any
- buffer. This adapter is a very low level adapter. This adapter
+ buffer. This adapter is a very low level adapter.
 */
 class file_input_adapter : public input_adapter_protocol
 {

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -53,17 +53,17 @@ Input adapter for stdio file access. This adapter read only 1 byte and do not us
 class file_input_adapter : public input_adapter_protocol
 {
   public:
-    explicit file_input_adapter(FILE* file)  noexcept
-        : file(file)
+    explicit file_input_adapter(std::FILE* f)  noexcept
+        : m_file(f)
     {}
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        return fgetc(file);
+        return std::fgetc(m_file);
     }
   private:
     /// the file pointer to read from
-    FILE* file;
+    std::FILE* m_file;
 };
 
 

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -309,7 +309,7 @@ class input_adapter
 {
   public:
     // native support
-    input_adapter(FILE* file)
+    input_adapter(std::FILE* file)
         : ia(std::make_shared<file_input_adapter>(file)) {}
     /// input adapter for input stream
     input_adapter(std::istream& i)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2097,22 +2097,22 @@ using input_adapter_t = std::shared_ptr<input_adapter_protocol>;
 
 /*!
 Input adapter for stdio file access. This adapter read only 1 byte and do not use any
- buffer. This adapter is a very low level adapter. This adapter
+ buffer. This adapter is a very low level adapter.
 */
 class file_input_adapter : public input_adapter_protocol
 {
   public:
-    explicit file_input_adapter(const FILE* file)  noexcept
+    explicit file_input_adapter(FILE* file)  noexcept
         : file(file)
     {}
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        return fgetc(const_cast<FILE*>(file));
+        return fgetc(file);
     }
   private:
     /// the file pointer to read from
-    const FILE* file;
+    FILE* file;
 };
 
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2102,17 +2102,17 @@ Input adapter for stdio file access. This adapter read only 1 byte and do not us
 class file_input_adapter : public input_adapter_protocol
 {
   public:
-    explicit file_input_adapter(FILE* file)  noexcept
-        : file(file)
+    explicit file_input_adapter(std::FILE* f)  noexcept
+        : m_file(f)
     {}
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        return fgetc(file);
+        return std::fgetc(m_file);
     }
   private:
     /// the file pointer to read from
-    FILE* file;
+    std::FILE* m_file;
 };
 
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2358,7 +2358,7 @@ class input_adapter
 {
   public:
     // native support
-    input_adapter(FILE* file)
+    input_adapter(std::FILE* file)
         : ia(std::make_shared<file_input_adapter>(file)) {}
     /// input adapter for input stream
     input_adapter(std::istream& i)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2295,16 +2295,13 @@ public:
 
     std::char_traits<char>::int_type get_character() noexcept override
     {
-        auto res = fgetc(const_cast<FILE *>(file));
-        if(res == EOF)
-            return std::char_traits<char>::eof();
-        else
-            return static_cast<std::char_traits<char>::int_type>(res);
+        return fgetc(const_cast<FILE *>(file));
     }
 private:
     /// the file pointer to read from
     const FILE * file;
 };
+
 template<typename WideStringType>
 class wide_string_input_adapter : public input_adapter_protocol
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <memory> // allocator
 #include <string> // string
 #include <vector> // vector
+#include <cstdio>
 
 /*!
 @brief namespace for Niels Lohmann
@@ -2285,6 +2286,25 @@ struct wide_string_input_helper<WideStringType, 2>
     }
 };
 
+class file_input_adapter : public input_adapter_protocol
+{
+public:
+    explicit file_input_adapter(const FILE *file)  noexcept
+            : file(file)
+    {}
+
+    std::char_traits<char>::int_type get_character() noexcept override
+    {
+        auto res = fgetc(const_cast<FILE *>(file));
+        if(res == EOF)
+            return std::char_traits<char>::eof();
+        else
+            return static_cast<std::char_traits<char>::int_type>(res);
+    }
+private:
+    /// the file pointer to read from
+    const FILE * file;
+};
 template<typename WideStringType>
 class wide_string_input_adapter : public input_adapter_protocol
 {
@@ -2353,6 +2373,9 @@ class input_adapter
 
     input_adapter(const std::u32string& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::u32string>>(ws)) {}
+
+    input_adapter(const FILE *file)
+        : ia(std::make_shared<file_input_adapter>(file)) {}
 
     /// input adapter for buffer
     template<typename CharT,

--- a/test/src/unit-testsuites.cpp
+++ b/test/src/unit-testsuites.cpp
@@ -386,42 +386,37 @@ TEST_CASE("json.org examples")
     }
     SECTION("FILE 1.json")
     {
-        auto f = fopen("test/data/json.org/1.json", "r");
+        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/1.json", "r"), &fclose);
         json j;
-        CHECK_NOTHROW(j.parse(f));
-        fclose(f);
+        CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 2.json")
     {
-        auto f = fopen("test/data/json.org/2.json", "r");
+        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/2.json", "r"), &fclose);
         json j;
-        CHECK_NOTHROW(j.parse(f));
-        fclose(f);
+        CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 3.json")
     {
-        auto f = fopen("test/data/json.org/3.json", "r");
+        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/3.json", "r"), &fclose);
         json j;
-        CHECK_NOTHROW(j.parse(f));
-        fclose(f);
+        CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 4.json")
     {
-        auto f = fopen("test/data/json.org/4.json", "r");
+        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/4.json", "r"), &fclose);
         json j;
-        CHECK_NOTHROW(j.parse(f));
-        fclose(f);
+        CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 5.json")
     {
-        auto f = fopen("test/data/json.org/5.json", "r");
+        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/5.json", "r"), &fclose);
         json j;
-        CHECK_NOTHROW(j.parse(f));
-        fclose(f);
+        CHECK_NOTHROW(j.parse(f.get()));
     }
 
 }

--- a/test/src/unit-testsuites.cpp
+++ b/test/src/unit-testsuites.cpp
@@ -386,35 +386,35 @@ TEST_CASE("json.org examples")
     }
     SECTION("FILE 1.json")
     {
-        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/1.json", "r"), &fclose);
+        std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen("test/data/json.org/1.json", "r"), &std::fclose);
         json j;
         CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 2.json")
     {
-        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/2.json", "r"), &fclose);
+        std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen("test/data/json.org/2.json", "r"), &std::fclose);
         json j;
         CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 3.json")
     {
-        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/3.json", "r"), &fclose);
+        std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen("test/data/json.org/3.json", "r"), &std::fclose);
         json j;
         CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 4.json")
     {
-        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/4.json", "r"), &fclose);
+        std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen("test/data/json.org/4.json", "r"), &std::fclose);
         json j;
         CHECK_NOTHROW(j.parse(f.get()));
     }
 
     SECTION("FILE 5.json")
     {
-        std::unique_ptr<FILE, decltype(&fclose)> f(fopen("test/data/json.org/5.json", "r"), &fclose);
+        std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen("test/data/json.org/5.json", "r"), &std::fclose);
         json j;
         CHECK_NOTHROW(j.parse(f.get()));
     }

--- a/test/src/unit-testsuites.cpp
+++ b/test/src/unit-testsuites.cpp
@@ -384,6 +384,46 @@ TEST_CASE("json.org examples")
         json j;
         CHECK_NOTHROW(f >> j);
     }
+    SECTION("FILE 1.json")
+    {
+        auto f = fopen("test/data/json.org/1.json", "r");
+        json j;
+        CHECK_NOTHROW(j.parse(f));
+        fclose(f);
+    }
+
+    SECTION("FILE 2.json")
+    {
+        auto f = fopen("test/data/json.org/2.json", "r");
+        json j;
+        CHECK_NOTHROW(j.parse(f));
+        fclose(f);
+    }
+
+    SECTION("FILE 3.json")
+    {
+        auto f = fopen("test/data/json.org/3.json", "r");
+        json j;
+        CHECK_NOTHROW(j.parse(f));
+        fclose(f);
+    }
+
+    SECTION("FILE 4.json")
+    {
+        auto f = fopen("test/data/json.org/4.json", "r");
+        json j;
+        CHECK_NOTHROW(j.parse(f));
+        fclose(f);
+    }
+
+    SECTION("FILE 5.json")
+    {
+        auto f = fopen("test/data/json.org/5.json", "r");
+        json j;
+        CHECK_NOTHROW(j.parse(f));
+        fclose(f);
+    }
+
 }
 
 TEST_CASE("RFC 7159 examples")


### PR DESCRIPTION
This pull request enable using stdio file acces to reduce at minimum the RAM usage. When using this library with arm-none-eabi-gcc, the streams are very heavy in RAM and Flash. This new adapter is not using the streams at all.  This fix the issue https://github.com/nlohmann/json/issues/1370

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
