### PR TITLE
Fix x64 target platform for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,17 +26,17 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x64
       FLAGS: ""
-      GENERATOR: Visual Studio 14 2015
+      GENERATOR: Visual Studio 14 2015 Win64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       FLAGS: ""
-      GENERATOR: Visual Studio 15 2017
+      GENERATOR: Visual Studio 15 2017 Win64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       FLAGS: "/permissive- /std:c++latest /utf-8"
-      GENERATOR: Visual Studio 15 2017
+      GENERATOR: Visual Studio 15 2017 Win64
 
 init:
   - cmake --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,37 +5,44 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       COMPILER: mingw
       platform: x86
-      FLAGS: ""
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
       GENERATOR: Ninja
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
-      FLAGS: ""
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
       GENERATOR: Visual Studio 14 2015
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
-      FLAGS: ""
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
       GENERATOR: Visual Studio 15 2017
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
-      FLAGS: "/permissive- /std:c++latest /utf-8"
+      CXX_FLAGS: "/permissive- /std:c++latest /utf-8"
+      LINKER_FLAGS: ""
       GENERATOR: Visual Studio 15 2017
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x64
-      FLAGS: ""
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
       GENERATOR: Visual Studio 14 2015 Win64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
-      FLAGS: ""
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
       GENERATOR: Visual Studio 15 2017 Win64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
-      FLAGS: "/permissive- /std:c++latest /utf-8"
+      CXX_FLAGS: "/permissive- /std:c++latest /utf-8 /F4000000"
+      LINKER_FLAGS: "/STACK:4000000"
       GENERATOR: Visual Studio 15 2017 Win64
 
 init:
@@ -50,7 +57,7 @@ install:
   - if "%COMPILER%"=="mingw" g++ --version
 
 before_build:
-  - cmake . -G "%GENERATOR%" -DCMAKE_CXX_FLAGS="%FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
+  - cmake . -G "%GENERATOR%" -DCMAKE_CXX_FLAGS="%CXX_FLAGS%" -DCMAKE_EXE_LINKER_FLAGS="%LINKER_FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
 
 build_script:
   - cmake --build . --config Release


### PR DESCRIPTION

This pull request fixes https://github.com/nlohmann/json/issues/1374.

More details are explained in cmake documentation for Visual Studio [2015](https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2014%202015.html)/[2017](https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2015%202017.html)

Note that the value of `platform` specified in `appveyor.yml` doesn't always match the target platform string required by cmake (e.g. `x86` in appveyor.yml vs. ` cmake -A Win32`). Therefore, we set the target platform for x64 directly in the generator name instead of passing the `platform` variable to cmake.

I've already run Appveyor on my fork to make sure this change is effective: https://ci.appveyor.com/project/nickaein/nlohmann-json/builds/21408703

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
