### PR TITLE
Add a CI test for the multi-header option

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,3 +14,15 @@ jobs:
       run: cmake --build build --parallel 10
     - name: test
       run: cd build ; ctest -j 10 --output-on-failure
+
+  build-multiple:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: cmake
+      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On -DJSON_MultipleHeaders=ON
+    - name: build
+      run: cmake --build build --parallel 10
+    - name: test
+      run: cd build ; ctest -j 10 --output-on-failure


### PR DESCRIPTION
For https://build.opensuse.org/package/show/home:Mailaender:branches:devel:libraries:c_c++/nlohmann_json some tests failed. This is just a check to verify this also happens in your integration environment.