### PR TITLE
Build tests with warnings as errors enabled

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,20 +15,6 @@ jobs:
     - name: test
       run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure
 
-  clang9:
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: install Clang
-        run: curl -fsSL -o LLVM9.exe https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe ; 7z x LLVM9.exe -y -o"C:/Program Files/LLVM"
-      - name: cmake
-        run: cmake -S . -B build -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe" -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On
-      - name: build
-        run: cmake --build build --parallel 10
-      - name: test
-        run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure
-
   clang10:
     runs-on: windows-latest
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,6 +142,18 @@ set(files
     src/unit-user_defined_input.cpp
     src/unit-wstring.cpp)
 
+set(CLANG_AS_MSVC 0)
+set(MSVC_LIKE 0)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(MSVC_LIKE 1)
+elseif(CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"
+       AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+       AND CMAKE_GENERATOR MATCHES "Visual Studio")
+  set(MSVC_LIKE 1)
+  set(CLANG_AS_MSVC 1)
+endif()
+
 foreach(file ${files})
     get_filename_component(file_basename ${file} NAME_WE)
     string(REGEX REPLACE "unit-([^$]+)" "test-\\1" testcase ${file_basename})
@@ -149,10 +161,12 @@ foreach(file ${files})
     add_executable(${testcase} $<TARGET_OBJECTS:doctest_main> ${file})
     target_compile_definitions(${testcase} PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS)
     target_compile_options(${testcase} PRIVATE
-        $<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal>
+        $<${MSVC_LIKE}:/EHsc;/W4;/WX;$<$<CONFIG:Release>:/Od>>
+        $<$<NOT:${MSVC_LIKE}>:-Wno-deprecated;-Wno-float-equal;-Wall;-Wextra;-pedantic;-Werror>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
+        $<${CLANG_AS_MSVC}:/clang:-Wno-deprecated;/clang:-pedantic;/clang:-Wno-deprecated-declarations;-Wno-float-equal>
     )
+
     target_include_directories(${testcase} PRIVATE ${CMAKE_BINARY_DIR}/include thirdparty/doctest thirdparty/fifo_map)
     target_link_libraries(${testcase} PRIVATE ${NLOHMANN_JSON_TARGET_NAME})
 
@@ -179,9 +193,10 @@ endforeach()
 add_executable(json_unit EXCLUDE_FROM_ALL $<TARGET_OBJECTS:doctest_main> ${files})
 target_compile_definitions(json_unit PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS)
 target_compile_options(json_unit PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal>
+    $<${MSVC_LIKE}:/EHsc;$<$<CONFIG:Release>:/Od>>
+    $<$<NOT:${MSVC_LIKE}>:-Wno-deprecated;-Wno-float-equal>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
+    $<${CLANG_AS_MSVC}:/clang:-Wno-deprecated-declarations>
 )
 target_include_directories(json_unit PRIVATE ${CMAKE_BINARY_DIR}/include thirdparty/doctest thirdparty/fifo_map)
 target_link_libraries(json_unit ${NLOHMANN_JSON_TARGET_NAME})

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;
@@ -95,6 +99,8 @@ struct my_allocator : std::allocator<T>
     {
         if (next_deallocate_fails)
         {
+            (void)p; // Ignored unused
+            (void)n; // ignored unused
             next_deallocate_fails = false;
             throw std::bad_alloc();
         }

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -114,6 +114,7 @@ struct my_allocator : std::allocator<T>
     {
         if (next_destroy_fails)
         {
+            (void)p; // Ignored unused
             next_destroy_fails = false;
             throw std::bad_alloc();
         }

--- a/test/src/unit-bson.cpp
+++ b/test/src/unit-bson.cpp
@@ -867,8 +867,9 @@ TEST_CASE("Negative size of binary value")
 
         0x00 // end marker
     };
-    CHECK_THROWS_AS(json::from_bson(input), json::parse_error);
-    CHECK_THROWS_WITH(json::from_bson(input), "[json.exception.parse_error.112] parse error at byte 15: syntax error while parsing BSON binary: byte array length cannot be negative, is -1");
+    json _;
+    CHECK_THROWS_AS(_ = json::from_bson(input), json::parse_error);
+    CHECK_THROWS_WITH(_ = json::from_bson(input), "[json.exception.parse_error.112] parse error at byte 15: syntax error while parsing BSON binary: byte array length cannot be negative, is -1");
 }
 
 TEST_CASE("Unsupported BSON input")

