### PR TITLE
templatized output adapters

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -6523,12 +6523,12 @@ class basic_json
     {
         // read width member and use it as indentation parameter if nonzero
         const bool pretty_print = o.width() > 0;
-        const auto indentation = pretty_print ? o.width() : 0;
+        const auto indentation = pretty_print ? o.width() : -1;
 
         // reset width to 0 for subsequent calls to this stream
         o.width(0);
 
-        j.dump_to(o, indentation, ' ', false);
+        j.dump_to(o, indentation, o.fill(), false);
         return o;
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22313,12 +22313,12 @@ class basic_json
     {
         // read width member and use it as indentation parameter if nonzero
         const bool pretty_print = o.width() > 0;
-        const auto indentation = pretty_print ? o.width() : 0;
+        const auto indentation = pretty_print ? o.width() : -1;
 
         // reset width to 0 for subsequent calls to this stream
         o.width(0);
 
-        j.dump_to(o, indentation, ' ', false);
+        j.dump_to(o, indentation, o.fill(), false);
         return o;
     }
 

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -1587,7 +1587,7 @@ TEST_CASE("parser class")
             CHECK (j_filtered1.size() == 2);
             CHECK (j_filtered1 == json({1, {{"qux", "baz"}}}));
 
-            json j_filtered2 = json::parse(structured_array, [](int, json::parse_event_t e, const json & /*parsed*/)
+            json j_filtered2 = json::parse(structured_array, [](int, json::parse_event_t e, const json& /*parsed*/)
             {
                 if (e == json::parse_event_t::object_end)
                 {

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -42,7 +42,8 @@ void check_escaped(const char* original, const char* escaped = "", const bool en
 void check_escaped(const char* original, const char* escaped, const bool ensure_ascii)
 {
     std::stringstream ss;
-    json::serializer s(nlohmann::detail::output_adapter<char>(ss), ' ');
+    auto oa = nlohmann::detail::output_adapter(ss);
+    json::serializer<decltype(oa)> s(std::move(oa), ' ');
     s.dump_escaped(original, ensure_ascii);
     CHECK(ss.str() == escaped);
 }


### PR DESCRIPTION
This is a **draft** Fix for #2172.

The `output_adapter_protocol` is replaced by templatizing the serializer on the output adapter.

The PR also adds the `basic_json::dump_to()` method, which allows for outputing json to arbitrary user-defined sinks.

Valid sinks are:

- `std::basic_string<>`, This will append to the string very efficiently
- any type that passes `std::iterator_traits<T>::iterator_tag == std::output_iterator_tag`
- Any type that for which `std::back_inserter(T)` works. In practice, that means having a `push_back(char)` function.

If all else fails, the output will be assumed to be:

- a type that has a ostream-like interface (`put(c)` and `write(ptr, len)`)


* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
