### PR TITLE
Allow std::unordered_map as ObjectType

### DIFF
--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -449,5 +449,23 @@ T conditional_static_cast(U value)
     return value;
 }
 
+// helper to check if a type has bucket_count function (and hence can tell a std::map and a std::unordered_map apart)
+template <typename T>
+class has_bucket_count
+{
+    typedef char one;
+
+    struct two
+    {
+        char x[2];
+    };
+
+    template <typename C> static one test( decltype(&C::bucket_count) ) ;
+    template <typename C> static two test(...);
+
+  public:
+    enum { value = sizeof(test<T>(0)) == sizeof(char) };
+};
+
 }  // namespace detail
 }  // namespace nlohmann

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -451,20 +451,19 @@ T conditional_static_cast(U value)
 
 // helper to check if a type has bucket_count function (and hence can tell a std::map and a std::unordered_map apart)
 template <typename T>
-class has_bucket_count
+struct has_bucket_count
 {
-    typedef char one;
+    using one = char;
 
     struct two
     {
-        char x[2];
+        char x[2]; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
     };
 
     template <typename C> static one test( decltype(&C::bucket_count) ) ;
     template <typename C> static two test(...);
 
-  public:
-    enum { value = sizeof(test<T>(0)) == sizeof(char) };
+    enum { value = sizeof(test<T>(nullptr)) == sizeof(char) };
 };
 
 }  // namespace detail

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -507,11 +507,22 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     8259](https://tools.ietf.org/html/rfc8259), because any order implements the
     specified "unordered" nature of JSON objects.
     */
-    using object_t = ObjectType<StringType,
-          basic_json,
-          object_comparator_t,
-          AllocatorType<std::pair<const StringType,
-          basic_json>>>;
+    using object_t = typename std::conditional <
+                     detail::has_bucket_count<ObjectType<int, int>>::value,
+
+                     std::unordered_map<StringType,
+                     basic_json,
+                     std::hash<StringType>,
+                     std::equal_to<StringType>,
+                     AllocatorType<std::pair<const StringType,
+                     basic_json>>>,
+
+                     std::map<StringType,
+                     basic_json,
+                     object_comparator_t,
+                     AllocatorType<std::pair<const StringType,
+                     basic_json>>>
+                     >::type;
 
     /*!
     @brief a type for an array

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -42,9 +42,11 @@ SOFTWARE.
     #include <iosfwd> // istream, ostream
 #endif  // JSON_NO_IO
 #include <iterator> // random_access_iterator_tag
+#include <map> // map
 #include <memory> // unique_ptr
 #include <numeric> // accumulate
 #include <string> // string, stoi, to_string
+#include <unordered_map> // unordered_map
 #include <utility> // declval, forward, move, pair, swap
 #include <vector> // vector
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -422,8 +422,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     // Use transparent comparator if possible, combined with perfect forwarding
     // on find() and count() calls prevents unnecessary string construction.
     using object_comparator_t = std::less<>;
+    using key_equal_t = std::equal_to<>;
 #else
     using object_comparator_t = std::less<StringType>;
+    using key_equal_t = std::equal_to<StringType>;
 #endif
 
     /*!
@@ -515,7 +517,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                      std::unordered_map<StringType,
                      basic_json,
                      std::hash<StringType>,
-                     std::equal_to<StringType>,
+                     key_equal_t,
                      AllocatorType<std::pair<const StringType,
                      basic_json>>>,
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3862,20 +3862,19 @@ T conditional_static_cast(U value)
 
 // helper to check if a type has bucket_count function (and hence can tell a std::map and a std::unordered_map apart)
 template <typename T>
-class has_bucket_count
+struct has_bucket_count
 {
-    typedef char one;
+    using one = char;
 
     struct two
     {
-        char x[2];
+        char x[2]; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
     };
 
     template <typename C> static one test( decltype(&C::bucket_count) ) ;
     template <typename C> static two test(...);
 
-  public:
-    enum { value = sizeof(test<T>(0)) == sizeof(char) };
+    enum { value = sizeof(test<T>(nullptr)) == sizeof(char) };
 };
 
 }  // namespace detail
@@ -17823,8 +17822,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     // Use transparent comparator if possible, combined with perfect forwarding
     // on find() and count() calls prevents unnecessary string construction.
     using object_comparator_t = std::less<>;
+    using key_equal_t = std::equal_to<>;
 #else
     using object_comparator_t = std::less<StringType>;
+    using key_equal_t = std::equal_to<StringType>;
 #endif
 
     /*!
@@ -17916,7 +17917,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                      std::unordered_map<StringType,
                      basic_json,
                      std::hash<StringType>,
-                     std::equal_to<StringType>,
+                     key_equal_t,
                      AllocatorType<std::pair<const StringType,
                      basic_json>>>,
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -42,9 +42,11 @@ SOFTWARE.
     #include <iosfwd> // istream, ostream
 #endif  // JSON_NO_IO
 #include <iterator> // random_access_iterator_tag
+#include <map> // map
 #include <memory> // unique_ptr
 #include <numeric> // accumulate
 #include <string> // string, stoi, to_string
+#include <unordered_map> // unordered_map
 #include <utility> // declval, forward, move, pair, swap
 #include <vector> // vector
 

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -56,8 +56,11 @@ using nlohmann::json;
 // for #972
 /////////////////////////////////////////////////////////////////////
 
-template<class K, class V, class dummy_compare, class A>
-using my_workaround_fifo_map = nlohmann::fifo_map<K, V, nlohmann::fifo_map_compare<K>, A>;
+//template<class K, class V, class dummy_compare, class A>
+//using my_workaround_fifo_map = nlohmann::fifo_map<K, V, nlohmann::fifo_map_compare<K>, A>;
+
+template<class K, class V>
+using my_workaround_fifo_map = nlohmann::fifo_map<K, V, nlohmann::fifo_map_compare<K>>;
 using my_json = nlohmann::basic_json<my_workaround_fifo_map>;
 
 /////////////////////////////////////////////////////////////////////

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -659,6 +659,18 @@ TEST_CASE("regression tests 2")
     {
         static_assert(std::is_copy_assignable<nlohmann::ordered_json>::value, "");
     }
+
+    SECTION("issue #2932 - Support for unordered_map as object_t")
+    {
+        using ujson = nlohmann::basic_json<std::unordered_map>;
+        ujson j;
+        j["a"] = 1;
+        j["b"] = 2;
+        CHECK(j.size() == 2);
+
+        // check that object_t is really a std::unordered_map
+        CHECK(ujson::object_t::hasher()("foo") == std::hash<std::string>()("foo"));
+    }
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
This PR fixes the definition of `object_t` to allow to use `std::unordered_map` as `ObjectType`.

Fixes #2932.