### PR TITLE
Fix conversion from empty json to std::optional<>

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -20,6 +20,14 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
@@ -42,6 +50,21 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
     }
     n = nullptr;
 }
+
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if (j.is_null())
+    {
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt = j.template get<T>();
+    }
+}
+#endif
 
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -59,7 +59,7 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
 }
 
 template<typename BasicJsonType, typename T>
-void from_json(const BasicJsonType& j, nlohmann::optional<T>& opt)
+void from_json(const BasicJsonType& j, optional<T>& opt)
 {
     if (j.is_null())
     {

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -20,14 +20,6 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
-
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
@@ -36,6 +28,7 @@
 #include <nlohmann/detail/meta/type_traits.hpp>
 #include <nlohmann/detail/string_concat.hpp>
 #include <nlohmann/detail/value_t.hpp>
+#include <nlohmann/optional.hpp>
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
@@ -54,6 +47,19 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if (j.is_null())
+    {
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt = j.template get<T>();
+    }
+}
+
+template<typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, nlohmann::optional<T>& opt)
 {
     if (j.is_null())
     {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -275,6 +275,13 @@ void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
         j = nullptr;
     }
 }
+
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+void to_json(BasicJsonType& j, const optional<T>& opt) noexcept
+{
+    to_json(j, opt.base());
+}
 #endif
 
 template<typename BasicJsonType, typename T,

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -23,14 +23,7 @@
 #include <nlohmann/detail/meta/std_fs.hpp>
 #include <nlohmann/detail/meta/type_traits.hpp>
 #include <nlohmann/detail/value_t.hpp>
-
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
+#include <nlohmann/optional.hpp>
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
@@ -271,7 +264,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::optional<T>& opt)
+void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -24,6 +24,14 @@
 #include <nlohmann/detail/meta/type_traits.hpp>
 #include <nlohmann/detail/value_t.hpp>
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {
@@ -259,6 +267,22 @@ struct external_constructor<value_t::object>
 /////////////
 // to_json //
 /////////////
+
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+void to_json(BasicJsonType& j, const std::optional<T>& opt)
+{
+    if (opt.has_value())
+    {
+        j = *opt;
+    }
+    else
+    {
+        j = nullptr;
+    }
+}
+#endif
 
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>

--- a/include/nlohmann/optional.hpp
+++ b/include/nlohmann/optional.hpp
@@ -86,7 +86,10 @@ class optional
         return std::move(base_value);
     }
 
-    constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>())) = default;
+    constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>()))
+        : base_value() // explicitly initialized to mitigate -Werror=effc++
+    {
+    }
 
     constexpr optional(std::nullopt_t /* unused */) noexcept
         : base_value(std::nullopt)

--- a/include/nlohmann/optional.hpp
+++ b/include/nlohmann/optional.hpp
@@ -71,17 +71,17 @@ class optional
 
   public:
 
-    base_type& base() &
+    base_type& base() & noexcept
     {
         return base_value;
     }
 
-    const base_type& base() const &
+    const base_type& base() const & noexcept
     {
         return base_value;
     }
 
-    base_type&& base() &&
+    base_type&& base() && noexcept
     {
         return std::move(base_value);
     }
@@ -150,8 +150,8 @@ class optional
     constexpr T* operator ->() noexcept { return base_value.operator ->(); }
     constexpr const T* operator ->() const noexcept { return base_value.operator ->(); }
 
-    operator base_type& () & { return base_value; }
-    operator base_type&& () && { return std::move(base_value); }
+    operator base_type& () & noexcept { return base_value; }
+    operator base_type&& () && noexcept { return std::move(base_value); }
 
     // *INDENT-ON*
 };

--- a/include/nlohmann/optional.hpp
+++ b/include/nlohmann/optional.hpp
@@ -170,159 +170,55 @@ template <typename T> const std::optional<T>& cmp_val(const optional<T>& v)
 {
     return v.base();
 }
-template <typename T> void cmp_val(const std::optional<T>& v) = delete;
 
 }  // namespace detail::opt
 
-#ifdef JSON_HAS_CPP_20
+#define JSON_OPTIONAL_COMPARISON_EXPR(OP) \
+    detail::opt::cmp_val(lhs) OP detail::opt::cmp_val(rhs)
 
