### PR TITLE
Avoid duplicate AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,3 +82,5 @@ test_script:
   # occasional timeouts on AppVeyor.
   # More info: https://github.com/nlohmann/json/pull/1570
   - if "%configuration%"=="Debug" ctest --exclude-regex "test-unicode" -C "%configuration%" -V -j
+
+skip_branch_with_pr: true


### PR DESCRIPTION
This PR sets the option

```yaml
skip_branch_with_pr: true
```

to avoid duplicate AppVeyor builds in case @nlohmann commits to a pull request.