### PR TITLE
appveyor.yml: Compile and test with latest version for __cplusplus macro on MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       configuration: Release
       platform: x64
-      CXX_FLAGS: "/permissive- /std:c++latest /utf-8 /F4000000"
+      CXX_FLAGS: "/permissive- /std:c++latest /Zc:__cplusplus /utf-8 /F4000000"
       LINKER_FLAGS: "/STACK:4000000"
       GENERATOR: Visual Studio 15 2017
 


### PR DESCRIPTION
According to [1] the C++ macro __cplusplus has always the value 199711L
even if you enable later version of C++ support via /std.

Use one job with /Zc:__cplusplus defined so that we know that it
compiles.

[1]: https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=vs-2019

Close #1695.