### PR TITLE
Fix lexer to properly cope with repeated comments

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1511,7 +1511,7 @@ scan_number_done:
         skip_whitespace();
 
         // ignore comments
-        if (ignore_comments && current == '/')
+        while (ignore_comments && current == '/')
         {
             if (!scan_comment())
             {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7390,7 +7390,7 @@ scan_number_done:
         skip_whitespace();
 
         // ignore comments
-        if (ignore_comments && current == '/')
+        while (ignore_comments && current == '/')
         {
             if (!scan_comment())
             {

--- a/test/src/unit-class_lexer.cpp
+++ b/test/src/unit-class_lexer.cpp
@@ -241,5 +241,8 @@ TEST_CASE("lexer class")
         CHECK((scan_string("/* true */", true) == json::lexer::token_type::end_of_input));
         CHECK((scan_string("/*/**/", true) == json::lexer::token_type::end_of_input));
         CHECK((scan_string("/*/* */", true) == json::lexer::token_type::end_of_input));
+
+        CHECK((scan_string("//\n//\n", true) == json::lexer::token_type::end_of_input));
+        CHECK((scan_string("/**//**//**/", true) == json::lexer::token_type::end_of_input));
     }
 }

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -478,4 +478,11 @@ TEST_CASE("regression tests 2")
         CHECK(jsonObj["aaaa"] == 11);
         CHECK(jsonObj["bbb"] == 222);
     }
+
+    SECTION("issue #2330 - ignore_comment=true fails on multiple consecutive lines starting with comments")
+    {
+        std::string ss = "//\n//\n{\n}\n";
+        json j = json::parse(ss, nullptr, true, true);
+        CHECK(j.dump() == "{}");
+    }
 }


### PR DESCRIPTION
This PR fixes a bug in the lexer that treated repeated comments as parse errors even if `ignore_comment` was set to true.

Closes #2330.