### PR TITLE
Regression tests for MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ environment:
       GENERATOR: Ninja
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Release
       COMPILER: mingw
       platform: x86
       CXX_FLAGS: ""
@@ -32,12 +33,14 @@ environment:
       GENERATOR: Ninja
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Release
       platform: x86
       CXX_FLAGS: ""
       LINKER_FLAGS: ""
       GENERATOR: Visual Studio 14 2015
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Release
       platform: x86
       name: with_win_header
       CXX_FLAGS: ""
@@ -45,30 +48,35 @@ environment:
       GENERATOR: Visual Studio 14 2015
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
       platform: x86
       CXX_FLAGS: ""
       LINKER_FLAGS: ""
       GENERATOR: Visual Studio 15 2017
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
       platform: x86
       CXX_FLAGS: "/permissive- /std:c++latest /utf-8"
       LINKER_FLAGS: ""
       GENERATOR: Visual Studio 15 2017
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Release
       platform: x64
       CXX_FLAGS: ""
       LINKER_FLAGS: ""
       GENERATOR: Visual Studio 14 2015 Win64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
       platform: x64
       CXX_FLAGS: ""
       LINKER_FLAGS: ""
       GENERATOR: Visual Studio 15 2017 Win64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
       platform: x64
       CXX_FLAGS: "/permissive- /std:c++latest /utf-8 /F4000000"
       LINKER_FLAGS: "/STACK:4000000"
@@ -77,8 +85,6 @@ environment:
 init:
   - cmake --version
   - msbuild /version
-  # set the default build configuration to Release
-  - if "%configuration%"=="" (set configuration="Release")
 
 install:
   - if "%COMPILER%"=="mingw" appveyor DownloadFile https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip -FileName ninja.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,13 @@ environment:
       LINKER_FLAGS: ""
       GENERATOR: Visual Studio 14 2015
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      name: with_win_header
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
+      GENERATOR: Visual Studio 14 2015
+
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       CXX_FLAGS: ""
@@ -81,6 +88,9 @@ install:
   - if "%COMPILER%"=="mingw" g++ --version
 
 before_build:
+  # for with_win_header build, inject the inclusion of Windows.h to the single-header library
+  - ps: if ($env:name -Eq "with_win_header") { $header_path = "single_include\nlohmann\json.hpp" }
+  - ps: if ($env:name -Eq "with_win_header") { "#include <Windows.h>`n" + (Get-Content $header_path | Out-String) | Set-Content $header_path }
   - cmake . -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%configuration%" -DCMAKE_CXX_FLAGS="%CXX_FLAGS%" -DCMAKE_EXE_LINKER_FLAGS="%LINKER_FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,6 +103,9 @@ build_script:
   - cmake --build . --config "%configuration%"
 
 test_script:
-  # Set 1 hour timeout to avoid the occasional
-  # timeouts on test-unicode_all
-  - ctest --timeout 3600 -C "%configuration%" -V -j
+  - if "%configuration%"=="Release" ctest -C "%configuration%" -V -j
+  # On Debug builds, skip test-unicode_all
+  # as it is extremely slow to run and cause
+  # occasional timeouts on AppVeyor.
+  # More info: https://github.com/nlohmann/json/pull/1570
+  - if "%configuration%"=="Debug" ctest --exclude-regex "test-unicode_all" -C "%configuration%" -V -j

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,28 @@ version: '{build}'
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Debug
+      platform: x86
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
+      GENERATOR: Visual Studio 14 2015
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Debug
+      platform: x86
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
+      GENERATOR: Visual Studio 15 2017
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Debug
+      COMPILER: mingw
+      platform: x86
+      CXX_FLAGS: ""
+      LINKER_FLAGS: ""
+      GENERATOR: Ninja
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       COMPILER: mingw
       platform: x86
       CXX_FLAGS: ""
@@ -48,6 +70,8 @@ environment:
 init:
   - cmake --version
   - msbuild /version
