### PR TITLE
explicit conversion of null into floating point NaN

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -59,17 +59,19 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::null:
         {
-            if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
-            {
-                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
-                break;
-            }
-            else if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
             {
                 val = std::numeric_limits<ArithmeticType>::signaling_NaN();
                 break;
             }
+            // LCOV_EXCL_START
+            else if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
+                break;
+            }
             // [[fallthrough]];
+            // LCOV_EXCL_STOP
         }
 
         case value_t::object:
@@ -364,17 +366,19 @@ void from_json(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::null:
         {
-            if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
-            {
-                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
-                break;
-            }
-            else if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
             {
                 val = std::numeric_limits<ArithmeticType>::signaling_NaN();
                 break;
             }
+            // LCOV_EXCL_START
+            else if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
+                break;
+            }
             // [[fallthrough]];
+            // LCOV_EXCL_STOP
         }
 
         case value_t::object:

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -59,13 +59,13 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::null:
         {
-            if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            if (std::numeric_limits<ArithmeticType>::has_signaling_NaN)
             {
                 val = std::numeric_limits<ArithmeticType>::signaling_NaN();
                 break;
             }
             // LCOV_EXCL_START
-            else if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            else if (std::numeric_limits<ArithmeticType>::has_quiet_NaN)
             {
                 val = std::numeric_limits<ArithmeticType>::quiet_NaN();
                 break;
@@ -366,13 +366,13 @@ void from_json(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::null:
         {
-            if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            if (std::numeric_limits<ArithmeticType>::has_signaling_NaN)
             {
                 val = std::numeric_limits<ArithmeticType>::signaling_NaN();
                 break;
             }
             // LCOV_EXCL_START
-            else if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            else if (std::numeric_limits<ArithmeticType>::has_quiet_NaN)
             {
                 val = std::numeric_limits<ArithmeticType>::quiet_NaN();
                 break;

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -57,8 +57,21 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
             break;
         }
-
         case value_t::null:
+        {
+            if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
+                break;
+            }
+            else if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::signaling_NaN();
+                break;
+            }
+            // [[fallthrough]];
+        }
+
         case value_t::object:
         case value_t::array:
         case value_t::string:
@@ -349,8 +362,21 @@ void from_json(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
             break;
         }
-
         case value_t::null:
+        {
+            if(std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
+                break;
+            }
+            else if(std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::signaling_NaN();
+                break;
+            }
+            // [[fallthrough]];
+        }
+
         case value_t::object:
         case value_t::array:
         case value_t::string:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3920,8 +3920,23 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
             break;
         }
-
         case value_t::null:
+        {
+            if (std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::signaling_NaN();
+                break;
+            }
+            // LCOV_EXCL_START
+            else if (std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
+                break;
+            }
+            // [[fallthrough]];
+            // LCOV_EXCL_STOP
+        }
+
         case value_t::object:
         case value_t::array:
         case value_t::string:
@@ -4212,8 +4227,23 @@ void from_json(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
             break;
         }
-
         case value_t::null:
+        {
+            if (std::numeric_limits<ArithmeticType>::has_signaling_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::signaling_NaN();
+                break;
+            }
+            // LCOV_EXCL_START
+            else if (std::numeric_limits<ArithmeticType>::has_quiet_NaN)
+            {
+                val = std::numeric_limits<ArithmeticType>::quiet_NaN();
+                break;
+            }
+            // [[fallthrough]];
+            // LCOV_EXCL_STOP
+        }
+
         case value_t::object:
         case value_t::array:
         case value_t::string:

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -1207,10 +1207,31 @@ TEST_CASE("value conversion")
             CHECK(json(n).m_value.number_float == Approx(j.m_value.number_float));
         }
 
-        SECTION("exception in case of a non-string type")
+        SECTION("null as NaN")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::number_float_t>(),
-                            json::type_error&);
+            json jNull(nullptr);
+            SECTION("number_float_t")
+            {
+                auto n = jNull.get<json::number_float_t>();
+                CHECK(std::isnan(n));
+            }
+
+            SECTION("float")
+            {
+                auto n = jNull.get<float>();
+                CHECK(std::isnan(n));
+            }
+
+            SECTION("double")
+            {
+                auto n = jNull.get<double>();
+                CHECK(std::isnan(n));
+            }
+        }
+        SECTION("exception in case of a non-numeric type")
+        {
+            // CHECK_THROWS_AS(json(json::value_t::null).get<json::number_float_t>(),
+            //                 json::type_error&);
             CHECK_THROWS_AS(json(json::value_t::object).get<json::number_float_t>(),
                             json::type_error&);
             CHECK_THROWS_AS(json(json::value_t::array).get<json::number_float_t>(),
@@ -1220,9 +1241,9 @@ TEST_CASE("value conversion")
             CHECK_THROWS_AS(json(json::value_t::boolean).get<json::number_float_t>(),
                             json::type_error&);
 
-            CHECK_THROWS_WITH(
-                json(json::value_t::null).get<json::number_float_t>(),
-                "[json.exception.type_error.302] type must be number, but is null");
+            // CHECK_THROWS_WITH(
+            //     json(json::value_t::null).get<json::number_float_t>(),
+            //     "[json.exception.type_error.302] type must be number, but is null");
             CHECK_THROWS_WITH(
                 json(json::value_t::object).get<json::number_float_t>(),
                 "[json.exception.type_error.302] type must be number, but is object");


### PR DESCRIPTION
Hi,

as discussed in #388, floating point NaNs can be stored in the json class but are then serialized as `null` to comply with the json RFC. This PR adds support for the reverse case and allows json `null` values to be explicitly converted to floating point NaNs, e.g.

```c++
json j(nullptr);
assert( std::isnan(j.get<double>()) );
```

The previous behavior was to always throw an exception (type_error) if this was attempted. The new code checks if the requested arithmetic type has NaN (since this is implementation defined) otherwise the same type error as previously is raised. This also means that there is no change in behavior for (signed or unsigned) integer types.

I made it so that signaling NaNs are used if available, with a fallback to quiet NaNs (I don't know of any architectures that implement only one kind of NaN, but better be safe). Note that because of this architecture dependence I added some `LCOV_EXCL` to keep the test coverage up. I hope this is ok, I can't think of any way to actually test those branches.

I also noticed the substantial code duplication between the two functions that I modified. Fixing this is not entirely trivial since the behavior of bools differs between the two functions, so I just left it as it was for now.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
