### PR TITLE
Skip some tests if JSON_Install is not set

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,8 +115,12 @@ add_dependencies(json_unit download_test_data)
 # Test the generated build configs
 #############################################################################
 
-add_subdirectory(cmake_import)
-add_subdirectory(cmake_import_minver)
+# these tests depend on the generated file nlohmann_jsonConfig.cmake
+if (JSON_Install)
+    add_subdirectory(cmake_import)
+    add_subdirectory(cmake_import_minver)
+endif()
+
 add_subdirectory(cmake_add_subdirectory)
 add_subdirectory(cmake_fetch_content)
 add_subdirectory(cmake_target_include_directories)


### PR DESCRIPTION
If `JSON_Install` is set to `OFF`, the following tests fail:

	 58 - cmake_import_configure (Failed)
	 59 - cmake_import_build (Not Run)
	 60 - cmake_import_minver_configure (Failed)
	 61 - cmake_import_minver_build (Not Run)

This PR skips them instead if `JSON_Install` is `OFF`.

Closes #2946 