### PR TITLE
Revert "buildsystem: relax requirement on cmake version"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 ##
 ## PROJECT

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(JSON_Benchmarks LANGUAGES CXX)
 
 # set compiler flags

--- a/test/cmake_add_subdirectory/project/CMakeLists.txt
+++ b/test/cmake_add_subdirectory/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(DummyImport CXX)
 

--- a/test/cmake_import/project/CMakeLists.txt
+++ b/test/cmake_import/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(DummyImport CXX)
 

--- a/test/cmake_import_minver/project/CMakeLists.txt
+++ b/test/cmake_import_minver/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(DummyImportMinVer CXX)
 


### PR DESCRIPTION
In e8b6b7a, we relaxed the cmake version check down to 3.1, the first
version to expose target_compile_features().

However, an error while testing that change improperly concluded that
the change was OK. While target_compile_features() was indeed introduced
in cmake 3.1, the actual feature we use it to test, cxx_std_11, was
really introduced only with cmake-3.8, which explained the actual
version that was requested before e8b6b7a.

Coming up with a working test is not as trivial as initially thought, so
a better solution will have to be devised in the future. In the mean
time, revert to the previously-working situation.

This reverts commit e8b6b7adc138a66f8d47396a2e707366d3771028.

Reported-by: Patrick Boettcher <patrick.boettcher@posteo.de>
Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
