### PR TITLE
Overwork warning flags

### DIFF
--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -114,7 +114,6 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
 # -Wno-aggregate-return     The library uses aggregate returns.
 # -Wno-long-long            The library uses the long long type to interface with system functions.
 # -Wno-namespaces           The library uses namespaces.
-# -Wno-noexcept
 # -Wno-padded               We do not care about padding warnings.
 # -Wno-system-headers       We do not care about warnings in system headers.
 # -Wno-templates            The library uses templates.

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -88,6 +88,14 @@ file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/nlohmann/*.hpp)
 # Thorough check with recent compilers
 ###############################################################################
 
+# Ignored Clang warnings:
+# -Wno-c++98-compat               The library targets C++11.
+# -Wno-c++98-compat-pedantic      The library targets C++11.
+# -Wno-deprecated-declarations    The library contains annotations for deprecated functions.
+# -Wno-extra-semi-stmt            The library uses std::assert which triggers this warning.
+# -Wno-padded                     We do not care about padding warnings.
+# -Wno-covered-switch-default     All switches list all cases and a default case.
+
 set(CLANG_CXXFLAGS "-std=c++11                        \
     -Werror                                           \
     -Weverything                                      \
@@ -97,7 +105,6 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
     -Wno-extra-semi-stmt                                 \
     -Wno-padded                                          \
     -Wno-covered-switch-default                          \
-    -Wno-weak-vtables                                    \
 ")
 
 set(GCC_CXXFLAGS "-std=c++11                          \

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -111,7 +111,7 @@ set(GCC_CXXFLAGS "-std=c++11                          \
     -Wno-abi-tag                                         \
     -Waddress                                         \
     -Waddress-of-packed-member                        \
-    -Waggregate-return                                \
+    -Wno-aggregate-return                                \
     -Waggressive-loop-optimizations                   \
     -Waligned-new=all                                 \
     -Wall                                             \

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -94,7 +94,6 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
     -Wno-c++98-compat                                    \
     -Wno-c++98-compat-pedantic                           \
     -Wno-deprecated-declarations                         \
-    -Wno-exit-time-destructors                           \
     -Wno-extra-semi-stmt                                 \
     -Wno-padded                                          \
     -Wno-covered-switch-default                          \

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -94,11 +94,9 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
     -Wno-c++98-compat                                    \
     -Wno-c++98-compat-pedantic                           \
     -Wno-deprecated-declarations                         \
-    -Wno-documentation-unknown-command                   \
     -Wno-exit-time-destructors                           \
     -Wno-extra-semi-stmt                                 \
     -Wno-padded                                          \
-    -Wno-range-loop-analysis                             \
     -Wno-covered-switch-default                          \
     -Wno-weak-vtables                                    \
 ")
@@ -113,7 +111,7 @@ set(GCC_CXXFLAGS "-std=c++11                          \
     -Wno-abi-tag                                         \
     -Waddress                                         \
     -Waddress-of-packed-member                        \
-    -Wno-aggregate-return                                \
+    -Waggregate-return                                \
     -Waggressive-loop-optimizations                   \
     -Waligned-new=all                                 \
     -Wall                                             \
@@ -203,10 +201,16 @@ set(GCC_CXXFLAGS "-std=c++11                          \
     -Wextra-semi                                      \
     -Wfloat-conversion                                \
     -Wfloat-equal                                     \
+    -Wformat-contains-nul                             \
     -Wformat-diag                                     \
+    -Wformat-extra-args                               \
+    -Wformat-nonliteral                               \
     -Wformat-overflow=2                               \
+    -Wformat-security                                 \
     -Wformat-signedness                               \
     -Wformat-truncation=2                             \
+    -Wformat-y2k                                      \
+    -Wformat-zero-length                              \
     -Wformat=2                                        \
     -Wframe-address                                   \
     -Wfree-nonheap-object                             \
@@ -277,7 +281,7 @@ set(GCC_CXXFLAGS "-std=c++11                          \
     -Wpragmas                                         \
     -Wprio-ctor-dtor                                  \
     -Wpsabi                                           \
-    -Wno-range-loop-construct                            \
+    -Wrange-loop-construct                            \
     -Wredundant-decls                                 \
     -Wredundant-move                                  \
     -Wredundant-tags                                  \

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -110,13 +110,13 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
 ")
 
 # Ignored GCC warnings:
-# -Wno-abi-tag              We do not care about ABI tags.
-# -Wno-aggregate-return     The library uses aggregate returns.
-# -Wno-long-long            The library uses the long long type to interface with system functions.
-# -Wno-namespaces           The library uses namespaces.
-# -Wno-padded               We do not care about padding warnings.
-# -Wno-system-headers       We do not care about warnings in system headers.
-# -Wno-templates            The library uses templates.
+# -Wno-abi-tag                    We do not care about ABI tags.
+# -Wno-aggregate-return           The library uses aggregate returns.
+# -Wno-long-long                  The library uses the long long type to interface with system functions.
+# -Wno-namespaces                 The library uses namespaces.
+# -Wno-padded                     We do not care about padding warnings.
+# -Wno-system-headers             We do not care about warnings in system headers.
+# -Wno-templates                  The library uses templates.
 
 set(GCC_CXXFLAGS "-std=c++11                          \
     -pedantic                                         \

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -95,6 +95,7 @@ file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/nlohmann/*.hpp)
 # -Wno-extra-semi-stmt            The library uses std::assert which triggers this warning.
 # -Wno-padded                     We do not care about padding warnings.
 # -Wno-covered-switch-default     All switches list all cases and a default case.
+# -Wno-weak-vtables               The library is header-only.
 
 set(CLANG_CXXFLAGS "-std=c++11                        \
     -Werror                                           \
@@ -105,7 +106,18 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
     -Wno-extra-semi-stmt                                 \
     -Wno-padded                                          \
     -Wno-covered-switch-default                          \
+    -Wno-weak-vtables                                    \
 ")
+
+# Ignored GCC warnings:
+# -Wno-abi-tag              We do not care about ABI tags.
+# -Wno-aggregate-return     The library uses aggregate returns.
+# -Wno-long-long            The library uses the long long type to interface with system functions.
+# -Wno-namespaces           The library uses namespaces.
+# -Wno-noexcept
+# -Wno-padded               We do not care about padding warnings.
+# -Wno-system-headers       We do not care about warnings in system headers.
+# -Wno-templates            The library uses templates.
 
 set(GCC_CXXFLAGS "-std=c++11                          \
     -pedantic                                         \
@@ -259,7 +271,7 @@ set(GCC_CXXFLAGS "-std=c++11                          \
     -Wmultistatement-macros                           \
     -Wno-namespaces                                      \
     -Wnarrowing                                       \
-    -Wno-noexcept                                        \
+    -Wnoexcept                                        \
     -Wnoexcept-type                                   \
     -Wnon-template-friend                             \
     -Wnon-virtual-dtor                                \

--- a/doc/mkdocs/docs/api/basic_json/binary_t.md
+++ b/doc/mkdocs/docs/api/basic_json/binary_t.md
@@ -64,4 +64,4 @@ type `#!cpp binary_t*` must be dereferenced.
 
 ## Version history
 
-- Added in version 3.8.0. Changed type of subtype to `std::uint64_t` in version 3.9.2.
+- Added in version 3.8.0. Changed type of subtype to `std::uint64_t` in version 3.10.0.

--- a/doc/mkdocs/docs/api/basic_json/cbor_tag_handler_t.md
+++ b/doc/mkdocs/docs/api/basic_json/cbor_tag_handler_t.md
@@ -22,4 +22,4 @@ store
 
 ## Version history
 
-- Added in version 3.9.0. Added value `store` in 3.9.2.
+- Added in version 3.9.0. Added value `store` in 3.10.0.

--- a/include/nlohmann/byte_container_with_subtype.hpp
+++ b/include/nlohmann/byte_container_with_subtype.hpp
@@ -18,7 +18,7 @@ order to override the binary type.
 @tparam BinaryType container to store bytes (`std::vector<std::uint8_t>` by
                    default)
 
-@since version 3.8.0; changed type of subtypes to std::uint64_t in 3.9.2.
+@since version 3.8.0; changed type of subtypes to std::uint64_t in 3.10.0.
 */
 template<typename BinaryType>
 class byte_container_with_subtype : public BinaryType
