### PR TITLE
Fix fallthrough warning

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -880,13 +880,13 @@ class lexer : public lexer_base<BasicJsonType>
                                 default:
                                 {
                                     unget();
-                                    break;
+                                    continue;
                                 }
                             }
                         }
 
                         default:
-                            break;
+                            continue;
                     }
                 }
             }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6759,13 +6759,13 @@ class lexer : public lexer_base<BasicJsonType>
                                 default:
                                 {
                                     unget();
-                                    break;
+                                    continue;
                                 }
                             }
                         }
 
                         default:
-                            break;
+                            continue;
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes a warning on an unannotated fall-through between switch labels `[-Wimplicit-fallthrough]`.