### PR TITLE
Add option to ignore comments in parse/accept functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1508,7 +1508,7 @@ The library supports **Unicode input** as follows:
 
 ### Comments in JSON
 
-This library does not support comments. It does so for three reasons:
+This library does not support comments by default. It does so for three reasons:
 
 1. Comments are not part of the [JSON specification](https://tools.ietf.org/html/rfc8259). You may argue that `//` or `/* */` are allowed in JavaScript, but JSON is not JavaScript.
 2. This was not an oversight: Douglas Crockford [wrote on this](https://plus.google.com/118095276221607585885/posts/RK8qyGVaGSr) in May 2012:
@@ -1519,11 +1519,7 @@ This library does not support comments. It does so for three reasons:
 
 3. It is dangerous for interoperability if some libraries would add comment support while others don't. Please check [The Harmful Consequences of the Robustness Principle](https://tools.ietf.org/html/draft-iab-protocol-maintenance-01) on this.
 
-This library will not support comments in the future. If you wish to use comments, I see three options:
-
-1. Strip comments before using this library.
-2. Use a different JSON library with comment support.
-3. Use a format that natively supports comments (e.g., YAML or JSON5).
+However, you can pass set parameter `ignore_comments` to true in the `parse` function to ignore `//` or `/* */` comments. Comments will then be treated as whitespace.
 
 ### Order of object keys
 

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -837,6 +837,7 @@ class lexer : public lexer_base<BasicJsonType>
     {
         switch (get())
         {
+            // single-line comments skip input until a newline or EOF is read
             case '/':
             {
                 while (true)
@@ -845,6 +846,8 @@ class lexer : public lexer_base<BasicJsonType>
                     {
                         case '\n':
                         case '\r':
+                        case std::char_traits<char_type>::eof():
+                        case '\0':
                             return true;
 
                         default:
@@ -853,6 +856,7 @@ class lexer : public lexer_base<BasicJsonType>
                 }
             }
 
+            // multi-line comments skip input until */ is read
             case '*':
             {
                 while (true)
@@ -877,10 +881,14 @@ class lexer : public lexer_base<BasicJsonType>
                                 }
                             }
                         }
+
+                        default:
+                            break;
                     }
                 }
             }
 
+            // unexpected character after reading '/'
             default:
                 return false;
         }

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -865,7 +865,10 @@ class lexer : public lexer_base<BasicJsonType>
                     {
                         case std::char_traits<char_type>::eof():
                         case '\0':
+                        {
+                            error_message = "invalid comment; missing closing '*/'";
                             return false;
+                        }
 
                         case '*':
                         {
@@ -890,7 +893,10 @@ class lexer : public lexer_base<BasicJsonType>
 
             // unexpected character after reading '/'
             default:
+            {
+                error_message = "invalid comment; expecting '/' or '*' after '/'";
                 return false;
+            }
         }
     }
 
@@ -1504,7 +1510,6 @@ scan_number_done:
         {
             if (not scan_comment())
             {
-                error_message = "invalid comment";
                 return token_type::parse_error;
             }
 

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -835,62 +835,54 @@ class lexer : public lexer_base<BasicJsonType>
      */
     bool scan_comment()
     {
-        // remember character after '/' to distinguish comment types
-        const auto comment_char = get();
-
-        // expect // or /* to start a comment
-        if (comment_char != '/' and comment_char != '*')
+        switch (get())
         {
-            return false;
-        }
-
-        while (true)
-        {
-            switch (get())
+            case '/':
             {
-                // EOF inside a /* comment is an error, in // it is OK
-                case std::char_traits<char_type>::eof():
-                case '\0':
+                while (true)
                 {
-                    return comment_char == '/';
-                }
-
-                // a newline ends the // comment
-                case '\n':
-                case '\r':
-                {
-                    if (comment_char == '/')
+                    switch (get())
                     {
-                        return true;
+                        case '\n':
+                        case '\r':
+                            return true;
+
+                        default:
+                            break;
                     }
-                    break;
                 }
+            }
 
-                // */ ends the /* comment
-                case '*':
+            case '*':
+            {
+                while (true)
                 {
-                    if (comment_char == '*')
+                    switch (get())
                     {
-                        switch (get())
-                        {
-                            case '/':
-                            {
-                                return true;
-                            }
+                        case std::char_traits<char_type>::eof():
+                        case '\0':
+                            return false;
 
-                            default:
+                        case '*':
+                        {
+                            switch (get())
                             {
-                                unget();
-                                break;
+                                case '/':
+                                    return true;
+
+                                default:
+                                {
+                                    unget();
+                                    break;
+                                }
                             }
                         }
                     }
-                    break;
                 }
-
-                default:
-                    break;
             }
+
+            default:
+                return false;
         }
     }
 

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1507,7 +1507,13 @@ scan_number_done:
                 error_message = "invalid comment";
                 return token_type::parse_error;
             }
-            get();
+
+            // skip following whitespace
+            do
+            {
+                get();
+            }
+            while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
         }
 
         switch (current)

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1489,6 +1489,15 @@ scan_number_done:
         return true;
     }
 