@@ -108,7 +108,7 @@ class byte_container_with_subtype : public BinaryType
     subtype
 
     @since version 3.8.0; fixed return value to properly return
-           subtype_type(-1) as documented in version 3.9.2
+           subtype_type(-1) as documented in version 3.10.0
     */
     constexpr subtype_type subtype() const noexcept
     {

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -38,9 +38,9 @@
 
 // disable documentation warnings on clang
 #if defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wdocumentation"
-    #pragma GCC diagnostic ignored "-Wdocumentation-unknown-command"
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdocumentation"
+    #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #endif
 
 // allow to disable exceptions

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -40,6 +40,7 @@
 #if defined(__clang__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wdocumentation"
+    #pragma GCC diagnostic ignored "-Wdocumentation-unknown-command"
 #endif
 
 // allow to disable exceptions

--- a/include/nlohmann/detail/macro_unscope.hpp
+++ b/include/nlohmann/detail/macro_unscope.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-// restore GCC/clang diagnostic settings
+// restore clang diagnostic settings
 #if defined(__clang__)
-    #pragma GCC diagnostic pop
+    #pragma clang diagnostic pop
 #endif
 
 // clean up

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2250,9 +2250,9 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 
 // disable documentation warnings on clang
 #if defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wdocumentation"
-    #pragma GCC diagnostic ignored "-Wdocumentation-unknown-command"
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdocumentation"
+    #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #endif
 
 // allow to disable exceptions
@@ -26424,9 +26424,9 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 // #include <nlohmann/detail/macro_unscope.hpp>
 
 
-// restore GCC/clang diagnostic settings
+// restore clang diagnostic settings
 #if defined(__clang__)
-    #pragma GCC diagnostic pop
+    #pragma clang diagnostic pop
 #endif
 
 // clean up

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5004,7 +5004,7 @@ order to override the binary type.
 @tparam BinaryType container to store bytes (`std::vector<std::uint8_t>` by
                    default)
 
-@since version 3.8.0; changed type of subtypes to std::uint64_t in 3.9.2.
+@since version 3.8.0; changed type of subtypes to std::uint64_t in 3.10.0.
 */
 template<typename BinaryType>
 class byte_container_with_subtype : public BinaryType
@@ -5094,7 +5094,7 @@ class byte_container_with_subtype : public BinaryType
     subtype
 
     @since version 3.8.0; fixed return value to properly return
-           subtype_type(-1) as documented in version 3.9.2
+           subtype_type(-1) as documented in version 3.10.0
     */
     constexpr subtype_type subtype() const noexcept
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2252,6 +2252,7 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 #if defined(__clang__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wdocumentation"
+    #pragma GCC diagnostic ignored "-Wdocumentation-unknown-command"
 #endif
 
 // allow to disable exceptions

--- a/test/src/unit-assert_macro.cpp
+++ b/test/src/unit-assert_macro.cpp
@@ -27,12 +27,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-// avoid warning when assert does not abort
-#if defined(__GNUC__)
-    #pragma GCC diagnostic ignored "-Wstrict-overflow"
-#endif
-
 #include "doctest_compatibility.h"
+
+// avoid warning when assert does not abort
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wstrict-overflow")
 
 /// global variable to record side effect of assert calls
 static int assert_counter;
@@ -63,3 +64,6 @@ TEST_CASE("JSON_ASSERT(x)")
     }
 }
 #endif
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -49,8 +49,8 @@ using nlohmann::json;
 #endif
 
 // NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
-DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wexit-time-destructors")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
 
 TEST_CASE("value conversion")
 {
@@ -1717,4 +1717,4 @@ TEST_CASE("JSON to enum mapping")
     #undef JSON_HAS_CPP_14
 #endif
 
-DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -48,6 +48,10 @@ using nlohmann::json;
     #define JSON_HAS_CPP_14
 #endif
 
+// NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wexit-time-destructors")
+
 TEST_CASE("value conversion")
 {
     SECTION("get an object (explicit)")
@@ -1712,3 +1716,5 @@ TEST_CASE("JSON to enum mapping")
 #ifdef JSON_HAS_CPP_14
     #undef JSON_HAS_CPP_14
 #endif
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP

--- a/test/src/unit-disabled_exceptions.cpp
+++ b/test/src/unit-disabled_exceptions.cpp
@@ -29,6 +29,9 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
+
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
@@ -64,3 +67,5 @@ TEST_CASE("Tests with disabled exceptions")
         delete sax_no_exception::error_string; // NOLINT(cppcoreguidelines-owning-memory)
     }
 }
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP

--- a/test/src/unit-disabled_exceptions.cpp
+++ b/test/src/unit-disabled_exceptions.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+// disable -Wnoexcept as exceptions are switched off for this test suite
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 

--- a/test/src/unit-items.cpp
+++ b/test/src/unit-items.cpp
@@ -42,6 +42,8 @@ using nlohmann::json;
 // This test suite uses range for loops where values are copied. This is inefficient in usual code, but required to achieve 100% coverage.
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 DOCTEST_GCC_SUPPRESS_WARNING("-Wrange-loop-construct")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wrange-loop-construct")
 
 TEST_CASE("iterator_wrapper")
 {
@@ -1462,3 +1464,4 @@ TEST_CASE("items()")
 #endif
 
 DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-items.cpp
+++ b/test/src/unit-items.cpp
@@ -41,7 +41,7 @@ using nlohmann::json;
 
 // This test suite uses range for loops where values are copied. This is inefficient in usual code, but required to achieve 100% coverage.
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING(-Wrange-loop-construct)
+DOCTEST_GCC_SUPPRESS_WARNING("-Wrange-loop-construct")
 
 TEST_CASE("iterator_wrapper")
 {

--- a/test/src/unit-items.cpp
+++ b/test/src/unit-items.cpp
@@ -39,6 +39,10 @@ using nlohmann::json;
     #define JSON_HAS_CPP_14
 #endif
 
+// This test suite uses range for loops where values are copied. This is inefficient in usual code, but required to achieve 100% coverage.
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+DOCTEST_MSVC_SUPPRESS_WARNING(-Wrange-loop-construct)
+
 TEST_CASE("iterator_wrapper")
 {
     SECTION("object")
@@ -1456,3 +1460,5 @@ TEST_CASE("items()")
 #ifdef JSON_HAS_CPP_14
     #undef JSON_HAS_CPP_14
 #endif
+
+DOCTEST_MSVC_SUPPRESS_WARNING_POP

--- a/test/src/unit-items.cpp
+++ b/test/src/unit-items.cpp
@@ -40,8 +40,8 @@ using nlohmann::json;
 #endif
 
 // This test suite uses range for loops where values are copied. This is inefficient in usual code, but required to achieve 100% coverage.
-DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(-Wrange-loop-construct)
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING(-Wrange-loop-construct)
 
 TEST_CASE("iterator_wrapper")
 {
@@ -1461,4 +1461,4 @@ TEST_CASE("items()")
     #undef JSON_HAS_CPP_14
 #endif
 
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -358,10 +358,10 @@ TEST_CASE("JSON pointers")
                 CHECK_THROWS_WITH(j_const[jp] == 1, throw_msg.c_str());
             }
 
-#if defined(_MSC_VER)
-#pragma warning (push)
-#pragma warning (disable : 4127) // on some machines, the check below is not constant
-#endif
+            // on some machines, the check below is not constant
+            DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+            DOCTEST_MSVC_SUPPRESS_WARNING(4127)
+
             if (sizeof(typename json::size_type) < sizeof(unsigned long long))
             {
                 auto size_type_max_uul = static_cast<unsigned long long>((std::numeric_limits<json::size_type>::max)());
@@ -375,9 +375,7 @@ TEST_CASE("JSON pointers")
                 CHECK_THROWS_WITH(j_const[jp] == 1, throw_msg.c_str());
             }
 
-#if defined(_MSC_VER)
-#pragma warning (pop)
-#endif
+            DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
             CHECK_THROWS_AS(j.at("/one"_json_pointer) = 1, json::parse_error&);
             CHECK_THROWS_WITH(j.at("/one"_json_pointer) = 1,

--- a/test/src/unit-noexcept.cpp
+++ b/test/src/unit-noexcept.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+// disable -Wnoexcept due to struct pod_bis
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 

--- a/test/src/unit-noexcept.cpp
+++ b/test/src/unit-noexcept.cpp
@@ -29,6 +29,9 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
+
 #include <nlohmann/json.hpp>
 
 using nlohmann::json;
@@ -95,3 +98,5 @@ TEST_CASE("runtime checks")
         from_json(j2, pod_bis());
     }
 }
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP

--- a/test/src/unit-readme.cpp
+++ b/test/src/unit-readme.cpp
@@ -42,10 +42,9 @@ using nlohmann::json;
 #include <sstream>
 #include <iomanip>
 
-#if defined(_MSC_VER)
-    #pragma warning (push)
-    #pragma warning (disable : 4189) // local variable is initialized but not referenced
-#endif
+// local variable is initialized but not referenced
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+DOCTEST_MSVC_SUPPRESS_WARNING(4189)
 
 TEST_CASE("README" * doctest::skip())
 {
@@ -321,6 +320,4 @@ TEST_CASE("README" * doctest::skip())
     }
 }
 
-#if defined(_MSC_VER)
-    #pragma warning (pop)
-#endif
+DOCTEST_MSVC_SUPPRESS_WARNING_POP

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -53,6 +53,10 @@ using nlohmann::json;
     #include <span>
 #endif
 
+// NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wexit-time-destructors")
+
 /////////////////////////////////////////////////////////////////////
 // for #1021
 /////////////////////////////////////////////////////////////////////
@@ -656,3 +660,5 @@ TEST_CASE("regression tests 2")
         static_assert(std::is_copy_assignable<nlohmann::ordered_json>::value, "");
     }
 }
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -54,8 +54,8 @@ using nlohmann::json;
 #endif
 
 // NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
-DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wexit-time-destructors")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
 
 /////////////////////////////////////////////////////////////////////
 // for #1021
@@ -661,4 +661,4 @@ TEST_CASE("regression tests 2")
     }
 }
 
-DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -29,6 +29,9 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
+
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
@@ -37,9 +40,6 @@ using nlohmann::json;
 #include <string>
 #include <memory>
 #include <utility>
-
-DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 
 namespace udt
 {

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -38,6 +38,9 @@ using nlohmann::json;
 #include <memory>
 #include <utility>
 
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
+
 namespace udt
 {
 enum class country
@@ -845,3 +848,5 @@ TEST_CASE("Issue #1237")
     struct non_convertible_type {};
     static_assert(!std::is_convertible<json, non_convertible_type>::value, "");
 }
+
+DOCTEST_GCC_SUPPRESS_WARNING_POP

--- a/test/src/unit-udt.cpp
+++ b/test/src/unit-udt.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+// disable -Wnoexcept due to class Evil
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 

--- a/test/src/unit-unicode2.cpp
+++ b/test/src/unit-unicode2.cpp
@@ -41,6 +41,10 @@ using nlohmann::json;
 #include <iomanip>
 #include <test_data.hpp>
 
+// this test suite uses static variables with non-trivial destructors
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
+
 namespace
 {
 extern size_t calls;
@@ -623,3 +627,5 @@ TEST_CASE("Unicode (2/5)" * doctest::skip())
         }
     }
 }
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-unicode3.cpp
+++ b/test/src/unit-unicode3.cpp
@@ -41,6 +41,10 @@ using nlohmann::json;
 #include <iomanip>
 #include <test_data.hpp>
 
