### PR TITLE
Ignores some cppcheck warnings

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -336,22 +336,28 @@ class input_adapter
   public:
     // native support
     JSON_HEDLEY_NON_NULL(2)
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(std::FILE* file)
         : ia(std::make_shared<file_input_adapter>(file)) {}
     /// input adapter for input stream
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(std::istream& i)
         : ia(std::make_shared<input_stream_adapter>(i)) {}
 
     /// input adapter for input stream
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(std::istream&& i)
         : ia(std::make_shared<input_stream_adapter>(i)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const std::wstring& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::wstring>>(ws)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const std::u16string& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::u16string>>(ws)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const std::u32string& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::u32string>>(ws)) {}
 
@@ -374,6 +380,7 @@ class input_adapter
                  std::is_integral<typename std::remove_pointer<CharT>::type>::value and
                  sizeof(typename std::remove_pointer<CharT>::type) == 1,
                  int>::type = 0>
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(CharT b)
         : input_adapter(reinterpret_cast<const char*>(b),
                         std::strlen(reinterpret_cast<const char*>(b))) {}
@@ -418,6 +425,7 @@ class input_adapter
 
     /// input adapter for array
     template<class T, std::size_t N>
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(T (&array)[N])
         : input_adapter(std::begin(array), std::end(array)) {}
 
@@ -426,6 +434,7 @@ class input_adapter
              std::enable_if<not std::is_pointer<ContiguousContainer>::value and
                             std::is_base_of<std::random_access_iterator_tag, typename iterator_traits<decltype(std::begin(std::declval<ContiguousContainer const>()))>::iterator_category>::value,
                             int>::type = 0>
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const ContiguousContainer& c)
         : input_adapter(std::begin(c), std::end(c)) {}
 

--- a/include/nlohmann/detail/json_ref.hpp
+++ b/include/nlohmann/detail/json_ref.hpp
@@ -15,14 +15,17 @@ class json_ref
   public:
     using value_type = BasicJsonType;
 
+    // cppcheck-suppress noExplicitConstructor
     json_ref(value_type&& value)
         : owned_value(std::move(value)), value_ref(&owned_value), is_rvalue(true)
     {}
 
+    // cppcheck-suppress noExplicitConstructor
     json_ref(const value_type& value)
         : value_ref(const_cast<value_type*>(&value)), is_rvalue(false)
     {}
 
+    // cppcheck-suppress noExplicitConstructor
     json_ref(std::initializer_list<json_ref> init)
         : owned_value(init), value_ref(&owned_value), is_rvalue(true)
     {}
@@ -30,6 +33,7 @@ class json_ref
     template <
         class... Args,
         enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0 >
+    // cppcheck-suppress noExplicitConstructor
     json_ref(Args && ... args)
         : owned_value(std::forward<Args>(args)...), value_ref(&owned_value),
           is_rvalue(true) {}

