### PR TITLE
Rename argument array_index to array_indx in json_pointer methods

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -126,8 +126,8 @@ class json_pointer
     /*!
     @brief append an array index at the end of this JSON pointer
 
-    @param[in] array_index  array index to append
-    @return JSON pointer with @a array_index appended
+    @param[in] array_indx  array index to append
+    @return JSON pointer with @a array_indx appended
 
     @liveexample{The example shows the usage of `operator/=`.,json_pointer__operator_add}
 
@@ -139,9 +139,9 @@ class json_pointer
 
     @since version 3.6.0
     */
-    json_pointer& operator/=(std::size_t array_index)
+    json_pointer& operator/=(std::size_t array_indx)
     {
-        return *this /= std::to_string(array_index);
+        return *this /= std::to_string(array_indx);
     }
 
     /*!
@@ -189,8 +189,8 @@ class json_pointer
     @brief create a new JSON pointer by appending the array-index-token at the end of the JSON pointer
 
     @param[in] ptr  JSON pointer
-    @param[in] array_index  array index
-    @return a new JSON pointer with @a array_index appended to @a ptr
+    @param[in] array_indx  array index
+    @return a new JSON pointer with @a array_indx appended to @a ptr
 
     @liveexample{The example shows the usage of `operator/`.,json_pointer__operator_add_binary}
 
@@ -200,9 +200,9 @@ class json_pointer
 
     @since version 3.6.0
     */
-    friend json_pointer operator/(const json_pointer& ptr, std::size_t array_index)
+    friend json_pointer operator/(const json_pointer& ptr, std::size_t array_indx)
     {
-        return json_pointer(ptr) /= array_index;
+        return json_pointer(ptr) /= array_indx;
     }
 
     /*!

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -126,8 +126,8 @@ class json_pointer
     /*!
     @brief append an array index at the end of this JSON pointer
 
-    @param[in] array_indx  array index to append
-    @return JSON pointer with @a array_indx appended
+    @param[in] array_idx  array index to append
+    @return JSON pointer with @a array_idx appended
 
     @liveexample{The example shows the usage of `operator/=`.,json_pointer__operator_add}
 
@@ -139,9 +139,9 @@ class json_pointer
 
     @since version 3.6.0
     */
-    json_pointer& operator/=(std::size_t array_indx)
+    json_pointer& operator/=(std::size_t array_idx)
     {
-        return *this /= std::to_string(array_indx);
+        return *this /= std::to_string(array_idx);
     }
 
     /*!
@@ -189,8 +189,8 @@ class json_pointer
     @brief create a new JSON pointer by appending the array-index-token at the end of the JSON pointer
 
     @param[in] ptr  JSON pointer
-    @param[in] array_indx  array index
-    @return a new JSON pointer with @a array_indx appended to @a ptr
+    @param[in] array_idx  array index
+    @return a new JSON pointer with @a array_idx appended to @a ptr
 
     @liveexample{The example shows the usage of `operator/`.,json_pointer__operator_add_binary}
 
@@ -200,9 +200,9 @@ class json_pointer
 
     @since version 3.6.0
     */
-    friend json_pointer operator/(const json_pointer& ptr, std::size_t array_indx)
+    friend json_pointer operator/(const json_pointer& ptr, std::size_t array_idx)
     {
-        return json_pointer(ptr) /= array_indx;
+        return json_pointer(ptr) /= array_idx;
     }
 
     /*!


### PR DESCRIPTION
Fixes gcc48 warning:

declaration of ‘array_index’ shadows a member of 'this' [-Wshadow]
