### PR TITLE
Add templated version of DEFINE_TYPE macros

### DIFF
--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -469,6 +469,40 @@
     {                                                                             \
     }
 
+/*!
+@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(Type, ...)                                             \
+    template<typename BasicJsonType>                                                            \
+    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)            \
+    {                                                                                           \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))                \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)          \
+    {                                                                                           \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))              \
+    }
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(Type, ...)                            \
+    template<typename BasicJsonType>                                               \
+    void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)      \
+    {                                                                              \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))   \
+    }                                                                              \
+    template<typename BasicJsonType>                                               \
+    void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)    \
+    {                                                                              \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) \
+    }
+
 #ifndef JSON_USE_IMPLICIT_CONVERSIONS
     #define JSON_USE_IMPLICIT_CONVERSIONS 1
 #endif

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -375,26 +375,56 @@
 #define NLOHMANN_JSON_FROM_WITH_DEFAULT(v1) nlohmann_json_t.v1 = nlohmann_json_j.value(#v1, nlohmann_json_default_obj.v1);
 
 /*!
-@brief macro
+@brief macro to briefly define intrusive serialization of a given type to/from JSON
+@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_INTRUSIVE
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(BasicJsonType, Type, ...)                  \
+    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
+    }                                                                                  \
+    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+    }
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from JSON
+@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(BasicJsonType, Type, ...)              \
+    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
+    }                                                                                  \
+    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+    }
+
+/*!
+@brief macro to briefly define intrusive serialization of given type to/from nlohmann::json
 @def NLOHMANN_DEFINE_TYPE_INTRUSIVE
 @since version 3.9.0
+@sa NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...)  \
-    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
 
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 /*!
-@brief macro
+@brief macro to briefly define non-intrusive serialization of given type to/from nlohmann::json
 @def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
 @since version 3.9.0
+@sa NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...)  \
-    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
 
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -430,6 +430,57 @@
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
+#define NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, ...)                       \
+    template<typename BasicJsonType>                                                \
+    ReturnType to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) \
+    {                                                                               \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))    \
+    }
+
+#define NLOHMANN_DEFINE_TYPE_T_IMPL(ReturnType, Type, ...)                            \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                      \
+    template<typename BasicJsonType>                                                  \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                 \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))    \
+    }
+
+#define NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(ReturnType, Type, ...)                         \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                                \
+    template<typename BasicJsonType>                                                            \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)           \
+    {                                                                                           \
+        Type nlohmann_json_default_obj;                                                         \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) \
+    }
+
+/*!
+@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(Type, ...) NLOHMANN_DEFINE_TYPE_T_IMPL(friend void, Type, __VA_ARGS__)
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(Type, ...) NLOHMANN_DEFINE_TYPE_T_IMPL(void, Type, __VA_ARGS__)
+
+/*!
+@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object (works with missing fields in json)
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T_WITH_DEFAULT
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(friend void, Type, __VA_ARGS__)
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object (works with missing fields in json)
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T_WITH_DEFAULT
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(void, Type, __VA_ARGS__)
 
 // inspired from https://stackoverflow.com/a/26745591
 // allows to call any std function as if (e.g. with begin):
@@ -467,40 +518,6 @@
     template<typename... T>                                                       \
     struct would_call_std_##std_name : detail2::would_call_std_##std_name<T...>   \
     {                                                                             \
-    }
-
-/*!
-@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object
-@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(Type, ...)                                             \
-    template<typename BasicJsonType>                                                            \
-    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)            \
-    {                                                                                           \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))                \
-    }                                                                                           \
-    template<typename BasicJsonType>                                                            \
-    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)          \
-    {                                                                                           \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))              \
-    }
-
-/*!
-@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object
-@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(Type, ...)                            \
-    template<typename BasicJsonType>                                               \
-    void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)      \
-    {                                                                              \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))   \
-    }                                                                              \
-    template<typename BasicJsonType>                                               \
-    void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)    \
-    {                                                                              \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) \
     }
 
 #ifndef JSON_USE_IMPLICIT_CONVERSIONS

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -374,36 +374,23 @@
 #define NLOHMANN_JSON_FROM(v1) nlohmann_json_j.at(#v1).get_to(nlohmann_json_t.v1);
 #define NLOHMANN_JSON_FROM_WITH_DEFAULT(v1) nlohmann_json_t.v1 = nlohmann_json_j.value(#v1, nlohmann_json_default_obj.v1);
 
-/*!
-@brief macro to briefly define intrusive serialization of a given type to/from JSON
-@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_INTRUSIVE
-@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(BasicJsonType, Type, ...)                  \
-    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
-    }                                                                                  \
-    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+#define NLOHMANN_DEFINE_TYPE_TO_IMPL(ReturnType, BasicJsonType, Type, ...)          \
+    ReturnType to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) \
+    {                                                                               \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))    \
     }
-
-/*!
-@brief macro to briefly define non-intrusive serialization of a given type to/from JSON
-@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
-@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(BasicJsonType, Type, ...)              \
-    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
-    }                                                                                  \
-    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+#define NLOHMANN_DEFINE_TYPE_IMPL(ReturnType, BasicJsonType, Type, ...)               \
+    NLOHMANN_DEFINE_TYPE_TO_IMPL(ReturnType, BasicJsonType, Type, __VA_ARGS__)        \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                 \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))    \
+    }
+#define NLOHMANN_DEFINE_TYPE_WITH_DEFAULT_IMPL(ReturnType, BasicJsonType, Type, ...)            \
+    NLOHMANN_DEFINE_TYPE_TO_IMPL(ReturnType, BasicJsonType, Type, __VA_ARGS__)                  \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)           \
+    {                                                                                           \
+        Type nlohmann_json_default_obj;                                                         \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) \
     }
 
 /*!
@@ -412,11 +399,9 @@
 @since version 3.9.0
 @sa NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_IMPL(friend void, nlohmann::json, Type, __VA_ARGS__)
 
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
-    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_WITH_DEFAULT_IMPL(friend void, nlohmann::json, Type, __VA_ARGS__)
 
 /*!
 @brief macro to briefly define non-intrusive serialization of given type to/from nlohmann::json
@@ -424,11 +409,9 @@
 @since version 3.9.0
 @sa NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_IMPL(inline void, nlohmann::json, Type, __VA_ARGS__)
 
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
-    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_WITH_DEFAULT_IMPL(inline void, nlohmann::json, Type, __VA_ARGS__)
 
 #define NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, ...)                       \
     template<typename BasicJsonType>                                                \
@@ -438,7 +421,7 @@
     }
 
 #define NLOHMANN_DEFINE_TYPE_T_IMPL(ReturnType, Type, ...)                            \
-    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                      \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                     \
     template<typename BasicJsonType>                                                  \
     ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
     {                                                                                 \
@@ -446,7 +429,7 @@
     }
 
 #define NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(ReturnType, Type, ...)                         \
-    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                                \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                               \
     template<typename BasicJsonType>                                                            \
     ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)           \
     {                                                                                           \

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18627,7 +18627,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-    )
+                                 )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2684,6 +2684,40 @@ using is_detected_convertible =
     {                                                                             \
     }
 
+/*!
+@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(Type, ...)                                             \
+    template<typename BasicJsonType>                                                            \
+    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)            \
+    {                                                                                           \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))                \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)          \
+    {                                                                                           \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))              \
+    }                                                                                           \
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(Type, ...)                            \
+    template<typename BasicJsonType>                                               \
+    void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)      \
+    {                                                                              \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))   \
+    }                                                                              \
+    template<typename BasicJsonType>                                               \
+    void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)    \
+    {                                                                              \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) \
+    }
+
 #ifndef JSON_USE_IMPLICIT_CONVERSIONS
     #define JSON_USE_IMPLICIT_CONVERSIONS 1
 #endif

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2607,9 +2607,15 @@ using is_detected_convertible =
 @def NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
 @since version 3.9.2
 */
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(BasicJsonType, Type, ...)  \
-    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(BasicJsonType, Type, ...)                  \
+    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
+    }                                                                                  \
+    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+    }
 
 /*!
 @brief macro to briefly define non-intrusive serialization of a given type to/from JSON
@@ -2617,9 +2623,15 @@ using is_detected_convertible =
 @def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
 @since version 3.9.2
 */
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(BasicJsonType, Type, ...)  \
-    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(BasicJsonType, Type, ...)              \
+    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
+    }                                                                                  \
+    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                  \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+    }
 
 /*!
 @brief macro to briefly define intrusive serialization of given type to/from nlohmann::json
@@ -2699,7 +2711,7 @@ using is_detected_convertible =
     friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)          \
     {                                                                                           \
         NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))              \
-    }                                                                                           \
+    }
 
 /*!
 @brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2657,6 +2657,57 @@ using is_detected_convertible =
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
+#define NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, ...)                       \
+    template<typename BasicJsonType>                                                \
+    ReturnType to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) \
+    {                                                                               \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))    \
+    }
+
+#define NLOHMANN_DEFINE_TYPE_T_IMPL(ReturnType, Type, ...)                            \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                      \
+    template<typename BasicJsonType>                                                  \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                 \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))    \
+    }
+
+#define NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(ReturnType, Type, ...)                         \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                                \
+    template<typename BasicJsonType>                                                            \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)           \
+    {                                                                                           \
+        Type nlohmann_json_default_obj;                                                         \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) \
+    }
+
+/*!
+@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(Type, ...) NLOHMANN_DEFINE_TYPE_T_IMPL(friend void, Type, __VA_ARGS__)
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(Type, ...) NLOHMANN_DEFINE_TYPE_T_IMPL(void, Type, __VA_ARGS__)
+
+/*!
+@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object (works with missing fields in json)
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T_WITH_DEFAULT
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(friend void, Type, __VA_ARGS__)
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object (works with missing fields in json)
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T_WITH_DEFAULT
+@since version 3.10.6
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(void, Type, __VA_ARGS__)
 
 // inspired from https://stackoverflow.com/a/26745591
 // allows to call any std function as if (e.g. with begin):
@@ -2694,40 +2745,6 @@ using is_detected_convertible =
     template<typename... T>                                                       \
     struct would_call_std_##std_name : detail2::would_call_std_##std_name<T...>   \
     {                                                                             \
-    }
-
-/*!
-@brief macro to briefly define intrusive serialization of a given type to/from any basic_json object
-@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_T
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(Type, ...)                                             \
-    template<typename BasicJsonType>                                                            \
-    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)            \
-    {                                                                                           \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))                \
-    }                                                                                           \
-    template<typename BasicJsonType>                                                            \
-    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)          \
-    {                                                                                           \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))              \
-    }
-
-/*!
-@brief macro to briefly define non-intrusive serialization of a given type to/from any basic_json object
-@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(Type, ...)                            \
-    template<typename BasicJsonType>                                               \
-    void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)      \
-    {                                                                              \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))   \
-    }                                                                              \
-    template<typename BasicJsonType>                                               \
-    void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)    \
-    {                                                                              \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) \
     }
 
 #ifndef JSON_USE_IMPLICIT_CONVERSIONS
@@ -18627,7 +18644,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2602,26 +2602,44 @@ using is_detected_convertible =
 #define NLOHMANN_JSON_FROM_WITH_DEFAULT(v1) nlohmann_json_t.v1 = nlohmann_json_j.value(#v1, nlohmann_json_default_obj.v1);
 
 /*!
-@brief macro
+@brief macro to briefly define intrusive serialization of a given type to/from JSON
+@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_INTRUSIVE
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(BasicJsonType, Type, ...)  \
+    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
+    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+
+/*!
+@brief macro to briefly define non-intrusive serialization of a given type to/from JSON
+@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
+@since version 3.9.2
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(BasicJsonType, Type, ...)  \
+    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
+    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+
+/*!
+@brief macro to briefly define intrusive serialization of given type to/from nlohmann::json
 @def NLOHMANN_DEFINE_TYPE_INTRUSIVE
 @since version 3.9.0
+@sa NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...)  \
-    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
 
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 /*!
-@brief macro
+@brief macro to briefly define non-intrusive serialization of given type to/from nlohmann::json
 @def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
 @since version 3.9.0
+@sa NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...)  \
-    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
 
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2601,36 +2601,23 @@ using is_detected_convertible =
 #define NLOHMANN_JSON_FROM(v1) nlohmann_json_j.at(#v1).get_to(nlohmann_json_t.v1);
 #define NLOHMANN_JSON_FROM_WITH_DEFAULT(v1) nlohmann_json_t.v1 = nlohmann_json_j.value(#v1, nlohmann_json_default_obj.v1);
 
-/*!
-@brief macro to briefly define intrusive serialization of a given type to/from JSON
-@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_INTRUSIVE
-@def NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(BasicJsonType, Type, ...)                  \
-    friend void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
-    }                                                                                  \
-    friend void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+#define NLOHMANN_DEFINE_TYPE_TO_IMPL(ReturnType, BasicJsonType, Type, ...)          \
+    ReturnType to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t) \
+    {                                                                               \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))    \
     }
-
-/*!
-@brief macro to briefly define non-intrusive serialization of a given type to/from JSON
-@note you can define your own specialized macroses like NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
-@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
-@since version 3.9.2
-*/
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(BasicJsonType, Type, ...)              \
-    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)   \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__))       \
-    }                                                                                  \
-    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
-    {                                                                                  \
-        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))     \
+#define NLOHMANN_DEFINE_TYPE_IMPL(ReturnType, BasicJsonType, Type, ...)               \
+    NLOHMANN_DEFINE_TYPE_TO_IMPL(ReturnType, BasicJsonType, Type, __VA_ARGS__)        \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
+    {                                                                                 \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__))    \
+    }
+#define NLOHMANN_DEFINE_TYPE_WITH_DEFAULT_IMPL(ReturnType, BasicJsonType, Type, ...)            \
+    NLOHMANN_DEFINE_TYPE_TO_IMPL(ReturnType, BasicJsonType, Type, __VA_ARGS__)                  \
+    ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)           \
+    {                                                                                           \
+        Type nlohmann_json_default_obj;                                                         \
+        NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) \
     }
 
 /*!
@@ -2639,11 +2626,9 @@ using is_detected_convertible =
 @since version 3.9.0
 @sa NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_IMPL(friend void, nlohmann::json, Type, __VA_ARGS__)
 
-#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
-    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_WITH_DEFAULT_IMPL(friend void, nlohmann::json, Type, __VA_ARGS__)
 
 /*!
 @brief macro to briefly define non-intrusive serialization of given type to/from nlohmann::json
@@ -2651,11 +2636,9 @@ using is_detected_convertible =
 @since version 3.9.0
 @sa NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL
 */
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_IMPL(nlohmann::json, Type, __VA_ARGS__)
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...) NLOHMANN_DEFINE_TYPE_IMPL(inline void, nlohmann::json, Type, __VA_ARGS__)
 
