### PR TITLE
Remove -Wextra-semi-stmt suppression

### DIFF
--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -96,7 +96,6 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
     -Wno-deprecated-declarations                         \
     -Wno-documentation-unknown-command                   \
     -Wno-exit-time-destructors                           \
-    -Wno-extra-semi-stmt                                 \
     -Wno-padded                                          \
     -Wno-range-loop-analysis                             \
     -Wno-switch-enum -Wno-covered-switch-default         \

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -94,7 +94,7 @@ struct external_constructor<value_t::binary>
     {
         j.m_value.destroy(j.m_type);
         j.m_type = value_t::binary;
-        j.m_value = typename BasicJsonType::binary_t(std::move(b));;
+        j.m_value = typename BasicJsonType::binary_t(std::move(b));
         j.assert_invariant();
     }
 };

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -58,7 +58,7 @@ class binary_writer
 
             default:
             {
-                JSON_THROW(type_error::create(317, "to serialize to BSON, top-level type must be object, but is " + std::string(j.type_name()), j));;
+                JSON_THROW(type_error::create(317, "to serialize to BSON, top-level type must be object, but is " + std::string(j.type_name()), j));
             }
         }
     }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4572,7 +4572,7 @@ struct external_constructor<value_t::binary>
     {
         j.m_value.destroy(j.m_type);
         j.m_type = value_t::binary;
-        j.m_value = typename BasicJsonType::binary_t(std::move(b));;
+        j.m_value = typename BasicJsonType::binary_t(std::move(b));
         j.assert_invariant();
     }
 };
@@ -13359,7 +13359,7 @@ class binary_writer
 
             default:
             {
-                JSON_THROW(type_error::create(317, "to serialize to BSON, top-level type must be object, but is " + std::string(j.type_name()), j));;
+                JSON_THROW(type_error::create(317, "to serialize to BSON, top-level type must be object, but is " + std::string(j.type_name()), j));
             }
         }
     }


### PR DESCRIPTION
The warning was suppressed for some unknown reason before on Clang (but already fixed for GCC).