### PR TITLE
Fixed typo in docs/api/basic_json/parse.md

### DIFF
--- a/doc/mkdocs/docs/api/basic_json/parse.md
+++ b/doc/mkdocs/docs/api/basic_json/parse.md
@@ -79,7 +79,7 @@ super-linear complexity.
 
 ## Examples
 
-??? example "Parsing from a charater array"
+??? example "Parsing from a character array"
 
     The example below demonstrates the `parse()` function reading from an array.
 


### PR DESCRIPTION
Changed a word in the docs
Fixed a potential typo: "charater" -> "character" 