### PR TITLE
Clean up maintainer Makefiles and fix some linter warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -577,12 +577,12 @@ check-single-includes:
 # check if all flags of our CMake files work
 check_cmake_flags_do:
 	$(CMAKE_BINARY) --version
-	for flag in '' JSON_BuildTests JSON_Install JSON_MultipleHeaders JSON_Sanitizer JSON_Valgrind JSON_NoExceptions JSON_Coverage; do \
+	for flag in JSON_BuildTests JSON_Install JSON_MultipleHeaders JSON_Sanitizer JSON_Valgrind JSON_NoExceptions JSON_Coverage; do \
 		rm -fr cmake_build; \
 		mkdir cmake_build; \
-		echo "$(CMAKE_BINARY) .. -D$$flag=On" ; \
+		echo "\n\n$(CMAKE_BINARY) .. -D$$flag=On\n" ; \
 		cd cmake_build ; \
-		CXX=g++-8 $(CMAKE_BINARY) .. -D$$flag=On -DCMAKE_CXX_COMPILE_FEATURES="cxx_std_11;cxx_range_for" -DCMAKE_CXX_FLAGS="-std=gnu++11" ; \
+		$(CMAKE_BINARY) -Werror=dev .. -D$$flag=On -DCMAKE_CXX_COMPILE_FEATURES="cxx_std_11;cxx_range_for" -DCMAKE_CXX_FLAGS="-std=gnu++11" ; \
 		test -f Makefile || exit 1 ; \
 		cd .. ; \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ AMALGAMATED_FILE=single_include/nlohmann/json.hpp
 all:
 	@echo "amalgamate - amalgamate file single_include/nlohmann/json.hpp from the include/nlohmann sources"
 	@echo "ChangeLog.md - generate ChangeLog file"
-	@echo "check - compile and execute test suite"
 	@echo "check-amalgamation - check whether sources have been amalgamated"
 	@echo "clean - remove built files"
 	@echo "coverage - create coverage information with lcov"
@@ -44,24 +43,10 @@ all:
 	@echo "fuzz_testing_cbor - prepare fuzz testing of the CBOR parser"
 	@echo "fuzz_testing_msgpack - prepare fuzz testing of the MessagePack parser"
 	@echo "fuzz_testing_ubjson - prepare fuzz testing of the UBJSON parser"
-	@echo "json_unit - create single-file test executable"
 	@echo "pedantic_clang - run Clang with maximal warning flags"
 	@echo "pedantic_gcc - run GCC with maximal warning flags"
 	@echo "pretty - beautify code with Artistic Style"
 	@echo "run_benchmarks - build and run benchmarks"
-
-
-##########################################################################
-# unit tests
-##########################################################################
-
-# build unit tests
-json_unit:
-	@$(MAKE) json_unit -C test
-
-# run unit tests
-check:
-	$(MAKE) check -C test
 
 
 ##########################################################################
@@ -642,7 +627,6 @@ clean:
 	rm -fr cmake-3.1.0-Darwin64.tar.gz cmake-3.1.0-Darwin64
 	rm -fr build_coverage build_benchmarks fuzz-testing clang_analyze_build pvs_studio_build infer_build clang_sanitize_build cmake_build
 	$(MAKE) clean -Cdoc
-	$(MAKE) clean -Ctest
 
 ##########################################################################
 # Thirdparty code

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ##########################################################################
 
 # directory to recent compiler binaries
-COMPILER_DIR=/Users/niels/Documents/projects/compilers/local/bin
+COMPILER_DIR=/usr/local/opt/llvm/bin
 
 # find GNU sed to use `-i` parameter
 SED:=$(shell command -v gsed || which sed)
@@ -484,13 +484,13 @@ cpplint:
 
 # call Clang-Tidy <https://clang.llvm.org/extra/clang-tidy/>
 clang_tidy:
-	$(COMPILER_DIR)/clang-tidy $(AMALGAMATED_FILE) -- -Iinclude -std=c++11
+	$(COMPILER_DIR)/clang-tidy $(SRCS) -- -Iinclude -std=c++11
 
 # call PVS-Studio Analyzer <https://www.viva64.com/en/pvs-studio/>
 pvs_studio:
 	rm -fr pvs_studio_build
 	mkdir pvs_studio_build
