### PR TITLE
Add option to not rely on Internet connectivity during test stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1557,4 +1557,6 @@ $ cmake --build .
 $ ctest --output-on-failure
 ```
 
-For more information, have a look at the file [.travis.yml](https://github.com/nlohmann/json/blob/master/.travis.yml).
+Note that during the `ctest` stage, several JSON test files are downloaded from an [external repository](https://github.com/nlohmann/json_test_data). If policies forbid downloading artifacts during testing, you can download the files yourself and pass the directory with the test files via `-DJSON_TestDataDirectory=path` to CMake. Then, no Internet connectivity is required. See [issue #2189](https://github.com/nlohmann/json/issues/2189) for more information.
+
+In case you have downloaded the library rather than checked out the code via Git, test `cmake_fetch_content_configure`. Please execute `ctest -LE git_required` to skip these tests. See [issue #2189](https://github.com/nlohmann/json/issues/2189) for more information.

--- a/cmake/download_test_data.cmake
+++ b/cmake/download_test_data.cmake
@@ -1,5 +1,3 @@
-find_package(Git)
-
 set(JSON_TEST_DATA_URL     https://github.com/nlohmann/json_test_data)
 set(JSON_TEST_DATA_VERSION 2.0.0)
 
@@ -9,6 +7,7 @@ if(JSON_TestDataDirectory)
     add_custom_target(download_test_data)
     file(WRITE ${CMAKE_BINARY_DIR}/include/test_data.hpp "#define TEST_DATA_DIRECTORY \"${JSON_TestDataDirectory}\"\n")
 else()
+    find_package(Git)
     # target to download test data
     add_custom_target(download_test_data
         COMMAND test -d json_test_data || ${GIT_EXECUTABLE} clone -c advice.detachedHead=false --branch v${JSON_TEST_DATA_VERSION} ${JSON_TEST_DATA_URL}.git --quiet --depth 1

--- a/cmake/download_test_data.cmake
+++ b/cmake/download_test_data.cmake
@@ -3,15 +3,21 @@ find_package(Git)
 set(JSON_TEST_DATA_URL     https://github.com/nlohmann/json_test_data)
 set(JSON_TEST_DATA_VERSION 2.0.0)
 
-# target to download test data
-add_custom_target(download_test_data
-    COMMAND test -d json_test_data || ${GIT_EXECUTABLE} clone -c advice.detachedHead=false --branch v${JSON_TEST_DATA_VERSION} ${JSON_TEST_DATA_URL}.git --quiet --depth 1
-    COMMENT "Downloading test data from ${JSON_TEST_DATA_URL} (v${JSON_TEST_DATA_VERSION})"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
-
-# create a header with the path to the downloaded test data
-file(WRITE ${CMAKE_BINARY_DIR}/include/test_data.hpp "#define TEST_DATA_DIRECTORY \"${CMAKE_BINARY_DIR}/json_test_data\"\n")
+# if variable is set, use test data from given directory rather than downloading them
+if(JSON_TestDataDirectory)
+    message(STATUS "Using test data in ${JSON_TestDataDirectory}.")
+    add_custom_target(download_test_data)
+    file(WRITE ${CMAKE_BINARY_DIR}/include/test_data.hpp "#define TEST_DATA_DIRECTORY \"${JSON_TestDataDirectory}\"\n")
+else()
+    # target to download test data
+    add_custom_target(download_test_data
+        COMMAND test -d json_test_data || ${GIT_EXECUTABLE} clone -c advice.detachedHead=false --branch v${JSON_TEST_DATA_VERSION} ${JSON_TEST_DATA_URL}.git --quiet --depth 1
+        COMMENT "Downloading test data from ${JSON_TEST_DATA_URL} (v${JSON_TEST_DATA_VERSION})"
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    # create a header with the path to the downloaded test data
+    file(WRITE ${CMAKE_BINARY_DIR}/include/test_data.hpp "#define TEST_DATA_DIRECTORY \"${CMAKE_BINARY_DIR}/json_test_data\"\n")
+endif()
 
 # determine the operating system (for debug and support purposes)
 find_program(UNAME_COMMAND uname)

--- a/test/cmake_fetch_content/CMakeLists.txt
+++ b/test/cmake_fetch_content/CMakeLists.txt
@@ -11,8 +11,10 @@ if (${CMAKE_VERSION} VERSION_GREATER "3.11.0")
   )
   set_tests_properties(cmake_fetch_content_configure PROPERTIES
     FIXTURES_SETUP cmake_fetch_content
+    LABELS git_required
   )
   set_tests_properties(cmake_fetch_content_build PROPERTIES
     FIXTURES_REQUIRED cmake_fetch_content
+    LABELS git_required
   )
 endif()

--- a/test/cmake_fetch_content/project/CMakeLists.txt
+++ b/test/cmake_fetch_content/project/CMakeLists.txt
@@ -4,9 +4,8 @@ project(DummyImport CXX)
 
 include(FetchContent)
 
-FetchContent_Declare(json
-  GIT_REPOSITORY ${CMAKE_CURRENT_SOURCE_DIR}/../../..
-  GIT_TAG HEAD)
+get_filename_component(GIT_REPOSITORY_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../.. ABSOLUTE)
+FetchContent_Declare(json GIT_REPOSITORY ${GIT_REPOSITORY_DIRECTORY} GIT_TAG HEAD)
 
 FetchContent_GetProperties(json)
 if(NOT json_POPULATED)


### PR DESCRIPTION
This PR fixes two issues that were introduced in #2081:

- Adds a parameter `JSON_TestDataDirectory` to pass a directory of test files to avoid checking them out during `ctest` stage.
- Adds label `git_required` to tests that require a Git checkout and would fail if library is downloaded other than via Git.
- Add documentation to the test section of the README file.

Closes #2189