-template <typename T, typename U>
-auto operator == (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
+#define JSON_OPTIONAL_COMPARISON(OP, LHS, RHS) \
+    template <typename A, typename B> \
+    auto operator OP (const LHS& lhs, const RHS& rhs) \
+    noexcept(noexcept(JSON_OPTIONAL_COMPARISON_EXPR(OP))) \
+    -> decltype(JSON_OPTIONAL_COMPARISON_EXPR(OP)) \
+    { \
+        return JSON_OPTIONAL_COMPARISON_EXPR(OP); \
+    }
+
+#ifdef JSON_HAS_CPP_20
 
 // *INDENT-OFF*
 
-template <typename T, typename U>
-auto operator <=> (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <=> detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <=> detail::opt::cmp_val(rhs);
-}
+JSON_OPTIONAL_COMPARISON( <=>, optional<A>, B)
 
 // *INDENT-ON*
 
+JSON_OPTIONAL_COMPARISON( ==, optional<A>, B)
+JSON_OPTIONAL_COMPARISON( ==, optional<A>, std::optional<B>)
+JSON_OPTIONAL_COMPARISON( ==, std::optional<A>, optional<B>)
+
 #else // JSON_HAS_CPP_20
 
-template<class T, class U>
-constexpr auto operator == (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
+#define JSON_OPTIONAL_COMPARISON_OP(OP) \
+    JSON_OPTIONAL_COMPARISON(OP, optional<A>, optional<B>) \
+    JSON_OPTIONAL_COMPARISON(OP, optional<A>, std::optional<B>) \
+    JSON_OPTIONAL_COMPARISON(OP, std::optional<A>, optional<B>) \
+    JSON_OPTIONAL_COMPARISON(OP, optional<A>, B) \
+    JSON_OPTIONAL_COMPARISON(OP, A, optional<B>)
 
-template <class T, class U>
-constexpr auto operator == (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
+JSON_OPTIONAL_COMPARISON_OP( == )
+JSON_OPTIONAL_COMPARISON_OP( != )
+JSON_OPTIONAL_COMPARISON_OP( < )
+JSON_OPTIONAL_COMPARISON_OP( <= )
+JSON_OPTIONAL_COMPARISON_OP( > )
+JSON_OPTIONAL_COMPARISON_OP( >= )
 
-template <class T, class U>
-constexpr auto operator == (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator != (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator != (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator != (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator < (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator < (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator < (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator <= (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator <= (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator <= (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator > (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator > (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator > (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator >= (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator >= (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator >= (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
-}
+#undef JSON_OPTIONAL_COMPARISON_OP
 
 #endif // JSON_HAS_CPP_20
+
+#undef JSON_OPTIONAL_COMPARISON
+#undef JSON_OPTIONAL_COMPARISON_EXPR
 
 NLOHMANN_JSON_NAMESPACE_END
 

--- a/include/nlohmann/optional.hpp
+++ b/include/nlohmann/optional.hpp
@@ -65,7 +65,7 @@ class optional
             is_base_constructible_from<std::in_place_t, U...>
         >;
 
-    struct noexcept_fix_t {};
+    struct noexcept_fix_t {}; // trick for GCC8.1 (see default constructor)
 
     base_type base_value;
 

--- a/include/nlohmann/optional.hpp
+++ b/include/nlohmann/optional.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <nlohmann/detail/macro_scope.hpp>
+
+#ifdef JSON_HAS_CPP_17
+
+#include <optional>
+#include <utility>
+
+namespace nlohmann
+{
+
+template <typename T>
+class optional : public std::optional<T>
+{
+    // *INDENT-OFF*
+
+    using base_type = std::optional<T>;
+
+    template <typename U, typename = optional>
+    struct has_conversion_operator : std::false_type { };
+
+    template <typename U>
+    struct has_conversion_operator<U,
+        decltype(std::declval<U>().operator optional())> : std::true_type { };
+
+    template <typename... U>
+    using is_base_constructible_from = std::is_constructible<base_type, U...>;
+
+    template <typename U>
+    using is_convertible_to_base = std::is_convertible<U, base_type>;
+
+    template <typename U>
+    using enable_int_if = std::enable_if_t<U::value, int>;
+
+    template <typename U>
+    using use_conversion_operator =
+        enable_int_if<
+            has_conversion_operator<U>
+        >;
+
+    template <typename U>
+    using use_implicit_forwarding =
+        enable_int_if<
+            std::conjunction<
+                std::negation<has_conversion_operator<U>>,
+                is_base_constructible_from<U>,
+                is_convertible_to_base<U>
+            >
+        >;
+
+    template <typename U>
+    using use_explicit_forwarding =
+        enable_int_if<
+            std::conjunction<
+                std::negation<has_conversion_operator<U>>,
+                is_base_constructible_from<U>,
+                std::negation<is_convertible_to_base<U>>
+            >
+        >;
+
+    template <typename... U>
+    using can_construct_in_place_from =
+        enable_int_if<
+            is_base_constructible_from<std::in_place_t, U...>
+        >;
+
+    struct noexcept_fix_t {};
+
+  public:
+
+    const base_type& base() const
+    {
+        return *this;
+    }
+
+    constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>())) = default;
+
+    constexpr optional(std::nullopt_t /* unused */) noexcept
+        : base_type(std::nullopt)
+    {
+    }
+
+    template <typename U, use_conversion_operator<U> = 0>
+    constexpr optional(U&& value)
+        noexcept(noexcept(
+            base_type(std::forward<U>(value).operator optional())
+         )) :
+            base_type(std::forward<U>(value).operator optional())
+    {
+    }
+
+    template <typename U = T, use_implicit_forwarding<U> = 0>
+    constexpr optional(U&& value)
+        noexcept(noexcept(
+            base_type(std::forward<U>(value))
+        )) :
+            base_type(std::forward<U>(value))
+    {
+    }
+
+    template <typename U, use_explicit_forwarding<U> = 0>
+    explicit
+    constexpr optional(U&& value)
+        noexcept(noexcept(
+            base_type(std::forward<U>(value))
+        )) :
+            base_type(std::forward<U>(value))
+    {
+    }
+
+    template <typename U, typename... Args, can_construct_in_place_from<U, Args...> = 0>
+    explicit
+    constexpr optional(std::in_place_t /* unused */, U&& u, Args&&... args)
+        noexcept(noexcept(
+            base_type(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
+        )) :
+            base_type(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
+    {
+    }
+
+    template <typename U, typename... Args, can_construct_in_place_from<std::initializer_list<U>&, Args...> = 0>
+    explicit
+    constexpr optional(std::in_place_t /* unused */, std::initializer_list<U> u, Args&&... args)
+        noexcept(noexcept(
+            base_type(std::in_place, u, std::forward<Args>(args)...)
+        )) :
+            base_type(std::in_place, u, std::forward<Args>(args)...)
+    {
+    }
+
+    // *INDENT-ON*
+};
+
+template<class T, class U>
+constexpr bool operator == (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() == rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator != (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() != rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator < (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() < rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator <= (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() <= rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator > (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() > rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator >= (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() >= rhs.base();
+}
+
+}  // namespace nlohmann
+
+#endif // JSON_HAS_CPP_17

--- a/include/nlohmann/optional.hpp
+++ b/include/nlohmann/optional.hpp
@@ -179,7 +179,6 @@ template <typename T> const std::optional<T>& cmp_val(const optional<T>& v)
 #define JSON_OPTIONAL_COMPARISON(OP, LHS, RHS) \
     template <typename A, typename B> \
     auto operator OP (const LHS& lhs, const RHS& rhs) \
-    noexcept(noexcept(JSON_OPTIONAL_COMPARISON_EXPR(OP))) \
     -> decltype(JSON_OPTIONAL_COMPARISON_EXPR(OP)) \
     { \
         return JSON_OPTIONAL_COMPARISON_EXPR(OP); \

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -169,6 +169,14 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
@@ -4603,6 +4611,21 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
     n = nullptr;
 }
 
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if (j.is_null())
+    {
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt = j.template get<T>();
+    }
+}
+#endif
+
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,
            enable_if_t < std::is_arithmetic<ArithmeticType>::value&&
@@ -5334,6 +5357,14 @@ class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
 // #include <nlohmann/detail/value_t.hpp>
 
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {
@@ -5569,6 +5600,22 @@ struct external_constructor<value_t::object>
 /////////////
 // to_json //
 /////////////
+
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+void to_json(BasicJsonType& j, const std::optional<T>& opt)
+{
+    if (opt.has_value())
+    {
+        j = *opt;
+    }
+    else
+    {
+        j = nullptr;
+    }
+}
+#endif
 
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4678,7 +4678,10 @@ class optional
         return std::move(base_value);
     }
 
-    constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>())) = default;
+    constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>()))
+        : base_value() // explicitly initialized to mitigate -Werror=effc++
+    {
+    }
 
     constexpr optional(std::nullopt_t /* unused */) noexcept
         : base_value(std::nullopt)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4771,7 +4771,6 @@ template <typename T> const std::optional<T>& cmp_val(const optional<T>& v)
 #define JSON_OPTIONAL_COMPARISON(OP, LHS, RHS) \
     template <typename A, typename B> \
     auto operator OP (const LHS& lhs, const RHS& rhs) \
-    noexcept(noexcept(JSON_OPTIONAL_COMPARISON_EXPR(OP))) \
     -> decltype(JSON_OPTIONAL_COMPARISON_EXPR(OP)) \
     { \
         return JSON_OPTIONAL_COMPARISON_EXPR(OP); \

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4663,17 +4663,17 @@ class optional
 
   public:
 
-    base_type& base() &
+    base_type& base() & noexcept
     {
         return base_value;
     }
 
-    const base_type& base() const &
+    const base_type& base() const & noexcept
     {
         return base_value;
     }
 
-    base_type&& base() &&
+    base_type&& base() && noexcept
     {
         return std::move(base_value);
     }
@@ -4742,8 +4742,8 @@ class optional
     constexpr T* operator ->() noexcept { return base_value.operator ->(); }
     constexpr const T* operator ->() const noexcept { return base_value.operator ->(); }
 
-    operator base_type& () & { return base_value; }
-    operator base_type&& () && { return std::move(base_value); }
+    operator base_type& () & noexcept { return base_value; }
+    operator base_type&& () && noexcept { return std::move(base_value); }
 
     // *INDENT-ON*
 };

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4599,15 +4599,15 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <optional>
 #include <utility>
 
-namespace nlohmann
-{
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
 template <typename T>
-class optional : public std::optional<T>
+class optional
 {
     // *INDENT-OFF*
 
     using base_type = std::optional<T>;
+    using value_type = T;
 
     template <typename U, typename = optional>
     struct has_conversion_operator : std::false_type { };
@@ -4659,17 +4659,29 @@ class optional : public std::optional<T>
 
     struct noexcept_fix_t {};
 
+    base_type base_value;
+
   public:
 
-    const base_type& base() const
+    base_type& base() &
     {
-        return *this;
+        return base_value;
+    }
+
+    const base_type& base() const &
+    {
+        return base_value;
+    }
+
+    base_type&& base() &&
+    {
+        return std::move(base_value);
     }
 
     constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>())) = default;
 
     constexpr optional(std::nullopt_t /* unused */) noexcept
-        : base_type(std::nullopt)
+        : base_value(std::nullopt)
     {
     }
 
@@ -4678,7 +4690,7 @@ class optional : public std::optional<T>
         noexcept(noexcept(
             base_type(std::forward<U>(value).operator optional())
          )) :
-            base_type(std::forward<U>(value).operator optional())
+            base_value(std::forward<U>(value).operator optional())
     {
     }
 
@@ -4687,7 +4699,7 @@ class optional : public std::optional<T>
         noexcept(noexcept(
             base_type(std::forward<U>(value))
         )) :
-            base_type(std::forward<U>(value))
+            base_value(std::forward<U>(value))
     {
     }
 
@@ -4697,7 +4709,7 @@ class optional : public std::optional<T>
         noexcept(noexcept(
             base_type(std::forward<U>(value))
         )) :
-            base_type(std::forward<U>(value))
+            base_value(std::forward<U>(value))
     {
     }
 
@@ -4707,7 +4719,7 @@ class optional : public std::optional<T>
         noexcept(noexcept(
             base_type(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
         )) :
-            base_type(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
+            base_value(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
     {
     }
 
@@ -4717,50 +4729,191 @@ class optional : public std::optional<T>
         noexcept(noexcept(
             base_type(std::in_place, u, std::forward<Args>(args)...)
         )) :
-            base_type(std::in_place, u, std::forward<Args>(args)...)
+            base_value(std::in_place, u, std::forward<Args>(args)...)
     {
     }
+
+    constexpr T& operator *() & noexcept { return *base_value; }
+    constexpr const T& operator *() const& noexcept { return *base_value; }
+
+    constexpr T&& operator *() && noexcept { return static_cast<T&&>(*base_value); }
+    constexpr const T&& operator *() const&& noexcept { return static_cast<const T&&>(*base_value); }
+
+    constexpr T* operator ->() noexcept { return base_value.operator ->(); }
+    constexpr const T* operator ->() const noexcept { return base_value.operator ->(); }
+
+    operator base_type& () & { return base_value; }
+    operator base_type&& () && { return std::move(base_value); }
 
     // *INDENT-ON*
 };
 
-template<class T, class U>
-constexpr bool operator == (const optional<T>& lhs, const optional<U>& rhs)
+namespace detail::opt
 {
-    return lhs.base() == rhs.base();
+
+template <typename T> const T& cmp_val(const T& v)
+{
+    return v;
+}
+template <typename T> const std::optional<T>& cmp_val(const optional<T>& v)
+{
+    return v.base();
+}
+template <typename T> void cmp_val(const std::optional<T>& v) = delete;
+
+}  // namespace detail::opt
+
+#ifdef JSON_HAS_CPP_20
+
+template <typename T, typename U>
+auto operator == (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
+}
+
+// *INDENT-OFF*
+
+template <typename T, typename U>
+auto operator <=> (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) <=> detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) <=> detail::opt::cmp_val(rhs);
+}
+
+// *INDENT-ON*
+
+#else // JSON_HAS_CPP_20
+
+template<class T, class U>
+constexpr auto operator == (const optional<T>& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator == (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator == (const T& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
 }
 
 template<class T, class U>
-constexpr bool operator != (const optional<T>& lhs, const optional<U>& rhs)
+constexpr auto operator != (const optional<T>& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
 {
-    return lhs.base() != rhs.base();
+    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator != (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator != (const T& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
 }
 
 template<class T, class U>
-constexpr bool operator < (const optional<T>& lhs, const optional<U>& rhs)
+constexpr auto operator < (const optional<T>& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
 {
-    return lhs.base() < rhs.base();
+    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator < (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator < (const T& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
 }
 
 template<class T, class U>
-constexpr bool operator <= (const optional<T>& lhs, const optional<U>& rhs)
+constexpr auto operator <= (const optional<T>& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
 {
-    return lhs.base() <= rhs.base();
+    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator <= (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator <= (const T& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
 }
 
 template<class T, class U>
-constexpr bool operator > (const optional<T>& lhs, const optional<U>& rhs)
+constexpr auto operator > (const optional<T>& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
 {
-    return lhs.base() > rhs.base();
+    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator > (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator > (const T& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
 }
 
 template<class T, class U>
-constexpr bool operator >= (const optional<T>& lhs, const optional<U>& rhs)
+constexpr auto operator >= (const optional<T>& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
 {
-    return lhs.base() >= rhs.base();
+    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
 }
 
-}  // namespace nlohmann
+template <class T, class U>
+constexpr auto operator >= (const optional<T>& lhs, const U& rhs) ->
+decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
+}
+
+template <class T, class U>
+constexpr auto operator >= (const T& lhs, const optional<U>& rhs) ->
+decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
+{
+    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
+}
+
+#endif // JSON_HAS_CPP_20
+
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif // JSON_HAS_CPP_17
 
@@ -4794,7 +4947,7 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
 }
 
 template<typename BasicJsonType, typename T>
-void from_json(const BasicJsonType& j, nlohmann::optional<T>& opt)
+void from_json(const BasicJsonType& j, optional<T>& opt)
 {
     if (j.is_null())
     {
@@ -5789,6 +5942,13 @@ void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
     {
         j = nullptr;
     }
+}
+
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+void to_json(BasicJsonType& j, const optional<T>& opt) noexcept
+{
+    to_json(j, opt.base());
 }
 #endif
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -169,14 +169,6 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
-
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
@@ -4596,6 +4588,182 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/value_t.hpp>
 
+// #include <nlohmann/optional.hpp>
+
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+#ifdef JSON_HAS_CPP_17
+
+#include <optional>
+#include <utility>
+
+namespace nlohmann
+{
+
+template <typename T>
+class optional : public std::optional<T>
+{
+    // *INDENT-OFF*
+
+    using base_type = std::optional<T>;
+
+    template <typename U, typename = optional>
+    struct has_conversion_operator : std::false_type { };
+
+    template <typename U>
+    struct has_conversion_operator<U,
+        decltype(std::declval<U>().operator optional())> : std::true_type { };
+
+    template <typename... U>
+    using is_base_constructible_from = std::is_constructible<base_type, U...>;
+
+    template <typename U>
+    using is_convertible_to_base = std::is_convertible<U, base_type>;
+
+    template <typename U>
+    using enable_int_if = std::enable_if_t<U::value, int>;
+
+    template <typename U>
+    using use_conversion_operator =
+        enable_int_if<
+            has_conversion_operator<U>
+        >;
+
+    template <typename U>
+    using use_implicit_forwarding =
+        enable_int_if<
+            std::conjunction<
+                std::negation<has_conversion_operator<U>>,
+                is_base_constructible_from<U>,
+                is_convertible_to_base<U>
+            >
+        >;
+
+    template <typename U>
+    using use_explicit_forwarding =
+        enable_int_if<
+            std::conjunction<
+                std::negation<has_conversion_operator<U>>,
+                is_base_constructible_from<U>,
+                std::negation<is_convertible_to_base<U>>
+            >
+        >;
+
+    template <typename... U>
+    using can_construct_in_place_from =
+        enable_int_if<
+            is_base_constructible_from<std::in_place_t, U...>
+        >;
+
+    struct noexcept_fix_t {};
+
+  public:
+
+    const base_type& base() const
+    {
+        return *this;
+    }
+
+    constexpr optional() noexcept(noexcept(std::optional<noexcept_fix_t>())) = default;
+
+    constexpr optional(std::nullopt_t /* unused */) noexcept
+        : base_type(std::nullopt)
+    {
+    }
+
+    template <typename U, use_conversion_operator<U> = 0>
+    constexpr optional(U&& value)
+        noexcept(noexcept(
+            base_type(std::forward<U>(value).operator optional())
+         )) :
+            base_type(std::forward<U>(value).operator optional())
+    {
+    }
+
+    template <typename U = T, use_implicit_forwarding<U> = 0>
+    constexpr optional(U&& value)
+        noexcept(noexcept(
+            base_type(std::forward<U>(value))
+        )) :
+            base_type(std::forward<U>(value))
+    {
+    }
+
+    template <typename U, use_explicit_forwarding<U> = 0>
+    explicit
+    constexpr optional(U&& value)
+        noexcept(noexcept(
+            base_type(std::forward<U>(value))
+        )) :
+            base_type(std::forward<U>(value))
+    {
+    }
+
+    template <typename U, typename... Args, can_construct_in_place_from<U, Args...> = 0>
+    explicit
+    constexpr optional(std::in_place_t /* unused */, U&& u, Args&&... args)
+        noexcept(noexcept(
+            base_type(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
+        )) :
+            base_type(std::in_place, std::forward<U>(u), std::forward<Args>(args)...)
+    {
+    }
+
+    template <typename U, typename... Args, can_construct_in_place_from<std::initializer_list<U>&, Args...> = 0>
+    explicit
+    constexpr optional(std::in_place_t /* unused */, std::initializer_list<U> u, Args&&... args)
+        noexcept(noexcept(
+            base_type(std::in_place, u, std::forward<Args>(args)...)
+        )) :
+            base_type(std::in_place, u, std::forward<Args>(args)...)
+    {
+    }
+
+    // *INDENT-ON*
+};
+
+template<class T, class U>
+constexpr bool operator == (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() == rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator != (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() != rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator < (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() < rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator <= (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() <= rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator > (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() > rhs.base();
+}
+
+template<class T, class U>
+constexpr bool operator >= (const optional<T>& lhs, const optional<U>& rhs)
+{
+    return lhs.base() >= rhs.base();
+}
+
+}  // namespace nlohmann
+
+#endif // JSON_HAS_CPP_17
+
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
@@ -4614,6 +4782,19 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if (j.is_null())
+    {
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt = j.template get<T>();
+    }
+}
+
+template<typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, nlohmann::optional<T>& opt)
 {
     if (j.is_null())
     {
@@ -5356,14 +5537,8 @@ class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
 
 // #include <nlohmann/detail/value_t.hpp>
 
+// #include <nlohmann/optional.hpp>
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
@@ -5604,7 +5779,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::optional<T>& opt)
+void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4657,7 +4657,7 @@ class optional
             is_base_constructible_from<std::in_place_t, U...>
         >;
 
-    struct noexcept_fix_t {};
+    struct noexcept_fix_t {}; // trick for GCC8.1 (see default constructor)
 
     base_type base_value;
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4762,159 +4762,55 @@ template <typename T> const std::optional<T>& cmp_val(const optional<T>& v)
 {
     return v.base();
 }
-template <typename T> void cmp_val(const std::optional<T>& v) = delete;
 
 }  // namespace detail::opt
 
-#ifdef JSON_HAS_CPP_20
+#define JSON_OPTIONAL_COMPARISON_EXPR(OP) \
+    detail::opt::cmp_val(lhs) OP detail::opt::cmp_val(rhs)
 
-template <typename T, typename U>
-auto operator == (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
+#define JSON_OPTIONAL_COMPARISON(OP, LHS, RHS) \
+    template <typename A, typename B> \
+    auto operator OP (const LHS& lhs, const RHS& rhs) \
+    noexcept(noexcept(JSON_OPTIONAL_COMPARISON_EXPR(OP))) \
+    -> decltype(JSON_OPTIONAL_COMPARISON_EXPR(OP)) \
+    { \
+        return JSON_OPTIONAL_COMPARISON_EXPR(OP); \
+    }
+
+#ifdef JSON_HAS_CPP_20
 
 // *INDENT-OFF*
 
-template <typename T, typename U>
-auto operator <=> (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <=> detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <=> detail::opt::cmp_val(rhs);
-}
+JSON_OPTIONAL_COMPARISON( <=>, optional<A>, B)
 
 // *INDENT-ON*
 
+JSON_OPTIONAL_COMPARISON( ==, optional<A>, B)
+JSON_OPTIONAL_COMPARISON( ==, optional<A>, std::optional<B>)
+JSON_OPTIONAL_COMPARISON( ==, std::optional<A>, optional<B>)
+
 #else // JSON_HAS_CPP_20
 
-template<class T, class U>
-constexpr auto operator == (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
+#define JSON_OPTIONAL_COMPARISON_OP(OP) \
+    JSON_OPTIONAL_COMPARISON(OP, optional<A>, optional<B>) \
+    JSON_OPTIONAL_COMPARISON(OP, optional<A>, std::optional<B>) \
+    JSON_OPTIONAL_COMPARISON(OP, std::optional<A>, optional<B>) \
+    JSON_OPTIONAL_COMPARISON(OP, optional<A>, B) \
+    JSON_OPTIONAL_COMPARISON(OP, A, optional<B>)
 
-template <class T, class U>
-constexpr auto operator == (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
+JSON_OPTIONAL_COMPARISON_OP( == )
+JSON_OPTIONAL_COMPARISON_OP( != )
+JSON_OPTIONAL_COMPARISON_OP( < )
+JSON_OPTIONAL_COMPARISON_OP( <= )
+JSON_OPTIONAL_COMPARISON_OP( > )
+JSON_OPTIONAL_COMPARISON_OP( >= )
 
-template <class T, class U>
-constexpr auto operator == (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) == detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator != (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator != (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator != (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) != detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator < (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator < (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator < (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) < detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator <= (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator <= (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator <= (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) <= detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator > (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator > (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator > (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) > detail::opt::cmp_val(rhs);
-}
-
-template<class T, class U>
-constexpr auto operator >= (const optional<T>& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator >= (const optional<T>& lhs, const U& rhs) ->
-decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
-}
-
-template <class T, class U>
-constexpr auto operator >= (const T& lhs, const optional<U>& rhs) ->
-decltype(detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs))
-{
-    return detail::opt::cmp_val(lhs) >= detail::opt::cmp_val(rhs);
-}
+#undef JSON_OPTIONAL_COMPARISON_OP
 
 #endif // JSON_HAS_CPP_20
+
+#undef JSON_OPTIONAL_COMPARISON
+#undef JSON_OPTIONAL_COMPARISON_EXPR
 
 NLOHMANN_JSON_NAMESPACE_END
 

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1584,7 +1584,7 @@ TEST_CASE("std::optional")
     SECTION("null")
     {
         json j_null;
-        std::optional<std::string> opt_null;
+        std::optional<std::string> const opt_null;
 
         CHECK(json(opt_null) == j_null);
         CHECK(j_null.get<std::optional<std::string>>() == std::nullopt);

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -32,6 +32,14 @@ using nlohmann::json;
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 TEST_CASE("value conversion")
 {
     SECTION("get an object (explicit)")
@@ -1568,5 +1576,64 @@ TEST_CASE("JSON to enum mapping")
         CHECK(TS_INVALID == json("what?").get<TaskState>());
     }
 }
+
+#ifdef JSON_HAS_CPP_17
+TEST_CASE("std::optional")
+{
+    SECTION("null")
+    {
+        json j_null;
+        std::optional<std::string> opt_null;
+
+        CHECK(json(opt_null) == j_null);
+        CHECK(std::optional<std::string>(j_null) == std::nullopt);
+    }
+
+    SECTION("string")
+    {
+        json j_string = "string";
+        std::optional<std::string> opt_string = "string";
+
+        CHECK(json(opt_string) == j_string);
+        CHECK(std::optional<std::string>(j_string) == opt_string);
+    }
+
+    SECTION("bool")
+    {
+        json j_bool = true;
+        std::optional<bool> opt_bool = true;
+
+        CHECK(json(opt_bool) == j_bool);
+        CHECK(std::optional<bool>(j_bool) == opt_bool);
+    }
+
+    SECTION("number")
+    {
+        json j_number = 1;
+        std::optional<int> opt_int = 1;
+
+        CHECK(json(opt_int) == j_number);
+        CHECK(std::optional<int>(j_number) == opt_int);
+    }
+
+    SECTION("array")
+    {
+        json j_array = {1, 2, nullptr};
+        std::vector<std::optional<int>> opt_array = {{1, 2, std::nullopt}};
+
+        CHECK(json(opt_array) == j_array);
+        CHECK(std::vector<std::optional<int>>(j_array) == opt_array);
+    }
+
+    SECTION("object")
+    {
+        json j_object = {{"one", 1}, {"two", 2}, {"zero", nullptr}};
+        std::map<std::string, std::optional<int>> opt_object {{"one", 1}, {"two", 2}, {"zero", std::nullopt}};
+
+        CHECK(json(opt_object) == j_object);
+        CHECK(std::map<std::string, std::optional<int>>(j_object) == opt_object);
+    }
+}
+#endif
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -31,14 +31,15 @@ using nlohmann::json;
 // NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-macros")
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
+// For testing copy-initialization of std::optional and nlohmann::optional
+// (clang doesn't need the suppressing)
+#define SUPPRESS_CONVERSION_WARNING \
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wconversion")
+
+#define RESTORE_CONVERSION_WARNING \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 TEST_CASE("value conversion")
 {
@@ -1586,7 +1587,22 @@ TEST_CASE("std::optional")
         std::optional<std::string> opt_null;
 
         CHECK(json(opt_null) == j_null);
-        CHECK(std::optional<std::string>(j_null) == std::nullopt);
+        CHECK(j_null.get<std::optional<std::string>>() == std::nullopt);
+
+        using opt_int = std::optional<int>;
+
+        auto opt1 = []() -> opt_int { return json().get<opt_int>(); };
+        auto opt2 = []() -> opt_int { return opt_int(json()); }; // NOLINT(modernize-return-braced-init-list)
+
+        CHECK(opt1() == std::nullopt);
+        CHECK_THROWS_AS(opt2(), json::type_error&);
+
+#if JSON_USE_IMPLICIT_CONVERSIONS
+        SUPPRESS_CONVERSION_WARNING
+        auto opt3 = []() -> opt_int { return json(); };
+        RESTORE_CONVERSION_WARNING
+        CHECK_THROWS_AS(opt3(), json::type_error&);
+#endif
     }
 
     SECTION("string")
@@ -1622,7 +1638,7 @@ TEST_CASE("std::optional")
         std::vector<std::optional<int>> opt_array = {{1, 2, std::nullopt}};
 
         CHECK(json(opt_array) == j_array);
-        CHECK(std::vector<std::optional<int>>(j_array) == opt_array);
+        CHECK(j_array.get<std::vector<std::optional<int>>>() == opt_array);
     }
 
     SECTION("object")
@@ -1631,7 +1647,76 @@ TEST_CASE("std::optional")
         std::map<std::string, std::optional<int>> opt_object {{"one", 1}, {"two", 2}, {"zero", std::nullopt}};
 
         CHECK(json(opt_object) == j_object);
-        CHECK(std::map<std::string, std::optional<int>>(j_object) == opt_object);
+        CHECK(j_object.get<std::map<std::string, std::optional<int>>>() == opt_object);
+    }
+}
+
+TEST_CASE("nlohmann::optional")
+{
+    SECTION("null")
+    {
+        json j_null;
+        nlohmann::optional<std::string> opt_null;
+
+        CHECK(json(opt_null) == j_null);
+        CHECK(j_null.get<nlohmann::optional<std::string>>() == std::nullopt);
+
+        using opt_int = nlohmann::optional<int>;
+
+        auto opt1 = []() -> opt_int { return json().get<opt_int>(); };
+        auto opt2 = []() -> opt_int { return opt_int(json()); }; // NOLINT(modernize-return-braced-init-list)
+        SUPPRESS_CONVERSION_WARNING
+        auto opt3 = []() -> opt_int { return json(); };
+        RESTORE_CONVERSION_WARNING
+
+        CHECK(opt1() == std::nullopt);
+        CHECK(opt2() == std::nullopt);
+        CHECK(opt3() == std::nullopt);
+    }
+
+    SECTION("string")
+    {
+        json j_string = "string";
+        nlohmann::optional<std::string> opt_string = "string";
+
+        CHECK(json(opt_string) == j_string);
+        CHECK(nlohmann::optional<std::string>(j_string) == opt_string);
+    }
+
+    SECTION("bool")
+    {
+        json j_bool = true;
+        nlohmann::optional<bool> opt_bool = true;
+
+        CHECK(json(opt_bool) == j_bool);
+        CHECK(nlohmann::optional<bool>(j_bool) == opt_bool);
+    }
+
+    SECTION("number")
+    {
+        json j_number = 1;
+        nlohmann::optional<int> opt_int = 1;
+
+        CHECK(json(opt_int) == j_number);
+        CHECK(nlohmann::optional<int>(j_number) == opt_int);
+    }
+
+    SECTION("array")
+    {
+        json j_array = {1, 2, nullptr};
+        std::vector<nlohmann::optional<int>> opt_array = {{1, 2, std::nullopt}};
+
+        CHECK(json(opt_array) == j_array);
+        CHECK(j_array.get<std::vector<nlohmann::optional<int>>>() == opt_array);
+    }
+
+    SECTION("object")
+    {
+        json j_object = {{"one", 1}, {"two", 2}, {"zero", nullptr}};
+        std::map<std::string, nlohmann::optional<int>> opt_object{{"one", 1}, {"two", 2}, {"zero", std::nullopt}};
+
+        CHECK(json(opt_object) == j_object);
+        CHECK(j_object.get<std::map<std::string, nlohmann::optional<int>>>() == opt_object);
     }
 }
 #endif

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1656,7 +1656,7 @@ TEST_CASE("nlohmann::optional")
     SECTION("null")
     {
         json j_null;
-        nlohmann::optional<std::string> opt_null;
+        nlohmann::optional<std::string> const opt_null;
 
         CHECK(json(opt_null) == j_null);
         CHECK(j_null.get<nlohmann::optional<std::string>>() == std::nullopt);

--- a/tests/src/unit-optional.cpp
+++ b/tests/src/unit-optional.cpp
@@ -1,0 +1,153 @@
+#include "doctest_compatibility.h"
+
+#include <nlohmann/json.hpp>
+
+#ifdef JSON_HAS_CPP_17
+
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
+
+#include <memory>
+#include <vector>
+#include <utility>
+
+using std::nullopt;
+using std::in_place;
+using nlohmann::optional;
+
+using opt_int = optional<int>;
+using opt_vec = optional<std::vector<int>>;
+using opt_ptr = optional<std::unique_ptr<int>>;
+
+using std_opt_int = std::optional<int>;
+using std_opt_vec = std::optional<std::vector<int>>;
+using std_opt_ptr = std::optional<std::unique_ptr<int>>;
+
+// NOLINTBEGIN(bugprone-unchecked-optional-access,bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
+
+TEST_CASE("nlohmann::optional comparison")
+{
+    CHECK(opt_int() == nullopt);
+    CHECK(nullopt == opt_int());
+    CHECK(opt_int() == opt_int(nullopt));
+    CHECK(opt_int(0) == opt_int(0));
+    CHECK_FALSE(opt_int(0) == nullopt);
+    CHECK_FALSE(nullopt == opt_int(0));
+    CHECK_FALSE(opt_int(0) == opt_int(1));
+
+    CHECK(opt_int(0) != nullopt);
+    CHECK(nullopt != opt_int(0));
+    CHECK(opt_int(0) != opt_int(1));
+    CHECK_FALSE(opt_int() != nullopt);
+    CHECK_FALSE(nullopt != opt_int());
+    CHECK_FALSE(opt_int() != opt_int(nullopt));
+    CHECK_FALSE(opt_int(0) != opt_int(0));
+
+    CHECK(opt_int(0) > nullopt);
+    CHECK(opt_int(1) > opt_int(0));
+    CHECK_FALSE(nullopt > opt_int(0));
+    CHECK_FALSE(opt_int(0) > opt_int(1));
+
+    CHECK(opt_int(0) >= nullopt);
+    CHECK(opt_int(1) >= opt_int(0));
+    CHECK_FALSE(nullopt >= opt_int(0));
+    CHECK_FALSE(opt_int(0) >= opt_int(1));
+
+    CHECK(nullopt < opt_int(0));
+    CHECK(opt_int(0) < opt_int(1));
+    CHECK_FALSE(opt_int(0) < nullopt);
+    CHECK_FALSE(opt_int(1) < opt_int(0));
+
+    CHECK(nullopt <= opt_int(0));
+    CHECK(opt_int(0) <= opt_int(1));
+    CHECK_FALSE(opt_int(0) <= nullopt);
+    CHECK_FALSE(opt_int(1) <= opt_int(0));
+}
+
+TEST_CASE("nlohmann::optional constructors")
+{
+    struct S1
+    {
+        operator int() noexcept
+        {
+            return 0;
+        }
+    };
+    struct S2 : S1
+    {
+        operator opt_int() noexcept
+        {
+            return nullopt;
+        }
+    };
+
+    CHECK(opt_int(S1()) == opt_int(0));
+    CHECK(opt_int(S2()) == nullopt);
+
+    CHECK(opt_int(S1()) == std_opt_int(S1()));
+    CHECK(opt_int(S2()) != std_opt_int(S2()));
+
+    CHECK(opt_int(std_opt_int(0)) == opt_int(0));
+    CHECK(std_opt_int(opt_int(0)) == opt_int(0));
+
+    CHECK(opt_int(in_place) == std_opt_int(in_place));
+    CHECK(opt_vec(in_place) == std_opt_vec(in_place));
+    CHECK(opt_ptr(in_place) == std_opt_ptr(in_place));
+
+    CHECK(opt_vec(in_place, 5)->size() == 5);
+    CHECK(opt_vec(in_place, {1, 2, 3}) == std_opt_vec(in_place, {1, 2, 3}));
+    CHECK(**opt_ptr(in_place, new int{42}) == **std_opt_ptr(in_place, new int{42}));
+
+    std::vector<int> vec{1, 2, 3};
+    CHECK(*opt_vec(in_place, vec.begin(), vec.end()) == vec);
+
+    CHECK(opt_vec({1, 2, 3})->size() == 3);
+}
+
+TEST_CASE("nlohmann::optional copy")
+{
+    opt_int opt1 = 111;
+    std_opt_int opt2 = 222;
+
+    SECTION("1")
+    {
+        opt1 = std::as_const(opt2);
+        CHECK(*opt1 == 222);
+        CHECK(*opt_int(std::as_const(opt1)) == 222);
+    }
+
+    SECTION("2")
+    {
+        opt2 = std::as_const(opt1);
+        CHECK(*opt2 == 111);
+        CHECK(*opt_int(std::as_const(opt2)) == 111);
+    }
+}
+
+TEST_CASE("nlohmann::optional move")
+{
+    opt_ptr opt1(new int(111));
+    std_opt_ptr opt2(new int(222));
+
+    SECTION("1")
+    {
+        opt1 = std::move(opt2);
+        CHECK(*opt2 == nullptr);
+        CHECK(**opt1 == 222);
+        CHECK(**opt_ptr(std::move(opt1)) == 222);
+    }
+
+    SECTION("2")
+    {
+        opt2 = std::move(opt1);
+        CHECK(*opt1 == nullptr);
+        CHECK(**opt2 == 111);
+        CHECK(**opt_ptr(std::move(opt2)) == 111);
+    }
+}
+
+// NOLINTEND(bugprone-unchecked-optional-access,bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+#endif  // JSON_HAS_CPP_17

--- a/tests/src/unit-optional.cpp
+++ b/tests/src/unit-optional.cpp
@@ -35,6 +35,14 @@ TEST_CASE("nlohmann::optional comparison")
     CHECK_FALSE(nullopt == opt_int(0));
     CHECK_FALSE(opt_int(0) == opt_int(1));
 
+    CHECK(opt_int() == std_opt_int());
+    CHECK(opt_int(0) == std_opt_int(0));
+    CHECK_FALSE(opt_int(0) == std_opt_int(1));
+
+    CHECK(std_opt_int() == opt_int());
+    CHECK(std_opt_int(0) == opt_int(0));
+    CHECK_FALSE(std_opt_int(0) == opt_int(1));
+
     CHECK(opt_int(0) != nullopt);
     CHECK(nullopt != opt_int(0));
     CHECK(opt_int(0) != opt_int(1));
@@ -43,25 +51,45 @@ TEST_CASE("nlohmann::optional comparison")
     CHECK_FALSE(opt_int() != opt_int(nullopt));
     CHECK_FALSE(opt_int(0) != opt_int(0));
 
+    CHECK_FALSE(opt_int() != std_opt_int());
+    CHECK_FALSE(opt_int(0) != std_opt_int(0));
+    CHECK(opt_int(0) != std_opt_int(1));
+
+    CHECK_FALSE(std_opt_int() != opt_int());
+    CHECK_FALSE(std_opt_int(0) != opt_int(0));
+    CHECK(std_opt_int(0) != opt_int(1));
+
     CHECK(opt_int(0) > nullopt);
     CHECK(opt_int(1) > opt_int(0));
     CHECK_FALSE(nullopt > opt_int(0));
     CHECK_FALSE(opt_int(0) > opt_int(1));
+
+    CHECK(opt_int(0) > std_opt_int());
+    CHECK(std_opt_int(0) > opt_int());
 
     CHECK(opt_int(0) >= nullopt);
     CHECK(opt_int(1) >= opt_int(0));
     CHECK_FALSE(nullopt >= opt_int(0));
     CHECK_FALSE(opt_int(0) >= opt_int(1));
 
+    CHECK(opt_int(0) >= std_opt_int());
+    CHECK(std_opt_int(0) >= opt_int());
+
     CHECK(nullopt < opt_int(0));
     CHECK(opt_int(0) < opt_int(1));
     CHECK_FALSE(opt_int(0) < nullopt);
     CHECK_FALSE(opt_int(1) < opt_int(0));
 
+    CHECK_FALSE(opt_int(0) < std_opt_int());
+    CHECK_FALSE(std_opt_int(0) < opt_int());
+
     CHECK(nullopt <= opt_int(0));
     CHECK(opt_int(0) <= opt_int(1));
     CHECK_FALSE(opt_int(0) <= nullopt);
     CHECK_FALSE(opt_int(1) <= opt_int(0));
+
+    CHECK_FALSE(opt_int(0) <= std_opt_int());
+    CHECK_FALSE(std_opt_int(0) <= opt_int());
 }
 
 TEST_CASE("nlohmann::optional constructors")

--- a/tests/src/unit-optional.cpp
+++ b/tests/src/unit-optional.cpp
@@ -113,12 +113,12 @@ TEST_CASE("nlohmann::optional copy")
     {
         opt1 = std::as_const(opt2);
         CHECK(*opt1 == 222);
-        CHECK(*opt_int(std::as_const(opt1)) == 222);
+        CHECK(*opt_int(std::as_const(opt1).base()) == 222);
     }
 
     SECTION("2")
     {
-        opt2 = std::as_const(opt1);
+        opt2 = std::as_const(opt1).base();
         CHECK(*opt2 == 111);
         CHECK(*opt_int(std::as_const(opt2)) == 111);
     }


### PR DESCRIPTION
Here is possible solution (or workaround) for issues in PR #2117, #2213.
The problem is caused by "wrong" user defined conversion selected by overload resolution. Compiler selects a converting constructor for `std::optional<std::string>`, while ` template <...> json::operator ValueType` is needed. This behavoir is correct because `json` can be implicitly converted to `std::string`. The constructor is unaware about `from_json` function.
"Non-template" version of conversion operator presented here "adjusts" the resolution process. However, the desired result is achieved for copy initailization only. Direct initialization still selects the converting constructor (this probably cannot be changed).