### PR TITLE
Iterative destruction of JSON containers (objects and arrays)

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1002,7 +1002,7 @@ class basic_json
                     if ((t == value_t::object && !this->object->empty()) || (t == value_t::array && !this->array->empty()))
                     {
                         std::vector<std::pair<json_value*, value_t>> stack;
-                        stack.push_back(std::make_pair(this, t));
+                        stack.emplace_back(this, t);
                         while (!stack.empty())
                         {
                             json_value* value;
@@ -1016,7 +1016,7 @@ class basic_json
                                     value_t inner_type = inner_value.type();
                                     if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
                                     {
-                                        stack.push_back(std::make_pair(&inner_value.m_value, inner_type));
+                                        stack.emplace_back(&inner_value.m_value, inner_type);
                                         break;
                                     }
                                     else
@@ -1037,7 +1037,7 @@ class basic_json
                                     value_t inner_type = inner_value.type();
                                     if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
                                     {
-                                        stack.push_back(std::make_pair(&inner_value.m_value, inner_type));
+                                        stack.emplace_back(&inner_value.m_value, inner_type);
                                         break;
                                     }
                                     else

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -997,73 +997,28 @@ class basic_json
             switch (t)
             {
                 case value_t::object:
+                {
+                    if (!this->object->empty())
+                    {
+                        destroy_subelements_iterative(t);
+                    }
+
+                    AllocatorType<object_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
+                    break;
+                }
+
                 case value_t::array:
                 {
-                    if ((t == value_t::object && !this->object->empty()) || (t == value_t::array && !this->array->empty()))
+                    if (!this->array->empty())
                     {
-                        std::vector<std::pair<json_value*, value_t>> stack;
-                        stack.emplace_back(this, t);
-                        while (!stack.empty())
-                        {
-                            json_value* value;
-                            value_t type;
-                            std::tie(value, type) = stack.back();
-                            if (type == value_t::object)
-                            {
-                                while (!value->object->empty())
-                                {
-                                    basic_json& inner_value = value->object->begin()->second;
-                                    value_t inner_type = inner_value.type();
-                                    if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
-                                    {
-                                        stack.emplace_back(&inner_value.m_value, inner_type);
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        value->object->erase(value->object->begin());
-                                    }
-                                }
-                                if (value->object->empty())
-                                {
-                                    stack.pop_back();
-                                }
-                            }
-                            else
-                            {
-                                while (!value->array->empty())
-                                {
-                                    basic_json& inner_value = value->array->back();
-                                    value_t inner_type = inner_value.type();
-                                    if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
-                                    {
-                                        stack.emplace_back(&inner_value.m_value, inner_type);
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        value->array->pop_back();
-                                    }
-                                }
-                                if (value->array->empty())
-                                {
-                                    stack.pop_back();
-                                }
-                            }
-                        }
+                        destroy_subelements_iterative(t);
                     }
-                    if (t == value_t::object)
-                    {
-                        AllocatorType<object_t> alloc;
-                        std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
-                        std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
-                    }
-                    else
-                    {
-                        AllocatorType<array_t> alloc;
-                        std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
-                        std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
-                    }
+
+                    AllocatorType<array_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
                     break;
                 }
 
@@ -1081,6 +1036,78 @@ class basic_json
                 }
             }
         }
