### PR TITLE
buildsystem: fix support for cmake older than 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 ##
 add_library(${NLOHMANN_JSON_TARGET_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${NLOHMANN_JSON_TARGET_NAME} ALIAS ${NLOHMANN_JSON_TARGET_NAME})
-target_compile_features(${NLOHMANN_JSON_TARGET_NAME} INTERFACE cxx_std_11)
+target_compile_features(${NLOHMANN_JSON_TARGET_NAME} INTERFACE cxx_range_for)
 
 target_include_directories(
     ${NLOHMANN_JSON_TARGET_NAME}

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -23,5 +23,5 @@ file(COPY ${CMAKE_SOURCE_DIR}/../test/data/regression/floats.json
 
 # benchmark binary
 add_executable(json_benchmarks src/benchmarks.cpp)
-target_compile_features(json_benchmarks PRIVATE cxx_std_11)
+target_compile_features(json_benchmarks PRIVATE cxx_range_for)
 target_link_libraries(json_benchmarks benchmark ${CMAKE_THREAD_LIBS_INIT})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(catch_main PROPERTIES
     COMPILE_DEFINITIONS "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
     COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>"
 )
-target_compile_features(catch_main PUBLIC cxx_std_11)
+target_compile_features(catch_main PUBLIC cxx_range_for)
 target_include_directories(catch_main PRIVATE "thirdparty/catch")
 
 # https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake


### PR DESCRIPTION
In e8b6b7ad, we relaxed the cmake version check down to 3.1, the first
version to expose target_compile_features().

However, an error while testing that change improperly concluded that
the change was OK. While target_compile_features() was indeed intriduced
in cmake 3.1, the actual feature we use it to test, cxx_std_11, was
really introduced only with cmake-3.8, which explained the actual
version that was requested before e8b6b7ad.

As Patrick noted, however, we can still convince cmake-3.1 to test
for C++11, by testing for an actual feature introduced in C++11, like
testing for cxx_range_for, which will instruct cmake to set the
appropriate C++11 options for the current compiler, which for gcc would
be adding -std=gnu++11.

Reported-by: Patrick Boettcher <patrick.boettcher@posteo.de>
Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
