### PR TITLE
Ranged insert test section is added in unit-ordered_json.cpp

### DIFF
--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -168,6 +168,19 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         Container::push_back(value);
         return {--this->end(), true};
     }
+
+    template<typename InputIt>
+    using require_input_iter = typename std::enable_if<std::is_convertible<typename std::iterator_traits<InputIt>::iterator_category,
+            std::input_iterator_tag>::value>::type;
+
+    template<typename InputIt, typename = require_input_iter<InputIt>>
+    void insert(InputIt first, InputIt last)
+    {
+        for (auto it = first; it != last; ++it)
+        {
+            insert(*it);
+        }
+    }
 };
 
 }  // namespace nlohmann

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16634,6 +16634,19 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         Container::push_back(value);
         return {--this->end(), true};
     }
+
+    template<typename InputIt>
+    using require_input_iter = typename std::enable_if<std::is_convertible<typename std::iterator_traits<InputIt>::iterator_category,
+            std::input_iterator_tag>::value>::type;
+
+    template<typename InputIt, typename = require_input_iter<InputIt>>
+    void insert(InputIt first, InputIt last)
+    {
+        for (auto it = first; it != last; ++it)
+        {
+            insert(*it);
+        }
+    }
 };
 
 }  // namespace nlohmann

--- a/test/src/unit-ordered_json.cpp
+++ b/test/src/unit-ordered_json.cpp
@@ -76,4 +76,18 @@ TEST_CASE("ordered_json")
     CHECK(multi_ordered.dump() == "{\"z\":1,\"m\":2,\"y\":4}");
     CHECK(multi_ordered.erase("m") == 1);
     CHECK(multi_ordered.dump() == "{\"z\":1,\"y\":4}");
+    
+    // Ranged insert test.
+    // It seems that values shouldn't be overwritten. Only new values are added
+    json j1 {{"c", 1}, {"b", 2}, {"a", 3}};
+    const json j2 {{"c", 77}, {"d", 42}, {"a", 4}};
+    j1.insert( j2.cbegin(), j2.cend() );
+    CHECK(j1.size() == 4);
+    CHECK(j1.dump() == "{\"a\":3,\"b\":2,\"c\":1,\"d\":42}");
+    
+    ordered_json oj1 {{"c", 1}, {"b", 2}, {"a", 3}};
+    const ordered_json oj2 {{"c", 77}, {"d", 42}, {"a", 4}};
+    oj1.insert( oj2.cbegin(), oj2.cend() );
+    CHECK(oj1.size() == 4);
+    CHECK(oj1.dump() == "{\"c\":1,\"b\":2,\"a\":3,\"d\":42}");
 }

--- a/test/src/unit-ordered_json.cpp
+++ b/test/src/unit-ordered_json.cpp
@@ -76,7 +76,7 @@ TEST_CASE("ordered_json")
     CHECK(multi_ordered.dump() == "{\"z\":1,\"m\":2,\"y\":4}");
     CHECK(multi_ordered.erase("m") == 1);
     CHECK(multi_ordered.dump() == "{\"z\":1,\"y\":4}");
-    
+
     // Ranged insert test.
     // It seems that values shouldn't be overwritten. Only new values are added
     json j1 {{"c", 1}, {"b", 2}, {"a", 3}};
@@ -84,7 +84,7 @@ TEST_CASE("ordered_json")
     j1.insert( j2.cbegin(), j2.cend() );
     CHECK(j1.size() == 4);
     CHECK(j1.dump() == "{\"a\":3,\"b\":2,\"c\":1,\"d\":42}");
-    
+
     ordered_json oj1 {{"c", 1}, {"b", 2}, {"a", 3}};
     const ordered_json oj2 {{"c", 77}, {"d", 42}, {"a", 4}};
     oj1.insert( oj2.cbegin(), oj2.cend() );


### PR DESCRIPTION
Fix proposal for "#2490 Missing "void insert( InputIt first, InputIt last );" overload in nlohmann::ordered_map"
This PR is in Work In Progress state

Todo:

- [X]  Add missing test case that fails
- [X]  Add proposed method implementation
- [X]  Make sure test is passed
- [X]  PR is done and ready for approval

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [X]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [X]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [X]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).