### PR TITLE
Set parent pointers for values inserted via update() (fixes #3007).

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -6072,6 +6072,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         for (auto it = first; it != last; ++it)
         {
             m_value.object->operator[](it.key()) = it.value();
+#if JSON_DIAGNOSTICS
+            m_value.object->operator[](it.key()).m_parent = this;
+#endif
         }
     }
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -6009,6 +6009,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         for (auto it = j.cbegin(); it != j.cend(); ++it)
         {
             m_value.object->operator[](it.key()) = it.value();
+#if JSON_DIAGNOSTICS
+            m_value.object->operator[](it.key()).m_parent = this;
+#endif
         }
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -23414,6 +23414,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         for (auto it = j.cbegin(); it != j.cend(); ++it)
         {
             m_value.object->operator[](it.key()) = it.value();
+#if JSON_DIAGNOSTICS
+            m_value.object->operator[](it.key()).m_parent = this;
+#endif
         }
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -23477,6 +23477,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         for (auto it = first; it != last; ++it)
         {
             m_value.object->operator[](it.key()) = it.value();
+#if JSON_DIAGNOSTICS
+            m_value.object->operator[](it.key()).m_parent = this;
+#endif
         }
     }
 

--- a/test/src/unit-diagnostics.cpp
+++ b/test/src/unit-diagnostics.cpp
@@ -184,4 +184,20 @@ TEST_CASE("Better diagnostics")
         j["second"] = value;
         j2["something"] = j;
     }
+
+    SECTION("Regression test for issue #3007 - Parent pointers properly set when using update()")
+    {
+      json j = json::object();
+
+      {
+        json j2 = json::object();
+        j2["one"] = 1;
+
+        j.update(j2);
+      }
+
+      for (auto const & kv : j) {
+        CHECK(kv.m_parent == &j);
+      }
+    }
 }

--- a/test/src/unit-diagnostics.cpp
+++ b/test/src/unit-diagnostics.cpp
@@ -197,7 +197,8 @@ TEST_CASE("Better diagnostics")
             j.update(j2);
         }
 
-        for (auto const & kv : j) {
+        for (auto const& kv : j)
+        {
             CHECK(kv.m_parent == &j);
         }
     }

--- a/test/src/unit-diagnostics.cpp
+++ b/test/src/unit-diagnostics.cpp
@@ -187,8 +187,8 @@ TEST_CASE("Better diagnostics")
 
     SECTION("Regression test for issue #3007 - Parent pointers properly set when using update()")
     {
+        // void update(const_reference j)
         {
-            // void update(const_reference j)
             json j = json::object();
 
             {
@@ -203,8 +203,8 @@ TEST_CASE("Better diagnostics")
             CHECK_THROWS_WITH_AS(constJ["one"].at(0), "[json.exception.type_error.304] (/one) cannot use at() with number", json::type_error);
         }
 
+        // void update(const_iterator first, const_iterator last)
         {
-            // void update(const_iterator first, const_iterator last)
             json j = json::object();
 
             {
@@ -217,6 +217,21 @@ TEST_CASE("Better diagnostics")
             // Must call operator[] on const element, otherwise m_parent gets updated.
             auto const& constJ = j;
             CHECK_THROWS_WITH_AS(constJ["one"].at(0), "[json.exception.type_error.304] (/one) cannot use at() with number", json::type_error);
+        }
+
+        // Code from #3007 triggering unwanted assertion without fix to update().
+        {
+            json root = json::array();
+            json lower = json::object();
+
+            {
+                json lowest = json::object();
+                lowest["one"] = 1;
+
+                lower.update(lowest);
+            }
+
+            root.push_back(lower);
         }
     }
 }

--- a/test/src/unit-diagnostics.cpp
+++ b/test/src/unit-diagnostics.cpp
@@ -188,17 +188,17 @@ TEST_CASE("Better diagnostics")
 
     SECTION("Regression test for issue #3007 - Parent pointers properly set when using update()")
     {
-      json j = json::object();
+        json j = json::object();
 
-      {
-        json j2 = json::object();
-        j2["one"] = 1;
+        {
+            json j2 = json::object();
+            j2["one"] = 1;
 
-        j.update(j2);
-      }
+            j.update(j2);
+        }
 
-      for (auto const & kv : j) {
-        CHECK(kv.m_parent == &j);
-      }
+        for (auto const & kv : j) {
+            CHECK(kv.m_parent == &j);
+        }
     }
 }

--- a/test/src/unit-diagnostics.cpp
+++ b/test/src/unit-diagnostics.cpp
@@ -34,6 +34,7 @@ SOFTWARE.
 #endif
 
 #define JSON_DIAGNOSTICS 1
+#define JSON_TESTS_PRIVATE
 
 #include <nlohmann/json.hpp>
 using nlohmann::json;

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -679,6 +679,23 @@ TEST_CASE("regression tests 2")
         test3[json::json_pointer(p)] = json::object();
         CHECK(test3.dump() == "{\"/root\":{}}");
     }
+
+    SECTION("issue #3007 - Parent pointers properly set when using update()")
+    {
+      json j = json::object();
+      json lower = json::object();
+
+      {
+        json j2 = json::object();
+        j2["one"] = 1;
+
+        j.update(j2);
+      }
+
+      for (auto const & kv : j) {
+        CHECK(kv.m_parent == &j);
+      }
+    }
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -679,23 +679,6 @@ TEST_CASE("regression tests 2")
         test3[json::json_pointer(p)] = json::object();
         CHECK(test3.dump() == "{\"/root\":{}}");
     }
-
-    SECTION("issue #3007 - Parent pointers properly set when using update()")
-    {
-      json j = json::object();
-      json lower = json::object();
-
-      {
-        json j2 = json::object();
-        j2["one"] = 1;
-
-        j.update(j2);
-      }
-
-      for (auto const & kv : j) {
-        CHECK(kv.m_parent == &j);
-      }
-    }
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
Fixes parent pointers not being set when using `update()` (#3007).

I've added a test which successfully failed before my changes and passed afterwards.

## Pull request checklist

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

