### PR TITLE
Fix compilation error with Clang, C++17, libc++, ordered_json and NLOHMANN_JSON_SERIALIZE_ENUM

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           platform: ${{ matrix.architecture }}
       - name: cmake
-        run: cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On
+        run: cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj
       - name: build
         run: cmake --build build --parallel 10
       - name: test

--- a/include/nlohmann/detail/meta/detected.hpp
+++ b/include/nlohmann/detail/meta/detected.hpp
@@ -37,7 +37,7 @@ struct detector<Default, void_t<Op<Args...>>, Op, Args...>
 };
 
 template<template<class...> class Op, class... Args>
-using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
+struct is_detected : detector<nonesuch, void, Op, Args...>::value_t {};
 
 template<template<class...> class Op, class... Args>
 using detected_t = typename detector<nonesuch, void, Op, Args...>::type;

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3342,15 +3342,18 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     @since version 1.0.0
     */
     template < typename ValueType, typename std::enable_if <
-                   !std::is_pointer<ValueType>::value&&
-                   !std::is_same<ValueType, detail::json_ref<basic_json>>::value&&
-                   !std::is_same<ValueType, typename string_t::value_type>::value&&
-                   !detail::is_basic_json<ValueType>::value
-                   && !std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
+                   detail::conjunction <
+                       std::integral_constant < bool,
+                               !std::is_pointer<ValueType>::value&&
+                               !std::is_same<ValueType, detail::json_ref<basic_json>>::value&&
+                               !std::is_same<ValueType, typename string_t::value_type>::value&&
+                               !detail::is_basic_json<ValueType>::value
+                               && !std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
 #if defined(JSON_HAS_CPP_17) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER <= 1914))
-                   && !std::is_same<ValueType, typename std::string_view>::value
+                               && !std::is_same<ValueType, typename std::string_view>::value
 #endif
-                   && detail::is_detected<detail::get_template_function, const basic_json_t&, ValueType>::value
+                               >,
+                       detail::is_detected<detail::get_template_function, const basic_json_t&, ValueType >>::value
                    , int >::type = 0 >
     JSON_EXPLICIT operator ValueType() const
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3305,7 +3305,7 @@ struct detector<Default, void_t<Op<Args...>>, Op, Args...>
 };
 
 template<template<class...> class Op, class... Args>
-using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
+struct is_detected : detector<nonesuch, void, Op, Args...>::value_t {};
 
 template<template<class...> class Op, class... Args>
 using detected_t = typename detector<nonesuch, void, Op, Args...>::type;
@@ -20362,15 +20362,18 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     @since version 1.0.0
     */
     template < typename ValueType, typename std::enable_if <
-                   !std::is_pointer<ValueType>::value&&
-                   !std::is_same<ValueType, detail::json_ref<basic_json>>::value&&
-                   !std::is_same<ValueType, typename string_t::value_type>::value&&
-                   !detail::is_basic_json<ValueType>::value
-                   && !std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
+                   detail::conjunction <
+                       std::integral_constant < bool,
+                               !std::is_pointer<ValueType>::value&&
+                               !std::is_same<ValueType, detail::json_ref<basic_json>>::value&&
+                               !std::is_same<ValueType, typename string_t::value_type>::value&&
+                               !detail::is_basic_json<ValueType>::value
+                               && !std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
 #if defined(JSON_HAS_CPP_17) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER <= 1914))
-                   && !std::is_same<ValueType, typename std::string_view>::value
+                               && !std::is_same<ValueType, typename std::string_view>::value
 #endif
-                   && detail::is_detected<detail::get_template_function, const basic_json_t&, ValueType>::value
+                               >,
+                       detail::is_detected<detail::get_template_function, const basic_json_t&, ValueType >>::value
                    , int >::type = 0 >
     JSON_EXPLICIT operator ValueType() const
     {

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -32,6 +32,7 @@ SOFTWARE.
 #define JSON_TESTS_PRIVATE
 #include <nlohmann/json.hpp>
 using nlohmann::json;
+using nlohmann::ordered_json;
 
 #include <deque>
 #include <forward_list>
@@ -1684,6 +1685,9 @@ TEST_CASE("JSON to enum mapping")
 
         // invalid json -> first enum
         CHECK(cards::kreuz == json("what?").get<cards>());
+
+        // issue #2491, fixed in #2624
+        CHECK(ordered_json(cards::kreuz) == "kreuz");
     }
 
     SECTION("traditional enum")


### PR DESCRIPTION
Closes #2491.

Caused by the strange behavior (or maybe even a bug) of Clang described in the linked issue #2491 and also on [LLVM bug tracker](https://bugs.llvm.org/show_bug.cgi?id=48507).

There are 2 commits - the first one is to add testing usage of `ordered_json` with enum (just like in the issue), the second resolves the problem for Clang with libc++ and C++17+. Since there is no CI workflow for that, I made a temporary workflow with Clang, C++17 and libc++ in my fork just to demonstrate the build results of these commits:

commit | Ubuntu | MacOS
-------|----------|------
add test for enum and ordered_json | [:x: failed](https://github.com/alexezeder/json/runs/1840711777?check_suite_focus=true#step:5:63) | [:x: failed](https://github.com/alexezeder/json/runs/1840711816?check_suite_focus=true#step:4:142)
guard instantiation of detail::detector in conversion operator of basic_json | [:heavy_check_mark: successful](https://github.com/alexezeder/json/runs/1844458015?check_suite_focus=true#step:5:125) | [:heavy_check_mark: successful](https://github.com/alexezeder/json/runs/1844458018?check_suite_focus=true#step:4:194)

P.S. I tried to reuse the existing Clang C++20 workflow for the temporary workflow with libc++, since there is no difference in Clang's behavior between C++17 and C++20 standards in this case, but libc++ of the used LLVM version does not provide `<span>` header, just for information.

<details><summary>Filled checklist here</summary>

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
</details>