--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -1591,14 +1591,16 @@ TEST_CASE("CBOR")
             {
                 // array with three empty byte strings
                 std::vector<std::uint8_t> input = {0x83, 0x40, 0x40, 0x40};
-                CHECK_NOTHROW(json::from_cbor(input));
+                json _;
+                CHECK_NOTHROW(_ = json::from_cbor(input));
             }
 
             SECTION("binary in object")
             {
                 // object mapping "foo" to empty byte string
                 std::vector<std::uint8_t> input = {0xA1, 0x63, 0x66, 0x6F, 0x6F, 0x40};
-                CHECK_NOTHROW(json::from_cbor(input));
+                json _;
+                CHECK_NOTHROW(_ = json::from_cbor(input));
             }
 
             SECTION("SAX callback with binary")
@@ -2551,8 +2553,9 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), b);
 
             // check that parsing fails in error mode
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
 
             // check that parsing succeeds and gets original value in ignore mode
             auto j_tagged = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore);
@@ -2570,8 +2573,9 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xD8); // tag
 
             // check that parsing fails in error mode
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
 
             // check that parsing succeeds and gets original value in ignore mode
             auto j_tagged = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore);
@@ -2585,9 +2589,10 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xD8); // tag
 
             // check that parsing fails in all modes
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
         }
     }
 
@@ -2602,8 +2607,9 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xD9); // tag
 
             // check that parsing fails in error mode
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
 
             // check that parsing succeeds and gets original value in ignore mode
             auto j_tagged = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore);
@@ -2618,9 +2624,10 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xD9); // tag
 
             // check that parsing fails in all modes
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
         }
     }
 
@@ -2637,8 +2644,9 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xDA); // tag
 
             // check that parsing fails in error mode
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
 
             // check that parsing succeeds and gets original value in ignore mode
             auto j_tagged = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore);
@@ -2655,9 +2663,10 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xDA); // tag
 
             // check that parsing fails in all modes
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
         }
     }
 
@@ -2678,8 +2687,9 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xDB); // tag
 
             // check that parsing fails in error mode
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
 
             // check that parsing succeeds and gets original value in ignore mode
             auto j_tagged = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore);
@@ -2700,9 +2710,10 @@ TEST_CASE("Tagged values")
             v_tagged.insert(v_tagged.begin(), 0xDB); // tag
 
             // check that parsing fails in all modes
-            CHECK_THROWS_AS(json::from_cbor(v_tagged), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
-            CHECK_THROWS_AS(json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
         }
     }
 
@@ -2717,8 +2728,9 @@ TEST_CASE("Tagged values")
         CHECK(vec == std::vector<std::uint8_t> {0xA1, 0x66, 0x62, 0x69, 0x6E, 0x61, 0x72, 0x79, 0xD8, 0x2A, 0x44, 0xCA, 0xFE, 0xBA, 0xBE});
 
         // parse error when parsing tagged value
-        CHECK_THROWS_AS(json::from_cbor(vec), json::parse_error);
-        CHECK_THROWS_WITH(json::from_cbor(vec), "[json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: invalid byte: 0xD8");
+        json _;
+        CHECK_THROWS_AS(_ = json::from_cbor(vec), json::parse_error);
+        CHECK_THROWS_WITH(_ = json::from_cbor(vec), "[json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: invalid byte: 0xD8");
 
         // binary without subtype when tags are ignored
         json jb = json::from_cbor(vec, true, true, json::cbor_tag_handler_t::ignore);