--- a/include/nlohmann/detail/output/output_adapters.hpp
+++ b/include/nlohmann/detail/output/output_adapters.hpp
@@ -102,12 +102,15 @@ template<typename CharType, typename StringType = std::basic_string<CharType>>
 class output_adapter
 {
   public:
+    // cppcheck-suppress noExplicitConstructor
     output_adapter(std::vector<CharType>& vec)
         : oa(std::make_shared<output_vector_adapter<CharType>>(vec)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     output_adapter(std::basic_ostream<CharType>& s)
         : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     output_adapter(StringType& s)
         : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1206,6 +1206,7 @@ class basic_json
 
     @since version 1.0.0
     */
+    // cppcheck-suppress noExplicitConstructor
     basic_json(const value_t v)
         : m_type(v), m_value(v)
     {
@@ -1230,6 +1231,7 @@ class basic_json
 
     @since version 1.0.0
     */
+    // cppcheck-suppress noExplicitConstructor
     basic_json(std::nullptr_t = nullptr) noexcept
         : basic_json(value_t::null)
     {
@@ -1297,6 +1299,7 @@ class basic_json
               typename U = detail::uncvref_t<CompatibleType>,
               detail::enable_if_t<
                   not detail::is_basic_json<U>::value and detail::is_compatible_type<basic_json_t, U>::value, int> = 0>
+    // cppcheck-suppress noExplicitConstructor
     basic_json(CompatibleType && val) noexcept(noexcept(
                 JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
                                            std::forward<CompatibleType>(val))))
@@ -1334,6 +1337,7 @@ class basic_json
     template <typename BasicJsonType,
               detail::enable_if_t<
                   detail::is_basic_json<BasicJsonType>::value and not std::is_same<basic_json, BasicJsonType>::value, int> = 0>
+    // cppcheck-suppress noExplicitConstructor
     basic_json(const BasicJsonType& val)
     {
         using other_boolean_t = typename BasicJsonType::boolean_t;
@@ -1774,6 +1778,7 @@ class basic_json
     ///////////////////////////////////////
 
     /// @private
+    // cppcheck-suppress noExplicitConstructor
     basic_json(const detail::json_ref<basic_json>& ref)
         : basic_json(ref.moved_or_copied())
     {}

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4199,22 +4199,28 @@ class input_adapter
   public:
     // native support
     JSON_HEDLEY_NON_NULL(2)
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(std::FILE* file)
         : ia(std::make_shared<file_input_adapter>(file)) {}
     /// input adapter for input stream
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(std::istream& i)
         : ia(std::make_shared<input_stream_adapter>(i)) {}
 
     /// input adapter for input stream
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(std::istream&& i)
         : ia(std::make_shared<input_stream_adapter>(i)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const std::wstring& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::wstring>>(ws)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const std::u16string& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::u16string>>(ws)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const std::u32string& ws)
         : ia(std::make_shared<wide_string_input_adapter<std::u32string>>(ws)) {}
 
@@ -4237,6 +4243,7 @@ class input_adapter
                  std::is_integral<typename std::remove_pointer<CharT>::type>::value and
                  sizeof(typename std::remove_pointer<CharT>::type) == 1,
                  int>::type = 0>
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(CharT b)
         : input_adapter(reinterpret_cast<const char*>(b),
                         std::strlen(reinterpret_cast<const char*>(b))) {}
@@ -4281,6 +4288,7 @@ class input_adapter
 
     /// input adapter for array
     template<class T, std::size_t N>
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(T (&array)[N])
         : input_adapter(std::begin(array), std::end(array)) {}
 
@@ -4289,6 +4297,7 @@ class input_adapter
              std::enable_if<not std::is_pointer<ContiguousContainer>::value and
                             std::is_base_of<std::random_access_iterator_tag, typename iterator_traits<decltype(std::begin(std::declval<ContiguousContainer const>()))>::iterator_category>::value,
                             int>::type = 0>
+    // cppcheck-suppress noExplicitConstructor
     input_adapter(const ContiguousContainer& c)
         : input_adapter(std::begin(c), std::end(c)) {}
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11282,12 +11282,15 @@ template<typename CharType, typename StringType = std::basic_string<CharType>>
 class output_adapter
 {
   public:
+    // cppcheck-suppress noExplicitConstructor
     output_adapter(std::vector<CharType>& vec)
         : oa(std::make_shared<output_vector_adapter<CharType>>(vec)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     output_adapter(std::basic_ostream<CharType>& s)
         : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
+    // cppcheck-suppress noExplicitConstructor
     output_adapter(StringType& s)
         : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15749,6 +15749,7 @@ class basic_json
 
     @since version 1.0.0
     */
+    // cppcheck-suppress noExplicitConstructor
     basic_json(const value_t v)
         : m_type(v), m_value(v)
     {
@@ -15773,6 +15774,7 @@ class basic_json
 
     @since version 1.0.0
     */
+    // cppcheck-suppress noExplicitConstructor
     basic_json(std::nullptr_t = nullptr) noexcept
         : basic_json(value_t::null)
     {
@@ -15840,6 +15842,7 @@ class basic_json
               typename U = detail::uncvref_t<CompatibleType>,
               detail::enable_if_t<
                   not detail::is_basic_json<U>::value and detail::is_compatible_type<basic_json_t, U>::value, int> = 0>
+    // cppcheck-suppress noExplicitConstructor
     basic_json(CompatibleType && val) noexcept(noexcept(
                 JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
                                            std::forward<CompatibleType>(val))))
@@ -15877,6 +15880,7 @@ class basic_json
     template <typename BasicJsonType,
               detail::enable_if_t<
                   detail::is_basic_json<BasicJsonType>::value and not std::is_same<basic_json, BasicJsonType>::value, int> = 0>
+    // cppcheck-suppress noExplicitConstructor
     basic_json(const BasicJsonType& val)
     {
         using other_boolean_t = typename BasicJsonType::boolean_t;
@@ -16317,6 +16321,7 @@ class basic_json
     ///////////////////////////////////////
 
     /// @private
+    // cppcheck-suppress noExplicitConstructor
     basic_json(const detail::json_ref<basic_json>& ref)
         : basic_json(ref.moved_or_copied())
     {}

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11103,14 +11103,17 @@ class json_ref
   public:
     using value_type = BasicJsonType;
 
+    // cppcheck-suppress noExplicitConstructor
     json_ref(value_type&& value)
         : owned_value(std::move(value)), value_ref(&owned_value), is_rvalue(true)
     {}
 
+    // cppcheck-suppress noExplicitConstructor
     json_ref(const value_type& value)
         : value_ref(const_cast<value_type*>(&value)), is_rvalue(false)
     {}
 
+    // cppcheck-suppress noExplicitConstructor
     json_ref(std::initializer_list<json_ref> init)
         : owned_value(init), value_ref(&owned_value), is_rvalue(true)
     {}
@@ -11118,6 +11121,7 @@ class json_ref
     template <
         class... Args,
         enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0 >
+    // cppcheck-suppress noExplicitConstructor
     json_ref(Args && ... args)
         : owned_value(std::forward<Args>(args)...), value_ref(&owned_value),
           is_rvalue(true) {}


### PR DESCRIPTION
This Pull Request adds comments made so that, when using `inline-suppr` option, cppcheck will ignore the warnings about not using explicit keyword when a constructor has one parameter.

It addresses some of the warnings in #1759 

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
