### PR TITLE
Add operator/= and operator/ to construct a JSON pointer by appending two JSON pointers

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -77,6 +77,52 @@ class json_pointer
     }
 
     /*!
+    @brief append another JSON pointer at the end of this JSON pointer
+    */
+    json_pointer& operator/=(const json_pointer& ptr)
+    {
+        reference_tokens.insert(reference_tokens.end(), ptr.reference_tokens.begin(), ptr.reference_tokens.end());
+        return *this;
+    }
+
+    /// @copydoc push_back(std::string&&)
+    json_pointer& operator/=(std::string token)
+    {
+        push_back(std::move(token));
+        return *this;
+    }
+
+    /// @copydoc operator/=(std::string)
+    json_pointer& operator/=(std::size_t array_index)
+    {
+        return *this /= std::to_string(array_index);
+    }
+
+    /*!
+    @brief create a new JSON pointer by appending the right JSON pointer at the end of the left JSON pointer
+    */
+    friend json_pointer operator/(const json_pointer& left_ptr, const json_pointer& right_ptr)
+    {
+        return json_pointer(left_ptr) /= right_ptr;
+    }
+
+    /*!
+    @brief create a new JSON pointer by appending the unescaped token at the end of the JSON pointer
+    */
+    friend json_pointer operator/(const json_pointer& ptr, std::string token)
+    {
+        return json_pointer(ptr) /= std::move(token);
+    }
+
+    /*!
+    @brief create a new JSON pointer by appending the array-index-token at the end of the JSON pointer
+    */
+    friend json_pointer operator/(const json_pointer& lhs, std::size_t array_index)
+    {
+        return json_pointer(lhs) /= array_index;
+    }
+
+    /*!
     @param[in] s  reference token to be converted into an array index
 
     @return integer representation of @a s
@@ -98,7 +144,7 @@ class json_pointer
     }
 
     /*!
-    @brief remove and return last reference pointer
+    @brief remove and return last reference token
     @throw out_of_range.405 if JSON pointer has no parent
     */
     std::string pop_back()
@@ -114,31 +160,17 @@ class json_pointer
     }
 
     /*!
-    @brief append a token at the end of the reference pointer
+    @brief append an unescaped token at the end of the reference pointer
     */
-    void push_back(const std::string& tok)
+    void push_back(const std::string& token)
     {
-        reference_tokens.push_back(tok);
+        reference_tokens.push_back(token);
     }
 
-    /*!
-    @brief append a key-token at the end of the reference pointer and return a new json-pointer.
-    */
-    json_pointer operator+(const std::string& tok) const
+    /// @copydoc push_back(const std::string&)
+    void push_back(std::string&& token)
     {
-        auto ptr = *this;
-        ptr.push_back(tok);
-        return ptr;
-    }
-
-    /*!
-    @brief append a array-index-token at the end of the reference pointer and return a new json-pointer.
-    */
-    json_pointer operator+(const size_t& index) const
-    {
-        auto ptr = *this;
-        ptr.push_back(std::to_string(index));
-        return ptr;
+        reference_tokens.push_back(std::move(token));
     }
 
   private:

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -149,7 +149,7 @@ class json_pointer
     */
     std::string pop_back()
     {
-        if (JSON_UNLIKELY(is_root()))
+        if (JSON_UNLIKELY(empty()))
         {
             JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
         }
@@ -173,16 +173,16 @@ class json_pointer
         reference_tokens.push_back(std::move(token));
     }
 
-  private:
     /// return whether pointer points to the root document
-    bool is_root() const noexcept
+    bool empty() const noexcept
     {
         return reference_tokens.empty();
     }
 
