### PR TITLE
Specify signed char

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1492,7 +1492,7 @@ scan_number_done:
     position_t position {};
 
     /// raw input token string (for error messages)
-    std::vector<char> token_string {};
+    std::vector<signed char> token_string {};
 
     /// buffer for variable-length tokens (numbers, strings)
     string_t token_buffer {};

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8622,7 +8622,7 @@ scan_number_done:
     position_t position {};
 
     /// raw input token string (for error messages)
-    std::vector<char> token_string {};
+    std::vector<signed char> token_string {};
 
     /// buffer for variable-length tokens (numbers, strings)
     string_t token_buffer {};


### PR DESCRIPTION
Addresses https://github.com/nlohmann/json/issues/1939


x86 architecture default to signed characters.  Other architectures
default to unsigned characters.  When building on non-x86 arch we
get the following error

```
./json.hpp:22700:42:   required from here
./json.hpp:8494:24: error: comparison is always true due to limited
                           range of data type [-Werror=type-limits]
 8494 |             if ('\x00' <= c and c <= '\x1F')
      |                 ~~~~~~~^~~~
```
Signed-off-by: Tony Asleson <tasleson@redhat.com>
