### PR TITLE
add more CI steps

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,11 @@
 name: macOS
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
 
 jobs:
   xcode:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,11 @@
 name: Ubuntu
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
 
 jobs:
   ci_test_clang:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,20 +3,6 @@ name: Ubuntu
 on: [push, pull_request]
 
 jobs:
-  ci_test_clang_cxx20:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install_clang
-      run: |
-        sudo apt update
-        sudo apt install clang-10 ninja-build
-      shell: bash
-    - name: cmake
-      run: cmake -S . -B build -DJSON_CI=On
-    - name: build
-      run: cmake --build build --target ci_test_clang_cxx20
-
   ci_test_clang:
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +39,7 @@ jobs:
     container: nlohmann/json-ci:latest
     strategy:
       matrix:
-        target: [ci_clang_tidy, ci_cppcheck, ci_test_valgrind, ci_test_clang_sanitizer, ci_test_amalgamation, ci_clang_analyze, ci_cpplint]
+        target: [ci_clang_tidy, ci_cppcheck, ci_test_valgrind, ci_test_clang_sanitizer, ci_test_amalgamation, ci_clang_analyze, ci_cpplint, ci_cmake_flags, ci_single_binaries, ci_reproducible_tests, ci_non_git_tests, ci_offline_testdata]
     steps:
       - uses: actions/checkout@v2
       - name: cmake
@@ -106,3 +92,17 @@ jobs:
         run: cmake -S . -B build -DJSON_CI=On
       - name: build
         run: cmake --build build --target ci_test_compiler_${{ matrix.compiler }}
+
+  ci_test_standards:
+    runs-on: ubuntu-latest
+    container: nlohmann/json-ci:latest
+    strategy:
+      matrix:
+        standard: [11, 14, 17, 20]
+        compiler: [gcc, clang]
+    steps:
+      - uses: actions/checkout@v2
+      - name: cmake
+        run: cmake -S . -B build -DJSON_CI=On
+      - name: build
+        run: cmake --build build --target ci_test_{{ matrix.compiler }}_cxx{{ matrix.standard }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -110,4 +110,4 @@ jobs:
       - name: cmake
         run: cmake -S . -B build -DJSON_CI=On
       - name: build
-        run: cmake --build build --target ci_test_{{ matrix.compiler }}_cxx{{ matrix.standard }}
+        run: cmake --build build --target ci_test_${{ matrix.compiler }}_cxx${{ matrix.standard }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,11 @@
 name: Windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
 
 jobs:
   mingw:

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -401,7 +401,7 @@ foreach(CXX_STANDARD 11 14 17 20)
         COMMAND CXX=${GCC_TOOL} ${CMAKE_COMMAND}
             -DCMAKE_BUILD_TYPE=Debug -GNinja
             -DCMAKE_CXX_STANDARD=${CXX_STANDARD} -DCMAKE_CXX_STANDARD_REQUIRED=ON
-            -DJSON_BuildTests=ON
+            -DJSON_BuildTests=ON -DJSON_FastTests=ON
             -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_gcc_cxx${CXX_STANDARD}
         COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_gcc_cxx${CXX_STANDARD}
         COMMAND cd ${PROJECT_BINARY_DIR}/build_gcc_cxx${CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
@@ -650,7 +650,7 @@ add_custom_target(ci_offline_testdata
     COMMAND cd ${PROJECT_BINARY_DIR}/build_offline_testdata/test_data && ${GIT_TOOL} clone -c advice.detachedHead=false --branch v3.0.0 https://github.com/nlohmann/json_test_data.git --quiet --depth 1
     COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
-        -DJSON_BuildTests=ON -DJSON_TestDataDirectory=${PROJECT_BINARY_DIR}/build_offline_testdata/test_data/json_test_data
+        -DJSON_BuildTests=ON -DJSON_FastTests=ON -DJSON_TestDataDirectory=${PROJECT_BINARY_DIR}/build_offline_testdata/test_data/json_test_data
         -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_offline_testdata
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_offline_testdata
     COMMAND cd ${PROJECT_BINARY_DIR}/build_offline_testdata && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
@@ -666,7 +666,7 @@ add_custom_target(ci_non_git_tests
     COMMAND cd ${PROJECT_SOURCE_DIR} && for FILE in `${GIT_TOOL} ls-tree --name-only HEAD`\; do cp -r $$FILE ${PROJECT_BINARY_DIR}/build_non_git_tests/sources \; done
     COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
-        -DJSON_BuildTests=ON
+        -DJSON_BuildTests=ON -DJSON_FastTests=ON
         -S${PROJECT_BINARY_DIR}/build_non_git_tests/sources -B${PROJECT_BINARY_DIR}/build_non_git_tests
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_non_git_tests
     COMMAND cd ${PROJECT_BINARY_DIR}/build_non_git_tests && ${CMAKE_CTEST_COMMAND} --parallel ${N} -LE git_required --output-on-failure
@@ -680,7 +680,7 @@ add_custom_target(ci_non_git_tests
 add_custom_target(ci_reproducible_tests
     COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
-        -DJSON_BuildTests=ON
+        -DJSON_BuildTests=ON -DJSON_FastTests=ON
         -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_reproducible_tests
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_reproducible_tests
     COMMAND cd ${PROJECT_BINARY_DIR}/build_reproducible_tests && ${CMAKE_CTEST_COMMAND} --parallel ${N} -LE not_reproducible --output-on-failure


### PR DESCRIPTION
- add tests for C++ versions
- add tests ci_cmake_flags, ci_single_binaries, ci_reproducible_tests, ci_non_git_tests, and ci_offline_testdata
- only check pushes to default branches