+    void skip_whitespace()
+    {
+        do
+        {
+            get();
+        }
+        while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+    }
+
     token_type scan()
     {
         // initially, skip the BOM
@@ -1499,11 +1508,7 @@ scan_number_done:
         }
 
         // read next character and ignore whitespace
-        do
-        {
-            get();
-        }
-        while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+        skip_whitespace();
 
         // ignore comments
         if (ignore_comments and current == '/')
@@ -1514,11 +1519,7 @@ scan_number_done:
             }
 
             // skip following whitespace
-            do
-            {
-                get();
-            }
-            while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+            skip_whitespace();
         }
 
         switch (current)

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -63,8 +63,11 @@ class parser
     /// a parser reading from an input adapter
     explicit parser(InputAdapterType&& adapter,
                     const parser_callback_t<BasicJsonType> cb = nullptr,
-                    const bool allow_exceptions_ = true)
-        : callback(cb), m_lexer(std::move(adapter)), allow_exceptions(allow_exceptions_)
+                    const bool allow_exceptions_ = true,
+                    const bool skip_comments = false)
+        : callback(cb)
+        , m_lexer(std::move(adapter), skip_comments)
+        , allow_exceptions(allow_exceptions_)
     {
         // read first token
         get_token();

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -6565,8 +6565,9 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default)
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -6623,8 +6624,9 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default)
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -6676,8 +6678,9 @@ class basic_json
       iterators.
 
     @param[in] i input to read from
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default)
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default)
 
     @return Whether the input read from @a i is valid JSON.
 
@@ -6728,9 +6731,9 @@ class basic_json
     @param[in,out] sax  SAX event listener
     @param[in] format  the format to parse (JSON, CBOR, MessagePack, or UBJSON)
     @param[in] strict  whether the input has to be consumed completely
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default); only applieds to
-    the JSON file format.
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default); only applies to the JSON file format.
 
     @return return value of the last processed SAX event
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -196,10 +196,12 @@ class basic_json
     static ::nlohmann::detail::parser<basic_json, InputAdapterType> parser(
         InputAdapterType adapter,
         detail::parser_callback_t<basic_json>cb = nullptr,
-        bool allow_exceptions = true
+        const bool allow_exceptions = true,
+        const bool ignore_comments = false
     )
     {
-        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter), std::move(cb), allow_exceptions);
+        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
+                std::move(cb), allow_exceptions, ignore_comments);
     }
 
     using primitive_iterator_t = ::nlohmann::detail::primitive_iterator_t;
@@ -6563,6 +6565,8 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -6591,16 +6595,18 @@ class basic_json
     @liveexample{The example below demonstrates the `parse()` function reading
     from a contiguous container.,parse__contiguouscontainer__parser_callback_t}
 
