### PR TITLE
Fix gcc9 build error test/src/unit-allocator.cpp (Issue #1472)

### DIFF
--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -110,6 +110,11 @@ struct my_allocator : std::allocator<T>
             p->~T();
         }
     }
+
+    template <class U>
+    struct rebind {
+        using other = my_allocator<U>;
+    };
 };
 
 // allows deletion of raw pointer, usually hold by json_value


### PR DESCRIPTION
Hello,
This fix the compilation of  test/src/unit-allocator.cpp as described in issue #1472.

I validated the compilation + tests on:

- gcc (GCC) 9.0.1 20190205 (experimental)
- gcc (GCC) 8.2.1 20190205
- gcc (GCC) 6.5.0

Congrats to @theodelrieu for this nice catch.