### PR TITLE
iteration_proxy: Fix integer truncation from std::size_t to int

### DIFF
--- a/include/nlohmann/detail/iterators/iteration_proxy.hpp
+++ b/include/nlohmann/detail/iterators/iteration_proxy.hpp
@@ -13,7 +13,7 @@ namespace nlohmann
 namespace detail
 {
 template<typename string_type>
-void int_to_string( string_type& target, int value )
+void int_to_string( string_type& target, std::size_t value )
 {
     target = std::to_string(value);
 }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3187,7 +3187,7 @@ namespace nlohmann
 namespace detail
 {
 template<typename string_type>
-void int_to_string( string_type& target, int value )
+void int_to_string( string_type& target, std::size_t value )
 {
     target = std::to_string(value);
 }

--- a/test/src/unit-alt-string.cpp
+++ b/test/src/unit-alt-string.cpp
@@ -154,7 +154,7 @@ class alt_string
     friend bool ::operator<(const char*, const alt_string&);
 };
 
-void int_to_string( alt_string& target, int value )
+void int_to_string( alt_string& target, std::size_t value )
 {
     target = std::to_string(value).c_str();
 }


### PR DESCRIPTION
Bug introduced in 0f073e26 (Allow items() to be used with custom string,
2019-09-26).

@crazyjul FYI.

See also #1765. 