--- a/test/src/unit-class_const_iterator.cpp
+++ b/test/src/unit-class_const_iterator.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-class_iterator.cpp
+++ b/test/src/unit-class_iterator.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-class_lexer.cpp
+++ b/test/src/unit-class_lexer.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -1879,7 +1879,8 @@ TEST_CASE("parser class")
 
     SECTION("error messages for comments")
     {
-        CHECK_THROWS_WITH_AS(json::parse("/a", nullptr, true, true), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid comment; expecting '/' or '*' after '/'; last read: '/a'", json::parse_error);
-        CHECK_THROWS_WITH_AS(json::parse("/*", nullptr, true, true), "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid comment; missing closing '*/'; last read: '/*<U+0000>'", json::parse_error);
+        json _;
+        CHECK_THROWS_WITH_AS(_ = json::parse("/a", nullptr, true, true), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid comment; expecting '/' or '*' after '/'; last read: '/a'", json::parse_error);
+        CHECK_THROWS_WITH_AS(_ = json::parse("/*", nullptr, true, true), "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid comment; missing closing '*/'; last read: '/*<U+0000>'", json::parse_error);
     }
 }

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-constructor1.cpp
+++ b/test/src/unit-constructor1.cpp
@@ -28,7 +28,12 @@ SOFTWARE.
 */
 
 #include "doctest_compatibility.h"
+
 DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
 
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-deserialization.cpp
+++ b/test/src/unit-deserialization.cpp
@@ -537,7 +537,8 @@ TEST_CASE("deserialization")
             SECTION("with empty range")
             {
                 std::vector<uint8_t> v;
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 SaxEventLogger l;
@@ -553,7 +554,8 @@ TEST_CASE("deserialization")
             SECTION("case 1")
             {
                 uint8_t v[] = {'\"', 'a', 'a', 'a', 'a', 'a', 'a', '\\', 'u'};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -569,7 +571,8 @@ TEST_CASE("deserialization")
             SECTION("case 2")
             {
                 uint8_t v[] = {'\"', 'a', 'a', 'a', 'a', 'a', 'a', '\\', 'u', '1'};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -585,7 +588,8 @@ TEST_CASE("deserialization")
             SECTION("case 3")
             {
                 uint8_t v[] = {'\"', 'a', 'a', 'a', 'a', 'a', 'a', '\\', 'u', '1', '1', '1', '1', '1', '1', '1', '1'};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -601,7 +605,8 @@ TEST_CASE("deserialization")
             SECTION("case 4")
             {
                 uint8_t v[] = {'\"', 'a', 'a', 'a', 'a', 'a', 'a', 'u', '1', '1', '1', '1', '1', '1', '1', '1', '\\'};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -617,7 +622,8 @@ TEST_CASE("deserialization")
             SECTION("case 5")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xC1};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -652,7 +658,8 @@ TEST_CASE("deserialization")
             SECTION("case 7")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xDF, 0xC0};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -668,7 +675,8 @@ TEST_CASE("deserialization")
             SECTION("case 8")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xE0, 0x9F};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -684,7 +692,8 @@ TEST_CASE("deserialization")
             SECTION("case 9")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xEF, 0xC0};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -700,7 +709,8 @@ TEST_CASE("deserialization")
             SECTION("case 10")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xED, 0x7F};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -716,7 +726,8 @@ TEST_CASE("deserialization")
             SECTION("case 11")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xF0, 0x8F};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -732,7 +743,8 @@ TEST_CASE("deserialization")
             SECTION("case 12")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xF0, 0xC0};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -748,7 +760,8 @@ TEST_CASE("deserialization")
             SECTION("case 13")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xF3, 0x7F};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -764,7 +777,8 @@ TEST_CASE("deserialization")
             SECTION("case 14")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xF3, 0xC0};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -780,7 +794,8 @@ TEST_CASE("deserialization")
             SECTION("case 15")
             {
                 uint8_t v[] = {'\"', 0x7F, 0xF4, 0x7F};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -796,7 +811,8 @@ TEST_CASE("deserialization")
             SECTION("case 16")
             {
                 uint8_t v[] = {'{', '\"', '\"', ':', '1', '1'};
-                CHECK_THROWS_AS(json::parse(std::begin(v), std::end(v)), json::parse_error&);
+                json _;
+                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;

--- a/test/src/unit-deserialization.cpp
+++ b/test/src/unit-deserialization.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 20, 0)
+DOCTEST_MSVC_SUPPRESS_WARNING(4309) // 'conversion' : truncation of constant value
+#endif // VS 14 2015 and 15 2017
+
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 

--- a/test/src/unit-items.cpp
+++ b/test/src/unit-items.cpp
@@ -39,6 +39,14 @@ using nlohmann::json;
     #define JSON_HAS_CPP_14
 #endif
 
+#if defined(DOCTEST_PLATFORM_WINDOWS) && defined(DOCTEST_CLANG) && DOCTEST_CLANG >= DOCTEST_COMPILER(10, 0, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wrange-loop-construct")
+// work around misdetection of platform on MacOSX Big Sur, this should be DOCTEST_PLATFORM_MAC
+// see also https://github.com/onqtam/doctest/issues/415
+#elif defined(DOCTEST_PLATFORM_LINUX) && defined(DOCTEST_CLANG) && DOCTEST_CLANG >= DOCTEST_COMPILER(12, 0, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wrange-loop-analysis")
+#endif
+
 TEST_CASE("iterator_wrapper")
 {
     SECTION("object")

--- a/test/src/unit-iterators1.cpp
+++ b/test/src/unit-iterators1.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -29,6 +29,12 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+DOCTEST_MSVC_SUPPRESS_WARNING(4127)
+
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-noexcept.cpp
+++ b/test/src/unit-noexcept.cpp
@@ -31,6 +31,8 @@ SOFTWARE.
 
 #include <nlohmann/json.hpp>
 
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wunneeded-internal-declaration")
+
 using nlohmann::json;
 
 namespace

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -30,6 +30,10 @@ SOFTWARE.
 #include "doctest_compatibility.h"
 DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 // for some reason including this after the json header leads to linker errors with VS 2017...
 #include <locale>
 

--- a/test/src/unit-to_chars.cpp
+++ b/test/src/unit-to_chars.cpp
@@ -33,6 +33,11 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if (DOCTEST_GCC >= DOCTEST_COMPILER(4, 8, 0)) && \
+    (DOCTEST_GCC < DOCTEST_COMPILER(5, 0, 0))
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")
+#endif // gcc 4.8.x and 4.9.x
+
 #include <nlohmann/json.hpp>
 using nlohmann::detail::dtoa_impl::reinterpret_bits;
 

--- a/test/src/unit-ubjson.cpp
+++ b/test/src/unit-ubjson.cpp
@@ -798,6 +798,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("errors")
                 {
+                    json _;
                     // error while parsing length
                     std::vector<uint8_t> vec0 = {'H', 'i'};
                     CHECK(json::from_ubjson(vec0, true, false).is_discarded());
@@ -806,11 +807,11 @@ TEST_CASE("UBJSON")
                     CHECK(json::from_ubjson(vec1, true, false).is_discarded());
 
                     std::vector<uint8_t> vec2 = {'H', 'i', 2, '1', 'A', '3'};
-                    CHECK_THROWS_WITH_AS(json::from_ubjson(vec2), "[json.exception.parse_error.115] parse error at byte 5: syntax error while parsing UBJSON high-precision number: invalid number text: 1A", json::parse_error);
+                    CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vec2), "[json.exception.parse_error.115] parse error at byte 5: syntax error while parsing UBJSON high-precision number: invalid number text: 1A", json::parse_error);
                     std::vector<uint8_t> vec3 = {'H', 'i', 2, '1', '.'};
-                    CHECK_THROWS_WITH_AS(json::from_ubjson(vec3), "[json.exception.parse_error.115] parse error at byte 5: syntax error while parsing UBJSON high-precision number: invalid number text: 1.", json::parse_error);
+                    CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vec3), "[json.exception.parse_error.115] parse error at byte 5: syntax error while parsing UBJSON high-precision number: invalid number text: 1.", json::parse_error);
                     std::vector<uint8_t> vec4 = {'H', 2, '1', '0'};