-    @since version 2.0.3 (contiguous containers)
+    @since version 2.0.3 (contiguous containers); version 3.9.0 allowed to
+    ignore comments.
     */
     template<typename InputType>
     JSON_HEDLEY_WARN_UNUSED_RESULT
     static basic_json parse(InputType&& i,
                             const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
     {
         basic_json result;
-        parser(detail::input_adapter(std::forward<InputType>(i)), cb, allow_exceptions).parse(true, result);
+        parser(detail::input_adapter(std::forward<InputType>(i)), cb, allow_exceptions, ignore_comments).parse(true, result);
         return result;
     }
 
@@ -6617,6 +6623,8 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -6632,10 +6640,11 @@ class basic_json
     static basic_json parse(IteratorType first,
                             IteratorType last,
                             const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
     {
         basic_json result;
-        parser(detail::input_adapter(std::move(first), std::move(last)), cb, allow_exceptions).parse(true, result);
+        parser(detail::input_adapter(std::move(first), std::move(last)), cb, allow_exceptions, ignore_comments).parse(true, result);
         return result;
     }
 
@@ -6643,10 +6652,11 @@ class basic_json
     JSON_HEDLEY_DEPRECATED_FOR(3.8.0, parse(ptr, ptr + len))
     static basic_json parse(detail::span_input_adapter&& i,
                             const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
     {
         basic_json result;
-        parser(i.get(), cb, allow_exceptions).parse(true, result);
+        parser(i.get(), cb, allow_exceptions, ignore_comments).parse(true, result);
         return result;
     }
 
@@ -6666,6 +6676,8 @@ class basic_json
       iterators.
 
     @param[in] i input to read from
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default)
 
     @return Whether the input read from @a i is valid JSON.
 
@@ -6678,22 +6690,25 @@ class basic_json
     from a string.,accept__string}
     */
     template<typename InputType>
-    static bool accept(InputType&& i)
+    static bool accept(InputType&& i,
+                       const bool ignore_comments = false)
     {
-        return parser(detail::input_adapter(std::forward<InputType>(i))).accept(true);
+        return parser(detail::input_adapter(std::forward<InputType>(i)), nullptr, false, ignore_comments).accept(true);
     }
 
     template<typename IteratorType>
-    static bool accept(IteratorType first, IteratorType last)
+    static bool accept(IteratorType first, IteratorType last,
+                       const bool ignore_comments = false)
     {
-        return parser(detail::input_adapter(std::move(first), std::move(last))).accept(true);
+        return parser(detail::input_adapter(std::move(first), std::move(last)), nullptr, false, ignore_comments).accept(true);
     }
 
     JSON_HEDLEY_WARN_UNUSED_RESULT
     JSON_HEDLEY_DEPRECATED_FOR(3.8.0, accept(ptr, ptr + len))
-    static bool accept(detail::span_input_adapter&& i)
+    static bool accept(detail::span_input_adapter&& i,
+                       const bool ignore_comments = false)
     {
-        return parser(i.get()).accept(true);
+        return parser(i.get(), nullptr, false, ignore_comments).accept(true);
     }
 
     /*!
@@ -6713,6 +6728,9 @@ class basic_json
     @param[in,out] sax  SAX event listener
     @param[in] format  the format to parse (JSON, CBOR, MessagePack, or UBJSON)
     @param[in] strict  whether the input has to be consumed completely
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default); only applieds to
+    the JSON file format.
 
     @return return value of the last processed SAX event
 
@@ -6737,11 +6755,12 @@ class basic_json
     JSON_HEDLEY_NON_NULL(2)
     static bool sax_parse(InputType&& i, SAX* sax,
                           input_format_t format = input_format_t::json,
-                          const bool strict = true)
+                          const bool strict = true,
+                          const bool ignore_comments = false)
     {
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         return format == input_format_t::json
-               ? parser(std::move(ia)).sax_parse(sax, strict)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia)).sax_parse(format, sax, strict);
     }
 
@@ -6749,11 +6768,12 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     static bool sax_parse(IteratorType first, IteratorType last, SAX* sax,
                           input_format_t format = input_format_t::json,
-                          const bool strict = true)
+                          const bool strict = true,
+                          const bool ignore_comments = false)
     {
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         return format == input_format_t::json
-               ? parser(std::move(ia)).sax_parse(sax, strict)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia)).sax_parse(format, sax, strict);
     }
 
@@ -6762,11 +6782,12 @@ class basic_json
     JSON_HEDLEY_NON_NULL(2)
     static bool sax_parse(detail::span_input_adapter&& i, SAX* sax,
                           input_format_t format = input_format_t::json,
-                          const bool strict = true)
+                          const bool strict = true,
+                          const bool ignore_comments = false)
     {
         auto ia = i.get();
         return format == input_format_t::json
-               ? parser(std::move(ia)).sax_parse(sax, strict)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia)).sax_parse(format, sax, strict);
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -9556,6 +9556,15 @@ scan_number_done:
         return true;
     }
 
+    void skip_whitespace()
+    {
+        do
+        {
+            get();
+        }
+        while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+    }
+
     token_type scan()
     {
         // initially, skip the BOM
@@ -9566,11 +9575,7 @@ scan_number_done:
         }
 
         // read next character and ignore whitespace
-        do
-        {
-            get();
-        }
-        while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+        skip_whitespace();
 
         // ignore comments
         if (ignore_comments and current == '/')
@@ -9581,11 +9586,7 @@ scan_number_done:
             }
 
             // skip following whitespace
-            do
-            {
-                get();
-            }
-            while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
+            skip_whitespace();
         }
 
         switch (current)
@@ -22451,8 +22452,9 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default)
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -22509,8 +22511,9 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default)
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -22562,8 +22565,9 @@ class basic_json
       iterators.
 
     @param[in] i input to read from
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default)
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default)
 
     @return Whether the input read from @a i is valid JSON.
 
@@ -22614,9 +22618,9 @@ class basic_json
     @param[in,out] sax  SAX event listener
     @param[in] format  the format to parse (JSON, CBOR, MessagePack, or UBJSON)
     @param[in] strict  whether the input has to be consumed completely
-    @param[in] ignore_comments  whether comments should be ignored (true) or
-    yield a parse error (true); (optional, false by default); only applieds to
-    the JSON file format.
+    @param[in] ignore_comments  whether comments should be ignored and treated
+    like whitespace (true) or yield a parse error (true); (optional, false by
+    default); only applies to the JSON file format.
 
     @return return value of the last processed SAX event
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8932,7 +8932,10 @@ class lexer : public lexer_base<BasicJsonType>
                     {
                         case std::char_traits<char_type>::eof():
                         case '\0':
+                        {
+                            error_message = "invalid comment; missing closing '*/'";
                             return false;
+                        }
 
                         case '*':
                         {
@@ -8957,7 +8960,10 @@ class lexer : public lexer_base<BasicJsonType>
 
             // unexpected character after reading '/'
             default:
+            {
+                error_message = "invalid comment; expecting '/' or '*' after '/'";
                 return false;
+            }
         }
     }
 
