### PR TITLE
fixes unused variable 'ex' for #2304

### DIFF
--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -263,6 +263,7 @@ class json_sax_dom_parser
                      const Exception& ex)
     {
         errored = true;
+        (void)ex;
         if (allow_exceptions)
         {
             JSON_THROW(ex);
@@ -501,6 +502,7 @@ class json_sax_dom_callback_parser
                      const Exception& ex)
     {
         errored = true;
+        (void)ex;
         if (allow_exceptions)
         {
             JSON_THROW(ex);

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -263,7 +263,7 @@ class json_sax_dom_parser
                      const Exception& ex)
     {
         errored = true;
-        (void)ex;
+        static_cast<void>(ex);
         if (allow_exceptions)
         {
             JSON_THROW(ex);
@@ -502,7 +502,7 @@ class json_sax_dom_callback_parser
                      const Exception& ex)
     {
         errored = true;
-        (void)ex;
+        static_cast<void>(ex);
         if (allow_exceptions)
         {
             JSON_THROW(ex);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5441,6 +5441,7 @@ class json_sax_dom_parser
                      const Exception& ex)
     {
         errored = true;
+        (void)ex;
         if (allow_exceptions)
         {
             JSON_THROW(ex);
@@ -5679,6 +5680,7 @@ class json_sax_dom_callback_parser
                      const Exception& ex)
     {
         errored = true;
+        (void)ex;
         if (allow_exceptions)
         {
             JSON_THROW(ex);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5441,7 +5441,7 @@ class json_sax_dom_parser
                      const Exception& ex)
     {
         errored = true;
-        (void)ex;
+        static_cast<void>(ex);
         if (allow_exceptions)
         {
             JSON_THROW(ex);
@@ -5680,7 +5680,7 @@ class json_sax_dom_callback_parser
                      const Exception& ex)
     {
         errored = true;
-        (void)ex;
+        static_cast<void>(ex);
         if (allow_exceptions)
         {
             JSON_THROW(ex);


### PR DESCRIPTION
Adds (void) to `ex` variables to prevent warnings when exceptions are disabled, as described in #2304 .