+// this test suite uses static variables with non-trivial destructors
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
+
 namespace
 {
 extern size_t calls;
@@ -337,3 +341,5 @@ TEST_CASE("Unicode (3/5)" * doctest::skip())
         }
     }
 }
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-unicode4.cpp
+++ b/test/src/unit-unicode4.cpp
@@ -41,6 +41,10 @@ using nlohmann::json;
 #include <iomanip>
 #include <test_data.hpp>
 
+// this test suite uses static variables with non-trivial destructors
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
+
 namespace
 {
 extern size_t calls;
@@ -337,3 +341,5 @@ TEST_CASE("Unicode (4/5)" * doctest::skip())
         }
     }
 }
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-unicode5.cpp
+++ b/test/src/unit-unicode5.cpp
@@ -41,6 +41,10 @@ using nlohmann::json;
 #include <iomanip>
 #include <test_data.hpp>
 
+// this test suite uses static variables with non-trivial destructors
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
+
 namespace
 {
 extern size_t calls;
@@ -337,3 +341,5 @@ TEST_CASE("Unicode (5/5)" * doctest::skip())
         }
     }
 }
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
- Review and document ignored warnings.
- Use `DOCTEST_GCC_SUPPRESS_WARNING_PUSH`, `DOCTEST_GCC_SUPPRESS_WARNING`, and `DOCTEST_GCC_SUPPRESS_WARNING_POP` in test code instead of `#pragma` and `#ifdef`.