-#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
-    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...) NLOHMANN_DEFINE_TYPE_WITH_DEFAULT_IMPL(inline void, nlohmann::json, Type, __VA_ARGS__)
 
 #define NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, ...)                       \
     template<typename BasicJsonType>                                                \
@@ -2665,7 +2648,7 @@ using is_detected_convertible =
     }
 
 #define NLOHMANN_DEFINE_TYPE_T_IMPL(ReturnType, Type, ...)                            \
-    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                      \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                     \
     template<typename BasicJsonType>                                                  \
     ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t) \
     {                                                                                 \
@@ -2673,7 +2656,7 @@ using is_detected_convertible =
     }
 
 #define NLOHMANN_DEFINE_TYPE_T_WITH_DEFAULT_IMPL(ReturnType, Type, ...)                         \
-    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                                \
+    NLOHMANN_DEFINE_TYPE_T_TO_IMPL(ReturnType, Type, __VA_ARGS__)                               \
     template<typename BasicJsonType>                                                            \
     ReturnType from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)           \
     {                                                                                           \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,10 +42,11 @@ target_compile_features(test_main PRIVATE cxx_std_11)
 target_compile_options(test_main PUBLIC
     $<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>
     # MSVC: Force to always compile with W4
+    #       Disable warning C4503: ...: decorated name length (4096) exceeded, name was truncated
     #       Disable warning C4566: character represented by universal-character-name '\uFF01'
     #                              cannot be represented in the current code page (1252)
     #       Disable warning C4996: 'nlohmann::basic_json<...>::operator <<': was declared deprecated
-    $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4566 /wd4996>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4503 /wd4566 /wd4996>
     # https://github.com/nlohmann/json/issues/1114
     $<$<CXX_COMPILER_ID:MSVC>:/bigobj> $<$<BOOL:${MINGW}>:-Wa,-mbig-obj>
 

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -36,92 +36,95 @@ using nlohmann::json;
 
 namespace persons
 {
-#define PERSON_CLASS_BODY(ClassName, Visibility)                               \
-    Visibility:                                                                \
-    std::string name = "";                                                     \
-    int age = 0;                                                               \
-    json metadata = nullptr;                                                   \
-    public:                                                                    \
-    bool operator==(const ClassName& rhs) const                                \
-    {                                                                          \
-        return name == rhs.name && age == rhs.age && metadata == rhs.metadata; \
-    }                                                                          \
-    ClassName() = default;                                                     \
-    ClassName(std::string name_, int age_, json metadata_)                     \
-        : name(std::move(name_))                                               \
-        , age(age_)                                                            \
-        , metadata(std::move(metadata_))                                       \
-    {}                                                                         \
-    std::string getName() const                                                \
-    {                                                                          \
-        return name;                                                           \
-    }                                                                          \
-    int getAge() const                                                         \
-    {                                                                          \
-        return age;                                                            \
-    }                                                                          \
-    json getMetadata() const                                                   \
-    {                                                                          \
-        return metadata;                                                       \
+#define PERSON_CLASS_BODY(ClassName, Visibility)                                    \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                                \
+    Visibility:                                                                     \
+    /* NOLINTNEXTLINE(readability-redundant-string-init): collides with -Weffc++ */ \
+    std::string name = "";                                                          \
+    int age = 0;                                                                    \
+    json metadata = nullptr;                                                        \
+    public:                                                                         \
+    bool operator==(const ClassName& rhs) const                                     \
+    {                                                                               \
+        return name == rhs.name && age == rhs.age && metadata == rhs.metadata;      \
+    }                                                                               \
+    ClassName() = default;                                                          \
+    ClassName(std::string name_, int age_, json metadata_)                          \
+        : name(std::move(name_))                                                    \
+        , age(age_)                                                                 \
+        , metadata(std::move(metadata_))                                            \
+    {}                                                                              \
+    std::string getName() const                                                     \
+    {                                                                               \
+        return name;                                                                \
+    }                                                                               \
+    int getAge() const                                                              \
+    {                                                                               \
+        return age;                                                                 \
+    }                                                                               \
+    json getMetadata() const                                                        \
+    {                                                                               \
+        return metadata;                                                            \
     }
 
-#define ALPHABET_CLASS_BODY(ClassName, Visibility) \
-    public:                                        \
-    bool operator==(const ClassName& other) const  \
-    {                                              \
-        return a == other.a &&                     \
-               b == other.b &&                     \
-               c == other.c &&                     \
-               d == other.d &&                     \
-               e == other.e &&                     \
-               f == other.f &&                     \
-               g == other.g &&                     \
-               h == other.h &&                     \
-               i == other.i &&                     \
-               j == other.j &&                     \
-               k == other.k &&                     \
-               l == other.l &&                     \
-               m == other.m &&                     \
-               n == other.n &&                     \
-               o == other.o &&                     \
-               p == other.p &&                     \
-               q == other.q &&                     \
-               r == other.r &&                     \
-               s == other.s &&                     \
-               t == other.t &&                     \
-               u == other.u &&                     \
-               v == other.v &&                     \
-               w == other.w &&                     \
-               x == other.x &&                     \
-               y == other.y &&                     \
-               z == other.z;                       \
-    }                                              \
-    Visibility:                                    \
-    int a = 0;                                     \
-    int b = 0;                                     \
-    int c = 0;                                     \
-    int d = 0;                                     \
-    int e = 0;                                     \
-    int f = 0;                                     \
-    int g = 0;                                     \
-    int h = 0;                                     \
-    int i = 0;                                     \
-    int j = 0;                                     \
-    int k = 0;                                     \
-    int l = 0;                                     \
-    int m = 0;                                     \
-    int n = 0;                                     \
-    int o = 0;                                     \
-    int p = 0;                                     \
-    int q = 0;                                     \
-    int r = 0;                                     \
-    int s = 0;                                     \
-    int t = 0;                                     \
-    int u = 0;                                     \
-    int v = 0;                                     \
-    int w = 0;                                     \
-    int x = 0;                                     \
-    int y = 0;                                     \
+#define ALPHABET_CLASS_BODY(ClassName, Visibility)   \
+    public:                                          \
+    bool operator==(const ClassName& other) const    \
+    {                                                \
+        return a == other.a &&                       \
+               b == other.b &&                       \
+               c == other.c &&                       \
+               d == other.d &&                       \
+               e == other.e &&                       \
+               f == other.f &&                       \
+               g == other.g &&                       \
+               h == other.h &&                       \
+               i == other.i &&                       \
+               j == other.j &&                       \
+               k == other.k &&                       \
+               l == other.l &&                       \
+               m == other.m &&                       \
+               n == other.n &&                       \
+               o == other.o &&                       \
+               p == other.p &&                       \
+               q == other.q &&                       \
+               r == other.r &&                       \
+               s == other.s &&                       \
+               t == other.t &&                       \
+               u == other.u &&                       \
+               v == other.v &&                       \
+               w == other.w &&                       \
+               x == other.x &&                       \
+               y == other.y &&                       \
+               z == other.z;                         \
+    }                                                \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
+    Visibility:                                      \
+    int a = 0;                                       \
+    int b = 0;                                       \
+    int c = 0;                                       \
+    int d = 0;                                       \
+    int e = 0;                                       \
+    int f = 0;                                       \
+    int g = 0;                                       \
+    int h = 0;                                       \
+    int i = 0;                                       \
+    int j = 0;                                       \
+    int k = 0;                                       \
+    int l = 0;                                       \
+    int m = 0;                                       \
+    int n = 0;                                       \
+    int o = 0;                                       \
+    int p = 0;                                       \
+    int q = 0;                                       \
+    int r = 0;                                       \
+    int s = 0;                                       \
+    int t = 0;                                       \
+    int u = 0;                                       \
+    int v = 0;                                       \
+    int w = 0;                                       \
+    int x = 0;                                       \
+    int y = 0;                                       \
     int z = 0;
 
 class person_with_private_data
@@ -218,8 +221,8 @@ struct TestTypePair
     using BasicJsonType = BasicJsonType_;
 };
 
-#define PERSON_TYPES_TO_TEST                                                            \
-    TestTypePair<persons::person_with_private_data>,                                    \
+#define PERSON_TYPES_TO_TEST                                                        \
+    TestTypePair<persons::person_with_private_data>,                                \
     TestTypePair<persons::person_without_private_data_1>,                           \
     TestTypePair<persons::person_without_private_data_2>,                           \
     TestTypePair<persons::person_t_with_private_data>,                              \
@@ -242,11 +245,11 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
         std::string json_string;
         if (std::is_same<json_t, nlohmann::ordered_json>::value)
         {
-            json_string = "{\"age\":1,\"name\":\"Erik\",\"metadata\":{\"haircuts\":2}}";
+            json_string = R"str({"age":1,"name":"Erik","metadata":{"haircuts":2}})str";
         }
         else
         {
-            json_string = "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}";
+            json_string = R"str({"age":1,"metadata":{"haircuts":2},"name":"Erik"})str";
         }
         CHECK(json_t(p1).dump() == json_string);
 
@@ -286,11 +289,11 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
         std::string json_string;
         if (std::is_same<json_t, nlohmann::ordered_json>::value)
         {
-            json_string = "{\"age\":0,\"name\":\"\",\"metadata\":null}";
+            json_string = R"str({"age":0,"name":"","metadata":null})str";
         }
         else
         {
-            json_string = "{\"age\":0,\"metadata\":null,\"name\":\"\"}";
+            json_string = R"str({"age":0,"metadata":null,"name":""})str";
         }
         CHECK(json_t(p0).dump() == json_string);
 
@@ -298,11 +301,11 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
         T p1("Erik", 1, {{"haircuts", 2}});
         if (std::is_same<json_t, nlohmann::ordered_json>::value)
         {
-            json_string = "{\"age\":1,\"name\":\"Erik\",\"metadata\":{\"haircuts\":2}}";
+            json_string = R"str({"age":1,"name":"Erik","metadata":{"haircuts":2}})str";
         }
         else
         {
-            json_string = "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}";
+            json_string = R"str({"age":1,"metadata":{"haircuts":2},"name":"Erik"})str";
         }
         CHECK(json_t(p1).dump() == json_string);
 

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -41,7 +41,6 @@ namespace persons
     std::string name = "";                                                     \
     int age = 0;                                                               \
     json metadata = nullptr;                                                   \
-                                                                               \
     public:                                                                    \
     bool operator==(const ClassName& rhs) const                                \
     {                                                                          \

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -34,23 +34,24 @@ SOFTWARE.
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
-namespace persons {
+namespace persons
+{
 #define PERSON_CLASS_BODY(ClassName, Visibility)                               \
-Visibility:                                                                    \
+    Visibility:                                                                \
     std::string name = "";                                                     \
     int age = 0;                                                               \
     json metadata = nullptr;                                                   \
                                                                                \
-  public:                                                                      \
+    public:                                                                    \
     bool operator==(const ClassName& rhs) const                                \
     {                                                                          \
         return name == rhs.name && age == rhs.age && metadata == rhs.metadata; \
     }                                                                          \
     ClassName() = default;                                                     \
     ClassName(std::string name_, int age_, json metadata_)                     \
-      : name(std::move(name_))                                                 \
-      , age(age_)                                                              \
-      , metadata(std::move(metadata_))                                         \
+        : name(std::move(name_))                                               \
+        , age(age_)                                                            \
+        , metadata(std::move(metadata_))                                       \
     {}                                                                         \
     std::string getName() const                                                \
     {                                                                          \
@@ -66,7 +67,7 @@ Visibility:                                                                    \
     }
 
 #define ALPHABET_CLASS_BODY(ClassName, Visibility) \
-  public:                                          \
+    public:                                        \
     bool operator==(const ClassName& other) const  \
     {                                              \
         return a == other.a &&                     \
@@ -96,7 +97,7 @@ Visibility:                                                                    \
                y == other.y &&                     \
                z == other.z;                       \
     }                                              \
-Visibility:                                        \
+    Visibility:                                    \
     int a = 0;                                     \
     int b = 0;                                     \
     int c = 0;                                     \
@@ -220,14 +221,14 @@ struct TestTypePair
 
 #define PERSON_TYPES_TO_TEST                                                            \
     TestTypePair<persons::person_with_private_data>,                                    \
-        TestTypePair<persons::person_without_private_data_1>,                           \
-        TestTypePair<persons::person_without_private_data_2>,                           \
-        TestTypePair<persons::person_t_with_private_data>,                              \
-        TestTypePair<persons::person_t_without_private_data_1>,                         \
-        TestTypePair<persons::person_t_without_private_data_2>,                         \
-        TestTypePair<persons::person_t_with_private_data, nlohmann::ordered_json>,      \
-        TestTypePair<persons::person_t_without_private_data_1, nlohmann::ordered_json>, \
-        TestTypePair<persons::person_t_without_private_data_2, nlohmann::ordered_json>
+    TestTypePair<persons::person_without_private_data_1>,                           \
+    TestTypePair<persons::person_without_private_data_2>,                           \
+    TestTypePair<persons::person_t_with_private_data>,                              \
+    TestTypePair<persons::person_t_without_private_data_1>,                         \
+    TestTypePair<persons::person_t_without_private_data_2>,                         \
+    TestTypePair<persons::person_t_with_private_data, nlohmann::ordered_json>,      \
+    TestTypePair<persons::person_t_without_private_data_1, nlohmann::ordered_json>, \
+    TestTypePair<persons::person_t_without_private_data_2, nlohmann::ordered_json>
 
 TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, PERSON_TYPES_TO_TEST)
 #undef PERSON_TYPES_TO_TEST
@@ -265,13 +266,13 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
     }
 }
 
-#define PERSON_TYPES_TO_TEST                                                         \
-    TestTypePair<persons::person_with_private_data_2>,                               \
-        TestTypePair<persons::person_without_private_data_3>,                        \
-        TestTypePair<persons::person_t_with_private_data_2>,                         \
-        TestTypePair<persons::person_t_without_private_data_3>,                      \
-        TestTypePair<persons::person_t_with_private_data_2, nlohmann::ordered_json>, \
-        TestTypePair<persons::person_t_without_private_data_3, nlohmann::ordered_json>
+#define PERSON_TYPES_TO_TEST                                                     \
+    TestTypePair<persons::person_with_private_data_2>,                           \
+    TestTypePair<persons::person_without_private_data_3>,                        \
+    TestTypePair<persons::person_t_with_private_data_2>,                         \
+    TestTypePair<persons::person_t_without_private_data_3>,                      \
+    TestTypePair<persons::person_t_with_private_data_2, nlohmann::ordered_json>, \
+    TestTypePair<persons::person_t_without_private_data_3, nlohmann::ordered_json>
 
 TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT", PairT, PERSON_TYPES_TO_TEST)
 #undef PERSON_TYPES_TO_TEST
@@ -326,13 +327,13 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
     }
 }
 
-#define ALPHABET_PAIRS                                                                 \
-    TestTypePair<persons::person_with_private_alphabet>,                               \
-        TestTypePair<persons::person_with_public_alphabet>,                            \
-        TestTypePair<persons::person_t_with_private_alphabet, nlohmann::json>,         \
-        TestTypePair<persons::person_t_with_public_alphabet, nlohmann::json>,          \
-        TestTypePair<persons::person_t_with_private_alphabet, nlohmann::ordered_json>, \
-        TestTypePair<persons::person_t_with_public_alphabet, nlohmann::ordered_json>
+#define ALPHABET_PAIRS                                                             \
+    TestTypePair<persons::person_with_private_alphabet>,                           \
+    TestTypePair<persons::person_with_public_alphabet>,                            \
+    TestTypePair<persons::person_t_with_private_alphabet, nlohmann::json>,         \
+    TestTypePair<persons::person_t_with_public_alphabet, nlohmann::json>,          \
+    TestTypePair<persons::person_t_with_private_alphabet, nlohmann::ordered_json>, \
+    TestTypePair<persons::person_t_with_public_alphabet, nlohmann::ordered_json>
 
 TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/private member variables via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, ALPHABET_PAIRS)
 #undef ALPHABET_PAIRS

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -36,295 +36,218 @@ using nlohmann::json;
 
 namespace persons
 {
-class person_with_private_data
-{
-  private:
-    std::string name{};
-    int age = 0;
-    json metadata = nullptr;
-
-  public:
-    bool operator==(const person_with_private_data& rhs) const
-    {
-        return name == rhs.name && age == rhs.age && metadata == rhs.metadata;
+#define PERSON_CLASS_BODY(ClassName, Visibility)                               \
+Visibility:                                                                    \
+    std::string name;                                                          \
+    int age = 0;                                                               \
+    json metadata = nullptr;                                                   \
+                                                                               \
+  public:                                                                      \
+    bool operator==(const ClassName& rhs) const                                \
+    {                                                                          \
+        return name == rhs.name && age == rhs.age && metadata == rhs.metadata; \
+    }                                                                          \
+    ClassName() = default;                                                     \
+    ClassName(std::string name_, int age_, json metadata_)                     \
+      : name(std::move(name_))                                                 \
+      , age(age_)                                                              \
+      , metadata(std::move(metadata_))                                         \
+    {}                                                                         \
+    std::string getName() const                                                \
+    {                                                                          \
+        return name;                                                           \
+    }                                                                          \
+    int getAge() const                                                         \
+    {                                                                          \
+        return age;                                                            \
+    }                                                                          \
+    json getMetadata() const                                                   \
+    {                                                                          \
+        return metadata;                                                       \
     }
 
-    person_with_private_data() = default;
-    person_with_private_data(std::string name_, int age_, json metadata_)
-        : name(std::move(name_))
-        , age(age_)
-        , metadata(std::move(metadata_))
-    {}
+#define ALPHABET_CLASS_BODY(ClassName, Visibility)    \
+      public:                                         \
+        bool operator==(const ClassName& other) const \
+        {                                             \
+            return a == other.a &&                    \
+                   b == other.b &&                    \
+                   c == other.c &&                    \
+                   d == other.d &&                    \
+                   e == other.e &&                    \
+                   f == other.f &&                    \
+                   g == other.g &&                    \
+                   h == other.h &&                    \
+                   i == other.i &&                    \
+                   j == other.j &&                    \
+                   k == other.k &&                    \
+                   l == other.l &&                    \
+                   m == other.m &&                    \
+                   n == other.n &&                    \
+                   o == other.o &&                    \
+                   p == other.p &&                    \
+                   q == other.q &&                    \
+                   r == other.r &&                    \
+                   s == other.s &&                    \
+                   t == other.t &&                    \
+                   u == other.u &&                    \
+                   v == other.v &&                    \
+                   w == other.w &&                    \
+                   x == other.x &&                    \
+                   y == other.y &&                    \
+                   z == other.z;                      \
+        }                                             \
+        Visibility : int a = 0;                       \
+        int b = 0;                                    \
+        int c = 0;                                    \
+        int d = 0;                                    \
+        int e = 0;                                    \
+        int f = 0;                                    \
+        int g = 0;                                    \
+        int h = 0;                                    \
+        int i = 0;                                    \
+        int j = 0;                                    \
+        int k = 0;                                    \
+        int l = 0;                                    \
+        int m = 0;                                    \
+        int n = 0;                                    \
+        int o = 0;                                    \
+        int p = 0;                                    \
+        int q = 0;                                    \
+        int r = 0;                                    \
+        int s = 0;                                    \
+        int t = 0;                                    \
+        int u = 0;                                    \
+        int v = 0;                                    \
+        int w = 0;                                    \
+        int x = 0;                                    \
+        int y = 0;                                    \
+        int z = 0;
 
+class person_with_private_data
+{
+    PERSON_CLASS_BODY(person_with_private_data, private)
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(person_with_private_data, age, name, metadata)
 };
 
 class person_with_private_data_2
 {
-  private:
-    std::string name{};
-    int age = 0;
-    json metadata = nullptr;
-
-  public:
-    bool operator==(const person_with_private_data_2& rhs) const
-    {
-        return name == rhs.name && age == rhs.age && metadata == rhs.metadata;
-    }
-
-    person_with_private_data_2() = default;
-    person_with_private_data_2(std::string name_, int age_, json metadata_)
-        : name(std::move(name_))
-        , age(age_)
-        , metadata(std::move(metadata_))
-    {}
-
-    std::string getName() const
-    {
-        return name;
-    }
-    int getAge() const
-    {
-        return age;
-    }
-    json getMetadata() const
-    {
-        return metadata;
-    }
-
+    PERSON_CLASS_BODY(person_with_private_data_2, private)
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(person_with_private_data_2, age, name, metadata)
 };
 
 class person_without_private_data_1
 {
-  public:
-    std::string name{};
-    int age = 0;
-    json metadata = nullptr;
-
-    bool operator==(const person_without_private_data_1& rhs) const
-    {
-        return name == rhs.name && age == rhs.age && metadata == rhs.metadata;
-    }
-
-    person_without_private_data_1() = default;
-    person_without_private_data_1(std::string name_, int age_, json metadata_)
-        : name(std::move(name_))
-        , age(age_)
-        , metadata(std::move(metadata_))
-    {}
-
+    PERSON_CLASS_BODY(person_without_private_data_1, public)
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(person_without_private_data_1, age, name, metadata)
 };
 
 class person_without_private_data_2
 {
-  public:
-    std::string name{};
-    int age = 0;
-    json metadata = nullptr;
-
-    bool operator==(const person_without_private_data_2& rhs) const
-    {
-        return name == rhs.name && age == rhs.age && metadata == rhs.metadata;
-    }
-
-    person_without_private_data_2() = default;
-    person_without_private_data_2(std::string name_, int age_, json metadata_)
-        : name(std::move(name_))
-        , age(age_)
-        , metadata(std::move(metadata_))
-    {}
+    PERSON_CLASS_BODY(person_without_private_data_2, public)
 };
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person_without_private_data_2, age, name, metadata)
 
 class person_without_private_data_3
 {
-  public:
-    std::string name{};
-    int age = 0;
-    json metadata = nullptr;
+    PERSON_CLASS_BODY(person_without_private_data_3, public)
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(person_without_private_data_3, age, name, metadata)
 
-    bool operator==(const person_without_private_data_3& rhs) const
-    {
-        return name == rhs.name && age == rhs.age && metadata == rhs.metadata;
-    }
-
-    person_without_private_data_3() = default;
-    person_without_private_data_3(std::string name_, int age_, json metadata_)
-        : name(std::move(name_))
-        , age(age_)
-        , metadata(std::move(metadata_))
-    {}
-
-    std::string getName() const
-    {
-        return name;
-    }
-    int getAge() const
-    {
-        return age;
-    }
-    json getMetadata() const
-    {
-        return metadata;
-    }
+class person_t_with_private_data
+{
+    PERSON_CLASS_BODY(person_t_with_private_data, private)
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(person_t_with_private_data, age, name, metadata)
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(person_without_private_data_3, age, name, metadata)
+class person_t_without_private_data_1
+{
+    PERSON_CLASS_BODY(person_t_without_private_data_1, public)
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(person_t_without_private_data_1, age, name, metadata)
+};
+
+class person_t_without_private_data_2
+{
+    PERSON_CLASS_BODY(person_t_without_private_data_2, public)
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(person_t_without_private_data_2, age, name, metadata)
 
 class person_with_private_alphabet
 {
-  public:
-    bool operator==(const person_with_private_alphabet& other) const
-    {
-        return  a == other.a &&
-                b == other.b &&
-                c == other.c &&
-                d == other.d &&
-                e == other.e &&
-                f == other.f &&
-                g == other.g &&
-                h == other.h &&
-                i == other.i &&
-                j == other.j &&
-                k == other.k &&
-                l == other.l &&
-                m == other.m &&
-                n == other.n &&
-                o == other.o &&
-                p == other.p &&
-                q == other.q &&
-                r == other.r &&
-                s == other.s &&
-                t == other.t &&
-                u == other.u &&
-                v == other.v &&
-                w == other.w &&
-                x == other.x &&
-                y == other.y &&
-                z == other.z;
-    }
-
-  private:
-    int a = 0;
-    int b = 0;
-    int c = 0;
-    int d = 0;
-    int e = 0;
-    int f = 0;
-    int g = 0;
-    int h = 0;
-    int i = 0;
-    int j = 0;
-    int k = 0;
-    int l = 0;
-    int m = 0;
-    int n = 0;
-    int o = 0;
-    int p = 0;
-    int q = 0;
-    int r = 0;
-    int s = 0;
-    int t = 0;
-    int u = 0;
-    int v = 0;
-    int w = 0;
-    int x = 0;
-    int y = 0;
-    int z = 0;
+    ALPHABET_CLASS_BODY(person_with_private_alphabet, private)
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(person_with_private_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
 };
 
 class person_with_public_alphabet
 {
-  public:
-    bool operator==(const person_with_public_alphabet& other) const
-    {
-        return  a == other.a &&
-                b == other.b &&
-                c == other.c &&
-                d == other.d &&
-                e == other.e &&
-                f == other.f &&
-                g == other.g &&
-                h == other.h &&
-                i == other.i &&
-                j == other.j &&
-                k == other.k &&
-                l == other.l &&
-                m == other.m &&
-                n == other.n &&
-                o == other.o &&
-                p == other.p &&
-                q == other.q &&
-                r == other.r &&
-                s == other.s &&
-                t == other.t &&
-                u == other.u &&
-                v == other.v &&
-                w == other.w &&
-                x == other.x &&
-                y == other.y &&
-                z == other.z;
-    }
-
-    int a = 0;
-    int b = 0;
-    int c = 0;
-    int d = 0;
-    int e = 0;
-    int f = 0;
-    int g = 0;
-    int h = 0;
-    int i = 0;
-    int j = 0;
-    int k = 0;
-    int l = 0;
-    int m = 0;
-    int n = 0;
-    int o = 0;
-    int p = 0;
-    int q = 0;
-    int r = 0;
-    int s = 0;
-    int t = 0;
-    int u = 0;
-    int v = 0;
-    int w = 0;
-    int x = 0;
-    int y = 0;
-    int z = 0;
+    ALPHABET_CLASS_BODY(person_with_public_alphabet, public)
 };
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person_with_public_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
 
+
+class person_t_with_private_alphabet
+{
+    ALPHABET_CLASS_BODY(person_t_with_private_alphabet, private)
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(person_t_with_private_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
+};
+
+class person_t_with_public_alphabet
+{
+    ALPHABET_CLASS_BODY(person_t_with_public_alphabet, public)
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(person_t_with_public_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
 } // namespace persons
 
-TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", T,
-                   persons::person_with_private_data,
-                   persons::person_without_private_data_1,
-                   persons::person_without_private_data_2)
+// Trick described in https://github.com/onqtam/doctest/blob/master/doc/markdown/parameterized-tests.md
+// in note "if you need parameterization on more than 1 type"
+template <typename TestedType_, typename BasicJsonType_ = nlohmann::json>
+struct TestTypePair
 {
+    using TestedType    = TestedType_;
+    using BasicJsonType = BasicJsonType_;
+};
+
+#define PERSON_PAIRS                                                                \
+    TestTypePair<persons::person_with_private_data>,                                \
+    TestTypePair<persons::person_without_private_data_1>,                           \
+    TestTypePair<persons::person_without_private_data_2>,                           \
+    TestTypePair<persons::person_t_with_private_data,      nlohmann::json>,         \
+    TestTypePair<persons::person_t_without_private_data_1, nlohmann::json>,         \
+    TestTypePair<persons::person_t_without_private_data_2, nlohmann::json>,         \
+    TestTypePair<persons::person_t_with_private_data,      nlohmann::ordered_json>, \
+    TestTypePair<persons::person_t_without_private_data_1, nlohmann::ordered_json>, \
+    TestTypePair<persons::person_t_without_private_data_2, nlohmann::ordered_json>
+
+TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, PERSON_PAIRS)
+{
+    using T = typename PairT::TestedType;
+    using json_t = typename PairT::BasicJsonType;
+
     SECTION("person")
     {
         // serialization
         T p1("Erik", 1, {{"haircuts", 2}});
-        CHECK(json(p1).dump() == "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}");
+        if ( std::is_same<json_t, nlohmann::ordered_json>::value )
+        {
+            CHECK(json_t(p1).dump() == "{\"age\":1,\"name\":\"Erik\",\"metadata\":{\"haircuts\":2}}");
+        }
+        else
+        {
+            CHECK(json_t(p1).dump() == "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}");
+        }
 
         // deserialization
-        auto p2 = json(p1).get<T>();
+        auto p2 = json_t(p1).template get<T>();
         CHECK(p2 == p1);
 
         // roundtrip
-        CHECK(T(json(p1)) == p1);
-        CHECK(json(T(json(p1))) == json(p1));
+        CHECK(T(json_t(p1)) == p1);
+        CHECK(json_t(T(json_t(p1))) == json_t(p1));
 
         // check exception in case of missing field
-        json j = json(p1);
+        json_t j = json_t(p1);
         j.erase("age");
-        CHECK_THROWS_WITH_AS(j.get<T>(), "[json.exception.out_of_range.403] key 'age' not found", json::out_of_range);
+        CHECK_THROWS_WITH_AS(j.template get<T>(), "[json.exception.out_of_range.403] key 'age' not found", typename json_t::out_of_range);
     }
 }
 
@@ -362,15 +285,24 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
     }
 }
 
-TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/private member variables via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", T,
-                   persons::person_with_private_alphabet,
-                   persons::person_with_public_alphabet)
+#define ALPHABET_PAIRS                                                             \
+    TestTypePair<persons::person_with_private_alphabet>,                           \
+    TestTypePair<persons::person_with_public_alphabet>,                            \
+    TestTypePair<persons::person_t_with_private_alphabet, nlohmann::json>,         \
+    TestTypePair<persons::person_t_with_public_alphabet,  nlohmann::json>,         \
+    TestTypePair<persons::person_t_with_private_alphabet, nlohmann::ordered_json>, \
+    TestTypePair<persons::person_t_with_public_alphabet,  nlohmann::ordered_json>
+
+TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/private member variables via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, ALPHABET_PAIRS)
 {
+    using T = typename PairT::TestedType;
+    using json_t = typename PairT::BasicJsonType;
+
     SECTION("alphabet")
     {
         {
             T obj1;
-            nlohmann::json j = obj1; //via json object
+            json_t j = obj1; //via json object
             T obj2;
             j.get_to(obj2);
             bool ok = (obj1 == obj2);
@@ -379,9 +311,9 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            nlohmann::json j1 = obj1; //via json string
+            json_t j1 = obj1; //via json string
             std::string s = j1.dump();
-            nlohmann::json j2 = nlohmann::json::parse(s);
+            json_t j2 = json_t::parse(s);
             T obj2;
             j2.get_to(obj2);
             bool ok = (obj1 == obj2);
@@ -390,9 +322,9 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            nlohmann::json j1 = obj1; //via msgpack
-            std::vector<uint8_t> buf = nlohmann::json::to_msgpack(j1);
-            nlohmann::json j2 = nlohmann::json::from_msgpack(buf);
+            json_t j1 = obj1; //via msgpack
+            std::vector<uint8_t> buf = json_t::to_msgpack(j1);
+            json_t j2 = json_t::from_msgpack(buf);
             T obj2;
             j2.get_to(obj2);
             bool ok = (obj1 == obj2);
@@ -401,9 +333,9 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            nlohmann::json j1 = obj1; //via bson
-            std::vector<uint8_t> buf = nlohmann::json::to_bson(j1);
-            nlohmann::json j2 = nlohmann::json::from_bson(buf);
+            json_t j1 = obj1; //via bson
+            std::vector<uint8_t> buf = json_t::to_bson(j1);
+            json_t j2 = json_t::from_bson(buf);
             T obj2;
             j2.get_to(obj2);
             bool ok = (obj1 == obj2);
@@ -412,9 +344,9 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            nlohmann::json j1 = obj1; //via cbor
-            std::vector<uint8_t> buf = nlohmann::json::to_cbor(j1);
-            nlohmann::json j2 = nlohmann::json::from_cbor(buf);
+            json_t j1 = obj1; //via cbor
+            std::vector<uint8_t> buf = json_t::to_cbor(j1);
+            json_t j2 = json_t::from_cbor(buf);
             T obj2;
             j2.get_to(obj2);
             bool ok = (obj1 == obj2);
@@ -423,9 +355,9 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            nlohmann::json j1 = obj1; //via ubjson
-            std::vector<uint8_t> buf = nlohmann::json::to_ubjson(j1);
-            nlohmann::json j2 = nlohmann::json::from_ubjson(buf);
+            json_t j1 = obj1; //via ubjson
+            std::vector<uint8_t> buf = json_t::to_ubjson(j1);
+            json_t j2 = json_t::from_ubjson(buf);
             T obj2;
             j2.get_to(obj2);
             bool ok = (obj1 == obj2);

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -37,7 +37,7 @@ using nlohmann::json;
 namespace persons {
 #define PERSON_CLASS_BODY(ClassName, Visibility)                               \
 Visibility:                                                                    \
-    std::string name;                                                          \
+    std::string name = "";                                                     \
     int age = 0;                                                               \
     json metadata = nullptr;                                                   \
                                                                                \

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -27,15 +27,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "doctest_compatibility.h"
 #include <string>
 #include <vector>
-#include "doctest_compatibility.h"
 
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
-namespace persons
-{
+namespace persons {
 #define PERSON_CLASS_BODY(ClassName, Visibility)                               \
 Visibility:                                                                    \
     std::string name;                                                          \
@@ -66,63 +65,64 @@ Visibility:                                                                    \
         return metadata;                                                       \
     }
 
-#define ALPHABET_CLASS_BODY(ClassName, Visibility)    \
-      public:                                         \
-        bool operator==(const ClassName& other) const \
-        {                                             \
-            return a == other.a &&                    \
-                   b == other.b &&                    \
-                   c == other.c &&                    \
-                   d == other.d &&                    \
-                   e == other.e &&                    \
-                   f == other.f &&                    \
-                   g == other.g &&                    \
-                   h == other.h &&                    \
-                   i == other.i &&                    \
-                   j == other.j &&                    \
-                   k == other.k &&                    \
-                   l == other.l &&                    \
-                   m == other.m &&                    \
-                   n == other.n &&                    \
-                   o == other.o &&                    \
-                   p == other.p &&                    \
-                   q == other.q &&                    \
-                   r == other.r &&                    \
-                   s == other.s &&                    \
-                   t == other.t &&                    \
-                   u == other.u &&                    \
-                   v == other.v &&                    \
-                   w == other.w &&                    \
-                   x == other.x &&                    \
-                   y == other.y &&                    \
-                   z == other.z;                      \
-        }                                             \
-      Visibility : int a = 0;                       \
-        int b = 0;                                    \
-        int c = 0;                                    \
-        int d = 0;                                    \
-        int e = 0;                                    \
-        int f = 0;                                    \
-        int g = 0;                                    \
-        int h = 0;                                    \
-        int i = 0;                                    \
-        int j = 0;                                    \
-        int k = 0;                                    \
-        int l = 0;                                    \
-        int m = 0;                                    \
-        int n = 0;                                    \
-        int o = 0;                                    \
-        int p = 0;                                    \
-        int q = 0;                                    \
-        int r = 0;                                    \
-        int s = 0;                                    \
-        int t = 0;                                    \
-        int u = 0;                                    \
-        int v = 0;                                    \
-        int w = 0;                                    \
-        int x = 0;                                    \
-        int y = 0;                                    \
-        int z = 0;
+#define ALPHABET_CLASS_BODY(ClassName, Visibility) \
+  public:                                          \
+    bool operator==(const ClassName& other) const  \
+    {                                              \
+        return a == other.a &&                     \
+               b == other.b &&                     \
+               c == other.c &&                     \
+               d == other.d &&                     \
+               e == other.e &&                     \
+               f == other.f &&                     \
+               g == other.g &&                     \
+               h == other.h &&                     \
+               i == other.i &&                     \
+               j == other.j &&                     \
+               k == other.k &&                     \
+               l == other.l &&                     \
+               m == other.m &&                     \
+               n == other.n &&                     \
+               o == other.o &&                     \
+               p == other.p &&                     \
+               q == other.q &&                     \
+               r == other.r &&                     \
+               s == other.s &&                     \
+               t == other.t &&                     \
+               u == other.u &&                     \
+               v == other.v &&                     \
+               w == other.w &&                     \
+               x == other.x &&                     \
+               y == other.y &&                     \
+               z == other.z;                       \
+    }                                              \
+Visibility:                                        \
+    int a = 0;                                     \
+    int b = 0;                                     \
+    int c = 0;                                     \
+    int d = 0;                                     \
+    int e = 0;                                     \
+    int f = 0;                                     \
+    int g = 0;                                     \
+    int h = 0;                                     \
+    int i = 0;                                     \
+    int j = 0;                                     \
+    int k = 0;                                     \
+    int l = 0;                                     \
+    int m = 0;                                     \
+    int n = 0;                                     \
+    int o = 0;                                     \
+    int p = 0;                                     \
+    int q = 0;                                     \
+    int r = 0;                                     \
+    int s = 0;                                     \
+    int t = 0;                                     \
+    int u = 0;                                     \
+    int v = 0;                                     \
+    int w = 0;                                     \
+    int x = 0;                                     \
+    int y = 0;                                     \
+    int z = 0;
 
 class person_with_private_data
 {
@@ -160,6 +160,12 @@ class person_t_with_private_data
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_T(person_t_with_private_data, age, name, metadata)
 };
 
+class person_t_with_private_data_2
+{
+    PERSON_CLASS_BODY(person_t_with_private_data_2, private)
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_T_WITH_DEFAULT(person_t_with_private_data_2, age, name, metadata)
+};
+
 class person_t_without_private_data_1
 {
     PERSON_CLASS_BODY(person_t_without_private_data_1, public)
@@ -171,6 +177,12 @@ class person_t_without_private_data_2
     PERSON_CLASS_BODY(person_t_without_private_data_2, public)
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(person_t_without_private_data_2, age, name, metadata)
+
+class person_t_without_private_data_3
+{
+    PERSON_CLASS_BODY(person_t_without_private_data_3, public)
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T_WITH_DEFAULT(person_t_without_private_data_3, age, name, metadata)
 
 class person_with_private_alphabet
 {
@@ -184,7 +196,6 @@ class person_with_public_alphabet
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person_with_public_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
 
-
 class person_t_with_private_alphabet
 {
     ALPHABET_CLASS_BODY(person_t_with_private_alphabet, private)
@@ -196,29 +207,30 @@ class person_t_with_public_alphabet
     ALPHABET_CLASS_BODY(person_t_with_public_alphabet, public)
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_T(person_t_with_public_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
-} // namespace persons
+}  // namespace persons
 
 // Trick described in https://github.com/onqtam/doctest/blob/master/doc/markdown/parameterized-tests.md
 // in note "if you need parameterization on more than 1 type"
-template <typename TestedType_, typename BasicJsonType_ = nlohmann::json>
+template<typename TestedType_, typename BasicJsonType_ = nlohmann::json>
 struct TestTypePair
 {
-    using TestedType    = TestedType_;
+    using TestedType = TestedType_;
     using BasicJsonType = BasicJsonType_;
 };
 
-#define PERSON_PAIRS                                                                \
-    TestTypePair<persons::person_with_private_data>,                                \
-    TestTypePair<persons::person_without_private_data_1>,                           \
-    TestTypePair<persons::person_without_private_data_2>,                           \
-    TestTypePair<persons::person_t_with_private_data,      nlohmann::json>,         \
-    TestTypePair<persons::person_t_without_private_data_1, nlohmann::json>,         \
-    TestTypePair<persons::person_t_without_private_data_2, nlohmann::json>,         \
-    TestTypePair<persons::person_t_with_private_data,      nlohmann::ordered_json>, \
-    TestTypePair<persons::person_t_without_private_data_1, nlohmann::ordered_json>, \
-    TestTypePair<persons::person_t_without_private_data_2, nlohmann::ordered_json>
+#define PERSON_TYPES_TO_TEST                                                            \
+    TestTypePair<persons::person_with_private_data>,                                    \
+        TestTypePair<persons::person_without_private_data_1>,                           \
+        TestTypePair<persons::person_without_private_data_2>,                           \
+        TestTypePair<persons::person_t_with_private_data>,                              \
+        TestTypePair<persons::person_t_without_private_data_1>,                         \
+        TestTypePair<persons::person_t_without_private_data_2>,                         \
+        TestTypePair<persons::person_t_with_private_data, nlohmann::ordered_json>,      \
+        TestTypePair<persons::person_t_without_private_data_1, nlohmann::ordered_json>, \
+        TestTypePair<persons::person_t_without_private_data_2, nlohmann::ordered_json>
 
-TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, PERSON_PAIRS)
+TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, PERSON_TYPES_TO_TEST)
+#undef PERSON_TYPES_TO_TEST
 {
     using T = typename PairT::TestedType;
     using json_t = typename PairT::BasicJsonType;
@@ -227,14 +239,16 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
     {
         // serialization
         T p1("Erik", 1, {{"haircuts", 2}});
-        if ( std::is_same<json_t, nlohmann::ordered_json>::value )
+        std::string json_string;
+        if (std::is_same<json_t, nlohmann::ordered_json>::value)
         {
-            CHECK(json_t(p1).dump() == "{\"age\":1,\"name\":\"Erik\",\"metadata\":{\"haircuts\":2}}");
+            json_string = "{\"age\":1,\"name\":\"Erik\",\"metadata\":{\"haircuts\":2}}";
         }
         else
         {
-            CHECK(json_t(p1).dump() == "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}");
+            json_string = "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}";
         }
+        CHECK(json_t(p1).dump() == json_string);
 
         // deserialization
         auto p2 = json_t(p1).template get<T>();
@@ -251,49 +265,77 @@ TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRU
     }
 }
 
-TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT", T,
-                   persons::person_with_private_data_2,
-                   persons::person_without_private_data_3)
+#define PERSON_TYPES_TO_TEST                                                         \
+    TestTypePair<persons::person_with_private_data_2>,                               \
+        TestTypePair<persons::person_without_private_data_3>,                        \
+        TestTypePair<persons::person_t_with_private_data_2>,                         \
+        TestTypePair<persons::person_t_without_private_data_3>,                      \
+        TestTypePair<persons::person_t_with_private_data_2, nlohmann::ordered_json>, \
+        TestTypePair<persons::person_t_without_private_data_3, nlohmann::ordered_json>
+
+TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT", PairT, PERSON_TYPES_TO_TEST)
+#undef PERSON_TYPES_TO_TEST
 {
+    using T = typename PairT::TestedType;
+    using json_t = typename PairT::BasicJsonType;
+
     SECTION("person with default values")
     {
         // serialization of default constructed object
         T p0;
-        CHECK(json(p0).dump() == "{\"age\":0,\"metadata\":null,\"name\":\"\"}");
+        std::string json_string;
+        if (std::is_same<json_t, nlohmann::ordered_json>::value)
+        {
+            json_string = "{\"age\":0,\"name\":\"\",\"metadata\":null}";
+        }
+        else
+        {
+            json_string = "{\"age\":0,\"metadata\":null,\"name\":\"\"}";
+        }
+        CHECK(json_t(p0).dump() == json_string);
 
         // serialization
         T p1("Erik", 1, {{"haircuts", 2}});
-        CHECK(json(p1).dump() == "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}");
+        if (std::is_same<json_t, nlohmann::ordered_json>::value)
+        {
+            json_string = "{\"age\":1,\"name\":\"Erik\",\"metadata\":{\"haircuts\":2}}";
+        }
+        else
+        {
+            json_string = "{\"age\":1,\"metadata\":{\"haircuts\":2},\"name\":\"Erik\"}";
+        }
+        CHECK(json_t(p1).dump() == json_string);
 
         // deserialization
-        auto p2 = json(p1).get<T>();
+        auto p2 = json_t(p1).template get<T>();
         CHECK(p2 == p1);
 
         // roundtrip
-        CHECK(T(json(p1)) == p1);
-        CHECK(json(T(json(p1))) == json(p1));
+        CHECK(T(json_t(p1)) == p1);
+        CHECK(json_t(T(json_t(p1))) == json_t(p1));
 
         // check default value in case of missing field
-        json j = json(p1);
+        json_t j = json_t(p1);
         j.erase("name");
         j.erase("age");
         j.erase("metadata");
-        T p3 = j.get<T>();
+        T p3 = j.template get<T>();
         CHECK(p3.getName() == "");
         CHECK(p3.getAge() == 0);
         CHECK(p3.getMetadata() == nullptr);
     }
 }
 
-#define ALPHABET_PAIRS                                                             \
-    TestTypePair<persons::person_with_private_alphabet>,                           \
-    TestTypePair<persons::person_with_public_alphabet>,                            \
-    TestTypePair<persons::person_t_with_private_alphabet, nlohmann::json>,         \
-    TestTypePair<persons::person_t_with_public_alphabet,  nlohmann::json>,         \
-    TestTypePair<persons::person_t_with_private_alphabet, nlohmann::ordered_json>, \
-    TestTypePair<persons::person_t_with_public_alphabet,  nlohmann::ordered_json>
+#define ALPHABET_PAIRS                                                                 \
+    TestTypePair<persons::person_with_private_alphabet>,                               \
+        TestTypePair<persons::person_with_public_alphabet>,                            \
+        TestTypePair<persons::person_t_with_private_alphabet, nlohmann::json>,         \
+        TestTypePair<persons::person_t_with_public_alphabet, nlohmann::json>,          \
+        TestTypePair<persons::person_t_with_private_alphabet, nlohmann::ordered_json>, \
+        TestTypePair<persons::person_t_with_public_alphabet, nlohmann::ordered_json>
 
 TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/private member variables via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", PairT, ALPHABET_PAIRS)
+#undef ALPHABET_PAIRS
 {
     using T = typename PairT::TestedType;
     using json_t = typename PairT::BasicJsonType;
@@ -302,7 +344,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
     {
         {
             T obj1;
-            json_t j = obj1; //via json object
+            json_t j = obj1;  //via json object
             T obj2;
             j.get_to(obj2);
             bool ok = (obj1 == obj2);
@@ -311,7 +353,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            json_t j1 = obj1; //via json string
+            json_t j1 = obj1;  //via json string
             std::string s = j1.dump();
             json_t j2 = json_t::parse(s);
             T obj2;
@@ -322,7 +364,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            json_t j1 = obj1; //via msgpack
+            json_t j1 = obj1;  //via msgpack
             std::vector<uint8_t> buf = json_t::to_msgpack(j1);
             json_t j2 = json_t::from_msgpack(buf);
             T obj2;
@@ -333,7 +375,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            json_t j1 = obj1; //via bson
+            json_t j1 = obj1;  //via bson
             std::vector<uint8_t> buf = json_t::to_bson(j1);
             json_t j2 = json_t::from_bson(buf);
             T obj2;
@@ -344,7 +386,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            json_t j1 = obj1; //via cbor
+            json_t j1 = obj1;  //via cbor
             std::vector<uint8_t> buf = json_t::to_cbor(j1);
             json_t j2 = json_t::from_cbor(buf);
             T obj2;
@@ -355,7 +397,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
         {
             T obj1;
-            json_t j1 = obj1; //via ubjson
+            json_t j1 = obj1;  //via ubjson
             std::vector<uint8_t> buf = json_t::to_ubjson(j1);
             json_t j2 = json_t::from_ubjson(buf);
             T obj2;

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -97,7 +97,7 @@ Visibility:                                                                    \
                    y == other.y &&                    \
                    z == other.z;                      \
         }                                             \
-        Visibility : int a = 0;                       \
+      Visibility : int a = 0;                       \
         int b = 0;                                    \
         int c = 0;                                    \
         int d = 0;                                    \


### PR DESCRIPTION
Picking up from #2532

- Add macros for custom types in DEFINE_TYPE_{NON_,}INTRUSIVE
- Add macros for template version of DEFINE_TYPE_{NON_,}INTRUSIVE
- Refactor and add tests for templated version of DEFINE_TYPE macros

`make amalgamate` was not found, so the change was performed manually

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
