### PR TITLE
Fixes #1971 (memory leak in basic_json::push_back)

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -4878,9 +4878,7 @@ class basic_json
 
         // add element to array (move semantics)
         m_value.array->push_back(std::move(val));
-        // invalidate object: mark it null so we do not call the destructor
-        // cppcheck-suppress accessMoved
-        val.m_type = value_t::null;
+        // if val is moved from, basic_json move constructor marks it null so we do not call the destructor
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19421,9 +19421,7 @@ class basic_json
 
         // add element to array (move semantics)
         m_value.array->push_back(std::move(val));
-        // invalidate object: mark it null so we do not call the destructor
-        // cppcheck-suppress accessMoved
-        val.m_type = value_t::null;
+        // if val is moved from, basic_json move constructor marks it null so we do not call the destructor
     }
 
     /*!

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -240,7 +240,7 @@ namespace
 template<class T>
 struct allocator_no_forward
 {
-    typedef std::remove_const_t<T> value_type;
+    typedef T value_type;
     template <typename U>
     struct rebind
     {

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -240,8 +240,7 @@ namespace
 template<class T>
 struct allocator_no_forward : std::allocator<T>
 {
-    using std::allocator<T>::allocator;
-
+    allocator_no_forward() {}
     template <class U>
     allocator_no_forward(allocator_no_forward<U>) {}
 
@@ -253,6 +252,7 @@ struct allocator_no_forward : std::allocator<T>
     template <class... Args>
     void construct(T* p, const Args&... args)
     {
+        // force copy even if move is available
         ::new (static_cast<void*>(p)) T(args...);
     }
 };

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -240,9 +240,14 @@ namespace
 template<class T>
 struct allocator_no_forward : std::allocator<T>
 {
-    template <typename U>
+    using std::allocator<T>::allocator;
+
+    template <class U>
+    allocator_no_forward(allocator_no_forward<U>) {}
+
+    template <class U>
     struct rebind {
-        typedef allocator_no_forward<U> other;
+        using other =  allocator_no_forward<U>;
     };
 
     template <class... Args>


### PR DESCRIPTION
Fixes leak in `basic_json::push_back(basic_json&&)`. Old code incorrectly assumed that `std::move` moves, which is not always the case. basic_json move constructor marks argument as null anyway, so that line of code was redundant.
I also added valgrind-oriented unit test to address such situation.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [X]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [X]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
