### PR TITLE
Fix: abnormal termination

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3531,6 +3531,11 @@ class basic_json
         // const operator[] only works for arrays
         if (JSON_HEDLEY_LIKELY(is_array()))
         {
+            if (JSON_HEDLEY_LIKELY(idx >= m_value.array->size()))
+            {
+                JSON_THROW(out_of_range::create(401, "array index (" + std::to_string(idx) +
+                                                ") is out of range"));
+            }
             return m_value.array->operator[](idx);
         }
 
@@ -3618,7 +3623,11 @@ class basic_json
         // const operator[] only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            assert(m_value.object->find(key) != m_value.object->end());
+            if (JSON_HEDLEY_LIKELY(m_value.object->find(key) == m_value.object->end()))
+            {
+                // create better exception explanation
+                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
+            }
             return m_value.object->find(key)->second;
         }
 
@@ -3710,7 +3719,11 @@ class basic_json
         // at only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            assert(m_value.object->find(key) != m_value.object->end());
+            if (JSON_HEDLEY_LIKELY(m_value.object->find(key) == m_value.object->end()))
+            {
+                // create better exception explanation
+                JSON_THROW(out_of_range::create(403, "key '" + std::string(key) + "' not found"));
+            }
             return m_value.object->find(key)->second;
         }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19312,6 +19312,11 @@ class basic_json
         // const operator[] only works for arrays
         if (JSON_HEDLEY_LIKELY(is_array()))
         {
+            if (JSON_HEDLEY_LIKELY(idx >= m_value.array->size()))
+            {
+                JSON_THROW(out_of_range::create(401, "array index (" + std::to_string(idx) +
+                                                ") is out of range"));
+            }
             return m_value.array->operator[](idx);
         }
 
@@ -19399,7 +19404,11 @@ class basic_json
         // const operator[] only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            assert(m_value.object->find(key) != m_value.object->end());
+            if (JSON_HEDLEY_LIKELY(m_value.object->find(key) == m_value.object->end()))
+            {
+                // create better exception explanation
+                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
+            }
             return m_value.object->find(key)->second;
         }
 
@@ -19491,7 +19500,11 @@ class basic_json
         // at only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            assert(m_value.object->find(key) != m_value.object->end());
+            if (JSON_HEDLEY_LIKELY(m_value.object->find(key) == m_value.object->end()))
+            {
+                // create better exception explanation
+                JSON_THROW(out_of_range::create(403, "key '" + std::string(key) + "' not found"));
+            }
             return m_value.object->find(key)->second;
         }
 

--- a/test/src/unit-element_access1.cpp
+++ b/test/src/unit-element_access1.cpp
@@ -185,6 +185,13 @@ TEST_CASE("element access 1")
                 CHECK(j_const[7] == json({1, 2, 3}));
             }
 
+            SECTION("access outside bounds")
+            {
+                CHECK_THROWS_AS(j_const[8], json::out_of_range&);
+                CHECK_THROWS_WITH(j_const[8],
+                                  "[json.exception.out_of_range.401] array index (8) is out of range");
+            }
+
             SECTION("access on non-array type")
             {
                 SECTION("null")

--- a/test/src/unit-element_access2.cpp
+++ b/test/src/unit-element_access2.cpp
@@ -464,6 +464,14 @@ TEST_CASE("element access 2")
                 CHECK(j_const[json::object_t::key_type("array")] == j["array"]);
             }
 
+            SECTION("access not-existing value")
+            {
+                // not existing access
+                CHECK_THROWS_AS(j_const["not-existing"], json::out_of_range&);
+                CHECK_THROWS_WITH(j_const["not-existing"],
+                                  "[json.exception.out_of_range.403] key 'not-existing' not found");
+            }
+
             SECTION("access on non-object type")
             {
                 SECTION("null")

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -202,6 +202,10 @@ TEST_CASE("JSON pointers")
             CHECK(j[json::json_pointer("/foo/1")] == j["foo"][1]);
             CHECK(j["/foo/1"_json_pointer] == j["foo"][1]);
 
+            CHECK_THROWS_AS(j[json::json_pointer("/foo/2")], json::out_of_range&);
+            CHECK_THROWS_WITH(j[json::json_pointer("/foo/2")],
+                              "[json.exception.out_of_range.401] array index (2) is out of range");
+
             // checked array access
             CHECK(j.at(json::json_pointer("/foo/0")) == j["foo"][0]);
             CHECK(j.at(json::json_pointer("/foo/1")) == j["foo"][1]);
@@ -216,6 +220,11 @@ TEST_CASE("JSON pointers")
             CHECK(j[json::json_pointer("/g|h")] == j["g|h"]);
             CHECK(j[json::json_pointer("/i\\j")] == j["i\\j"]);
             CHECK(j[json::json_pointer("/k\"l")] == j["k\"l"]);
+
+            // not existing access
+            CHECK_THROWS_AS(j[json::json_pointer("/not-existing")], json::out_of_range&);
+            CHECK_THROWS_WITH(j[json::json_pointer("/not-existing")],
+                              "[json.exception.out_of_range.403] key 'not-existing' not found");
 
             // checked access
             CHECK(j.at(json::json_pointer("/ ")) == j[" "]);


### PR DESCRIPTION
Example:
```
    const json j = R"({
        "bad": {
            "0": "one",
            "1": "two",
            "t": "three"
        },
        "foo": ["one","two","three"]
    })"_json;
    auto res2 = j["foo"][3];
    std::cout << res2 << std::endl;
    ...
```
Sometimes everything is ok and the program is finished with exit code 0, but sometimes it will terminate with exit 3. The problem is the assert. 
But I think it's not a good way to use assert and abort when we access not-existing value of the const value.
For the non-const version, operator[] methods will result in creation, it is fine because we can change the value. But for the const version, we can not modify and the program should tell us that we are doing some dangerous operations.