### PR TITLE
Treat MSVC warnings as errors

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4"
+      run: cmake -S . -B build -G "Visual Studio 15 2017" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
     - name: build
       run: cmake --build build --config Release --parallel 10
     - name: test
@@ -88,7 +88,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4"
+      run: cmake -S . -B build -G "Visual Studio 16 2019" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
     - name: build
       run: cmake --build build --config Release --parallel 10
     - name: test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,13 +37,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_EXE_LINKER_FLAGS="/STACK:4000000"
+      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_EXE_LINKER_FLAGS="/STACK:4000000" -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Release' && matrix.architecture == 'x64'
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On
+      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Release' && matrix.architecture != 'x64'
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON
+      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Debug'
     - name: build
       run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
@@ -72,10 +72,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On
+      run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Release'
     - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON
+      run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Debug'
     - name: build
       run: cmake --build build --config ${{ matrix.build_type }} --parallel 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       configuration: Debug
       platform: x86
-      CXX_FLAGS: ""
+      CXX_FLAGS: "/W4 /WX"
       LINKER_FLAGS: ""
       CMAKE_OPTIONS: ""
       GENERATOR: Visual Studio 14 2015
@@ -13,7 +13,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       configuration: Release
       platform: x86
-      CXX_FLAGS: ""
+      CXX_FLAGS: "/W4 /WX"
       LINKER_FLAGS: ""
       CMAKE_OPTIONS: ""
       GENERATOR: Visual Studio 14 2015
@@ -22,7 +22,7 @@ environment:
       configuration: Release
       platform: x86
       name: with_win_header
-      CXX_FLAGS: ""
+      CXX_FLAGS: "/W4 /WX"
       LINKER_FLAGS: ""
       CMAKE_OPTIONS: ""
       GENERATOR: Visual Studio 14 2015
@@ -30,7 +30,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       configuration: Release
       platform: x86
-      CXX_FLAGS: "/permissive- /std:c++latest /utf-8"
+      CXX_FLAGS: "/permissive- /std:c++latest /utf-8 /W4 /WX"
       LINKER_FLAGS: ""
       CMAKE_OPTIONS: ""
       GENERATOR: Visual Studio 15 2017
@@ -38,7 +38,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       configuration: Release
       platform: x86
-      CXX_FLAGS: ""
+      CXX_FLAGS: "/W4 /WX"
       LINKER_FLAGS: ""
       CMAKE_OPTIONS: "-DJSON_ImplicitConversions=OFF"
       GENERATOR: Visual Studio 16 2019
@@ -46,7 +46,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       configuration: Release
       platform: x64
-      CXX_FLAGS: ""
+      CXX_FLAGS: "/W4 /WX"
       LINKER_FLAGS: ""
       CMAKE_OPTIONS: ""
       GENERATOR: Visual Studio 14 2015
@@ -54,7 +54,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       configuration: Release
       platform: x64
-      CXX_FLAGS: "/permissive- /std:c++latest /Zc:__cplusplus /utf-8 /F4000000"
+      CXX_FLAGS: "/permissive- /std:c++latest /Zc:__cplusplus /utf-8 /F4000000 /W4 /WX"
       LINKER_FLAGS: "/STACK:4000000"
       CMAKE_OPTIONS: ""
       GENERATOR: Visual Studio 15 2017

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -100,6 +100,9 @@ struct my_allocator : std::allocator<T>
         std::allocator<T>::deallocate(p, n);
     }
 
+    // the code below warns about p in MSVC 2015 - this could be a bug
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+    DOCTEST_MSVC_SUPPRESS_WARNING(4100)
     void destroy(T* p)
     {
         if (next_destroy_fails)
@@ -110,6 +113,7 @@ struct my_allocator : std::allocator<T>
 
         p->~T();
     }
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <class U>
     struct rebind

--- a/test/src/unit-allocator.cpp
+++ b/test/src/unit-allocator.cpp
@@ -100,9 +100,6 @@ struct my_allocator : std::allocator<T>
         std::allocator<T>::deallocate(p, n);
     }
 
-    // the code below warns about p in MSVC 2015 - this could be a bug
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-    DOCTEST_MSVC_SUPPRESS_WARNING(4100)
     void destroy(T* p)
     {
         if (next_destroy_fails)
@@ -111,9 +108,9 @@ struct my_allocator : std::allocator<T>
             throw std::bad_alloc();
         }
 
+        static_cast<void>(p); // fix MSVC's C4100 warning
         p->~T();
     }
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <class U>
     struct rebind

--- a/test/src/unit-deserialization.cpp
+++ b/test/src/unit-deserialization.cpp
@@ -1089,7 +1089,7 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-8)", T,
                    char, unsigned char, std::uint8_t)
 {
     // a star emoji
-    std::vector<T> v = {'"', static_cast<T>(0xe2), static_cast<T>(0xad), static_cast<T>(0x90), static_cast<T>(0xef), static_cast<T>(0xb8), static_cast<T>(0x8f), '"'};
+    std::vector<T> v = {'"', static_cast<T>(0xe2u), static_cast<T>(0xadu), static_cast<T>(0x90u), static_cast<T>(0xefu), static_cast<T>(0xb8u), static_cast<T>(0x8fu), '"'};
     CHECK(json::parse(v).dump(-1, ' ', true) == "\"\\u2b50\\ufe0f\"");
     CHECK(json::accept(v));
 

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -809,6 +809,10 @@ TEST_CASE("an incomplete type does not trigger a compiler error in non-evaluated
     static_assert(!is_constructible_patched<json, incomplete>::value, "");
 }
 
+// the code below warns about t in MSVC 2015 - this could be a bug
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+DOCTEST_MSVC_SUPPRESS_WARNING(4100)
+
 namespace
 {
 class Evil
@@ -820,6 +824,8 @@ class Evil
 
     int m_i = 0;
 };
+
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 void from_json(const json& /*unused*/, Evil& /*unused*/) {}
 } // namespace

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -809,10 +809,6 @@ TEST_CASE("an incomplete type does not trigger a compiler error in non-evaluated
     static_assert(!is_constructible_patched<json, incomplete>::value, "");
 }
 
-// the code below warns about t in MSVC 2015 - this could be a bug
-DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4100)
-
 namespace
 {
 class Evil
@@ -820,12 +816,13 @@ class Evil
   public:
     Evil() = default;
     template <typename T>
-    Evil(T t) : m_i(sizeof(t)) {}
+    Evil(T t) : m_i(sizeof(t))
+    {
+        static_cast<void>(t); // fix MSVC's C4100 warning
+    }
 
     int m_i = 0;
 };
-
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 void from_json(const json& /*unused*/, Evil& /*unused*/) {}
 } // namespace


### PR DESCRIPTION
This PR is a follow up to #2924 and treats all MSVC warnings as errors.