-	cd pvs_studio_build ; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+	cd pvs_studio_build ; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DJSON_MultipleHeaders=ON
 	cd pvs_studio_build ; pvs-studio-analyzer analyze -j 10
 	cd pvs_studio_build ; plog-converter -a'GA:1,2;64:1;CS' -t fullhtml PVS-Studio.log -o pvs
 	open pvs_studio_build/pvs/index.html
@@ -499,7 +499,7 @@ pvs_studio:
 infer:
 	rm -fr infer_build
 	mkdir infer_build
-	cd infer_build ; infer compile -- cmake .. ; infer run -- make -j 4
+	cd infer_build ; infer compile -- cmake .. -DJSON_MultipleHeaders=ON ; infer run -- make -j 4
 
 # call OCLint <http://oclint.org> static analyzer
 oclint:

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -36,7 +36,7 @@ class file_input_adapter
     using char_type = char;
 
     JSON_HEDLEY_NON_NULL(2)
-    explicit file_input_adapter(std::FILE* f)  noexcept
+    explicit file_input_adapter(std::FILE* f) noexcept
         : m_file(f)
     {}
 
@@ -90,7 +90,7 @@ class input_stream_adapter
     input_stream_adapter& operator=(input_stream_adapter&) = delete;
     input_stream_adapter& operator=(input_stream_adapter&& rhs) = delete;
 
-    input_stream_adapter(input_stream_adapter&& rhs) : is(rhs.is), sb(rhs.sb)
+    input_stream_adapter(input_stream_adapter&& rhs) noexcept : is(rhs.is), sb(rhs.sb)
     {
         rhs.is = nullptr;
         rhs.sb = nullptr;

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -258,30 +258,14 @@ class json_sax_dom_parser
         return true;
     }
 
+    template<class Exception>
     bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
-                     const detail::exception& ex)
+                     const Exception& ex)
     {
         errored = true;
         if (allow_exceptions)
         {
-            // determine the proper exception type from the id
-            switch ((ex.id / 100) % 100)
-            {
-                case 1:
-                    JSON_THROW(*dynamic_cast<const detail::parse_error*>(&ex));
-                case 4:
-                    JSON_THROW(*dynamic_cast<const detail::out_of_range*>(&ex));
-                // LCOV_EXCL_START
-                case 2:
-                    JSON_THROW(*dynamic_cast<const detail::invalid_iterator*>(&ex));
-                case 3:
-                    JSON_THROW(*dynamic_cast<const detail::type_error*>(&ex));
-                case 5:
-                    JSON_THROW(*dynamic_cast<const detail::other_error*>(&ex));
-                default:
-                    JSON_ASSERT(false);
-                    // LCOV_EXCL_STOP
-            }
+            JSON_THROW(ex);
         }
         return false;
     }
@@ -512,30 +496,14 @@ class json_sax_dom_callback_parser
         return true;
     }
 
+    template<class Exception>
     bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
-                     const detail::exception& ex)
+                     const Exception& ex)
     {
         errored = true;
         if (allow_exceptions)
         {
-            // determine the proper exception type from the id
-            switch ((ex.id / 100) % 100)
-            {
-                case 1:
-                    JSON_THROW(*dynamic_cast<const detail::parse_error*>(&ex));
-                case 4:
-                    JSON_THROW(*dynamic_cast<const detail::out_of_range*>(&ex));
-                // LCOV_EXCL_START
-                case 2:
-                    JSON_THROW(*dynamic_cast<const detail::invalid_iterator*>(&ex));
-                case 3:
-                    JSON_THROW(*dynamic_cast<const detail::type_error*>(&ex));
-                case 5:
-                    JSON_THROW(*dynamic_cast<const detail::other_error*>(&ex));
-                default:
-                    JSON_ASSERT(false);
-                    // LCOV_EXCL_STOP
-            }
+            JSON_THROW(ex);
         }
         return false;
     }

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1521,7 +1521,6 @@ scan_number_done:
             // skip following whitespace
             skip_whitespace();
         }
