### PR TITLE
Fix compilation of input_adapter(container) in edge cases

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -371,14 +371,35 @@ typename iterator_input_adapter_factory<IteratorType>::adapter_type input_adapte
 }
 
 // Convenience shorthand from container to iterator
-template<typename ContainerType>
-auto input_adapter(const ContainerType& container) -> decltype(input_adapter(begin(container), end(container)))
-{
-    // Enable ADL
-    using std::begin;
-    using std::end;
+// Enables ADL on begin(container) and end(container)
+// Encloses the using declarations in namespace for not to leak them to outside scope
 
-    return input_adapter(begin(container), end(container));
+namespace container_input_adapter_factory_impl {
+
+using std::begin;
+using std::end;
+
+template<typename ContainerType, typename Enable = void>
+struct container_input_adapter_factory {};
+
+template<typename ContainerType>
+struct container_input_adapter_factory< ContainerType,
+                                        void_t<decltype(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>()))> >
+{
+    using adapter_type = decltype(input_adapter(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>())));
+
+    static adapter_type create(const ContainerType& container)
+    {
+        return input_adapter(begin(container), end(container));
+    }
+};
+
+}
+
+template<typename ContainerType>
+typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type input_adapter(const ContainerType& container)
+{
+    return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(container);
 }
 
 // Special cases with fast paths

--- a/test/src/unit-user_defined_input.cpp
+++ b/test/src/unit-user_defined_input.cpp
@@ -63,7 +63,7 @@ const char* end(const MyContainer& c)
     return c.data + strlen(c.data);
 }
 
-TEST_CASE("Custom container")
+TEST_CASE("Custom container non-member begin/end")
 {
 
     MyContainer data{"[1,2,3,4]"};
@@ -73,6 +73,31 @@ TEST_CASE("Custom container")
     CHECK(as_json.at(2) == 3);
     CHECK(as_json.at(3) == 4);
 
+}
+
+TEST_CASE("Custom container member begin/end")
+{
+    struct MyContainer2
+    {
+        const char* data;
+
+        const char* begin() const
+        {
+            return data;
+        }
+
+        const char* end() const
+        {
+            return data + strlen(data);
+        }
+    };
+
+    MyContainer2 data{"[1,2,3,4]"};
+    json as_json = json::parse(data);
+    CHECK(as_json.at(0) == 1);
+    CHECK(as_json.at(1) == 2);
+    CHECK(as_json.at(2) == 3);
+    CHECK(as_json.at(3) == 4);
 }
 
 TEST_CASE("Custom iterator")


### PR DESCRIPTION
This fixes a compilation issue with the library if trying to use containers that don't have non-member `begin()` and `end()` functions via ADL.

Example of a test program that fails with the current library version:

    $ g++ --version
    g++ (Ubuntu 10.2.0-13ubuntu1) 10.2.0
    Copyright (C) 2020 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

    $ cat test.cc
    #include <iostream>

    #include <nlohmann/json.hpp>

    const char DATA[] = R"("Hello, world!")";

    struct MyContainer {
        const char* begin() const { return DATA; }
        const char* end() const { return DATA + sizeof(DATA); }
    };

    int main()
    {
        MyContainer c;
        std::cout << nlohmann::json::parse(c) << "\n";
        return 0;
    }
    $ g++ test.cc
    In file included from test.cc:3:
    /usr/include/nlohmann/json.hpp: In instantiation of ‘static nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::parse(InputType&&, nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::parser_callback_t, bool, bool) [with InputType = MyContainer&; ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer; BinaryType = std::vector<unsigned char>; nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::parser_callback_t = std::function<bool(int, nlohmann::detail::parse_event_t, nlohmann::basic_json<>&)>]’:
    test.cc:15:41:   required from here
    /usr/include/nlohmann/json.hpp:6654:37: error: no matching function for call to ‘input_adapter(MyContainer&)’
    etc...

This PR fixes the issue with types that only have member `begin()` and `end()` functions. Please see the commit for further details.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [X]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [X]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [X]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [X]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
