### PR TITLE
Fix compilation of input_adapter(container) in edge cases

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -372,7 +372,7 @@ typename iterator_input_adapter_factory<IteratorType>::adapter_type input_adapte
 
 // Convenience shorthand from container to iterator
 template<typename ContainerType>
-auto input_adapter(const ContainerType& container) -> decltype(input_adapter(begin(container), end(container)))
+typename iterator_input_adapter_factory<typename ContainerType::const_iterator>::adapter_type input_adapter(const ContainerType& container)
 {
     // Enable ADL
     using std::begin;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5179,7 +5179,7 @@ typename iterator_input_adapter_factory<IteratorType>::adapter_type input_adapte
 
 // Convenience shorthand from container to iterator
 template<typename ContainerType>
-auto input_adapter(const ContainerType& container) -> decltype(input_adapter(begin(container), end(container)))
+typename iterator_input_adapter_factory<typename ContainerType::const_iterator>::adapter_type input_adapter(const ContainerType& container)
 {
     // Enable ADL
     using std::begin;
@@ -16793,7 +16793,7 @@ class basic_json
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);
@@ -25338,7 +25338,7 @@ template<>
 inline void swap<nlohmann::json>(nlohmann::json& j1, nlohmann::json& j2) noexcept(
     is_nothrow_move_constructible<nlohmann::json>::value&&
     is_nothrow_move_assignable<nlohmann::json>::value
-                              )
+)
 {
     j1.swap(j2);
 }

--- a/test/src/unit-user_defined_input.cpp
+++ b/test/src/unit-user_defined_input.cpp
@@ -50,6 +50,8 @@ TEST_CASE("Use arbitrary stdlib container")
 
 struct MyContainer
 {
+    using iterator = const char*;
+    using const_iterator = iterator;
     const char* data;
 };
 


### PR DESCRIPTION
This fixes a compilation issue with the library if trying to parse JSON from a
custom container type that doesn't support detecting `begin()` and `end()`
functions via ADL.

`include/nlohmann/detail/input/input_adapters.hpp` defines convenience function
for creating input adapter for STL-like containers. It should support iterators
both via `std::begin()` and `std::end()`, as well as `begin()` and `end()` found
via ADL. However, the former doesn't actually work for iterable types not
defined in the `std` namespace, due to the way the return type deduction is
implemented:

    $ cat test.cc
    #include <iostream>
    #include <nlohmann/json.hpp>

    const char DATA[] = R"("Hello, world!")";

    struct MyIterable {
        using iterator = const char*;
        using const_iterator = iterator;
        const_iterator begin() const { return DATA; }
        const_iterator end() const { return DATA + sizeof(DATA); }
    };

    int main()
    {
        const auto c = MyIterable {};
        std::cout << nlohmann::json::parse(c) << "\n";
        return 0;
    }
    $ g++ --version
    g++ (Ubuntu 10.2.0-13ubuntu1) 10.2.0
    Copyright (C) 2020 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

    $ g++ -std=c++11 test.cc
    ...
    /usr/include/nlohmann/detail/input/input_adapters.hpp:375:6: note: candidate: ‘template<class ContainerType> decltype (nlohmann::detail::input_adapter(begin(container), end(container))) nlohmann::detail::input_adapter(const ContainerType&)’
      375 | auto input_adapter(const ContainerType& container) -> decltype(input_adapter(begin(container), end(container)))
          |      ^~~~~~~~~~~~~
    /usr/include/nlohmann/detail/input/input_adapters.hpp:375:6: note:   template argument deduction/substitution failed:
    /usr/include/nlohmann/detail/input/input_adapters.hpp: In substitution of ‘template<class ContainerType> decltype (nlohmann::detail::input_adapter(begin(container), end(container))) nlohmann::detail::input_adapter(const ContainerType&) [with ContainerType = MyIterable]’:
    ...

In the above example the trailing type deduction won't look for the `begin()`
and `end()` functions in the `std` namespace, although the function body would.

I don't know about a more elegant fix in C++11 except to spell out the return
type verbatim.

[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
