### PR TITLE
Fix issue#1275

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3770,7 +3770,7 @@ class basic_json
     template<class ValueType, typename std::enable_if<
                  std::is_convertible<basic_json_t, ValueType>::value
                  and not std::is_same<value_t, ValueType>::value, int>::type = 0>
-    ValueType value(const typename object_t::key_type& key, const ValueType& default_value) const
+    ValueType value(const typename object_t::key_type& key, ValueType && default_value) const
     {
         // at only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
@@ -3782,36 +3782,12 @@ class basic_json
                 return *it;
             }
 
-            return default_value;
+            return std::move(default_value);
         }
 
         JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
     }
 
-    /*!
-    @brief overload for a default value of type rvalue
-    @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
-    */
-    template<class ValueType, typename std::enable_if<
-                 std::is_convertible<basic_json_t, detail::uncvref_t<ValueType>>::value
-                 and not std::is_same<value_t, ValueType>::value, int>::type = 0>
-    detail::uncvref_t<ValueType> value(const typename object_t::key_type& key, ValueType && default_value) &&
-    {
-        // only works for objects
-        if (JSON_HEDLEY_LIKELY(is_object()))
-        {
-            // if key is found, return value and given default value otherwise
-            const auto it = find(key);
-            if (it != end())
-            {
-                return std::move(it->template get_ref<ValueType&>());
-            }
-
-            return std::forward<ValueType>(default_value);
-        }
-
-        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
-    }
 
     /*!
     @brief overload for a default value of type const char*
@@ -3819,7 +3795,7 @@ class basic_json
     */
     string_t value(const typename object_t::key_type& key, const char* default_value) const
     {
-        return value(key, string_t(default_value));
+        return value(key, std::move(string_t(default_value)));
     }
 
     /*!
@@ -3867,7 +3843,7 @@ class basic_json
     */
     template<class ValueType, typename std::enable_if<
                  std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
-    ValueType value(const json_pointer& ptr, const ValueType& default_value) const
+    ValueType value(const json_pointer& ptr, ValueType && default_value) const
     {
         // at only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
@@ -3879,7 +3855,7 @@ class basic_json
             }
             JSON_INTERNAL_CATCH (out_of_range&)
             {
-                return default_value;
+                return std::move(default_value);
             }
         }
 
@@ -3893,7 +3869,7 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     string_t value(const json_pointer& ptr, const char* default_value) const
     {
-        return value(ptr, string_t(default_value));
+        return value(ptr, std::move(string_t(default_value)));
     }
 
     /*!

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3788,7 +3788,6 @@ class basic_json
         JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
     }
 
-
     /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3789,6 +3789,31 @@ class basic_json
     }
 
     /*!
+    @brief overload for a default value of type rvalue
+    @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
+    */
+    template<class ValueType, typename std::enable_if<
+                 std::is_convertible<basic_json_t, detail::uncvref_t<ValueType>>::value
+                 and not std::is_same<value_t, ValueType>::value, int>::type = 0>
+    detail::uncvref_t<ValueType> value(const typename object_t::key_type& key, ValueType && default_value) &&
+    {
+        // only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(key);
+            if (it != end())
+            {
+                return std::move(it->template get_ref<ValueType&>());
+            }
+
+            return std::forward<ValueType>(default_value);
+        }
+
+        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+    }
+
+    /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
     */

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19548,7 +19548,7 @@ class basic_json
     template<class ValueType, typename std::enable_if<
                  std::is_convertible<basic_json_t, ValueType>::value
                  and not std::is_same<value_t, ValueType>::value, int>::type = 0>
-    ValueType value(const typename object_t::key_type& key, const ValueType& default_value) const
+    ValueType value(const typename object_t::key_type& key, ValueType && default_value) const
     {
         // at only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
@@ -19560,36 +19560,12 @@ class basic_json
                 return *it;
             }
 
-            return default_value;
+            return std::move(default_value);
         }
 
         JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
     }
 
-    /*!
-    @brief overload for a default value of type rvalue
-    @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
-    */
-    template<class ValueType, typename std::enable_if<
-                 std::is_convertible<basic_json_t, detail::uncvref_t<ValueType>>::value
-                 and not std::is_same<value_t, ValueType>::value, int>::type = 0>
-    detail::uncvref_t<ValueType> value(const typename object_t::key_type& key, ValueType && default_value) &&
-    {
-        // only works for objects
-        if (JSON_HEDLEY_LIKELY(is_object()))
-        {
-            // if key is found, return value and given default value otherwise
-            const auto it = find(key);
-            if (it != end())
-            {
-                return std::move(it->template get_ref<ValueType&>());
-            }
-
-            return std::forward<ValueType>(default_value);
-        }
-
-        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
-    }
 
     /*!
     @brief overload for a default value of type const char*
@@ -19597,7 +19573,7 @@ class basic_json
     */
     string_t value(const typename object_t::key_type& key, const char* default_value) const
     {
-        return value(key, string_t(default_value));
+        return value(key, std::move(string_t(default_value)));
     }
 
     /*!
@@ -19645,7 +19621,7 @@ class basic_json
     */
     template<class ValueType, typename std::enable_if<
                  std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
