### PR TITLE
Use new Docker image

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: '*,
          -altera-struct-pack-align,
          -android-cloexec-fopen,
+         -concurrency-mt-unsafe,
          -cppcoreguidelines-avoid-goto,
          -cppcoreguidelines-avoid-magic-numbers,
          -cppcoreguidelines-avoid-non-const-global-variables,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks: '*,
+         -altera-struct-pack-align,
          -android-cloexec-fopen,
          -cppcoreguidelines-avoid-goto,
          -cppcoreguidelines-avoid-magic-numbers,
@@ -30,6 +31,7 @@ Checks: '*,
          -misc-non-private-member-variables-in-classes,
          -modernize-use-trailing-return-type,
          -readability-function-size,
+         -readability-function-cognitive-complexity,
          -readability-magic-numbers,
          -readability-redundant-access-specifiers,
          -readability-uppercase-literal-suffix'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
 
   ci_test_gcc:
     runs-on: ubuntu-latest
-    container: nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:latest
     steps:
       - uses: actions/checkout@v2
       - name: cmake
@@ -42,7 +42,7 @@ jobs:
 
   ci_static_analysis:
     runs-on: ubuntu-latest
-    container: nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:latest
     strategy:
       matrix:
         target: [ci_clang_tidy, ci_cppcheck, ci_test_valgrind, ci_test_clang_sanitizer, ci_test_amalgamation, ci_clang_analyze, ci_cpplint, ci_cmake_flags, ci_single_binaries, ci_reproducible_tests, ci_non_git_tests, ci_offline_testdata, ci_infer]
@@ -55,7 +55,7 @@ jobs:
 
   ci_cmake_options:
     runs-on: ubuntu-latest
-    container: nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:latest
     strategy:
       matrix:
         target: [ci_test_diagnostics, ci_test_noexceptions, ci_test_noimplicitconversions]
@@ -68,7 +68,7 @@ jobs:
 
   ci_test_coverage:
     runs-on: ubuntu-latest
-    container: nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:latest
     steps:
       - uses: actions/checkout@v2
       - name: cmake
@@ -88,7 +88,7 @@ jobs:
 
   ci_test_compilers:
     runs-on: ubuntu-latest
-    container: nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:latest
     strategy:
       matrix:
         compiler: [g++-4.8, g++-4.9, g++-5, g++-7, g++-8, g++-9, g++-10, clang++-3.5, clang++-3.6, clang++-3.7, clang++-3.8, clang++-3.9, clang++-4.0, clang++-5.0, clang++-6.0, clang++-7, clang++-8, clang++-9, clang++-10, clang++-11]
@@ -101,7 +101,7 @@ jobs:
 
   ci_test_standards:
     runs-on: ubuntu-latest
-    container: nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:latest
     strategy:
       matrix:
         standard: [11, 14, 17, 20]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,20 +11,9 @@ on:
 jobs:
   ci_test_clang:
     runs-on: ubuntu-latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     steps:
       - uses: actions/checkout@v2
-      - name: install_ninja
-        run: |
-          sudo apt update
-          sudo apt install ninja-build
-        shell: bash
-      - name: install_clang
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 11
-          sudo apt-get install clang-tools-11
-        shell: bash
       - name: cmake
         run: cmake -S . -B build -DJSON_CI=On
       - name: build
@@ -32,7 +21,7 @@ jobs:
 
   ci_test_gcc:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     steps:
       - uses: actions/checkout@v2
       - name: cmake
@@ -42,7 +31,7 @@ jobs:
 
   ci_static_analysis:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     strategy:
       matrix:
         target: [ci_clang_tidy, ci_cppcheck, ci_test_valgrind, ci_test_clang_sanitizer, ci_test_amalgamation, ci_clang_analyze, ci_cpplint, ci_cmake_flags, ci_single_binaries, ci_reproducible_tests, ci_non_git_tests, ci_offline_testdata, ci_infer]
@@ -55,7 +44,7 @@ jobs:
 
   ci_cmake_options:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     strategy:
       matrix:
         target: [ci_test_diagnostics, ci_test_noexceptions, ci_test_noimplicitconversions]
@@ -68,7 +57,7 @@ jobs:
 
   ci_test_coverage:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     steps:
       - uses: actions/checkout@v2
       - name: cmake
@@ -88,7 +77,7 @@ jobs:
 
   ci_test_compilers:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     strategy:
       matrix:
         compiler: [g++-4.8, g++-4.9, g++-5, g++-7, g++-8, g++-9, g++-10, clang++-3.5, clang++-3.6, clang++-3.7, clang++-3.8, clang++-3.9, clang++-4.0, clang++-5.0, clang++-6.0, clang++-7, clang++-8, clang++-9, clang++-10, clang++-11]
@@ -101,7 +90,7 @@ jobs:
 
   ci_test_standards:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
     strategy:
       matrix:
         standard: [11, 14, 17, 20]

