### PR TITLE
buildsystem: relax requirement on cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 
 ##
 ## PROJECT

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 project(JSON_Benchmarks LANGUAGES CXX)
 
 # set compiler flags

--- a/test/cmake_add_subdirectory/project/CMakeLists.txt
+++ b/test/cmake_add_subdirectory/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(DummyImport CXX)
 

--- a/test/cmake_import/project/CMakeLists.txt
+++ b/test/cmake_import/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(DummyImport CXX)
 

--- a/test/cmake_import_minver/project/CMakeLists.txt
+++ b/test/cmake_import_minver/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(DummyImportMinVer CXX)
 


### PR DESCRIPTION
Commit 73cc5089 (Using target_compile_features to specify C++ 11
standard) bumped the required cmake version, from 3.0 to 3.8, so
as to get the definition of target_compile_features().

However, target_compile_features() was introduced in cmake-3.1:
    https://cmake.org/cmake/help/v3.1/command/target_compile_features.html

And using cmake-3.1 is indeed sufficient to properly build.

As such, relax the minimum required version down to cmake-3.1,
so we can build on oldish, entreprise-grade distributions that
only have cmake-3.1 (or at least, don't have up to cmake-3.8).

Reported-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>