+
+private:
+
+        /// destroys all children in an iterative depth-first traversal using an explicit stack
+        /// to avoid stack overflows in a recursive destruction of deeply nested hierarchies
+        void destroy_subelements_iterative(value_t t) noexcept
+        {
+            std::vector<std::pair<json_value*, value_t>> stack;
+            stack.emplace_back(this, t);
+            while (!stack.empty())
+            {
+                json_value* value;
+                value_t type;
+                std::tie(value, type) = stack.back();
+                switch (type)
+                {
+                    case value_t::object:
+                        destroy_object_subelements(stack, value);
+                        break;
+                    case value_t::array:
+                        destroy_array_subelements(stack, value);
+                        break;
+                    default:
+                        // this should never happen
+                        break;
+                }
+            }
+        }
+
+        void destroy_object_subelements(std::vector<std::pair<json_value*, value_t>>& stack, json_value* value) noexcept
+        {
+            while (!value->object->empty())
+            {
+                basic_json& inner_value = value->object->begin()->second;
+                value_t inner_type = inner_value.type();
+                if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
+                {
+                    // the current inner value has children, push it onto the stack and return to continue the depth-first
+                    // traversal with the children, this limits the maximal stack size exactly to the maximal hierarchy depth
+                    stack.emplace_back(&inner_value.m_value, inner_type);
+                    return;
+                }
+                // the current inner value does not have any children (anymore), remove it from this object
+                value->object->erase(value->object->begin());
+            }
+            // the object does not have any children anymore, remove it from the stack
+            // the object itself will be destroyed later
+            stack.pop_back();
+        }
+
+        void destroy_array_subelements(std::vector<std::pair<json_value*, value_t>>& stack, json_value* value) noexcept
+        {
+            while (!value->array->empty())
+            {
+                // start removing children from the back of the array, to guarantee O(1) removal complexity
+                basic_json& inner_value = value->array->back();
+                value_t inner_type = inner_value.type();
+                if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
+                {
+                    // the current inner value has children, push it onto the stack and return to continue the depth-first
+                    // traversal with the children, this limits the maximal stack size exactly to the maximal hierarchy depth
+                    stack.emplace_back(&inner_value.m_value, inner_type);
+                    return;
+                }
+                // the current inner value does not have any children (anymore), remove it from this array
+                value->array->pop_back();
+            }
+            // the array does not have any children anymore, remove it from the stack
+            // the array itself will be destroyed later
+            stack.pop_back();
+        }
+
     };
 
     /*!

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -997,18 +997,73 @@ class basic_json
             switch (t)
             {
                 case value_t::object:
-                {
-                    AllocatorType<object_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
-                    break;
-                }
-
                 case value_t::array:
                 {
-                    AllocatorType<array_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
+                    if ((t == value_t::object && !this->object->empty()) || (t == value_t::array && !this->array->empty()))
+                    {
+                        std::vector<std::pair<json_value*, value_t>> stack;
+                        stack.push_back(std::make_pair(this, t));
+                        while (!stack.empty())
+                        {
+                            json_value* value;
+                            value_t type;
+                            std::tie(value, type) = stack.back();
+                            if (type == value_t::object)
+                            {
+                                while (!value->object->empty())
+                                {
+                                    basic_json& inner_value = value->object->begin()->second;
+                                    value_t inner_type = inner_value.type();
+                                    if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
+                                    {
+                                        stack.push_back(std::make_pair(&inner_value.m_value, inner_type));
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        value->object->erase(value->object->begin());
+                                    }
+                                }
+                                if (value->object->empty())
+                                {
+                                    stack.pop_back();
+                                }
+                            }
+                            else
+                            {
+                                while (!value->array->empty())
+                                {
+                                    basic_json& inner_value = value->array->back();
+                                    value_t inner_type = inner_value.type();
+                                    if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
+                                    {
+                                        stack.push_back(std::make_pair(&inner_value.m_value, inner_type));
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        value->array->pop_back();
+                                    }
+                                }
+                                if (value->array->empty())
+                                {
+                                    stack.pop_back();
+                                }
+                            }
+                        }
+                    }
+                    if (t == value_t::object)
+                    {
+                        AllocatorType<object_t> alloc;
+                        std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
+                        std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
+                    }
+                    else
+                    {
+                        AllocatorType<array_t> alloc;
+                        std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
+                        std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
+                    }
                     break;
                 }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13470,7 +13470,7 @@ class basic_json
                     if ((t == value_t::object && !this->object->empty()) || (t == value_t::array && !this->array->empty()))
                     {
                         std::vector<std::pair<json_value*, value_t>> stack;
-                        stack.push_back(std::make_pair(this, t));
+                        stack.emplace_back(this, t);
                         while (!stack.empty())
                         {
                             json_value* value;
@@ -13484,7 +13484,7 @@ class basic_json
                                     value_t inner_type = inner_value.type();
                                     if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
                                     {
-                                        stack.push_back(std::make_pair(&inner_value.m_value, inner_type));
+                                        stack.emplace_back(&inner_value.m_value, inner_type);
                                         break;
                                     }
                                     else
@@ -13505,7 +13505,7 @@ class basic_json
                                     value_t inner_type = inner_value.type();
                                     if ((inner_type == value_t::object || inner_type == value_t::array) && !inner_value.empty())
                                     {
-                                        stack.push_back(std::make_pair(&inner_value.m_value, inner_type));
+                                        stack.emplace_back(&inner_value.m_value, inner_type);
                                         break;
                                     }
                                     else


### PR DESCRIPTION
Deeply nested JSON hierarchies may lead to stack overflows during destruction, since JSON containers call the destructor of their children recursively (see issue #832).

This change provides an iterative destruction of JSON containers, avoiding a deep call stack by maintaining an explicit stack on the heap.