### PR TITLE
Fix code to work without exceptions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -5,6 +5,8 @@
 #include <utility> // pair
 #include <vector> // vector
 
+#include <nlohmann/detail/macro_scope.hpp>
+
 namespace nlohmann
 {
 
@@ -64,7 +66,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
             }
         }
 
-        throw std::out_of_range("key not found");
+        JSON_THROW(std::out_of_range("key not found"));
     }
 
     const T& at(const Key& key) const
@@ -77,7 +79,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
             }
         }
 
-        throw std::out_of_range("key not found");
+        JSON_THROW(std::out_of_range("key not found"));
     }
 
     size_type erase(const Key& key)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16395,6 +16395,9 @@ class serializer
 #include <utility> // pair
 #include <vector> // vector
 
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
 namespace nlohmann
 {
 
@@ -16454,7 +16457,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
             }
         }
 
-        throw std::out_of_range("key not found");
+        JSON_THROW(std::out_of_range("key not found"));
     }
 
     const T& at(const Key& key) const
@@ -16467,7 +16470,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
             }
         }
 
-        throw std::out_of_range("key not found");
+        JSON_THROW(std::out_of_range("key not found"));
     }
 
     size_type erase(const Key& key)

--- a/test/cmake_add_subdirectory/project/CMakeLists.txt
+++ b/test/cmake_add_subdirectory/project/CMakeLists.txt
@@ -11,3 +11,10 @@ target_link_libraries(with_namespace_target nlohmann_json::nlohmann_json)
 
 add_executable(without_namespace_target main.cpp)
 target_link_libraries(without_namespace_target nlohmann_json)
+
+if(NOT MSVC)
+    add_executable(without_exceptions main.cpp)
+    target_link_libraries(without_exceptions nlohmann_json::nlohmann_json)
+    target_compile_definitions(without_exceptions PRIVATE JSON_NOEXCEPTION)
+    target_compile_options(without_exceptions PRIVATE -fno-exceptions)
+endif()


### PR DESCRIPTION
This PR fixes a regression introduced in #2206: container `ordered_map` throws exceptions via `throw` instead of macro `JSON_THROW` which breaks the possibility to compile the code with `-fno-exceptions`. The reason this bug was not detected earlier is that we have no step in the CI that sets the flags `-fno-exceptions`, but only relies on the CMake flag `JSON_NoExceptions`. As a consequence, we added a test to compile a simple binary with `-fno-exceptions` set.