### PR TITLE
Fix typos in operator[] documentation

### DIFF
--- a/doc/mkdocs/docs/api/basic_json/operator[].md
+++ b/doc/mkdocs/docs/api/basic_json/operator[].md
@@ -33,7 +33,7 @@ const_reference operator[](const json_pointer& ptr) const;
 :   index of the element to access
 
 `key` (in)
-:   object key of the elements to remove
+:   object key of the element to access
     
 `ptr` (in)
 :   JSON pointer to the desired element


### PR DESCRIPTION
Was reading the docs and this doesn't really make sense 😄 