### PR TITLE
Added flags to cmakelists in test project to treat all warnings as errors

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,15 +78,7 @@ else()
 endif()
 target_include_directories(doctest_main PRIVATE "thirdparty/doctest")
 
-# https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake
 if(MSVC)
-    # Force to always compile with W4
-    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-    endif()
-
 	# Disable warning C4566: character represented by universal-character-name '\uFF01' cannot be represented in the current code page (1252)
 	# Disable warning C4996: 'nlohmann::basic_json<std::map,std::vector,std::string,bool,int64_t,uint64_t,double,std::allocator,nlohmann::adl_serializer>::operator <<': was declared deprecated
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4566 /wd4996")
@@ -156,6 +148,12 @@ foreach(file ${files})
         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
     )
+    # Force to compile with highest warning level and treat warnings as errors
+    if(MSVC)
+      target_compile_options(${testcase} PRIVATE /W4 /WX)
+    else()
+      target_compile_options(${testcase} PRIVATE -Wall -Wextra -pedantic -Werror)
+    endif()
     target_include_directories(${testcase} PRIVATE
         thirdparty/doctest
         thirdparty/fifo_map

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,13 +144,9 @@ foreach(file ${files})
       DOCTEST_CONFIG_SUPER_FAST_ASSERTS
     )
     target_compile_options(${testcase} PRIVATE
-        $<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal>
+        $<$<CXX_COMPILER_ID:MSVC>:/EHsc;/W4;/WX;$<$<CONFIG:Release>:/Od>>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal;-Wall;-Wextra;-pedantic;-Werror>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
-    )
-    target_compile_options(${testcase} PRIVATE
-        $<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall;-Wextra;-pedantic;-Werror>>
     )    
     target_include_directories(${testcase} PRIVATE
         thirdparty/doctest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,12 +148,10 @@ foreach(file ${files})
         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
     )
