### PR TITLE
Fix compilation error that can occur with custom StringType

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3499,7 +3499,7 @@ class basic_json
             JSON_CATCH (std::out_of_range&)
             {
                 // create better exception explanation
-                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found", *this));
+                JSON_THROW(out_of_range::create(403, "key '" + std::string(key.begin(), key.end()) + "' not found", *this));
             }
         }
         else
@@ -3550,7 +3550,7 @@ class basic_json
             JSON_CATCH (std::out_of_range&)
             {
                 // create better exception explanation
-                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found", *this));
+                JSON_THROW(out_of_range::create(403, "key '" + std::string(key.begin(), key.end()) + "' not found", *this));
             }
         }
         else

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20282,7 +20282,7 @@ class basic_json
             JSON_CATCH (std::out_of_range&)
             {
                 // create better exception explanation
-                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found", *this));
+                JSON_THROW(out_of_range::create(403, "key '" + std::string(key.begin(), key.end()) + "' not found", *this));
             }
         }
         else
@@ -20333,7 +20333,7 @@ class basic_json
             JSON_CATCH (std::out_of_range&)
             {
                 // create better exception explanation
-                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found", *this));
+                JSON_THROW(out_of_range::create(403, "key '" + std::string(key.begin(), key.end()) + "' not found", *this));
             }
         }
         else


### PR DESCRIPTION
Fix compilation errors occurring in some ```JSON_THROW``` when using custom ```StringType```.

For instance, here is the compilation error when using ```at()``` method with ```folly::fbstring```:
```
_deps/json-src/include/nlohmann/json.hpp:19903:68: error: cannot convert ‘folly::basic_fbstring<char>’ to ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’}
19903 |                 JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
      |                                                      ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
      |                                                                    |
      |                                                                    folly::basic_fbstring<char>
_deps/json-src/include/nlohmann/json.hpp:2065:41: note: in definition of macro ‘JSON_THROW’
 2065 |     #define JSON_THROW(exception) throw exception
      |                                         ^~~~~~~~~
```
I am a new user of this json library so there may be other areas which need to be updated as well.