### PR TITLE
add inline specifier for detail::combine

### DIFF
--- a/include/nlohmann/detail/hash.hpp
+++ b/include/nlohmann/detail/hash.hpp
@@ -9,7 +9,7 @@ namespace detail
 {
 
 // boost::hash_combine
-std::size_t combine(std::size_t seed, std::size_t h) noexcept
+inline std::size_t combine(std::size_t seed, std::size_t h) noexcept
 {
     seed ^= h + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
     return seed;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4454,7 +4454,7 @@ namespace detail
 {
 
 // boost::hash_combine
-std::size_t combine(std::size_t seed, std::size_t h) noexcept
+inline std::size_t combine(std::size_t seed, std::size_t h) noexcept
 {
     seed ^= h + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
     return seed;


### PR DESCRIPTION
fix compiles where multiple source files include the header and generate multiple definitions of `nlohmann::detail::combine` by adding an inline specifier.

I hope it's okay I skipped the unit test and stuff since I would figure this literally can't break anything.

Fixes #2281.