+  # set the default build configuration to Release
+  - if "%configuration%"=="" (set configuration="Release")
 
 install:
   - if "%COMPILER%"=="mingw" appveyor DownloadFile https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip -FileName ninja.zip
@@ -57,10 +81,10 @@ install:
   - if "%COMPILER%"=="mingw" g++ --version
 
 before_build:
-  - cmake . -G "%GENERATOR%" -DCMAKE_CXX_FLAGS="%CXX_FLAGS%" -DCMAKE_EXE_LINKER_FLAGS="%LINKER_FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
+  - cmake . -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%configuration%" -DCMAKE_CXX_FLAGS="%CXX_FLAGS%" -DCMAKE_EXE_LINKER_FLAGS="%LINKER_FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
 
 build_script:
-  - cmake --build . --config Release
+  - cmake --build . --config "%configuration%"
 
 test_script:
-  - ctest -C Release -V -j
+  - ctest -C "%configuration%" -V -j

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,4 +103,6 @@ build_script:
   - cmake --build . --config "%configuration%"
 
 test_script:
-  - ctest -C "%configuration%" -V -j
+  # Set 1 hour timeout to avoid the occasional
+  # timeouts on test-unicode_all
+  - ctest --timeout 3600 -C "%configuration%" -V -j

--- a/include/nlohmann/detail/iterators/iter_impl.hpp
+++ b/include/nlohmann/detail/iterators/iter_impl.hpp
@@ -118,10 +118,13 @@ class iter_impl
           to iterator is not defined.
     */
 
-    /* We had to explicitly define the copy constructor for the const
-       case to circumvent a bug on msvc 2015 debug build.
-       More info: https://github.com/nlohmann/json/issues/1608
-     */
+    /*!
+    @brief const copy constructor
+    @param[in] other const iterator to copy from
+    @note This copy constuctor had to be defined explicitely to circumvent a bug
+          occuring on msvc v19.0 compiler (VS 2015) debug build. For more
+          information refer to: https://github.com/nlohmann/json/issues/1608
+    */
     iter_impl(const iter_impl<const BasicJsonType>& other) noexcept
         : m_object(other.m_object), m_it(other.m_it) {}
 

--- a/include/nlohmann/detail/iterators/iter_impl.hpp
+++ b/include/nlohmann/detail/iterators/iter_impl.hpp
@@ -118,6 +118,13 @@ class iter_impl
           to iterator is not defined.
     */
 
+    /* We had to explicitly define the copy constructor for the const
+       case to circumvent a bug on msvc 2015 debug build.
+       More info: https://github.com/nlohmann/json/issues/1608
+     */
+    iter_impl(const iter_impl<const BasicJsonType>& other) noexcept
+        : m_object(other.m_object), m_it(other.m_it) {}
+
     /*!
     @brief converting constructor
     @param[in] other  non-const iterator to copy from

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7821,6 +7821,13 @@ class iter_impl
           to iterator is not defined.
     */
 
+    /* We had to explicitly define the copy constructor for the const
+       case to circumvent a bug on msvc 2015 debug build.
+       More info: https://github.com/nlohmann/json/issues/1608
+     */
+    iter_impl(const iter_impl<const BasicJsonType>& other) noexcept
+        : m_object(other.m_object), m_it(other.m_it) {}
+
     /*!
     @brief converting constructor
     @param[in] other  non-const iterator to copy from

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7821,10 +7821,13 @@ class iter_impl
           to iterator is not defined.
     */
 
-    /* We had to explicitly define the copy constructor for the const
-       case to circumvent a bug on msvc 2015 debug build.
-       More info: https://github.com/nlohmann/json/issues/1608
-     */
+    /*!
+    @brief const copy constructor
+    @param[in] other const iterator to copy from
+    @note This copy constuctor had to be defined explicitely to circumvent a bug
+          occuring on msvc v19.0 compiler (VS 2015) debug build. For more
+          information refer to: https://github.com/nlohmann/json/issues/1608
+    */
     iter_impl(const iter_impl<const BasicJsonType>& other) noexcept
         : m_object(other.m_object), m_it(other.m_it) {}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,12 +133,6 @@ foreach(file ${files})
     )
     set_tests_properties("${testcase}_all" PROPERTIES LABELS "all")
 
