### PR TITLE
Update tests that generate CMake projects to use main project's C++ compiler

### DIFF
--- a/test/cmake_add_subdirectory/CMakeLists.txt
+++ b/test/cmake_add_subdirectory/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_test(NAME cmake_add_subdirectory_configure
   COMMAND ${CMAKE_COMMAND}
     -G "${CMAKE_GENERATOR}"
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -Dnlohmann_json_source=${PROJECT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/project
 )

--- a/test/cmake_import/CMakeLists.txt
+++ b/test/cmake_import/CMakeLists.txt
@@ -2,6 +2,7 @@ add_test(NAME cmake_import_configure
   COMMAND ${CMAKE_COMMAND}
     -G "${CMAKE_GENERATOR}"
     -A "${CMAKE_GENERATOR_PLATFORM}"
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -Dnlohmann_json_DIR=${PROJECT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/project
 )

--- a/test/cmake_import_minver/CMakeLists.txt
+++ b/test/cmake_import_minver/CMakeLists.txt
@@ -2,6 +2,7 @@ add_test(NAME cmake_import_minver_configure
   COMMAND ${CMAKE_COMMAND}
     -G "${CMAKE_GENERATOR}"
     -A "${CMAKE_GENERATOR_PLATFORM}"
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -Dnlohmann_json_DIR=${PROJECT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/project
 )


### PR DESCRIPTION
Update tests that generate CMake projects to use the CMAKE_CXX_COMPILER the main project was CMake'd with. Fixes #1747.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