@@ -9571,7 +9577,6 @@ scan_number_done:
         {
             if (not scan_comment())
             {
-                error_message = "invalid comment";
                 return token_type::parse_error;
             }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8902,62 +8902,54 @@ class lexer : public lexer_base<BasicJsonType>
      */
     bool scan_comment()
     {
-        // remember character after '/' to distinguish comment types
-        const auto comment_char = get();
-
-        // expect // or /* to start a comment
-        if (comment_char != '/' and comment_char != '*')
+        switch (get())
         {
-            return false;
-        }
-
-        while (true)
-        {
-            switch (get())
+            case '/':
             {
-                // EOF inside a /* comment is an error, in // it is OK
-                case std::char_traits<char_type>::eof():
-                case '\0':
+                while (true)
                 {
-                    return comment_char == '/';
-                }
-
-                // a newline ends the // comment
-                case '\n':
-                case '\r':
-                {
-                    if (comment_char == '/')
+                    switch (get())
                     {
-                        return true;
+                        case '\n':
+                        case '\r':
+                            return true;
+
+                        default:
+                            break;
                     }
-                    break;
                 }
+            }
 
-                // */ ends the /* comment
-                case '*':
+            case '*':
+            {
+                while (true)
                 {
-                    if (comment_char == '*')
+                    switch (get())
                     {
-                        switch (get())
-                        {
-                            case '/':
-                            {
-                                return true;
-                            }
+                        case std::char_traits<char_type>::eof():
+                        case '\0':
+                            return false;
 
-                            default:
+                        case '*':
+                        {
+                            switch (get())
                             {
-                                unget();
-                                break;
+                                case '/':
+                                    return true;
+
+                                default:
+                                {
+                                    unget();
+                                    break;
+                                }
                             }
                         }
                     }
-                    break;
                 }
-
-                default:
-                    break;
             }
+
+            default:
+                return false;
         }
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -9574,7 +9574,13 @@ scan_number_done:
                 error_message = "invalid comment";
                 return token_type::parse_error;
             }
-            get();
+
+            // skip following whitespace
+            do
+            {
+                get();
+            }
+            while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
         }
 
         switch (current)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8904,6 +8904,7 @@ class lexer : public lexer_base<BasicJsonType>
     {
         switch (get())
         {
+            // single-line comments skip input until a newline or EOF is read
             case '/':
             {
                 while (true)
@@ -8912,6 +8913,8 @@ class lexer : public lexer_base<BasicJsonType>
                     {
                         case '\n':
                         case '\r':
+                        case std::char_traits<char_type>::eof():
+                        case '\0':
                             return true;
 
                         default:
@@ -8920,6 +8923,7 @@ class lexer : public lexer_base<BasicJsonType>
                 }
             }
 
+            // multi-line comments skip input until */ is read
             case '*':
             {
                 while (true)
@@ -8944,10 +8948,14 @@ class lexer : public lexer_base<BasicJsonType>
                                 }
                             }
                         }
+
+                        default:
+                            break;
                     }
                 }
             }
 