-    # Increase timeout for test-unicode_all on Debug build
-    string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
-	if (("${testcase}" STREQUAL "test-unicode") AND (uppercase_CMAKE_BUILD_TYPE  STREQUAL DEBUG))
-		set_tests_properties("${testcase}_all" PROPERTIES TIMEOUT 3600)
-	endif()
-
     if(JSON_Valgrind)
         add_test(NAME "${testcase}_valgrind"
           COMMAND ${memcheck_command} ${CMAKE_CURRENT_BINARY_DIR}/${testcase} ${DOCTEST_TEST_FILTER}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,6 +133,12 @@ foreach(file ${files})
     )
     set_tests_properties("${testcase}_all" PROPERTIES LABELS "all")
 
+    # Increase timeout for test-unicode_all on Debug build
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+	if (("${testcase}" STREQUAL "test-unicode") AND (uppercase_CMAKE_BUILD_TYPE  STREQUAL DEBUG))
+		set_tests_properties("${testcase}_all" PROPERTIES TIMEOUT 3600)
+	endif()
+
     if(JSON_Valgrind)
         add_test(NAME "${testcase}_valgrind"
           COMMAND ${memcheck_command} ${CMAKE_CURRENT_BINARY_DIR}/${testcase} ${DOCTEST_TEST_FILTER}

--- a/test/src/unit-concepts.cpp
+++ b/test/src/unit-concepts.cpp
@@ -73,8 +73,8 @@ TEST_CASE("concepts")
         // X::size_type must return an unsigned integer
         CHECK((std::is_unsigned<json::size_type>::value));
         // X::size_type can represent any non-negative value of X::difference_type
-        CHECK(static_cast<json::size_type>(std::numeric_limits<json::difference_type>::max()) <=
-              std::numeric_limits<json::size_type>::max());
+        CHECK(static_cast<json::size_type>((std::numeric_limits<json::difference_type>::max)()) <=
+              (std::numeric_limits<json::size_type>::max)());
 
         // the expression "X u" has the post-condition "u.empty()"
         {

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -719,7 +719,7 @@ TEST_CASE("regression tests")
         };
 
         check_roundtrip(100000000000.1236);
-        check_roundtrip(std::numeric_limits<json::number_float_t>::max());
+        check_roundtrip((std::numeric_limits<json::number_float_t>::max)());
 
         // Some more numbers which fail to roundtrip when serialized with digits10 significand digits (instead of max_digits10)
         check_roundtrip(1.541888611948064e-17);


### PR DESCRIPTION
Fixes #1543 (and avoid regression to issues like #1531 and #1536).
Fixes #1608.

This pull request:

1. Adds Debug builds on Appveyor for VS2015 and VS2017.

2. Add a separate build job that first injects `#include <Windows.h>` line to the top of `json.hpp` header. This build job helps to detect whether the presence of `Windows.h` could have any undersiable side-effects.

**On point 2:** Currently the unit-test for case 2 doesn't do much and only can catch compile errors. Also, I tested it on my `json.hpp` with some unfixed `numeric_limits<>::max()` and `numeric_limits<>min()` functions and it only caused compiler errors on Debug builds. Probably on Release builds, the compiler eliminates the codes related to unfixed macro definitions. Therefore, the unit-test only can catch compiler *errors* on Debug mode.

A more thorough approach is that instead of adding a unit-test with `#include <Windows.h>` on top, we add a separate build configuration in which the `#include <Windows.h>` gets  injected to the top of `json.hpp`. In this build, all codes and unit-tests will be complied and checked in presence of `Windows.h`.

I have implemented and tested the second approach on my fork but and wanted to double check and get some feedback before adding it to the PR.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
