### PR TITLE
test/CMakeLists.txt: Use an explicit list instead of GLOB

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,7 +101,49 @@ endif()
 # one executable for each unit test file
 #############################################################################
 
-file(GLOB files "src/unit-*.cpp")
+set(files
+    src/unit-algorithms.cpp
+    src/unit-allocator.cpp
+    src/unit-alt-string.cpp
+    src/unit-bson.cpp
+    src/unit-capacity.cpp
+    src/unit-cbor.cpp
+    src/unit-class_const_iterator.cpp
+    src/unit-class_iterator.cpp
+    src/unit-class_lexer.cpp
+    src/unit-class_parser.cpp
+    src/unit-comparison.cpp
+    src/unit-concepts.cpp
+    src/unit-constructor1.cpp
+    src/unit-constructor2.cpp
+    src/unit-convenience.cpp
+    src/unit-conversions.cpp
+    src/unit-deserialization.cpp
+    src/unit-element_access1.cpp
+    src/unit-element_access2.cpp
+    src/unit-inspection.cpp
+    src/unit-items.cpp
+    src/unit-iterators1.cpp
+    src/unit-iterators2.cpp
+    src/unit-json_patch.cpp
+    src/unit-json_pointer.cpp
+    src/unit-merge_patch.cpp
+    src/unit-meta.cpp
+    src/unit-modifiers.cpp
+    src/unit-msgpack.cpp
+    src/unit-noexcept.cpp
+    src/unit-pointer_access.cpp
+    src/unit-readme.cpp
+    src/unit-reference_access.cpp
+    src/unit-regression.cpp
+    src/unit-serialization.cpp
+    src/unit-testsuites.cpp
+    src/unit-to_chars.cpp
+    src/unit-ubjson.cpp
+    src/unit-udt.cpp
+    src/unit-unicode.cpp
+    src/unit-wstring.cpp)
+
 foreach(file ${files})
     get_filename_component(file_basename ${file} NAME_WE)
     string(REGEX REPLACE "unit-([^$]+)" "test-\\1" testcase ${file_basename})


### PR DESCRIPTION
Using GLOB is slow and considered bad practice.

From https://cmake.org/cmake/help/latest/command/file.html:

> We do not recommend using GLOB to collect a list of source files from
> your source tree. If no CMakeLists.txt file changes when a source is
> added or removed then the generated build system cannot know when to ask
> CMake to regenerate. The CONFIGURE_DEPENDS flag may not work reliably on
> all generators, or if a new generator is added in the future that cannot
> support it, projects using it will be stuck. Even if CONFIGURE_DEPENDS
> works reliably, there is still a cost to perform the check on every
> rebuild.

Close #1686.