+            // unexpected character after reading '/'
             default:
                 return false;
         }
@@ -9742,8 +9750,11 @@ class parser
     /// a parser reading from an input adapter
     explicit parser(InputAdapterType&& adapter,
                     const parser_callback_t<BasicJsonType> cb = nullptr,
-                    const bool allow_exceptions_ = true)
-        : callback(cb), m_lexer(std::move(adapter)), allow_exceptions(allow_exceptions_)
+                    const bool allow_exceptions_ = true,
+                    const bool skip_comments = false)
+        : callback(cb)
+        , m_lexer(std::move(adapter), skip_comments)
+        , allow_exceptions(allow_exceptions_)
     {
         // read first token
         get_token();
@@ -16051,10 +16062,12 @@ class basic_json
     static ::nlohmann::detail::parser<basic_json, InputAdapterType> parser(
         InputAdapterType adapter,
         detail::parser_callback_t<basic_json>cb = nullptr,
-        bool allow_exceptions = true
+        const bool allow_exceptions = true,
+        const bool ignore_comments = false
     )
     {
-        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter), std::move(cb), allow_exceptions);
+        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
+                std::move(cb), allow_exceptions, ignore_comments);
     }
 
     using primitive_iterator_t = ::nlohmann::detail::primitive_iterator_t;
@@ -22418,6 +22431,8 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -22446,16 +22461,18 @@ class basic_json
     @liveexample{The example below demonstrates the `parse()` function reading
     from a contiguous container.,parse__contiguouscontainer__parser_callback_t}
 
-    @since version 2.0.3 (contiguous containers)
+    @since version 2.0.3 (contiguous containers); version 3.9.0 allowed to
+    ignore comments.
     */
     template<typename InputType>
     JSON_HEDLEY_WARN_UNUSED_RESULT
     static basic_json parse(InputType&& i,
                             const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
     {
         basic_json result;
-        parser(detail::input_adapter(std::forward<InputType>(i)), cb, allow_exceptions).parse(true, result);
+        parser(detail::input_adapter(std::forward<InputType>(i)), cb, allow_exceptions, ignore_comments).parse(true, result);
         return result;
     }
 
@@ -22472,6 +22489,8 @@ class basic_json
     (optional)
     @param[in] allow_exceptions  whether to throw exceptions in case of a
     parse error (optional, true by default)
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default)
 
     @return deserialized JSON value; in case of a parse error and
             @a allow_exceptions set to `false`, the return value will be