-        while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
 
         switch (current)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -9626,7 +9626,6 @@ scan_number_done:
             // skip following whitespace
             skip_whitespace();
         }
-        while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
 
         switch (current)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4500,7 +4500,7 @@ class file_input_adapter
     using char_type = char;
 
     JSON_HEDLEY_NON_NULL(2)
-    explicit file_input_adapter(std::FILE* f)  noexcept
+    explicit file_input_adapter(std::FILE* f) noexcept
         : m_file(f)
     {}
 
@@ -4554,7 +4554,7 @@ class input_stream_adapter
     input_stream_adapter& operator=(input_stream_adapter&) = delete;
     input_stream_adapter& operator=(input_stream_adapter&& rhs) = delete;
 
-    input_stream_adapter(input_stream_adapter&& rhs) : is(rhs.is), sb(rhs.sb)
+    input_stream_adapter(input_stream_adapter&& rhs) noexcept : is(rhs.is), sb(rhs.sb)
     {
         rhs.is = nullptr;
         rhs.sb = nullptr;
@@ -5180,30 +5180,14 @@ class json_sax_dom_parser
         return true;
     }
 
+    template<class Exception>
     bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
-                     const detail::exception& ex)
+                     const Exception& ex)
     {
         errored = true;
         if (allow_exceptions)
         {
-            // determine the proper exception type from the id
-            switch ((ex.id / 100) % 100)
-            {
-                case 1:
-                    JSON_THROW(*dynamic_cast<const detail::parse_error*>(&ex));
-                case 4:
-                    JSON_THROW(*dynamic_cast<const detail::out_of_range*>(&ex));
-                // LCOV_EXCL_START
-                case 2:
-                    JSON_THROW(*dynamic_cast<const detail::invalid_iterator*>(&ex));
-                case 3:
-                    JSON_THROW(*dynamic_cast<const detail::type_error*>(&ex));
-                case 5:
-                    JSON_THROW(*dynamic_cast<const detail::other_error*>(&ex));
-                default:
-                    JSON_ASSERT(false);
-                    // LCOV_EXCL_STOP
-            }
+            JSON_THROW(ex);
         }
         return false;
     }
@@ -5434,30 +5418,14 @@ class json_sax_dom_callback_parser
         return true;
     }
 
+    template<class Exception>
     bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
-                     const detail::exception& ex)
+                     const Exception& ex)
     {
         errored = true;
         if (allow_exceptions)
         {
-            // determine the proper exception type from the id
-            switch ((ex.id / 100) % 100)
-            {
-                case 1:
-                    JSON_THROW(*dynamic_cast<const detail::parse_error*>(&ex));
-                case 4:
-                    JSON_THROW(*dynamic_cast<const detail::out_of_range*>(&ex));
-                // LCOV_EXCL_START
-                case 2:
-                    JSON_THROW(*dynamic_cast<const detail::invalid_iterator*>(&ex));
-                case 3:
-                    JSON_THROW(*dynamic_cast<const detail::type_error*>(&ex));
-                case 5:
-                    JSON_THROW(*dynamic_cast<const detail::other_error*>(&ex));
-                default:
-                    JSON_ASSERT(false);
-                    // LCOV_EXCL_STOP
-            }
+            JSON_THROW(ex);
         }
         return false;
     }

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,98 +1,13 @@
-##########################################################################
-# unit tests
-##########################################################################
+##############################################################################
+# OSS-Fuzz
+##############################################################################
+
+# The following targets realize the integration to OSS-Fuzz.
+# See <https://github.com/google/oss-fuzz/blob/master/projects/json/build.sh> for more information.
 
 # additional flags
