### PR TITLE
Change argument name "subtype" in byte_container_with_subtype

### DIFF
--- a/include/nlohmann/byte_container_with_subtype.hpp
+++ b/include/nlohmann/byte_container_with_subtype.hpp
@@ -39,15 +39,15 @@ class byte_container_with_subtype : public BinaryType
         : container_type(std::move(b))
     {}
 
-    byte_container_with_subtype(const container_type& b, std::uint8_t _subtype) noexcept(noexcept(container_type(b)))
+    byte_container_with_subtype(const container_type& b, std::uint8_t subtype_) noexcept(noexcept(container_type(b)))
         : container_type(b)
-        , m_subtype(_subtype)
+        , m_subtype(subtype_)
         , m_has_subtype(true)
     {}
 
-    byte_container_with_subtype(container_type&& b, std::uint8_t _subtype) noexcept(noexcept(container_type(std::move(b))))
+    byte_container_with_subtype(container_type&& b, std::uint8_t subtype_) noexcept(noexcept(container_type(std::move(b))))
         : container_type(std::move(b))
-        , m_subtype(_subtype)
+        , m_subtype(subtype_)
         , m_has_subtype(true)
     {}
 
@@ -80,9 +80,9 @@ class byte_container_with_subtype : public BinaryType
 
     @since version 3.8.0
     */
-    void set_subtype(std::uint8_t _subtype) noexcept
+    void set_subtype(std::uint8_t subtype_) noexcept
     {
-        m_subtype = _subtype;
+        m_subtype = subtype_;
         m_has_subtype = true;
     }
 

--- a/include/nlohmann/byte_container_with_subtype.hpp
+++ b/include/nlohmann/byte_container_with_subtype.hpp
@@ -39,15 +39,15 @@ class byte_container_with_subtype : public BinaryType
         : container_type(std::move(b))
     {}
 
-    byte_container_with_subtype(const container_type& b, std::uint8_t subtype) noexcept(noexcept(container_type(b)))
+    byte_container_with_subtype(const container_type& b, std::uint8_t _subtype) noexcept(noexcept(container_type(b)))
         : container_type(b)
-        , m_subtype(subtype)
+        , m_subtype(_subtype)
         , m_has_subtype(true)
     {}
 
-    byte_container_with_subtype(container_type&& b, std::uint8_t subtype) noexcept(noexcept(container_type(std::move(b))))
+    byte_container_with_subtype(container_type&& b, std::uint8_t _subtype) noexcept(noexcept(container_type(std::move(b))))
         : container_type(std::move(b))
-        , m_subtype(subtype)
+        , m_subtype(_subtype)
         , m_has_subtype(true)
     {}
 
@@ -80,9 +80,9 @@ class byte_container_with_subtype : public BinaryType
 
     @since version 3.8.0
     */
-    void set_subtype(std::uint8_t subtype) noexcept
+    void set_subtype(std::uint8_t _subtype) noexcept
     {
-        m_subtype = subtype;
+        m_subtype = _subtype;
         m_has_subtype = true;
     }
 


### PR DESCRIPTION
Fix warnings on gcc 4.8.5: `declaration of ‘subtype’ shadows a member of 'this'`