@@ -22487,10 +22506,11 @@ class basic_json
     static basic_json parse(IteratorType first,
                             IteratorType last,
                             const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
     {
         basic_json result;
-        parser(detail::input_adapter(std::move(first), std::move(last)), cb, allow_exceptions).parse(true, result);
+        parser(detail::input_adapter(std::move(first), std::move(last)), cb, allow_exceptions, ignore_comments).parse(true, result);
         return result;
     }
 
@@ -22498,10 +22518,11 @@ class basic_json
     JSON_HEDLEY_DEPRECATED_FOR(3.8.0, parse(ptr, ptr + len))
     static basic_json parse(detail::span_input_adapter&& i,
                             const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
     {
         basic_json result;
-        parser(i.get(), cb, allow_exceptions).parse(true, result);
+        parser(i.get(), cb, allow_exceptions, ignore_comments).parse(true, result);
         return result;
     }
 
@@ -22521,6 +22542,8 @@ class basic_json
       iterators.
 
     @param[in] i input to read from
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default)
 
     @return Whether the input read from @a i is valid JSON.
 
@@ -22533,22 +22556,25 @@ class basic_json
     from a string.,accept__string}
     */
     template<typename InputType>
-    static bool accept(InputType&& i)
+    static bool accept(InputType&& i,
+                       const bool ignore_comments = false)
     {
-        return parser(detail::input_adapter(std::forward<InputType>(i))).accept(true);
+        return parser(detail::input_adapter(std::forward<InputType>(i)), nullptr, false, ignore_comments).accept(true);
     }
 
     template<typename IteratorType>
-    static bool accept(IteratorType first, IteratorType last)
+    static bool accept(IteratorType first, IteratorType last,
+                       const bool ignore_comments = false)
     {
-        return parser(detail::input_adapter(std::move(first), std::move(last))).accept(true);
+        return parser(detail::input_adapter(std::move(first), std::move(last)), nullptr, false, ignore_comments).accept(true);
     }
 
     JSON_HEDLEY_WARN_UNUSED_RESULT
     JSON_HEDLEY_DEPRECATED_FOR(3.8.0, accept(ptr, ptr + len))
