### PR TITLE
readme: fix tilde character display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,37 +1230,37 @@ Please note:
 
 The following compilers are currently used in continuous integration at [Travis](https://travis-ci.org/nlohmann/json), [AppVeyor](https://ci.appveyor.com/project/nlohmann/json), [GitHub Actions](https://github.com/nlohmann/json/actions), and [CircleCI](https://circleci.com/gh/nlohmann/json):
 
-| Compiler                                                        | Operating System   | CI Provider    |
-|-----------------------------------------------------------------|--------------------|----------------|
-| Apple Clang 10.0.1 (clang-1001.0.46.4); Xcode 10.2.1            | macOS 10.14.4      | Travis         |
-| Apple Clang 11.0.0 (clang-1100.0.33.12); Xcode 11.2.1           | macOS 10.14.6      | Travis         |
-| Apple Clang 11.0.3 (clang-1103.0.32.59); Xcode 11.4.1           | macOS 10.15.4      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.22.7); Xcode 11.4.1            | macOS 10.15.5      | Travis         |
-| Clang 3.5.0 (3.5.0-4ubuntu2~trusty2)                            | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 3.6.2 (3.6.2-svn240577-1~exp1)                            | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 3.7.1 (3.7.1-svn253571-1~exp1)                            | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 3.8.0 (3.8.0-2ubuntu3~trusty5)                            | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 3.9.1 (3.9.1-4ubuntu3~14.04.3)                            | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 4.0.1 (4.0.1-svn305264-1~exp1)                            | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 5.0.2 (version 5.0.2-svn328729-1~exp1~20180509123505.100) | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 6.0.1 (6.0.1-svn334776-1~exp1~20190309042707.121)         | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 7.1.0 (7.1.0-svn353565-1~exp1~20190419134007.64)          | Ubuntu 14.04.5 LTS | Travis         |
-| Clang 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)                       | Ubuntu 18.04.4 LTS | Travis         |
-| Clang 9.0.0 (x86_64-pc-windows-msvc)                            | Windows-10.0.17763 | GitHub Actions |
-| Clang 10.0.0 (x86_64-pc-windows-msvc)                           | Windows-10.0.17763 | GitHub Actions |
-| GCC 4.8.5 (Ubuntu 4.8.5-4ubuntu8~14.04.2)                       | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 4.9.4 (Ubuntu 4.9.4-2ubuntu1~14.04.1)                       | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 5.5.0 (Ubuntu 5.5.0-12ubuntu1~14.04)                        | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 6.3.0 (Debian 6.3.0-18+deb9u1)                              | Debian 9           | Circle CI      |
-| GCC 6.5.0 (Ubuntu 6.5.0-2ubuntu1~14.04.1)                       | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 7.3.0 (x86_64-posix-seh-rev0, Built by MinGW-W64 project)   | Windows-6.3.9600   | AppVeyor       |
-| GCC 7.5.0 (Ubuntu 7.5.0-3ubuntu1~14.04.1)                       | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)                         | Ubuntu 18.04.4 LTS | GitHub Actions |
-| GCC 8.4.0 (Ubuntu 8.4.0-1ubuntu1~14.04)                         | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 9.3.0 (Ubuntu 9.3.0-11ubuntu0~14.04)                        | Ubuntu 14.04.5 LTS | Travis         |
-| GCC 10.1.0 (Arch Linux latest)                                  | Arch Linux         | Circle CI      |
-| MSVC 19.0.24241.7 (Build Engine version 14.0.25420.1)           | Windows-6.3.9600   | AppVeyor       |
-| MSVC 19.16.27035.0 (15.9.21+g9802d43bc3 for .NET Framework)     | Windows-10.0.14393 | AppVeyor       |
+| Compiler                                                          | Operating System   | CI Provider    |
+|-------------------------------------------------------------------|--------------------|----------------|
+| Apple Clang 10.0.1 (clang-1001.0.46.4); Xcode 10.2.1              | macOS 10.14.4      | Travis         |
+| Apple Clang 11.0.0 (clang-1100.0.33.12); Xcode 11.2.1             | macOS 10.14.6      | Travis         |
+| Apple Clang 11.0.3 (clang-1103.0.32.59); Xcode 11.4.1             | macOS 10.15.4      | GitHub Actions |
+| Apple Clang 12.0.0 (clang-1200.0.22.7); Xcode 11.4.1              | macOS 10.15.5      | Travis         |
+| Clang 3.5.0 (3.5.0-4ubuntu2\~trusty2)                             | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 3.6.2 (3.6.2-svn240577-1\~exp1)                             | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 3.7.1 (3.7.1-svn253571-1\~exp1)                             | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 3.8.0 (3.8.0-2ubuntu3\~trusty5)                             | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 3.9.1 (3.9.1-4ubuntu3\~14.04.3)                             | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 4.0.1 (4.0.1-svn305264-1\~exp1)                             | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 5.0.2 (version 5.0.2-svn328729-1\~exp1\~20180509123505.100) | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 6.0.1 (6.0.1-svn334776-1\~exp1\~20190309042707.121)         | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 7.1.0 (7.1.0-svn353565-1\~exp1\~20190419134007.64)          | Ubuntu 14.04.5 LTS | Travis         |
+| Clang 7.5.0 (Ubuntu 7.5.0-3ubuntu1\~18.04)                        | Ubuntu 18.04.4 LTS | Travis         |
+| Clang 9.0.0 (x86_64-pc-windows-msvc)                              | Windows-10.0.17763 | GitHub Actions |
+| Clang 10.0.0 (x86_64-pc-windows-msvc)                             | Windows-10.0.17763 | GitHub Actions |
+| GCC 4.8.5 (Ubuntu 4.8.5-4ubuntu8\~14.04.2)                        | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 4.9.4 (Ubuntu 4.9.4-2ubuntu1\~14.04.1)                        | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 5.5.0 (Ubuntu 5.5.0-12ubuntu1\~14.04)                         | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 6.3.0 (Debian 6.3.0-18+deb9u1)                                | Debian 9           | Circle CI      |
+| GCC 6.5.0 (Ubuntu 6.5.0-2ubuntu1\~14.04.1)                        | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 7.3.0 (x86_64-posix-seh-rev0, Built by MinGW-W64 project)     | Windows-6.3.9600   | AppVeyor       |
+| GCC 7.5.0 (Ubuntu 7.5.0-3ubuntu1\~14.04.1)                        | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 7.5.0 (Ubuntu 7.5.0-3ubuntu1\~18.04)                          | Ubuntu 18.04.4 LTS | GitHub Actions |
+| GCC 8.4.0 (Ubuntu 8.4.0-1ubuntu1\~14.04)                          | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 9.3.0 (Ubuntu 9.3.0-11ubuntu0\~14.04)                         | Ubuntu 14.04.5 LTS | Travis         |
+| GCC 10.1.0 (Arch Linux latest)                                    | Arch Linux         | Circle CI      |
+| MSVC 19.0.24241.7 (Build Engine version 14.0.25420.1)             | Windows-6.3.9600   | AppVeyor       |
+| MSVC 19.16.27035.0 (15.9.21+g9802d43bc3 for .NET Framework)       | Windows-10.0.14393 | AppVeyor       |
 | MSVC 19.25.28614.0 (Build Engine version 16.5.0+d4cbfca49 for .NET Framework) | Windows-10.0.17763  | AppVeyor       |
 | MSVC 19.25.28614.0 (Build Engine version 16.5.0+d4cbfca49 for .NET Framework) | Windows-10.0.17763  | GitHub Actions |
 | MSVC 19.25.28614.0 (Build Engine version 16.5.0+d4cbfca49 for .NET Framework) with ClangCL 10.0.0 | Windows-10.0.17763  | GitHub Actions |


### PR DESCRIPTION
- Harmonizes references to the project version (3.9.1)
- Fixes display of `~` character in GitHub in compiler table (it used to look like this: ...1~exp~1... instead of ...1\~exp\~1...)