### PR TITLE
Fix README.md. Missing ```

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ if(NOT json_POPULATED)
 endif()
 
 target_link_libraries(foo PRIVATE nlohmann_json::nlohmann_json)
+```
 
 **Note**: The repository https://github.com/nlohmann/json download size is huge.
 It contains all the dataset used for the benchmarks. You might want to depend on


### PR DESCRIPTION
This patch follows the one from: https://github.com/nlohmann/json/pull/2074.

An error has been introduced by accepting the suggestions. See:
https://github.com/ArthurSonzogni/json/commit/4be4a038ccd17aab0a4cc85200a6a0b41e1cccf2

One suggestion was about removing ~~~, but it was meant to be replaced
by ``` in reality. This caused the README.md to be slightly broken.