### PR TITLE
Fix Coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,11 +99,11 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-4.9', 'ninja-build']
+        packages: ['g++-7', 'ninja-build']
     before_script:
       - pip install --user cpp-coveralls
     after_success:
-      - coveralls --build-root test --include include/nlohmann --gcov 'gcov-4.9' --gcov-options '\-lp'
+      - coveralls --build-root test --include include/nlohmann --gcov 'gcov-7' --gcov-options '\-lp'
     env:
       - COMPILER=g++-4.9
       - CMAKE_OPTIONS=-DJSON_Coverage=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,13 +95,12 @@ matrix:
 
   - os: linux
     compiler: gcc
+    dist: bionic
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['g++-4.9', 'ninja-build']
     before_script:
-      - pip install --upgrade pip
-      - pip install --user urllib3[secure]
       - pip install --user cpp-coveralls
     after_success:
       - coveralls --build-root test --include include/nlohmann --gcov 'gcov-4.9' --gcov-options '\-lp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['g++-4.9', 'ninja-build']
     before_script:
-      - pip install --user requests[security] cpp-coveralls
+      - pip install --user httplib2 cpp-coveralls
     after_success:
       - coveralls --build-root test --include include/nlohmann --gcov 'gcov-4.9' --gcov-options '\-lp'
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ matrix:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['g++-4.9', 'ninja-build']
     before_script:
+      - pip install --upgrade pip
       - pip install --user urllib3[secure]
       - pip install --user cpp-coveralls
     after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,8 @@ matrix:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['g++-4.9', 'ninja-build']
     before_script:
-      - pip install --user httplib2 cpp-coveralls
+      - pip install --user urllib3[secure]
+      - pip install --user cpp-coveralls
     after_success:
       - coveralls --build-root test --include include/nlohmann --gcov 'gcov-4.9' --gcov-options '\-lp'
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
     after_success:
       - coveralls --build-root test --include include/nlohmann --gcov 'gcov-7' --gcov-options '\-lp'
     env:
-      - COMPILER=g++-4.9
+      - COMPILER=g++-7
       - CMAKE_OPTIONS=-DJSON_Coverage=ON
       - MULTIPLE_HEADERS=ON
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['g++-4.9', 'ninja-build']
     before_script:
-      - pip install --user cpp-coveralls
+      - pip install --user requests[security] cpp-coveralls
     after_success:
       - coveralls --build-root test --include include/nlohmann --gcov 'gcov-4.9' --gcov-options '\-lp'
     env:


### PR DESCRIPTION
This PR fixes the Coveralls integration which was broken silently as Python was outdated and could not send encrypted data.