### PR TITLE
Fixed a compilation error in MSVC

### DIFF
--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -195,7 +195,7 @@ class binary_writer
                 else
                 {
                     if (static_cast<double>(j.m_value.number_float) >= static_cast<double>(std::numeric_limits<float>::lowest()) and
-                            static_cast<double>(j.m_value.number_float) <= static_cast<double>(std::numeric_limits<float>::max()) and
+                            static_cast<double>(j.m_value.number_float) <= static_cast<double>((std::numeric_limits<float>::max)()) and
                             static_cast<double>(static_cast<float>(j.m_value.number_float)) == static_cast<double>(j.m_value.number_float))
                     {
                         oa->write_character(get_cbor_float_prefix(static_cast<float>(j.m_value.number_float)));

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12206,7 +12206,7 @@ class binary_writer
                 else
                 {
                     if (static_cast<double>(j.m_value.number_float) >= static_cast<double>(std::numeric_limits<float>::lowest()) and
-                            static_cast<double>(j.m_value.number_float) <= static_cast<double>(std::numeric_limits<float>::max()) and
+                            static_cast<double>(j.m_value.number_float) <= static_cast<double>((std::numeric_limits<float>::max)()) and
                             static_cast<double>(static_cast<float>(j.m_value.number_float)) == static_cast<double>(j.m_value.number_float))
                     {
                         oa->write_character(get_cbor_float_prefix(static_cast<float>(j.m_value.number_float)));

--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -925,7 +925,7 @@ TEST_CASE("CBOR")
                 }
                 SECTION("3.40282e+38(max float)")
                 {
-                    float v = std::numeric_limits<float>::max();
+                    float v = (std::numeric_limits<float>::max)();
                     json j = v;
                     std::vector<uint8_t> expected =
                     {
@@ -953,7 +953,7 @@ TEST_CASE("CBOR")
                 }
                 SECTION("1 + 3.40282e+38(more than max float)")
                 {
-                    double v = static_cast<double>(std::numeric_limits<float>::max()) + 0.1e+34;
+                    double v = static_cast<double>((std::numeric_limits<float>::max)()) + 0.1e+34;
                     json j = v;
                     std::vector<uint8_t> expected =
                     {


### PR DESCRIPTION
Related to [#1514](https://github.com/nlohmann/json/issues/1514) and  [#1531](https://github.com/nlohmann/json/issues/1531) 

* What is the issue you have?
Failed to build if <Windows.h> is included:

> C4003: not enough arguments for function-like macro invocation 'max'

Code:  
`static_cast<double>(std::numeric_limits<float>::max())`  
should be:  
`static_cast<double>((std::numeric_limits<float>::max)())`