### PR TITLE
Fix issue#1939: Cast character to unsigned for comparison

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1367,7 +1367,7 @@ scan_number_done:
         std::string result;
         for (const auto c : token_string)
         {
-            if ('\x00' <= c and c <= '\x1F')
+            if (static_cast<unsigned char>(c) <= '\x1F')
             {
                 // escape control characters
                 std::array<char, 9> cs{{}};

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -9456,7 +9456,7 @@ scan_number_done:
         std::string result;
         for (const auto c : token_string)
         {
-            if ('\x00' <= c and c <= '\x1F')
+            if (static_cast<unsigned char>(c) <= '\x1F')
             {
                 // escape control characters
                 std::array<char, 9> cs{{}};


### PR DESCRIPTION
Addresses https://github.com/nlohmann/json/issues/1939

Hi,

I ran into https://github.com/nlohmann/json/issues/1939 today with GCC 10.1 on arm. I didn't want to cause any duplicate issues so I appologize if recycling that issue is causing any inconveniences.

The issue is reproducible with the following example with GCC 10.1 on x86 using `tag 3.7.3` as well as `develop`:

```
g++ -c -Wall -Wextra -Werror -std=c++11 -funsigned-char -I json/include -x c++ -o /dev/null - << EOF
#include <nlohmann/json.hpp>
EOF
```
```
...
json/include/nlohmann/detail/input/lexer.hpp:1370:24: error: comparison is always true due to limited range of data type [-Werror=type-limits]
 1370 |             if ('\x00' <= c and c <= '\x1F')
      |                 ~~~~~~~^~~~
cc1plus: all warnings being treated as errors
```

GCC 9.2 does _not_ issue a warning for this on my machine.

User @jaredgrubb already proposed this fix in https://github.com/nlohmann/json/pull/1940 and it is indeed most likely the best solution:

Looking at the assembly generated by GCC, Clang and MSVC, `c` gets compared with unsigned ops on x86. On platforms where char is already unsigned, `c` gets compared with unsigned ops as well (duh). Casting `c` to unsigned would change nothing code-gen wise and it is still clear what is being tested for.

---

Alternatively a three-way-comparison function could be implemented. This would silence the warning:
```c++
constexpr bool three_way_compare(char lower, char value, char upper) noexcept {
    return lower <= value && value <= upper;
}
```
(I am not really a fan of that idea but I thought I'd at least mention it.)