### PR TITLE
Fix and add test's for SFINAE problem

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -4010,7 +4010,7 @@ class basic_json
     @since version 3.6.0
     */
     template<typename KeyT, typename std::enable_if<
-                 not std::is_same<KeyT, json_pointer>::value, int>::type = 0>
+                 not std::is_same<typename std::decay<KeyT>::type, json_pointer>::value, int>::type = 0>
     bool contains(KeyT && key) const
     {
         return is_object() and m_value.object->find(std::forward<KeyT>(key)) != m_value.object->end();

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18445,7 +18445,7 @@ class basic_json
     @since version 3.6.0
     */
     template<typename KeyT, typename std::enable_if<
-                 not std::is_same<KeyT, json_pointer>::value, int>::type = 0>
+                 not std::is_same<typename std::decay<KeyT>::type, json_pointer>::value, int>::type = 0>
     bool contains(KeyT && key) const
     {
         return is_object() and m_value.object->find(std::forward<KeyT>(key)) != m_value.object->end();

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -1809,6 +1809,17 @@ TEST_CASE("regression tests")
         json j = smallest;
         CHECK(j.dump() == std::to_string(smallest));
     }
+
+    SECTION("issue #1727 - Contains with non-const lvalue json_pointer picks the wrong overload")
+    {
+        json j = {{"root", {{"settings", {{"logging", true}}}}}};
+
+        auto jptr1 = "/root/settings/logging"_json_pointer;
+        auto jptr2 = json::json_pointer{"/root/settings/logging"};
+
+        CHECK(j.contains(jptr1));
+        CHECK(j.contains(jptr2));
+    }
 }
 
 #if not defined(JSON_NOEXCEPTION)


### PR DESCRIPTION
This Pull Requests fixes https://github.com/nlohmann/json/issues/1727
And adds a test that would have not worked before to avoid regressions :smile: 

This was simply due to a pretty typical SFINAE bug. Since the function signature was
```c++
bool contains(KeyT && key) const
```

When a rvalue is passed (say int for simplicity reasons) you want this to be transformed into 
```c++
bool contains(int && key) const
```

So far so good, trouble begins when given a lvalue, since the end result should be 
```c++
bool contains(int & key) const
```

This can only be achieved by the special rule of type deduction in c++ where:
 *  `&` + `&&` -> `&`

In conclussion: 
`KeyT && key` -> `int & && key` -> `int & key`

More specific to the issue `KeyT` was being deducted to `json::json_pointer &` which is clearly not the same as `json::json_pointer` so our lovely friend the `std::enable_if` wasn't doing his job properly.

Decaying the type should fix this :smile: 

God... metaprogramming is hard...

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