-    static bool accept(detail::span_input_adapter&& i)
+    static bool accept(detail::span_input_adapter&& i,
+                       const bool ignore_comments = false)
     {
-        return parser(i.get()).accept(true);
+        return parser(i.get(), nullptr, false, ignore_comments).accept(true);
     }
 
     /*!
@@ -22568,6 +22594,9 @@ class basic_json
     @param[in,out] sax  SAX event listener
     @param[in] format  the format to parse (JSON, CBOR, MessagePack, or UBJSON)
     @param[in] strict  whether the input has to be consumed completely
+    @param[in] ignore_comments  whether comments should be ignored (true) or
+    yield a parse error (true); (optional, false by default); only applieds to
+    the JSON file format.
 
     @return return value of the last processed SAX event
 
@@ -22592,11 +22621,12 @@ class basic_json
     JSON_HEDLEY_NON_NULL(2)
     static bool sax_parse(InputType&& i, SAX* sax,
                           input_format_t format = input_format_t::json,
-                          const bool strict = true)
+                          const bool strict = true,
+                          const bool ignore_comments = false)
     {
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         return format == input_format_t::json
-               ? parser(std::move(ia)).sax_parse(sax, strict)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia)).sax_parse(format, sax, strict);
     }
 
@@ -22604,11 +22634,12 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     static bool sax_parse(IteratorType first, IteratorType last, SAX* sax,
                           input_format_t format = input_format_t::json,
-                          const bool strict = true)
+                          const bool strict = true,
+                          const bool ignore_comments = false)
     {
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         return format == input_format_t::json
-               ? parser(std::move(ia)).sax_parse(sax, strict)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia)).sax_parse(format, sax, strict);
     }
 
@@ -22617,11 +22648,12 @@ class basic_json
     JSON_HEDLEY_NON_NULL(2)
     static bool sax_parse(detail::span_input_adapter&& i, SAX* sax,
                           input_format_t format = input_format_t::json,
-                          const bool strict = true)
+                          const bool strict = true,
+                          const bool ignore_comments = false)
     {
         auto ia = i.get();
         return format == input_format_t::json
-               ? parser(std::move(ia)).sax_parse(sax, strict)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia)).sax_parse(format, sax, strict);
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8179,8 +8179,11 @@ class lexer : public lexer_base<BasicJsonType>
   public:
     using token_type = typename lexer_base<BasicJsonType>::token_type;
 
-    explicit lexer(InputAdapterType&& adapter)
-        : ia(std::move(adapter)), decimal_point_char(static_cast<char_int_type>(get_decimal_point())) {}
+    explicit lexer(InputAdapterType&& adapter, bool ignore_comments_ = false)
+        : ia(std::move(adapter))
+        , ignore_comments(ignore_comments_)
+        , decimal_point_char(static_cast<char_int_type>(get_decimal_point()))
+    {}
 
     // delete because of pointer members
     lexer(const lexer&) = delete;
@@ -8198,7 +8201,7 @@ class lexer : public lexer_base<BasicJsonType>
     JSON_HEDLEY_PURE
     static char get_decimal_point() noexcept
     {
-        const auto loc = localeconv();
+        const auto* loc = localeconv();
         assert(loc != nullptr);
         return (loc->decimal_point == nullptr) ? '.' : *(loc->decimal_point);
     }
@@ -8893,6 +8896,71 @@ class lexer : public lexer_base<BasicJsonType>
         }
     }
 
+    /*!
+     * @brief scan a comment
+     * @return whether comment could be scanned successfully
+     */
+    bool scan_comment()
+    {
+        // remember character after '/' to distinguish comment types
+        const auto comment_char = get();
+
+        // expect // or /* to start a comment
+        if (comment_char != '/' and comment_char != '*')
+        {
+            return false;
+        }
+
+        while (true)
+        {
+            switch (get())
+            {
+                // EOF inside a /* comment is an error, in // it is OK
+                case std::char_traits<char_type>::eof():
+                case '\0':
+                {
+                    return comment_char == '/';
+                }
+
+                // a newline ends the // comment
+                case '\n':
+                case '\r':
+                {
+                    if (comment_char == '/')
+                    {
+                        return true;
+                    }
+                    break;
+                }
+
+                // */ ends the /* comment
+                case '*':
+                {
+                    if (comment_char == '*')
+                    {
+                        switch (get())
+                        {
+                            case '/':
+                            {
+                                return true;
+                            }
+
+                            default:
+                            {
+                                unget();
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+
+                default:
+                    break;
+            }
+        }
+    }
+
     JSON_HEDLEY_NON_NULL(2)
     static void strtof(float& f, const char* str, char** endptr) noexcept
     {
@@ -9498,6 +9566,17 @@ scan_number_done:
         }
         while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
 
+        // ignore comments
+        if (ignore_comments and current == '/')
+        {
+            if (not scan_comment())
+            {
+                error_message = "invalid comment";
+                return token_type::parse_error;
+            }
+            get();
+        }
+
         switch (current)
         {
             // structural characters
@@ -9565,6 +9644,9 @@ scan_number_done:
   private:
     /// input adapter
     InputAdapterType ia;
+
+    /// whether comments should be ignored (true) or signaled as errors (false)
+    const bool ignore_comments = false;
 
     /// the current character
     char_int_type current = std::char_traits<char_type>::eof();

--- a/test/src/unit-class_lexer.cpp
+++ b/test/src/unit-class_lexer.cpp
@@ -127,6 +127,8 @@ TEST_CASE("lexer class")
             // store scan() result
             const auto res = scan_string(s.c_str());
 
+            CAPTURE(s);
+
             switch (c)
             {
                 // single characters that are valid tokens
@@ -161,6 +163,9 @@ TEST_CASE("lexer class")
                     break;
                 }
 
+                //                case ('/'):
+                //                    break;
+
                 // anything else is not expected
                 default:
                 {
@@ -179,4 +184,19 @@ TEST_CASE("lexer class")
         s += "\"";
         CHECK((scan_string(s.c_str()) == json::lexer::token_type::value_string));
     }
+
+    //    SECTION("ignore comments")
+    //    {
+    //        CHECK((scan_string("/") == json::lexer::token_type::parse_error));
+    //
+    //        CHECK((scan_string("/!") == json::lexer::token_type::parse_error));
+    //        CHECK((scan_string("/*") == json::lexer::token_type::parse_error));
+    //        CHECK((scan_string("/**") == json::lexer::token_type::parse_error));
+    //
+    //        CHECK((scan_string("//") == json::lexer::token_type::end_of_input));
+    //        CHECK((scan_string("/**/") == json::lexer::token_type::end_of_input));
+    //        CHECK((scan_string("/** /") == json::lexer::token_type::parse_error));
+    //
+    //        CHECK((scan_string("/***/") == json::lexer::token_type::end_of_input));
+    //    }
 }

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -1877,4 +1877,10 @@ TEST_CASE("parser class")
             }
         }
     }
+
+    SECTION("error messages for comments")
+    {
+        CHECK_THROWS_WITH_AS(json::parse("/a", nullptr, true, true), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid comment; expecting '/' or '*' after '/'; last read: '/a'", json::parse_error);
+        CHECK_THROWS_WITH_AS(json::parse("/*", nullptr, true, true), "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid comment; missing closing '*/'; last read: '/*<U+0000>'", json::parse_error);
+    }
 }

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -224,6 +224,7 @@ class SaxCountdown : public nlohmann::json::json_sax_t
 
 json parser_helper(const std::string& s);
 bool accept_helper(const std::string& s);
+void comments_helper(const std::string& s);
 
 json parser_helper(const std::string& s)
 {
@@ -240,6 +241,8 @@ json parser_helper(const std::string& s)
     nlohmann::detail::json_sax_dom_parser<json> sdp(j_sax);
     json::sax_parse(s, &sdp);
     CHECK(j_sax == j);
+
+    comments_helper(s);
 
     return j;
 }
@@ -275,10 +278,50 @@ bool accept_helper(const std::string& s)
     // 6. check if this approach came to the same result
     CHECK(ok_noexcept == ok_noexcept_cb);
 
-    // 7. return result
+    // 7. check if comments are properly ignored
+    if (ok_accept)
+    {
+        comments_helper(s);
+    }
+
+    // 8. return result
     return ok_accept;
 }
