### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: [10, 11, 12]
+        version: [11, 12]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: [10, 11]
+        version: [10, 11, 12]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This MR removes Clang 10 from the Windows build and adds Clang 12 instead.