### PR TITLE
Allow to add metadata to json nodes

### DIFF
--- a/include/nlohmann/detail/json_metadata.hpp
+++ b/include/nlohmann/detail/json_metadata.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace nlohmann
+{
+namespace detail
+{
+template<class MetaDataType>
+class json_metadata
+{
+  public:
+    using metadata_t = MetaDataType;
+    metadata_t& metadata()
+    {
+        return m_metadata;
+    }
+    const metadata_t& metadata() const
+    {
+        return m_metadata;
+    }
+  private:
+    metadata_t m_metadata;
+};
+
+template<>
+class json_metadata<void>
+{
+    //no metadata
+};
+}  // namespace detail
+}  // namespace nlohmann

--- a/include/nlohmann/detail/json_metadata.hpp
+++ b/include/nlohmann/detail/json_metadata.hpp
@@ -18,7 +18,7 @@ class json_metadata
         return m_metadata;
     }
   private:
-    metadata_t m_metadata;
+    metadata_t m_metadata = {};
 };
 
 template<>

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -131,12 +131,13 @@
              class NumberUnsignedType, class NumberFloatType,              \
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer,     \
-             class BinaryType>
+             class BinaryType,                                             \
+             class MetaDataType>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
     basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer, BinaryType>
+    AllocatorType, JSONSerializer, BinaryType, MetaDataType>
 
 // Macros to simplify conversion from/to types
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -2333,11 +2333,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // check that passed value is valid
         other.assert_invariant();
 
-        json_metadata_t::operator=(std::move(other));
-
         using std::swap;
         swap(m_type, other.m_type);
         swap(m_value, other.m_value);
+        json_metadata_t::operator=(std::move(other));
 
         set_parents();
         assert_invariant();

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -34,7 +34,8 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename U> class AllocatorType = std::allocator,
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>>
+         class BinaryType = std::vector<std::uint8_t>,
+         class MetaDataType = void>
 class basic_json;
 
 /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12377,7 +12377,7 @@ class json_metadata
         return m_metadata;
     }
   private:
-    metadata_t m_metadata;
+    metadata_t m_metadata = {};
 };
 
 template<>
@@ -17649,7 +17649,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);
@@ -19772,11 +19772,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // check that passed value is valid
         other.assert_invariant();
 
-        json_metadata_t::operator=(std::move(other));
-
         using std::swap;
         swap(m_type, other.m_type);
         swap(m_value, other.m_value);
+        json_metadata_t::operator=(std::move(other));
 
         set_parents();
         assert_invariant();

--- a/test/src/unit-metadata.cpp
+++ b/test/src/unit-metadata.cpp
@@ -1,0 +1,185 @@
+/*
+    __ _____ _____ _____
+ __|  |   __|     |   | |  JSON for Modern C++ (test suite)
+|  |  |__   |  |  | | | |  version 3.10.2
+|_____|_____|_____|_|___|  https://github.com/nlohmann/json
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+SPDX-License-Identifier: MIT
+Copyright (c) 2013-2019 Niels Lohmann <http://nlohmann.me>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "doctest_compatibility.h"
+
+#include <nlohmann/json.hpp>
+
+template<class T>
+using json_with_metadata =
+    nlohmann::basic_json <
+    std::map,
+    std::vector,
+    std::string,
+    bool,
+    std::int64_t,
+    std::uint64_t,
+    double,
+    std::allocator,
+    nlohmann::adl_serializer,
+    std::vector<std::uint8_t>,
+    T
+    >;
+
+TEST_CASE("JSON Node Metadata")
+{
+    SECTION("type int")
+    {
+        using json = json_with_metadata<int>;
+        json null;
+        auto obj   = json::object();
+        auto array = json::array();
+
+        null.metadata()  = 1;
+        obj.metadata()   = 2;
+        array.metadata() = 3;
+        auto copy = array;
+
+        CHECK(null.metadata()  == 1);
+        CHECK(obj.metadata()   == 2);
+        CHECK(array.metadata() == 3);
+        CHECK(copy.metadata()  == 3);
+    }
+    SECTION("type vector<int>")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        auto copy = value;
+        value.metadata().emplace_back(2);
+
+        CHECK(copy.metadata().size()  == 1);
+        CHECK(copy.metadata().at(0)   == 1);
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+    }
+    SECTION("copy ctor")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json copy = value;
+
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(copy.metadata().at(0)   == 1);
+        CHECK(copy.metadata().at(1)   == 2);
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+
+        value.metadata().clear();
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(value.metadata().size() == 0);
+    }
+    SECTION("move ctor")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        const json moved = std::move(value);
+
+        CHECK(moved.metadata().size()  == 2);
+        CHECK(moved.metadata().at(0)   == 1);
+        CHECK(moved.metadata().at(1)   == 2);
+        CHECK(value.metadata().size()  == 0);
+    }
+    SECTION("move assign")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json moved;
+        moved = std::move(value);
+
+        CHECK(moved.metadata().size()  == 2);
+        CHECK(moved.metadata().at(0)   == 1);
+        CHECK(moved.metadata().at(1)   == 2);
+        CHECK(value.metadata().size()  == 0);
+    }
+    SECTION("copy assign")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json copy;
+        copy = value;
+
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(copy.metadata().at(0)   == 1);
+        CHECK(copy.metadata().at(1)   == 2);
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+
+        value.metadata().clear();
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(value.metadata().size() == 0);
+    }
+    SECTION("type unique_ptr<int>")
+    {
+        using json = json_with_metadata<std::unique_ptr<int>>;
+        json value;
+        value.metadata().reset(new int);
+        (*value.metadata()) = 42;
+        auto moved = std::move(value);
+
+        CHECK(value.metadata() == nullptr);
+        CHECK(moved.metadata() != nullptr);
+        CHECK(*moved.metadata() == 42);
+    }
+    SECTION("type vector<int> in json array")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json array(10, value);
+
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+
+        for (const auto& val : array)
+        {
+            CHECK(val.metadata().size() == 2);
+            CHECK(val.metadata().at(0)  == 1);
+            CHECK(val.metadata().at(1)  == 2);
+        }
+    }
+}


### PR DESCRIPTION
When processing json it is often useful to annotate nodes with some metadata. This PR adds an additional template parameter which allows to set the type of metadata. 
By default the parameter is set to void and no metadata is allowed. In this case the library behaves as it already did.
If a user explicitly adds metadata (last template parameter) each node has a data member of this type and access functions for this member.

This metadata can be used to tag nodes or store information such as the line and column number from an input file.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are **described in the pull request**, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src). **(should be. will update state aver coverall is done)**
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