+
+void comments_helper(const std::string& s)
+{
+    json _;
+
+    // parse/accept with default parser
+    CHECK_NOTHROW(_ = json::parse(s));
+    CHECK(json::accept(s));
+
+    // parse/accept while skipping comments
+    CHECK_NOTHROW(_ = json::parse(s, nullptr, false, true));
+    CHECK(json::accept(s, true));
+
+    std::vector<std::string> json_with_comments;
+
+    // start with a comment
+    json_with_comments.push_back(std::string("// this is a comment\n") + s);
+    json_with_comments.push_back(std::string("/* this is a comment */") + s);
+    // end with a comment
+    json_with_comments.push_back(s + "// this is a comment");
+    json_with_comments.push_back(s + "/* this is a comment */");
+
+    // check all strings
+    for (const auto& json_with_comment : json_with_comments)
+    {
+        CAPTURE(json_with_comment)
+        CHECK_THROWS_AS(_ = json::parse(json_with_comment), json::parse_error);
+        CHECK(not json::accept(json_with_comment));
+
+        CHECK_NOTHROW(_ = json::parse(json_with_comment, nullptr, true, true));
+        CHECK(json::accept(json_with_comment, true));
+    }
 }
+
+} // namespace
 
 TEST_CASE("parser class")
 {


### PR DESCRIPTION
This PR adds an option `ignore_comments` to the `parse` and `accept` family that allows to ignore `//` and `/* */` style comments.

PS: I still think there is a good reason JSON has no comment support. But it was by far the most popular request, and I understand that the lack of comments was a problem for a lot of folks that use JSON as configuration format. However, comments are still treated as parse error by default.

Closes #2061
Closes #1513
Closes #597
Closes #376
Closes #363
Closes #294

Related to #2090 #348 (comments only, no full JSON5 support).
Related to #311 (comments only, no JSON Schema support)