-CXXFLAGS += -std=c++11 -Wall -Wextra -pedantic -Wcast-align -Wcast-qual -Wno-ctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-declarations -Wmissing-include-dirs -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch -Wundef -Wno-unused -Wnon-virtual-dtor -Wreorder -Wdeprecated -Wno-float-equal
-CPPFLAGS += -I ../single_include -I . -I thirdparty/doctest -I thirdparty/fifo_map -DDOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-SOURCES = src/unit.cpp \
-          src/unit-algorithms.cpp \
-          src/unit-allocator.cpp \
-          src/unit-alt-string.cpp \
-          src/unit-bson.cpp \
-          src/unit-capacity.cpp \
-          src/unit-cbor.cpp \
-          src/unit-class_const_iterator.cpp \
-          src/unit-class_iterator.cpp \
-          src/unit-class_lexer.cpp \
-          src/unit-class_parser.cpp \
-          src/unit-comparison.cpp \
-          src/unit-concepts.cpp \
-          src/unit-constructor1.cpp \
-          src/unit-constructor2.cpp \
-          src/unit-convenience.cpp \
-          src/unit-conversions.cpp \
-          src/unit-deserialization.cpp \
-          src/unit-element_access1.cpp \
-          src/unit-element_access2.cpp \
-          src/unit-inspection.cpp \
-          src/unit-items.cpp \
-          src/unit-iterators1.cpp \
-          src/unit-iterators2.cpp \
-          src/unit-merge_patch.cpp \
-          src/unit-json_patch.cpp \
-          src/unit-json_pointer.cpp \
-          src/unit-meta.cpp \
-          src/unit-modifiers.cpp \
-          src/unit-msgpack.cpp \
-          src/unit-pointer_access.cpp \
-          src/unit-readme.cpp \
-          src/unit-reference_access.cpp \
-          src/unit-regression.cpp \
-          src/unit-serialization.cpp \
-          src/unit-testsuites.cpp \
-          src/unit-ubjson.cpp \
-          src/unit-unicode.cpp \
-          src/unit-user_defined_input.cpp \
-          src/unit-wstring.cpp
-
-OBJECTS = $(SOURCES:.cpp=.o)
-
-TESTCASES = $(patsubst src/unit-%.cpp,test-%,$(wildcard src/unit-*.cpp))
-
-##############################################################################
-# main rules
-##############################################################################
-
-all: $(TESTCASES)
-
-clean:
-	rm -fr json_unit $(OBJECTS) $(SOURCES:.cpp=.gcno) $(SOURCES:.cpp=.gcda) $(TESTCASES) $(FUZZERS) test_data.hpp
-
-test_data.hpp:
-	@echo "#define TEST_DATA_DIRECTORY" > $@
-
-##############################################################################
-# single test file
-##############################################################################
-
-json_unit: $(OBJECTS) ../single_include/nlohmann/json.hpp thirdparty/doctest/doctest.h
-	@echo "[CXXLD] $@"
-	@$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJECTS) -o $@
-
-%.o: %.cpp ../single_include/nlohmann/json.hpp thirdparty/doctest/doctest.h test_data.hpp
-	@echo "[CXX]   $@"
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
-
-
-##############################################################################
-# individual test cases
-##############################################################################
-
-test-%: src/unit-%.o src/unit.o ../single_include/nlohmann/json.hpp thirdparty/doctest/doctest.h test_data.hpp
-	@echo "[CXXLD] $@"
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $< src/unit.o -o $@
-
-TEST_PATTERN ?= "*"
-TEST_PREFIX = ""
-check: $(OBJECTS) $(TESTCASES)
-	@cd .. ; for testcase in $(TESTCASES); do echo "Executing $$testcase..."; $(TEST_PREFIX)test/$$testcase $(TEST_PATTERN) || exit 1; done
-
-
-##############################################################################
-# fuzzer
-##############################################################################
+CXXFLAGS += -std=c++11
+CPPFLAGS += -I ../single_include
 
 FUZZER_ENGINE = src/fuzzer-driver_afl.cpp
 FUZZERS = parse_afl_fuzzer parse_bson_fuzzer parse_cbor_fuzzer parse_msgpack_fuzzer parse_ubjson_fuzzer


### PR DESCRIPTION
This PR cleans up the maintainer targets in the Makefiles:

- Static analyzers use multi-header versions.
- CMake tests are executed with developer warnings.
- Test suite is exclusively managed by CMake (only kept fuzzer targets in `test/Makefile`).

Furthermore, some linter warnings have been fixed.