### PR TITLE
Add header to use value_t

### DIFF
--- a/include/nlohmann/detail/hash.hpp
+++ b/include/nlohmann/detail/hash.hpp
@@ -5,6 +5,7 @@
 #include <functional> // hash
 
 #include <nlohmann/detail/macro_scope.hpp>
+#include <nlohmann/detail/value_t.hpp>
 
 namespace nlohmann
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5169,6 +5169,8 @@ class byte_container_with_subtype : public BinaryType
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
+// #include <nlohmann/detail/value_t.hpp>
+
 
 namespace nlohmann
 {


### PR DESCRIPTION
This PR adds a missing include to use `value_t` inside `hash.hpp`. It was not detected by the CI, because the function using `value_t` is templated, but never instantiated.

Replaces #2873