### PR TITLE
Fix consistency in function `int_to_string()`

### DIFF
--- a/include/nlohmann/detail/iterators/iteration_proxy.hpp
+++ b/include/nlohmann/detail/iterators/iteration_proxy.hpp
@@ -12,7 +12,8 @@ namespace nlohmann
 {
 namespace detail
 {
-template<typename string_type>
+template<typename string_type, typename std::enable_if<
+             std::is_same<char, typename string_type::value_type>::value, int>::type = 0>
 void int_to_string( string_type& target, std::size_t value )
 {
     target = std::to_string(value);

--- a/include/nlohmann/detail/iterators/iteration_proxy.hpp
+++ b/include/nlohmann/detail/iterators/iteration_proxy.hpp
@@ -16,7 +16,9 @@ template<typename string_type, typename std::enable_if<
              std::is_same<char, typename string_type::value_type>::value, int>::type = 0>
 void int_to_string( string_type& target, std::size_t value )
 {
-    target = std::to_string(value);
+    // For ADL
+    using std::to_string;
+    target = to_string(value);
 }
 template <typename IteratorType> class iteration_proxy_value
 {

--- a/include/nlohmann/detail/iterators/iteration_proxy.hpp
+++ b/include/nlohmann/detail/iterators/iteration_proxy.hpp
@@ -12,8 +12,7 @@ namespace nlohmann
 {
 namespace detail
 {
-template<typename string_type, typename std::enable_if<
-             std::is_same<char, typename string_type::value_type>::value, int>::type = 0>
+template<typename string_type>
 void int_to_string( string_type& target, std::size_t value )
 {
     // For ADL

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3654,7 +3654,9 @@ template<typename string_type, typename std::enable_if<
              std::is_same<char, typename string_type::value_type>::value, int>::type = 0>
 void int_to_string( string_type& target, std::size_t value )
 {
-    target = std::to_string(value);
+    // For ADL
+    using std::to_string;
+    target = to_string(value);
 }
 template <typename IteratorType> class iteration_proxy_value
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3650,7 +3650,8 @@ namespace nlohmann
 {
 namespace detail
 {
-template<typename string_type>
+template<typename string_type, typename std::enable_if<
+             std::is_same<char, typename string_type::value_type>::value, int>::type = 0>
 void int_to_string( string_type& target, std::size_t value )
 {
     target = std::to_string(value);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3650,8 +3650,7 @@ namespace nlohmann
 {
 namespace detail
 {
-template<typename string_type, typename std::enable_if<
-             std::is_same<char, typename string_type::value_type>::value, int>::type = 0>
+template<typename string_type>
 void int_to_string( string_type& target, std::size_t value )
 {
     // For ADL


### PR DESCRIPTION
The function `int_to_string()` call `std::to_string()`, which will return std::string. For consistency, need to check `string_type` is `std::string`.

Refer: #2059 