-                    CHECK_THROWS_WITH_AS(json::from_ubjson(vec4), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON size: expected length type specification (U, i, I, l, L) after '#'; last byte: 0x02", json::parse_error);
+                    CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vec4), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON size: expected length type specification (U, i, I, l, L) after '#'; last byte: 0x02", json::parse_error);
                 }
 
                 SECTION("serialization")

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -817,7 +817,9 @@ class Evil
   public:
     Evil() = default;
     template <typename T>
-    Evil(T t) : m_i(sizeof(t)) {}
+    Evil(T t) : m_i(sizeof(t)) {
+      (void)t; // Ignored unused
+    }
 
     int m_i = 0;
 };

--- a/test/src/unit-unicode.cpp
+++ b/test/src/unit-unicode.cpp
@@ -1200,8 +1200,9 @@ TEST_CASE("Unicode" * doctest::skip())
 
         SECTION("with an iterator")
         {
+            json _;
             std::string i = "\xef\xbb\xbf{\n   \"foo\": true\n}";
-            CHECK_NOTHROW(json::parse(i.begin(), i.end()));
+            CHECK_NOTHROW(_ = json::parse(i.begin(), i.end()));
         }
     }
 

--- a/test/src/unit-unicode.cpp
+++ b/test/src/unit-unicode.cpp
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#if DOCTEST_CLANG && DOCTEST_CLANG >= DOCTEST_COMPILER(3, 6, 0)
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wkeyword-macro")
+#endif // clang 3.6.x
+
 // for some reason including this after the json header leads to linker errors with VS 2017...
 #include <locale>
 

--- a/test/src/unit-user_defined_input.cpp
+++ b/test/src/unit-user_defined_input.cpp
@@ -29,6 +29,8 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
+
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 


### PR DESCRIPTION
I'm trying to resurrect https://github.com/nlohmann/json/pull/1900.

- [x] Cleanup commits
- [x] `#if DOCTEST_CLANG >=` -> `#if DOCTEST_CLANG && DOCTEST_CLANG >=`
- [x] Fix https://github.com/nemequ/hedley/issues/40 upstream
- [x] Get it working

Close https://github.com/nlohmann/json/issues/1798.