### PR TITLE
fix eof for get_binary and get_string

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2271,15 +2271,15 @@ class binary_reader
                     string_t& result)
     {
         bool success = true;
-        std::generate_n(std::back_inserter(result), len, [this, &success, &format]()
-        {
+        for(NumberType i = 0; i < len; i++) {
             get();
             if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "string")))
             {
                 success = false;
+                break;
             }
             return std::char_traits<char_type>::to_char_type(current);
-        });
+        };
         return success;
     }
 
@@ -2303,15 +2303,15 @@ class binary_reader
                     binary_t& result)
     {
         bool success = true;
-        std::generate_n(std::back_inserter(result), len, [this, &success, &format]()
-        {
+        for(NumberType i = 0; i < len; i++) {
             get();
             if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "binary")))
             {
                 success = false;
+                break;
             }
             return static_cast<std::uint8_t>(current);
-        });
+        }
         return success;
     }
 

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2271,7 +2271,8 @@ class binary_reader
                     string_t& result)
     {
         bool success = true;
-        for(NumberType i = 0; i < len; i++) {
+        for (NumberType i = 0; i < len; i++)
+        {
             get();
             if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "string")))
             {
@@ -2303,7 +2304,8 @@ class binary_reader
                     binary_t& result)
     {
         bool success = true;
-        for(NumberType i = 0; i < len; i++) {
+        for (NumberType i = 0; i < len; i++)
+        {
             get();
             if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "binary")))
             {

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2278,7 +2278,7 @@ class binary_reader
                 success = false;
                 break;
             }
-            return std::char_traits<char_type>::to_char_type(current);
+            result.push_back(std::char_traits<char_type>::to_char_type(current));
         };
         return success;
     }
@@ -2310,7 +2310,7 @@ class binary_reader
                 success = false;
                 break;
             }
-            return static_cast<std::uint8_t>(current);
+            result.push_back(static_cast<std::uint8_t>(current));
         }
         return success;
     }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8136,15 +8136,16 @@ class binary_reader
                     string_t& result)
     {
         bool success = true;
-        std::generate_n(std::back_inserter(result), len, [this, &success, &format]()
+        for (NumberType i = 0; i < len; i++)
         {
             get();
             if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "string")))
             {
                 success = false;
+                break;
             }
-            return std::char_traits<char_type>::to_char_type(current);
-        });
+            result.push_back(std::char_traits<char_type>::to_char_type(current));
+        };
         return success;
     }
 
@@ -8168,15 +8169,16 @@ class binary_reader
                     binary_t& result)
     {
         bool success = true;
-        std::generate_n(std::back_inserter(result), len, [this, &success, &format]()
+        for (NumberType i = 0; i < len; i++)
         {
             get();
             if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "binary")))
             {
                 success = false;
+                break;
             }
-            return static_cast<std::uint8_t>(current);
-        });
+            result.push_back(static_cast<std::uint8_t>(current));
+        }
         return success;
     }
 

--- a/test/src/unit-regression.cpp
+++ b/test/src/unit-regression.cpp
@@ -1954,6 +1954,16 @@ TEST_CASE("regression tests")
         auto val = j.value("x", defval);
         auto val2 = j.value("y", defval);
     }
+
+    SECTION("issue #2293 - eof doesnt cause parsing to stop")
+    {
+        std::vector<uint8_t> data =
+        {
+            0x7B, 0x6F, 0x62, 0x6A, 0x65, 0x63, 0x74, 0x20, 0x4F, 0x42
+        };
+        json result = json::from_cbor(data, true, false);
+        CHECK(result.is_discarded());
+    }
 }
 
 #if !defined(JSON_NOEXCEPTION)


### PR DESCRIPTION
Fixes https://github.com/nlohmann/json/issues/2293 by breaking when encountering an `EOF` in `binary_reader::get_string()` and `binary_reader::get_binary()`

* * *

## Pull request checklist

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).