-    ValueType value(const json_pointer& ptr, const ValueType& default_value) const
+    ValueType value(const json_pointer& ptr, ValueType && default_value) const
     {
         // at only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
@@ -19657,7 +19633,7 @@ class basic_json
             }
             JSON_INTERNAL_CATCH (out_of_range&)
             {
-                return default_value;
+                return std::move(default_value);
             }
         }
 
@@ -19671,7 +19647,7 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     string_t value(const json_pointer& ptr, const char* default_value) const
     {
-        return value(ptr, string_t(default_value));
+        return value(ptr, std::move(string_t(default_value)));
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19566,7 +19566,6 @@ class basic_json
         JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
     }
 
-
     /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19567,6 +19567,31 @@ class basic_json
     }
 
     /*!
+    @brief overload for a default value of type rvalue
+    @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
+    */
+    template<class ValueType, typename std::enable_if<
+                 std::is_convertible<basic_json_t, detail::uncvref_t<ValueType>>::value
+                 and not std::is_same<value_t, ValueType>::value, int>::type = 0>
+    detail::uncvref_t<ValueType> value(const typename object_t::key_type& key, ValueType && default_value) &&
+    {
+        // only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(key);
+            if (it != end())
+            {
+                return std::move(it->template get_ref<ValueType&>());
+            }
+
+            return std::forward<ValueType>(default_value);
+        }
+
+        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+    }
+
+    /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
     */

--- a/test/src/unit-element_access2.cpp
+++ b/test/src/unit-element_access2.cpp
@@ -187,7 +187,6 @@ TEST_CASE("element access 2")
                     CHECK(j.value("_", 12.34) == Approx(12.34));
                     CHECK(j.value("_", json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
                     CHECK(j.value("_", json({10, 100})) == json({10, 100}));
-                    CHECK(j.value("_", std::move("default_value")) == "default_value");
 
                     CHECK(j_const.value("_", 2) == 2);
                     CHECK(j_const.value("_", 2u) == 2u);
@@ -196,7 +195,6 @@ TEST_CASE("element access 2")
                     CHECK(j_const.value("_", 12.34) == Approx(12.34));
                     CHECK(j_const.value("_", json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
                     CHECK(j_const.value("_", json({10, 100})) == json({10, 100}));
-                    CHECK(j_const.value("_", std::move("default_value")) == "default_value");
                 }
 
                 SECTION("access on non-object type")

--- a/test/src/unit-element_access2.cpp
+++ b/test/src/unit-element_access2.cpp
@@ -148,45 +148,6 @@ TEST_CASE("element access 2")
 
         SECTION("access specified element with default value")
         {
-            SECTION("move semantics")
-            {
-                SECTION("json is rvalue")
-                {
-                    json j = {{"x", "123"}};
-                    std::string defval = "default";
-                    auto val = std::move(j).value("x", defval);
-
-                    CHECK(j["x"] == "");
-                    CHECK(defval == "default");
-                    CHECK(val == "123");
-                }
-
-                SECTION("default is rvalue")
-                {
-                    json j = {{"x", "123"}};
-                    std::string defval = "default";
-                    auto val = std::move(j).value("y", std::move(defval));
-
-                    CHECK(j["x"] == "123");
-                    CHECK(defval == "");
-                    CHECK(val == "default");
-                }
-
-                SECTION("access on non-object value")
-                {
-                    json j_nonobject(json::value_t::array);
-                    const json j_nonobject_const(j_nonobject);
-                    std::string defval = "default";
-
-                    CHECK_THROWS_AS(std::move(j_nonobject).value("foo", defval), json::type_error&);
-                    CHECK_THROWS_AS(std::move(j_nonobject_const).value("foo", defval), json::type_error&);
-                    CHECK_THROWS_WITH(std::move(j_nonobject).value("foo", defval),
-                                      "[json.exception.type_error.306] cannot use value() with array");
-                    CHECK_THROWS_WITH(std::move(j_nonobject_const).value("foo", defval),
-                                      "[json.exception.type_error.306] cannot use value() with array");
-                }
-            }
-
             SECTION("given a key")
             {
                 SECTION("access existing value")
@@ -226,6 +187,7 @@ TEST_CASE("element access 2")
                     CHECK(j.value("_", 12.34) == Approx(12.34));
                     CHECK(j.value("_", json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
                     CHECK(j.value("_", json({10, 100})) == json({10, 100}));
+                    CHECK(j.value("_", std::move("default_value")) == "default_value");
 
                     CHECK(j_const.value("_", 2) == 2);
                     CHECK(j_const.value("_", 2u) == 2u);
@@ -234,6 +196,7 @@ TEST_CASE("element access 2")
                     CHECK(j_const.value("_", 12.34) == Approx(12.34));
                     CHECK(j_const.value("_", json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
                     CHECK(j_const.value("_", json({10, 100})) == json({10, 100}));
+                    CHECK(j_const.value("_", std::move("default_value")) == "default_value");
                 }
 
                 SECTION("access on non-object type")


### PR DESCRIPTION
Fix issue #1275 : add an overload of  function `value(key, default_value)`.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

