### PR TITLE
fix the bug

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3803,13 +3803,34 @@ class basic_json
         JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
     }
 
+    template<class ValueType, typename std::enable_if<
+                 std::is_convertible<basic_json_t, ValueType>::value
+                 and not std::is_same<value_t, ValueType>::value, int>::type = 0>
+    ValueType value(const typename object_t::key_type& key, ValueType && default_value) const
+    {
+        // at only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(key);
+            if (it != end())
+            {
+                return *it;
+            }
+
+            return std::move(default_value);
+        }
+
+        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+    }
+
     /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
     */
     string_t value(const typename object_t::key_type& key, const char* default_value) const
     {
-        return value(key, string_t(default_value));
+        return value(key, std::move(string_t(default_value)));
     }
 
     /*!
@@ -3876,6 +3897,27 @@ class basic_json
         JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
     }
 
+    template<class ValueType, typename std::enable_if<
+                 std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
+    ValueType value(const json_pointer& ptr, ValueType && default_value) const
+    {
+        // at only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if pointer resolves a value, return it or use default value
+            JSON_TRY
+            {
+                return ptr.get_checked(this);
+            }
+            JSON_INTERNAL_CATCH (out_of_range&)
+            {
+                return std::move(default_value);
+            }
+        }
+
+        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+    }
+
     /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const json_pointer&, ValueType) const
@@ -3883,7 +3925,7 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     string_t value(const json_pointer& ptr, const char* default_value) const
     {
-        return value(ptr, string_t(default_value));
+        return value(ptr, std::move(string_t(default_value)));
     }
 
     /*!

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3830,7 +3830,7 @@ class basic_json
     */
     string_t value(const typename object_t::key_type& key, const char* default_value) const
     {
-        return value(key, std::move(string_t(default_value)));
+        return value(key, string_t(default_value));
     }
 
     /*!
@@ -3925,7 +3925,7 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     string_t value(const json_pointer& ptr, const char* default_value) const
     {
-        return value(ptr, std::move(string_t(default_value)));
+        return value(ptr, string_t(default_value));
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19760,7 +19760,7 @@ class basic_json
     */
     string_t value(const typename object_t::key_type& key, const char* default_value) const
     {
-        return value(key, std::move(string_t(default_value)));
+        return value(key, string_t(default_value));
     }
 
     /*!
@@ -19855,7 +19855,7 @@ class basic_json
     JSON_HEDLEY_NON_NULL(3)
     string_t value(const json_pointer& ptr, const char* default_value) const
     {
-        return value(ptr, std::move(string_t(default_value)));
+        return value(ptr, string_t(default_value));
     }
 
     /*!

--- a/test/src/unit-element_access2.cpp
+++ b/test/src/unit-element_access2.cpp
@@ -282,6 +282,18 @@ TEST_CASE("element access 2")
                         CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
                                           "[json.exception.type_error.306] cannot use value() with number");
                     }
+                    SECTION("default value is lvalue")
+                    {
+                        json j_nonobject(json::value_t::number_float);
+                        const json j_nonobject_const(j_nonobject);
+                        std::string defval = "default value";
+                        CHECK_THROWS_AS(j_nonobject.value("foo", defval), json::type_error&);
+                        CHECK_THROWS_AS(j_nonobject_const.value("foo", defval), json::type_error&);
+                        CHECK_THROWS_WITH(j_nonobject.value("foo", defval),
+                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", defval),
+                                          "[json.exception.type_error.306] cannot use value() with number");
+                    }
                 }
             }
 


### PR DESCRIPTION
This is a new PR for #2181.
From CI logs, the test `SECTION("PR #2181 - regression bug with lvalue")` has no error for this new PR. 
I just added back the original method and then there would be two methods:
```
ValueType value(const typename object_t::key_type& key, const ValueType& default_value) const //  added back
...
ValueType value(const typename object_t::key_type& key, ValueType && default_value) const
```

But to be cautious, maybe some more testcases should be added.