+  private:
     json_pointer top() const
     {
-        if (JSON_UNLIKELY(is_root()))
+        if (JSON_UNLIKELY(empty()))
         {
             JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
         }

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -123,6 +123,21 @@ class json_pointer
     }
 
     /*!
+    @brief create a new JSON pointer that is the parent of this JSON pointer
+    */
+    json_pointer parent_pointer() const
+    {
+        if (empty())
+        {
+            return *this;
+        }
+
+        json_pointer res = *this;
+        res.pop_back();
+        return res;
+    }
+
+    /*!
     @param[in] s  reference token to be converted into an array index
 
     @return integer representation of @a s

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -114,12 +114,31 @@ class json_pointer
     }
 
     /*!
-    @brief remove and return last reference pointer
-    @throw out_of_range.405 if JSON pointer has no parent
+    @brief append a token at the end of the reference pointer
     */
     void push_back(const std::string& tok)
     {
         reference_tokens.push_back(tok);
+    }
+
+    /*!
+    @brief append a key-token at the end of the reference pointer and return a new json-pointer.
+    */
+    json_pointer operator+(const std::string& tok) const
+    {
+        auto ptr = *this;
+        ptr.push_back(tok);
+        return ptr;
+    }
+
+    /*!
+    @brief append a array-index-token at the end of the reference pointer and return a new json-pointer.
+    */
+    json_pointer operator+(const size_t& index) const
+    {
+        auto ptr = *this;
+        ptr.push_back(std::to_string(index));
+        return ptr;
     }
 
   private:

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -7466,7 +7466,7 @@ class basic_json
         const auto operation_add = [&result](json_pointer & ptr, basic_json val)
         {
             // adding to the root of the target document means replacing it
-            if (ptr.is_root())
+            if (ptr.empty())
             {
                 result = val;
             }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11959,7 +11959,7 @@ class json_pointer
     */
     std::string pop_back()
     {
-        if (JSON_UNLIKELY(is_root()))
+        if (JSON_UNLIKELY(empty()))
         {
             JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
         }
@@ -11983,16 +11983,16 @@ class json_pointer
         reference_tokens.push_back(std::move(token));
     }
 
-  private:
     /// return whether pointer points to the root document
-    bool is_root() const noexcept
+    bool empty() const noexcept
     {
         return reference_tokens.empty();
     }
 
+  private:
     json_pointer top() const
     {
-        if (JSON_UNLIKELY(is_root()))
+        if (JSON_UNLIKELY(empty()))
         {
             JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
         }
@@ -20016,7 +20016,7 @@ class basic_json
         const auto operation_add = [&result](json_pointer & ptr, basic_json val)
         {
             // adding to the root of the target document means replacing it
-            if (ptr.is_root())
+            if (ptr.empty())
             {
                 result = val;
             }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11887,6 +11887,52 @@ class json_pointer
     }
 
     /*!
+    @brief append another JSON pointer at the end of this JSON pointer
+    */
+    json_pointer& operator/=(const json_pointer& ptr)
+    {
+        reference_tokens.insert(reference_tokens.end(), ptr.reference_tokens.begin(), ptr.reference_tokens.end());
+        return *this;
+    }
+
+    /// @copydoc push_back(std::string&&)
+    json_pointer& operator/=(std::string token)
+    {
+        push_back(std::move(token));
+        return *this;
+    }
+
+    /// @copydoc operator/=(std::string)
+    json_pointer& operator/=(std::size_t array_index)
+    {
+        return *this /= std::to_string(array_index);
+    }
+
+    /*!
+    @brief create a new JSON pointer by appending the right JSON pointer at the end of the left JSON pointer
+    */
+    friend json_pointer operator/(const json_pointer& left_ptr, const json_pointer& right_ptr)
+    {
+        return json_pointer(left_ptr) /= right_ptr;
+    }
+
+    /*!
+    @brief create a new JSON pointer by appending the unescaped token at the end of the JSON pointer
+    */
+    friend json_pointer operator/(const json_pointer& ptr, std::string token)
+    {
+        return json_pointer(ptr) /= std::move(token);
+    }
+
+    /*!
+    @brief create a new JSON pointer by appending the array-index-token at the end of the JSON pointer
+    */
+    friend json_pointer operator/(const json_pointer& lhs, std::size_t array_index)
+    {
+        return json_pointer(lhs) /= array_index;
+    }
+
+    /*!
     @param[in] s  reference token to be converted into an array index
 
     @return integer representation of @a s
@@ -11908,7 +11954,7 @@ class json_pointer
     }
 
     /*!
-    @brief remove and return last reference pointer
+    @brief remove and return last reference token
     @throw out_of_range.405 if JSON pointer has no parent
     */
     std::string pop_back()
@@ -11924,31 +11970,17 @@ class json_pointer
     }
 
     /*!
-    @brief append a token at the end of the reference pointer
+    @brief append an unescaped token at the end of the reference pointer
     */
-    void push_back(const std::string& tok)
+    void push_back(const std::string& token)
     {
-        reference_tokens.push_back(tok);
+        reference_tokens.push_back(token);
     }
 
-    /*!
-    @brief append a key-token at the end of the reference pointer and return a new json-pointer.
-    */
-    json_pointer operator+(const std::string& tok) const
+    /// @copydoc push_back(const std::string&)
+    void push_back(std::string&& token)
     {
-        auto ptr = *this;
-        ptr.push_back(tok);
-        return ptr;
-    }
-
-    /*!
-    @brief append a array-index-token at the end of the reference pointer and return a new json-pointer.
-    */
-    json_pointer operator+(const size_t& index) const
-    {
-        auto ptr = *this;
-        ptr.push_back(std::to_string(index));
-        return ptr;
+        reference_tokens.push_back(std::move(token));
     }
 
   private:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11924,12 +11924,31 @@ class json_pointer
     }
 
     /*!
-    @brief remove and return last reference pointer
-    @throw out_of_range.405 if JSON pointer has no parent
+    @brief append a token at the end of the reference pointer
     */
     void push_back(const std::string& tok)
     {
         reference_tokens.push_back(tok);
+    }
+
+    /*!
+    @brief append a key-token at the end of the reference pointer and return a new json-pointer.
+    */
+    json_pointer operator+(const std::string& tok) const
+    {
+        auto ptr = *this;
+        ptr.push_back(tok);
+        return ptr;
+    }
+
+    /*!
+    @brief append a array-index-token at the end of the reference pointer and return a new json-pointer.
+    */
+    json_pointer operator+(const size_t& index) const
+    {
+        auto ptr = *this;
+        ptr.push_back(std::to_string(index));
+        return ptr;
     }
 
   private:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11933,6 +11933,21 @@ class json_pointer
     }
 
     /*!
+    @brief create a new JSON pointer that is the parent of this JSON pointer
+    */
+    json_pointer parent_pointer() const
+    {
+        if (empty())
+        {
+            return *this;
+        }
+
+        json_pointer res = *this;
+        res.pop_back();
+        return res;
+    }
+
+    /*!
     @param[in] s  reference token to be converted into an array index
 
     @return integer representation of @a s

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -438,6 +438,7 @@ TEST_CASE("JSON pointers")
                 })
         {
             CHECK(json::json_pointer(ptr).to_string() == ptr);
+            CHECK(std::string(json::json_pointer(ptr)) == ptr);
         }
     }
 

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -499,7 +499,8 @@ TEST_CASE("JSON pointers")
         CHECK(j[ptr] == j);
 
         // object and children access
-        ptr.push_back("answer");
+        const std::string answer("answer");
+        ptr.push_back(answer);
         ptr.push_back("everything");
         CHECK(j[ptr] == j["answer"]["everything"]);
 
@@ -546,24 +547,31 @@ TEST_CASE("JSON pointers")
         CHECK(j[ptr] == j);
 
         // simple field access
-        ptr = ptr + "pi";
+        ptr = ptr / "pi";
         CHECK(j[ptr] == j["pi"]);
 
         ptr.pop_back();
         CHECK(j[ptr] == j);
 
         // object and children access
-        ptr = ptr + "answer";
-        ptr = ptr + "everything";
+        const std::string answer("answer");
+        ptr /= answer;
+        ptr = ptr / "everything";
         CHECK(j[ptr] == j["answer"]["everything"]);
 
         ptr.pop_back();
         ptr.pop_back();
         CHECK(j[ptr] == j);
 
+        CHECK(ptr / ""_json_pointer == ptr);
+        CHECK(j["/answer"_json_pointer / "/everything"_json_pointer] == j["answer"]["everything"]);
+
+        // list children access
+        CHECK(j["/list"_json_pointer / 1] == j["list"][1]);
+
         // push key which has to be encoded
-        ptr = ptr + "object";
-        ptr = ptr + "/";
+        ptr /= "object";
+        ptr = ptr / "/";
         CHECK(j[ptr] == j["object"]["/"]);
         CHECK(ptr.to_string() == "/object/~1");
     }

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -513,4 +513,58 @@ TEST_CASE("JSON pointers")
         CHECK(j[ptr] == j["object"]["/"]);
         CHECK(ptr.to_string() == "/object/~1");
     }
+
+    SECTION("operators")
+    {
+        const json j =
+        {
+            {"", "Hello"},
+            {"pi", 3.141},
+            {"happy", true},
+            {"name", "Niels"},
+            {"nothing", nullptr},
+            {
+                "answer", {
+                    {"everything", 42}
+                }
+            },
+            {"list", {1, 0, 2}},
+            {
+                "object", {
+                    {"currency", "USD"},
+                    {"value", 42.99},
+                    {"", "empty string"},
+                    {"/", "slash"},
+                    {"~", "tilde"},
+                    {"~1", "tilde1"}
+                }
+            }
+        };
+
+        // empty json_pointer returns the root JSON-object
+        auto ptr = ""_json_pointer;
+        CHECK(j[ptr] == j);
+
+        // simple field access
+        ptr = ptr + "pi";
+        CHECK(j[ptr] == j["pi"]);
+
+        ptr.pop_back();
+        CHECK(j[ptr] == j);
+
+        // object and children access
+        ptr = ptr + "answer";
+        ptr = ptr + "everything";
+        CHECK(j[ptr] == j["answer"]["everything"]);
+
+        ptr.pop_back();
+        ptr.pop_back();
+        CHECK(j[ptr] == j);
+
+        // push key which has to be encoded
+        ptr = ptr + "object";
+        ptr = ptr + "/";
+        CHECK(j[ptr] == j["object"]["/"]);
+        CHECK(ptr.to_string() == "/object/~1");
+    }
 }


### PR DESCRIPTION
Add ``operator/=`` and ``operator/`` to construct a JSON pointer by appending two JSON pointers, as well as convenience ``op/=`` and ``op/`` to append a single unescaped token or array index. Design inspired by ``std::filesystem::path``, based on feedback on PR #1454.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
