### PR TITLE
Swift package manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
                 [
                     "_SwiftPackageManagerFile.cpp"
                 ],
-            publicHeadersPath: "./single_include/nlohmann/")
+            publicHeadersPath: "./single_include/")
     ],
     
     cxxLanguageStandard: .cxx11

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "json",
+    platforms: [
+        .iOS(.v9), .macOS(.v10_10), .tvOS(.v9), .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "json",
+            targets: ["json"]),
+    ],
+    targets: [
+        .target(
+            name: "json",
+            dependencies: [],
+            path: ".",
+            exclude:
+                [
+                    "appveyor.yml",
+                    "benchmarks",
+                    "cmake",
+                    "ChangeLog.md",
+                    "doc",
+                    "include",
+                    "test",
+                    "third_party",
+                    "CMakeLists.txt",
+                    "CODE_OF_CONDUCT.md",
+                    "LICENSE.MIT",
+                    "Makefile",
+                    "meson.build",
+                    "nlohmann_json.natvis",
+                    "README.md",
+                    "wsjcpp.yml",
+                ],
+            sources:
+                [
+                    "_SwiftPackageManagerFile.cpp"
+                ],
+            publicHeadersPath: "./single_include/nlohmann/")
+    ],
+    
+    cxxLanguageStandard: .cxx11
+)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ CPMAddPackage(
     VERSION 3.9.1)
 ```
 
+If you are using [Swift Package Manager](https://swift.org/package-manager/), you can use the library by adding a link to this repository. For instructions how to add this dependency to your app, follow the [official guide](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app).
+
 ### Pkg-config
 
 If you are using bare Makefiles, you can use `pkg-config` to generate the include flags that point to where the library is installed:

--- a/_SwiftPackageManagerFile.cpp
+++ b/_SwiftPackageManagerFile.cpp
@@ -1,0 +1,5 @@
+// This file exists only to trigger the json module to build; without
+// it swiftpm won't build anything, and then the package is not available for
+// the modules that need it.
+
+#include <json.hpp>


### PR DESCRIPTION
Issue: https://github.com/nlohmann/json/issues/2802
Discussion: https://github.com/nlohmann/json/discussions/2806

This adds support for the Swift Package Manager on Apple platforms.

I had to add an empty file to make SPM build the target, as header-only targets are not currently supported in the Swift Packages.

Similar solution has been used in Apple's swift-numerics repository:
Discussion: https://forums.swift.org/t/header-only-library-using-swift-package-manager/42700
Repository: https://github.com/apple/swift-numerics/blob/main/Sources/_NumericsShims/_NumericsShims.c


* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
