### PR TITLE
Introduce try_get() and try_deserialize()

### DIFF
--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -87,6 +87,9 @@ using to_json_function = decltype(T::to_json(std::declval<Args>()...));
 template<typename T, typename... Args>
 using from_json_function = decltype(T::from_json(std::declval<Args>()...));
 
+template<typename T, typename... Args>
+using try_deserialize_function = decltype(T::try_deserialize(std::declval<Args>()...));
+
 template<typename T, typename U>
 using get_template_function = decltype(std::declval<T>().template get<U>());
 
@@ -117,6 +120,20 @@ struct has_non_default_from_json < BasicJsonType, T, enable_if_t < !is_basic_jso
 
     static constexpr bool value =
         is_detected_exact<T, from_json_function, serializer,
+        const BasicJsonType&>::value;
+};
+
+template<typename BasicJsonType, typename T, typename = void>
+struct has_try_deserialize : std::false_type {};
+
+template<typename BasicJsonType, typename T>
+struct has_try_deserialize < BasicJsonType, T,
+           enable_if_t < !is_basic_json<T>::value >>
+{
+    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+
+    static constexpr bool value =
+        is_detected<try_deserialize_function, serializer,
         const BasicJsonType&>::value;
 };
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -2978,6 +2978,38 @@ class basic_json
     }
 
     /*!
+    @brief get a wrapped value (explicit)
+
+    Explicit type conversion between the JSON value and a compatible value wrapper
+    The value is converted by calling the @ref json_serializer<ValueType>
+    `try_deserialize()` method.
+
+    The function is equivalent to executing
+    @code {.cpp}
+    return JSONSerializer<ValueTypeCV>::try_deserialize(*this);
+    @endcode
+
+    @tparam ValueTypeCV the provided value type
+    @tparam ValueType the returned value type
+
+    @return copy of the JSON value, converted to @a ValueType wrapper
+
+    @throw what @ref json_serializer<ValueType> `try_deserialize()` method throws
+    */
+    template < typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>,
+               typename ReturnType = decltype(JSONSerializer<ValueType>::try_deserialize(std::declval<const basic_json_t&>())),
+               detail::enable_if_t < !std::is_same<basic_json_t, ValueType>::value &&
+                                     detail::has_try_deserialize<basic_json_t, ValueType>::value,
+                                     int > = 0 >
+    ReturnType try_get() const noexcept(noexcept(
+                                            JSONSerializer<ValueType>::try_deserialize(std::declval<const basic_json_t&>())))
+    {
+        static_assert(!std::is_reference<ValueTypeCV>::value,
+                      "get() cannot be used with reference types, you might want to use get_ref()");
+        return JSONSerializer<ValueType>::try_deserialize(*this);
+    }
+
+    /*!
     @brief get a value (explicit)
 
     Explicit type conversion between the JSON value and a compatible value.

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2902,6 +2902,9 @@ using to_json_function = decltype(T::to_json(std::declval<Args>()...));
 template<typename T, typename... Args>
 using from_json_function = decltype(T::from_json(std::declval<Args>()...));
 
+template<typename T, typename... Args>
+using try_deserialize_function = decltype(T::try_deserialize(std::declval<Args>()...));
+
 template<typename T, typename U>
 using get_template_function = decltype(std::declval<T>().template get<U>());
 
@@ -2932,6 +2935,20 @@ struct has_non_default_from_json < BasicJsonType, T, enable_if_t < !is_basic_jso
 
     static constexpr bool value =
         is_detected_exact<T, from_json_function, serializer,
+        const BasicJsonType&>::value;
+};
+
+template<typename BasicJsonType, typename T, typename = void>
+struct has_try_deserialize : std::false_type {};
+
+template<typename BasicJsonType, typename T>
+struct has_try_deserialize < BasicJsonType, T,
+           enable_if_t < !is_basic_json<T>::value >>
+{
+    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+
+    static constexpr bool value =
+        is_detected<try_deserialize_function, serializer,
         const BasicJsonType&>::value;
 };
 
@@ -19132,6 +19149,38 @@ class basic_json
         static_assert(!std::is_reference<ValueTypeCV>::value,
                       "get() cannot be used with reference types, you might want to use get_ref()");
         return JSONSerializer<ValueType>::from_json(*this);
+    }
+
+    /*!
+    @brief get a wrapped value (explicit)
+
+    Explicit type conversion between the JSON value and a compatible value wrapper
+    The value is converted by calling the @ref json_serializer<ValueType>
+    `try_deserialize()` method.
+
+    The function is equivalent to executing
+    @code {.cpp}
+    return JSONSerializer<ValueTypeCV>::try_deserialize(*this);
+    @endcode
+
+    @tparam ValueTypeCV the provided value type
+    @tparam ValueType the returned value type
+
+    @return copy of the JSON value, converted to @a ValueType wrapper
+
+    @throw what @ref json_serializer<ValueType> `try_deserialize()` method throws
+    */
+    template < typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>,
+               typename ReturnType = decltype(JSONSerializer<ValueType>::try_deserialize(std::declval<const basic_json_t&>())),
+               detail::enable_if_t < !std::is_same<basic_json_t, ValueType>::value &&
+                                     detail::has_try_deserialize<basic_json_t, ValueType>::value,
+                                     int > = 0 >
+    ReturnType try_get() const noexcept(noexcept(
+                                            JSONSerializer<ValueType>::try_deserialize(std::declval<const basic_json_t&>())))
+    {
+        static_assert(!std::is_reference<ValueTypeCV>::value,
+                      "get() cannot be used with reference types, you might want to use get_ref()");
+        return JSONSerializer<ValueType>::try_deserialize(*this);
     }
 
     /*!


### PR DESCRIPTION
I propose new method `json.try_get<MyType>()`, which works similar to `json.get<MyType>()`. It can be extended by providing `adl_serializer<MyType>::try_deserialize()` function. Unlike `get` method, the return type of `try_get` is assumed to have a different return type to `MyType` and can be `std::optional`, `tl::expected` or other wrapper

**Why is it needed?**
1) Users may prefer to handle errors without exceptions for the sake of performance
2) Or, some users like more functional program structuring, for example, using monads, this allows not only to handle errors, but also to return some additional info about deserialization, such as warnings or even detailed debug logs. 
3) Maybe something else?

**Why not just allow `json.get<MyType>()` to return any type, different from `MyType`?**
1) This is not obvious code behavior and some users may not expect a different return type
2) Some users may want to explicitly distinguish between `json.get<MyType>()` and `json.try_get<MyType>()`, or even have both

**What about `json.get<MyMonad<MyType>>()`? Why not?**
* Users can define their own version of `try_get()` with custom return type once and don't bother about return type anymore every time `get()` is called. This is quite important in a large codebase where `get()` calls many times for same type
* Or, even more importantly, I think `json.try_get<MyType>()` is easier to read and is a good abstraction compared to `json.get<MyMonad<MyType>>()`
* Also, I think `json.try_get<T>()` is the better way to return optional than `json.get<std::optional<T>>()`  from #2229

**So, is noexcept our goal? Does `json.try_get<X>()` throw exceptions?**
* It's depend on user implementation of `try_deserialize()` and it is the responsibility of the users to mark `try_deserialize()` as `noexcept(true)` or `noexcept(false)`.

**Should we implement `try_deserialize()` for basic types?**
* I'm not sure. `tl::expected` or `std::optional` could be suitable for this, but most likely, the user will want to write their own monadic type or wrapper.
Also, there may be a problem when users include two libraries that use nlohman_json and specializing different `adl_serializer` for the same basic type. Maybe we can implement `try_deserialize` lookup through tag dispatching with adl and allow additional arguments to be passed to `try_get()`, then users can create their own unambiguous overloads. More research is needed here and right now I think the answer is **no**

**About naming**
* I'm not sure about the naming. I think, `try_deserialize()` is too contrast to `from_json()`, but I don't know what name is better