--- a/README.md
+++ b/README.md
@@ -1110,7 +1110,8 @@ The following compilers are currently used in continuous integration at [Travis]
 | Clang 11.0.0 with GNU-like command-line                           | Windows-10.0.17763 | GitHub Actions |
 | Clang 11.0.0 with MSVC-like command-line                          | Windows-10.0.17763 | GitHub Actions |
 | Clang 11.0.0 (11.0.0-2~ubuntu20.04.1)                             | Ubuntu 20.04.2 LTS | GitHub Actions |
-| Clang 12.1.0 (12.0.1-++20210423082613+072c90a863aa-1~exp1~20210423063319.76 | Ubuntu 20.04.2 LTS | GitHub Actions |
+| Clang 12.0.0 (11.0.0-2~ubuntu20.04.1)                             | Ubuntu 20.04.2 LTS | GitHub Actions |
+| Clang 13.0.0 (13.0.0-++20210828094952+9c49fee5e7ac-1exp120210828075752.71 | Ubuntu 20.04.2 LTS | GitHub Actions |
 | Visual Studio 14 2015 MSVC 19.0.24241.7 (Build Engine version 14.0.25420.1) | Windows-6.3.9600 | AppVeyor |
 | Visual Studio 15 2017 MSVC 19.16.27035.0 (Build Engine version 15.9.21+g9802d43bc3 for .NET Framework) | Windows-10.0.14393 | AppVeyor |
 | Visual Studio 15 2017 MSVC 19.16.27045.0 (Build Engine version 15.9.21+g9802d43bc3 for .NET Framework) | Windows-10.0.14393 | GitHub Actions |

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -79,7 +79,7 @@ message(STATUS "🔖 Valgrind ${VALGRIND_TOOL_VERSION} (${VALGRIND_TOOL})")
 find_program(GENHTML_TOOL NAMES genhtml)
 find_program(PLOG_CONVERTER_TOOL NAMES plog-converter)
 find_program(PVS_STUDIO_ANALYZER_TOOL NAMES pvs-studio-analyzer)
-find_program(SCAN_BUILD_TOOL NAMES scan-build-11 scan-build)
+find_program(SCAN_BUILD_TOOL NAMES scan-build-12 scan-build-11 scan-build)
 
 # the individual source files
 file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/nlohmann/*.hpp)
@@ -96,6 +96,7 @@ file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/nlohmann/*.hpp)
 # -Wno-padded                     We do not care about padding warnings.
 # -Wno-covered-switch-default     All switches list all cases and a default case.
 # -Wno-weak-vtables               The library is header-only.
+# -Wreserved-identifier           See https://github.com/onqtam/doctest/issues/536.
 
 set(CLANG_CXXFLAGS "-std=c++11                        \
     -Werror                                           \
@@ -107,6 +108,7 @@ set(CLANG_CXXFLAGS "-std=c++11                        \
     -Wno-padded                                          \
     -Wno-covered-switch-default                          \
     -Wno-weak-vtables                                    \
+    -Wno-reserved-identifier                             \
 ")
 
 # Ignored GCC warnings:

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -13,7 +13,7 @@ execute_process(COMMAND ${ASTYLE_TOOL} --version OUTPUT_VARIABLE ASTYLE_TOOL_VER
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" ASTYLE_TOOL_VERSION "${ASTYLE_TOOL_VERSION}")
 message(STATUS "🔖 Artistic Style ${ASTYLE_TOOL_VERSION} (${ASTYLE_TOOL})")
 
-find_program(CLANG_TOOL NAMES clang++-HEAD clang++-12 clang++-11 clang++)
+find_program(CLANG_TOOL NAMES clang++-HEAD clang++-13 clang++-12 clang++-11 clang++)
 execute_process(COMMAND ${CLANG_TOOL} --version OUTPUT_VARIABLE CLANG_TOOL_VERSION ERROR_VARIABLE CLANG_TOOL_VERSION)
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" CLANG_TOOL_VERSION "${CLANG_TOOL_VERSION}")
 message(STATUS "🔖 Clang ${CLANG_TOOL_VERSION} (${CLANG_TOOL})")
@@ -809,7 +809,7 @@ add_custom_target(ci_cmake_flags
 # Use more installed compilers.
 ###############################################################################
 
-foreach(COMPILER g++-4.8 g++-4.9 g++-5 g++-7 g++-8 g++-9 g++-10 clang++-3.5 clang++-3.6 clang++-3.7 clang++-3.8 clang++-3.9 clang++-4.0 clang++-5.0 clang++-6.0 clang++-7 clang++-8 clang++-9 clang++-10 clang++-11)
+foreach(COMPILER g++-4.8 g++-4.9 g++-5 g++-7 g++-8 g++-9 g++-10 clang++-3.5 clang++-3.6 clang++-3.7 clang++-3.8 clang++-3.9 clang++-4.0 clang++-5.0 clang++-6.0 clang++-7 clang++-8 clang++-9 clang++-10 clang++-11 clang++-12)
     find_program(COMPILER_TOOL NAMES ${COMPILER})
     if (COMPILER_TOOL)
         add_custom_target(ci_test_compiler_${COMPILER}


### PR DESCRIPTION
This PR adjusts the CI to use a tagged Docker image from GitHub rather than DockerHub. Furthermore, it updates Clang, Clang-Tidy, and CMake.