-    # Force to compile with highest warning level and treat warnings as errors
-    if(MSVC)
-      target_compile_options(${testcase} PRIVATE /W4 /WX)
-    else()
-      target_compile_options(${testcase} PRIVATE -Wall -Wextra -pedantic -Werror)
-    endif()
+    target_compile_options(${testcase} PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall;-Wextra;-pedantic;-Werror>>
+    )    
     target_include_directories(${testcase} PRIVATE
         thirdparty/doctest
         thirdparty/fifo_map

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 namespace
 {

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -98,6 +98,8 @@ struct my_allocator : std::allocator<T>
     {
         if (next_deallocate_fails)
         {
+			(void)p; // Ignored unused
+			(void)n; // ignored unused
             next_deallocate_fails = false;
             throw std::bad_alloc();
         }

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 namespace
 {

--- a/test/src/unit-class_const_iterator.cpp
+++ b/test/src/unit-class_const_iterator.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 TEST_CASE("const_iterator class")
 {

--- a/test/src/unit-class_const_iterator.cpp
+++ b/test/src/unit-class_const_iterator.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 TEST_CASE("const_iterator class")
 {

--- a/test/src/unit-class_iterator.cpp
+++ b/test/src/unit-class_iterator.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 TEST_CASE("iterator class")
 {

--- a/test/src/unit-class_iterator.cpp
+++ b/test/src/unit-class_iterator.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 TEST_CASE("iterator class")
 {

--- a/test/src/unit-class_lexer.cpp
+++ b/test/src/unit-class_lexer.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 namespace
 {

--- a/test/src/unit-class_lexer.cpp
+++ b/test/src/unit-class_lexer.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 namespace
 {

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 #include <valarray>
 

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 #include <valarray>
 

--- a/test/src/unit-constructor1.cpp
+++ b/test/src/unit-constructor1.cpp
@@ -29,16 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 #include <deque>
 #include <forward_list>

--- a/test/src/unit-constructor1.cpp
+++ b/test/src/unit-constructor1.cpp
@@ -30,10 +30,15 @@ SOFTWARE.
 #include "doctest_compatibility.h"
 DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 #include <deque>
 #include <forward_list>

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 #include <sstream>
 

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 #include <sstream>
 

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -29,15 +29,13 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 #include <deque>
 #include <forward_list>

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 #include <deque>
 #include <forward_list>

--- a/test/src/unit-iterators1.cpp
+++ b/test/src/unit-iterators1.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 TEST_CASE("iterators 1")
 {

--- a/test/src/unit-iterators1.cpp
+++ b/test/src/unit-iterators1.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 TEST_CASE("iterators 1")
 {

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -29,15 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 TEST_CASE("JSON pointers")
 {

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -29,10 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 TEST_CASE("JSON pointers")
 {

--- a/test/src/unit-noexcept.cpp
+++ b/test/src/unit-noexcept.cpp
@@ -31,6 +31,8 @@ SOFTWARE.
 
 #include <nlohmann/json.hpp>
 
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wunneeded-internal-declaration")
+
 using nlohmann::json;
 
 namespace
@@ -42,16 +44,11 @@ enum test
 struct pod {};
 struct pod_bis {};
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
-
 void to_json(json&, pod) noexcept{}
 void to_json(json&, pod_bis){}
 void from_json(const json&, pod) noexcept{}
 void from_json(const json&, pod_bis){}
 static json j;
-
-#pragma clang diagnostic pop
 
 static_assert(noexcept(json{}), "");
 static_assert(noexcept(nlohmann::to_json(j, 2)), "");

--- a/test/src/unit-noexcept.cpp
+++ b/test/src/unit-noexcept.cpp
@@ -42,11 +42,16 @@ enum test
 struct pod {};
 struct pod_bis {};
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
 void to_json(json&, pod) noexcept{}
 void to_json(json&, pod_bis){}
 void from_json(const json&, pod) noexcept{}
 void from_json(const json&, pod_bis){}
 static json j;
+
+#pragma clang diagnostic pop
 
 static_assert(noexcept(json{}), "");
 static_assert(noexcept(nlohmann::to_json(j, 2)), "");

--- a/test/src/unit-noexcept.cpp
+++ b/test/src/unit-noexcept.cpp
@@ -42,10 +42,10 @@ enum test
 struct pod {};
 struct pod_bis {};
 
-void to_json(json&, pod) noexcept;
-void to_json(json&, pod_bis);
-void from_json(const json&, pod) noexcept;
-void from_json(const json&, pod_bis);
+void to_json(json&, pod) noexcept{}
+void to_json(json&, pod_bis){}
+void from_json(const json&, pod) noexcept{}
+void from_json(const json&, pod_bis){}
 static json j;
 
 static_assert(noexcept(json{}), "");

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -33,10 +33,15 @@ DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 // for some reason including this after the json header leads to linker errors with VS 2017...
 #include <locale>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 #include <fstream>
 #include <sstream>

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -29,19 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
 
 // for some reason including this after the json header leads to linker errors with VS 2017...
 #include <locale>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 #include <fstream>
 #include <sstream>

--- a/test/src/unit-unicode.cpp
+++ b/test/src/unit-unicode.cpp
@@ -32,10 +32,15 @@ SOFTWARE.
 // for some reason including this after the json header leads to linker errors with VS 2017...
 #include <locale>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
+
+#pragma clang diagnostic pop
 
 #include <fstream>
 #include <sstream>

--- a/test/src/unit-unicode.cpp
+++ b/test/src/unit-unicode.cpp
@@ -29,18 +29,15 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+
 // for some reason including this after the json header leads to linker errors with VS 2017...
 #include <locale>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
 
 #define private public
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 #undef private
-
-#pragma clang diagnostic pop
 
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
Refer to #1798

Changes on test/CMakeLists.txt to always use -Wall, -Werror on GCC/Clang and the /WX, /W4 flags on MSVC.

Fixed build issue for GCC
Fixed build issues for Clang