### PR TITLE
Improve dump_integer performance

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -19,6 +19,7 @@ file(COPY ${CMAKE_SOURCE_DIR}/data DESTINATION .)
 file(COPY ${CMAKE_SOURCE_DIR}/../test/data/regression/floats.json
           ${CMAKE_SOURCE_DIR}/../test/data/regression/unsigned_ints.json
           ${CMAKE_SOURCE_DIR}/../test/data/regression/signed_ints.json
+          ${CMAKE_SOURCE_DIR}/../test/data/regression/small_signed_ints.json
     DESTINATION data/numbers)
 
 # benchmark binary

--- a/benchmarks/src/benchmarks.cpp
+++ b/benchmarks/src/benchmarks.cpp
@@ -28,14 +28,14 @@ static void ParseFile(benchmark::State& state, const char* filename)
     std::ifstream file(filename, std::ios::binary | std::ios::ate);
     state.SetBytesProcessed(state.iterations() * file.tellg());
 }
-BENCHMARK_CAPTURE(ParseFile, jeopardy,      "data/jeopardy/jeopardy.json");
-BENCHMARK_CAPTURE(ParseFile, canada,        "data/nativejson-benchmark/canada.json");
-BENCHMARK_CAPTURE(ParseFile, citm_catalog,  "data/nativejson-benchmark/citm_catalog.json");
-BENCHMARK_CAPTURE(ParseFile, twitter,       "data/nativejson-benchmark/twitter.json");
-BENCHMARK_CAPTURE(ParseFile, floats,        "data/numbers/floats.json");
-BENCHMARK_CAPTURE(ParseFile, signed_ints,   "data/numbers/signed_ints.json");
-BENCHMARK_CAPTURE(ParseFile, unsigned_ints, "data/numbers/unsigned_ints.json");
-
+BENCHMARK_CAPTURE(ParseFile, jeopardy,              "data/jeopardy/jeopardy.json");
+BENCHMARK_CAPTURE(ParseFile, canada,                "data/nativejson-benchmark/canada.json");
+BENCHMARK_CAPTURE(ParseFile, citm_catalog,          "data/nativejson-benchmark/citm_catalog.json");
+BENCHMARK_CAPTURE(ParseFile, twitter,               "data/nativejson-benchmark/twitter.json");
+BENCHMARK_CAPTURE(ParseFile, floats,                "data/numbers/floats.json");
+BENCHMARK_CAPTURE(ParseFile, signed_ints,           "data/numbers/signed_ints.json");
+BENCHMARK_CAPTURE(ParseFile, unsigned_ints,         "data/numbers/unsigned_ints.json");
+BENCHMARK_CAPTURE(ParseFile, small_signed_ints,     "data/numbers/small_signed_ints.json");
 
 //////////////////////////////////////////////////////////////////////////////
 // parse JSON from string
@@ -61,13 +61,14 @@ static void ParseString(benchmark::State& state, const char* filename)
 
     state.SetBytesProcessed(state.iterations() * str.size());
 }
-BENCHMARK_CAPTURE(ParseString, jeopardy,      "data/jeopardy/jeopardy.json");
-BENCHMARK_CAPTURE(ParseString, canada,        "data/nativejson-benchmark/canada.json");
-BENCHMARK_CAPTURE(ParseString, citm_catalog,  "data/nativejson-benchmark/citm_catalog.json");
-BENCHMARK_CAPTURE(ParseString, twitter,       "data/nativejson-benchmark/twitter.json");
-BENCHMARK_CAPTURE(ParseString, floats,        "data/numbers/floats.json");
-BENCHMARK_CAPTURE(ParseString, signed_ints,   "data/numbers/signed_ints.json");
-BENCHMARK_CAPTURE(ParseString, unsigned_ints, "data/numbers/unsigned_ints.json");
+BENCHMARK_CAPTURE(ParseString, jeopardy,            "data/jeopardy/jeopardy.json");
+BENCHMARK_CAPTURE(ParseString, canada,              "data/nativejson-benchmark/canada.json");
+BENCHMARK_CAPTURE(ParseString, citm_catalog,        "data/nativejson-benchmark/citm_catalog.json");
+BENCHMARK_CAPTURE(ParseString, twitter,             "data/nativejson-benchmark/twitter.json");
+BENCHMARK_CAPTURE(ParseString, floats,              "data/numbers/floats.json");
+BENCHMARK_CAPTURE(ParseString, signed_ints,         "data/numbers/signed_ints.json");
+BENCHMARK_CAPTURE(ParseString, unsigned_ints,       "data/numbers/unsigned_ints.json");
+BENCHMARK_CAPTURE(ParseString, small_signed_ints,   "data/numbers/small_signed_ints.json");
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -101,6 +102,8 @@ BENCHMARK_CAPTURE(Dump, signed_ints / -,   "data/numbers/signed_ints.json",     
 BENCHMARK_CAPTURE(Dump, signed_ints / 4,   "data/numbers/signed_ints.json",               4);
 BENCHMARK_CAPTURE(Dump, unsigned_ints / -, "data/numbers/unsigned_ints.json",             -1);
 BENCHMARK_CAPTURE(Dump, unsigned_ints / 4, "data/numbers/unsigned_ints.json",             4);
+BENCHMARK_CAPTURE(Dump, small_signed_ints / -,   "data/numbers/small_signed_ints.json",   -1);
+BENCHMARK_CAPTURE(Dump, small_signed_ints / 4,   "data/numbers/small_signed_ints.json",   4);
 
 
 BENCHMARK_MAIN();

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11411,6 +11411,40 @@ class serializer
     }
 
     /*!
+    @brief count digits
+
+    Count the number of decimal (base 10) digits for an input unsigned integer.
+
+    @param[in] x  unsigned integer number to count its digits
+    @return    number of decimal digits
+    */
+    inline unsigned int count_digits(number_unsigned_t x) noexcept
+    {
+        unsigned int n_digits = 1;
+        for (;;)
+        {
+            if (x < 10)
+            {
+                return n_digits;
+            }
+            if (x < 100)
+            {
+                return n_digits + 1;
+            }
+            if (x < 1000)
+            {
+                return n_digits + 2;
+            }
+            if (x < 10000)
+            {
+                return n_digits + 3;
+            }
+            x = x / 10000u;
+            n_digits += 4;
+        }
+    }
+
+    /*!
     @brief dump an integer
 
     Dump a given integer to output stream @a o. Works internally with
@@ -11425,6 +11459,22 @@ class serializer
                  int> = 0>
     void dump_integer(NumberType x)
     {
+        static constexpr std::array<std::array<char, 2>, 100> digits_to_99
+        {
+            {
+                {'0', '0'}, {'0', '1'}, {'0', '2'}, {'0', '3'}, {'0', '4'}, {'0', '5'}, {'0', '6'}, {'0', '7'}, {'0', '8'}, {'0', '9'},
+                {'1', '0'}, {'1', '1'}, {'1', '2'}, {'1', '3'}, {'1', '4'}, {'1', '5'}, {'1', '6'}, {'1', '7'}, {'1', '8'}, {'1', '9'},
+                {'2', '0'}, {'2', '1'}, {'2', '2'}, {'2', '3'}, {'2', '4'}, {'2', '5'}, {'2', '6'}, {'2', '7'}, {'2', '8'}, {'2', '9'},
+                {'3', '0'}, {'3', '1'}, {'3', '2'}, {'3', '3'}, {'3', '4'}, {'3', '5'}, {'3', '6'}, {'3', '7'}, {'3', '8'}, {'3', '9'},
+                {'4', '0'}, {'4', '1'}, {'4', '2'}, {'4', '3'}, {'4', '4'}, {'4', '5'}, {'4', '6'}, {'4', '7'}, {'4', '8'}, {'4', '9'},
+                {'5', '0'}, {'5', '1'}, {'5', '2'}, {'5', '3'}, {'5', '4'}, {'5', '5'}, {'5', '6'}, {'5', '7'}, {'5', '8'}, {'5', '9'},
+                {'6', '0'}, {'6', '1'}, {'6', '2'}, {'6', '3'}, {'6', '4'}, {'6', '5'}, {'6', '6'}, {'6', '7'}, {'6', '8'}, {'6', '9'},
+                {'7', '0'}, {'7', '1'}, {'7', '2'}, {'7', '3'}, {'7', '4'}, {'7', '5'}, {'7', '6'}, {'7', '7'}, {'7', '8'}, {'7', '9'},
+                {'8', '0'}, {'8', '1'}, {'8', '2'}, {'8', '3'}, {'8', '4'}, {'8', '5'}, {'8', '6'}, {'8', '7'}, {'8', '8'}, {'8', '9'},
+                {'9', '0'}, {'9', '1'}, {'9', '2'}, {'9', '3'}, {'9', '4'}, {'9', '5'}, {'9', '6'}, {'9', '7'}, {'9', '8'}, {'9', '9'},
+            }
+        };
+
         // special case for "0"
         if (x == 0)
         {
@@ -11432,28 +11482,58 @@ class serializer
             return;
         }
 
-        const bool is_negative = std::is_same<NumberType, number_integer_t>::value and not (x >= 0);  // see issue #755
-        std::size_t i = 0;
+        // use a pointer to fill the buffer
+        auto buffer_ptr = begin(number_buffer);
 
-        while (x != 0)
-        {
-            // spare 1 byte for '\0'
-            assert(i < number_buffer.size() - 1);
+        const bool is_negative = std::is_same<NumberType, number_integer_t>::value and not(x >= 0); // see issue #755
+        number_unsigned_t abs_value;
 
-            const auto digit = std::labs(static_cast<long>(x % 10));
-            number_buffer[i++] = static_cast<char>('0' + digit);
-            x /= 10;
-        }
+        unsigned int n_chars;
 
         if (is_negative)
         {
-            // make sure there is capacity for the '-'
-            assert(i < number_buffer.size() - 2);
-            number_buffer[i++] = '-';
+            *buffer_ptr = '-';
+            abs_value = static_cast<number_unsigned_t>(0 - x);
+
+            // account one more byte for the minus sign
+            n_chars = 1 + count_digits(abs_value);
+        }
+        else
+        {
+            abs_value = static_cast<number_unsigned_t>(x);
+            n_chars = count_digits(abs_value);
         }
 
-        std::reverse(number_buffer.begin(), number_buffer.begin() + i);
-        o->write_characters(number_buffer.data(), i);
+        // spare 1 byte for '\0'
+        assert(n_chars < number_buffer.size() - 1);
+
+        // jump to the end to generate the string from backward
+        // so we later avoid reversing the result
+        buffer_ptr += n_chars;
+
+        // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
+        // See: https://www.youtube.com/watch?v=o4-CwDo2zpg
+        const auto buffer_end = buffer_ptr;
+        while (abs_value >= 100)
+        {
+            const auto digits_index = static_cast<unsigned>((abs_value % 100));
+            abs_value /= 100;
+            *(--buffer_ptr) = digits_to_99[digits_index][1];
+            *(--buffer_ptr) = digits_to_99[digits_index][0];
+        }
+
+        if (abs_value >= 10)
+        {
+            const auto digits_index = static_cast<unsigned>(abs_value);
+            *(--buffer_ptr) = digits_to_99[digits_index][1];
+            *(--buffer_ptr) = digits_to_99[digits_index][0];
+        }
+        else
+        {
+            *(--buffer_ptr) = static_cast<char>('0' + abs_value);
+        }
+
+        o->write_characters(number_buffer.data(), n_chars);
     }
 
     /*!

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -669,7 +669,8 @@ TEST_CASE("regression tests")
                 {
                     "test/data/regression/floats.json",
                     "test/data/regression/signed_ints.json",
-                    "test/data/regression/unsigned_ints.json"
+                    "test/data/regression/unsigned_ints.json",
+                    "test/data/regression/small_signed_ints.json"
                 })
         {
             CAPTURE(filename)

--- a/test/src/unit-to_chars.cpp
+++ b/test/src/unit-to_chars.cpp
@@ -471,4 +471,64 @@ TEST_CASE("formatting")
         check_double(  1.2345e+21,   "1.2344999999999999e+21" ); //  1.2345e+21                1.2344999999999999e+21    1.2345e21
         check_double(  1.2345e+22,   "1.2345e+22"             ); //  1.2345e+22                1.2345e+22                1.2345e22
     }
+
+    SECTION("integer")
+    {
+        auto check_integer = [](std::int64_t number, const std::string & expected)
+        {
+            nlohmann::json j = number;
+            CHECK(j.dump() == expected);
+        };
+
+        // edge cases
+        check_integer(INT64_MIN, "-9223372036854775808");
+        check_integer(INT64_MAX, "9223372036854775807");
+
+        // few random big integers
+        check_integer(-3456789012345678901LL, "-3456789012345678901");
+        check_integer(3456789012345678901LL, "3456789012345678901");
+        check_integer(-5678901234567890123LL, "-5678901234567890123");
+        check_integer(5678901234567890123LL, "5678901234567890123");
+
+        // integers with various digit counts
+        check_integer(-1000000000000000000LL, "-1000000000000000000");
+        check_integer(-100000000000000000LL, "-100000000000000000");
+        check_integer(-10000000000000000LL, "-10000000000000000");
+        check_integer(-1000000000000000LL, "-1000000000000000");
+        check_integer(-100000000000000LL, "-100000000000000");
+        check_integer(-10000000000000LL, "-10000000000000");
+        check_integer(-1000000000000LL, "-1000000000000");
+        check_integer(-100000000000LL, "-100000000000");
+        check_integer(-10000000000LL, "-10000000000");
+        check_integer(-1000000000LL, "-1000000000");
+        check_integer(-100000000LL, "-100000000");
+        check_integer(-10000000LL, "-10000000");
+        check_integer(-1000000LL, "-1000000");
+        check_integer(-100000LL, "-100000");
+        check_integer(-10000LL, "-10000");
+        check_integer(-1000LL, "-1000");
+        check_integer(-100LL, "-100");
+        check_integer(-10LL, "-10");
+        check_integer(-1LL, "-1");
+        check_integer(0, "0");
+        check_integer(1LL, "1");
+        check_integer(10LL, "10");
+        check_integer(100LL, "100");
+        check_integer(1000LL, "1000");
+        check_integer(10000LL, "10000");
+        check_integer(100000LL, "100000");
+        check_integer(1000000LL, "1000000");
+        check_integer(10000000LL, "10000000");
+        check_integer(100000000LL, "100000000");
+        check_integer(1000000000LL, "1000000000");
+        check_integer(10000000000LL, "10000000000");
+        check_integer(100000000000LL, "100000000000");
+        check_integer(1000000000000LL, "1000000000000");
+        check_integer(10000000000000LL, "10000000000000");
+        check_integer(100000000000000LL, "100000000000000");
+        check_integer(1000000000000000LL, "1000000000000000");
+        check_integer(10000000000000000LL, "10000000000000000");
+        check_integer(100000000000000000LL, "100000000000000000");
+        check_integer(1000000000000000000LL, "1000000000000000000");
+    }
 }


### PR DESCRIPTION
This PR improves the performance of `dump_integer` using a tuned int2ascii implementation. The technique is discussed in [Fastware talk by Andrei Alexandrescu](https://youtu.be/o4-CwDo2zpg?t=1680) and has been already incorporated in some of other well-known libraries like [fmtlib](https://github.com/fmtlib/fmt/blob/master/include/fmt/format.h#L954).

In this pull request:

1. The fast int2ascii implementation is implemented (adapted from fmtlib implementation)
2. A benchmark for small integers is added. Previous benchmarks for integer are biased to very large integers. Also, in the original talk Andrei argues that the performance gain is larger (~2x) for smaller integers compared to a Naive implementation. Therefore, I believe it is worth covering the small integers in a separate benchmark too since in most use cases in the real world the integers are not that large. This lets us to keep track of the performance for both small and larger integer values.
3. I couldn't find unit-tests for integer formatting that checks different number of digits. To bring the code coverage to 100%, I have added some unit tests too.

The benchmarks show an considerable performance improvement (~1.5x) on my VM linux. This could be different (and probably higher) in a non-VM environment. Here is the original performance of Dump* operations (Ubuntu 18.04 x64, Clang 6):

```
Run on (4 X 2601 MHz CPU s)
CPU Caches:
  L1 Data 32K (x1)
  L1 Instruction 32K (x1)
  L2 Unified 256K (x1)
  L3 Unified 6144K (x1)
Dump/jeopardy / -           310113722 ns  308222627 ns         45   162.468MB/s
Dump/jeopardy / 4           367662837 ns  367510814 ns         38   181.292MB/s
Dump/canada / -              13027324 ns   13027200 ns       1096   153.024MB/s
Dump/canada / 4              16393044 ns   16328034 ns        858   473.766MB/s
Dump/citm_catalog / -         1956277 ns    1951371 ns       7267   244.506MB/s
Dump/citm_catalog / 4         2648083 ns    2647870 ns       5007   622.081MB/s
Dump/twitter / -              1912959 ns    1912949 ns       7319    232.77MB/s
Dump/twitter / 4              2181181 ns    2171835 ns       6523   336.927MB/s
Dump/floats / -             107072183 ns  106987779 ns        128    166.43MB/s
Dump/floats / 4             117135279 ns  117133075 ns        119   192.724MB/s
Dump/signed_ints / -         72700522 ns   72323217 ns        192   268.724MB/s
Dump/signed_ints / 4         80542202 ns   80504633 ns        173   300.645MB/s
Dump/unsigned_ints / -       61854487 ns   61853677 ns        230   314.503MB/s
Dump/unsigned_ints / 4       69747684 ns   69491170 ns        202   348.555MB/s
Dump/small_signed_ints / -   31521619 ns   31516332 ns        438   223.579MB/s
Dump/small_signed_ints / 4   39854903 ns   39854301 ns        349   296.449MB/s
```

And this is the performance with fast int2ascii method (note the last six benchmarks):

```
Dump/jeopardy / -           286181485 ns  286013895 ns         48   175.083MB/s
Dump/jeopardy / 4           349974284 ns  349965305 ns         40   190.381MB/s
Dump/canada / -              13124489 ns   13047201 ns       1069   152.789MB/s
Dump/canada / 4              17334759 ns   17313192 ns        876   446.808MB/s
Dump/citm_catalog / -         1871325 ns    1871283 ns       7435   254.971MB/s
Dump/citm_catalog / 4         2462448 ns    2462047 ns       5452   669.033MB/s
Dump/twitter / -              1825330 ns    1817293 ns       7690   245.022MB/s
Dump/twitter / 4              2058264 ns    2057411 ns       6820   355.666MB/s
Dump/floats / -             107943518 ns  107941378 ns        129    164.96MB/s
Dump/floats / 4             118865187 ns  118097256 ns        117   191.151MB/s
Dump/signed_ints / -         42482922 ns   42401566 ns        329   458.355MB/s
Dump/signed_ints / 4         49180866 ns   49179644 ns        285   492.142MB/s
Dump/unsigned_ints / -       41778353 ns   41575626 ns        333   467.898MB/s
Dump/unsigned_ints / 4       48426047 ns   48365002 ns        288   500.807MB/s
Dump/small_signed_ints / -   25048480 ns   25048284 ns        554   281.313MB/s
Dump/small_signed_ints / 4   34388632 ns   34332533 ns        401   344.128MB/s
````

More detailed benchmark results (including gcc, msvc) is available here: https://docs.google.com/spreadsheets/d/1sGE3UvLeLT_KrnC_Ujvtl_NFXPIp28xFOe9u9-6GSU0/edit?usp=sharing

This is my first contribution so any feedback is welcome.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
