### PR TITLE
Allow custom base class as node customization point

### DIFF
--- a/docs/examples/json_base_class_t.cpp
+++ b/docs/examples/json_base_class_t.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+class visitor_adaptor_with_metadata
+{
+  public:
+    template <class Fnc>
+    void visit(const Fnc& fnc) const;
+
+    int metadata = 42;
+  private:
+    template <class Ptr, class Fnc>
+    void do_visit(const Ptr& ptr, const Fnc& fnc) const;
+};
+
+using json = nlohmann::basic_json <
+             std::map,
+             std::vector,
+             std::string,
+             bool,
+             std::int64_t,
+             std::uint64_t,
+             double,
+             std::allocator,
+             nlohmann::adl_serializer,
+             std::vector<std::uint8_t>,
+             visitor_adaptor_with_metadata
+             >;
+
+template <class Fnc>
+void visitor_adaptor_with_metadata::visit(const Fnc& fnc) const
+{
+    do_visit(json::json_pointer{}, fnc);
+}
+
+template <class Ptr, class Fnc>
+void visitor_adaptor_with_metadata::do_visit(const Ptr& ptr, const Fnc& fnc) const
+{
+    using value_t = nlohmann::detail::value_t;
+    const json& j = *static_cast<const json*>(this);
+    switch (j.type())
+    {
+        case value_t::object:
+            fnc(ptr, j);
+            for (const auto& entry : j.items())
+            {
+                entry.value().do_visit(ptr / entry.key(), fnc);
+            }
+            break;
+        case value_t::array:
+            fnc(ptr, j);
+            for (std::size_t i = 0; i < j.size(); ++i)
+            {
+                j.at(i).do_visit(ptr / std::to_string(i), fnc);
+            }
+            break;
+        case value_t::discarded:
+            break;
+        case value_t::null:
+        case value_t::string:
+        case value_t::boolean:
+        case value_t::number_integer:
+        case value_t::number_unsigned:
+        case value_t::number_float:
+        case value_t::binary:
+        default:
+            fnc(ptr, j);
+    }
+}
+
+int main()
+{
+    // create a json object
+    json j;
+    j["null"];
+    j["object"]["uint"] = 1U;
+    j["object"].metadata = 21;
+
+    // visit and output
+    j.visit(
+        [&](const json::json_pointer & p,
+            const json & j)
+    {
+        std::cout << (p.empty() ? std::string{"/"} : p.to_string())
+                  << " - metadata = " << j.metadata << " -> " << j.dump() << '\n';
+    });
+}

--- a/docs/examples/json_base_class_t.cpp
+++ b/docs/examples/json_base_class_t.cpp
@@ -54,8 +54,6 @@ void visitor_adaptor_with_metadata::do_visit(const Ptr& ptr, const Fnc& fnc) con
                 j.at(i).do_visit(ptr / std::to_string(i), fnc);
             }
             break;
-        case value_t::discarded:
-            break;
         case value_t::null:
         case value_t::string:
         case value_t::boolean:
@@ -63,8 +61,11 @@ void visitor_adaptor_with_metadata::do_visit(const Ptr& ptr, const Fnc& fnc) con
         case value_t::number_unsigned:
         case value_t::number_float:
         case value_t::binary:
-        default:
             fnc(ptr, j);
+            break;
+        case value_t::discarded:
+        default:
+            break;
     }
 }
 

--- a/docs/examples/json_base_class_t.output
+++ b/docs/examples/json_base_class_t.output
@@ -1,0 +1,4 @@
+/ - metadata = 42 -> {"null":null,"object":{"uint":1}}
+/null - metadata = 42 -> null
+/object - metadata = 21 -> {"uint":1}
+/object/uint - metadata = 42 -> 1

--- a/docs/mkdocs/docs/api/basic_json/index.md
+++ b/docs/mkdocs/docs/api/basic_json/index.md
@@ -13,7 +13,8 @@ template<
     class NumberFloatType = double,
     template<typename U> class AllocatorType = std::allocator,
     template<typename T, typename SFINAE = void> class JSONSerializer = adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>
+    class BinaryType = std::vector<std::uint8_t,
+    class CustomBaseClass = void>
 >
 class basic_json;
 ```
@@ -32,6 +33,7 @@ class basic_json;
 | `AllocatorType`      | type of the allocator to use                                              |                                             |
 | `JSONSerializer`     | the serializer to resolve internal calls to `to_json()` and `from_json()` | [`json_serializer`](json_serializer.md)     |
 | `BinaryType`         | type for binary arrays                                                    | [`binary_t`](binary_t.md)                   |
+| `CustomBaseClass`    | extension point for user code                                             | [`json_base_class_t`](json_base_class_t.md) |
 
 ## Specializations
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -18,7 +18,7 @@ Examples for such functionality might be metadata, additional member functions (
 
 The default value for `CustomBaseClass` is `void`. In this case an empty base class is used and no additional functionality is injected.
 
-#### Limits
+#### Limitations
 
 The type `CustomBaseClass` has to be a default constructible class.
 `basic_json` only supports  copy/move construction/assignement if `CustomBaseClass` does so as well.

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -20,7 +20,7 @@ The default value for `CustomBaseClass` is `void`. In this case an empty base cl
 
 #### Limitations
 
-The type `CustomBaseClass` has to be a default constructible class.
+The type `CustomBaseClass` has to be a default-constructible class.
 `basic_json` only supports  copy/move construction/assignment if `CustomBaseClass` does so as well.
 
 ## Examples

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -16,7 +16,7 @@ Examples of such functionality might be metadata, additional member functions (e
 
 #### Default type
 
-The default value for `CustomBaseClass` is `void`. In this case an empty base class is used and no additional functionality is injected.
+The default value for `CustomBaseClass` is `void`. In this case an [empty base class](https://en.cppreference.com/w/cpp/language/ebo) is used and no additional functionality is injected.
 
 #### Limitations
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -21,7 +21,7 @@ The default value for `CustomBaseClass` is `void`. In this case an empty base cl
 #### Limits
 
 The type `CustomBaseClass` has to be a default constructible class.
-`basic_json` only supports  copy/move constructor/assignement if `CustomBaseClass` does so as well.
+`basic_json` only supports  copy/move construction/assignement if `CustomBaseClass` does so as well.
 
 ## Examples
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -1,0 +1,44 @@
+# <small>nlohmann::basic_json::</small>json_base_class_t
+
+```cpp
+using json_base_class_t = detail::json_base_class<CustomBaseClass>;
+```
+
+The base class used to inject custom functionality into each instance of `basic_json`.
+Examples for such functionality might be metadata, additional member functions (e.g. visitors) or other application specific code.
+
+## Template parameters
+
+`CustomBaseClass`
+:   the base class to be added to `basic_json`
+
+## Notes
+
+#### Default type
+
+The default value for `CustomBaseClass` is `void`. In this case an empty base class is used and no additional functionality is injected.
+
+#### Limits
+
+The type `CustomBaseClass` has to be a default constructible class.
+`basic_json` only supports  copy/move constructor/assignement if `CustomBaseClass` does so as well.
+
+## Examples
+
+??? example
+
+    The following code shows how to inject custom data and methods for each node.
+     
+    ```cpp
+    --8<-- "examples/json_base_class_t.cpp"
+    ```
+    
+    Output:
+    
+    ```json
+    --8<-- "examples/json_base_class_t.output"
+    ```
+
+## Version history
+
+- Added in version ?.?.?.

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -21,7 +21,7 @@ The default value for `CustomBaseClass` is `void`. In this case an empty base cl
 #### Limitations
 
 The type `CustomBaseClass` has to be a default constructible class.
-`basic_json` only supports  copy/move construction/assignement if `CustomBaseClass` does so as well.
+`basic_json` only supports  copy/move construction/assignment if `CustomBaseClass` does so as well.
 
 ## Examples
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -5,7 +5,7 @@ using json_base_class_t = detail::json_base_class<CustomBaseClass>;
 ```
 
 The base class used to inject custom functionality into each instance of `basic_json`.
-Examples for such functionality might be metadata, additional member functions (e.g. visitors) or other application specific code.
+Examples of such functionality might be metadata, additional member functions (e.g. visitors), or other application-specific code.
 
 ## Template parameters
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -41,4 +41,4 @@ The type `CustomBaseClass` has to be a default-constructible class.
 
 ## Version history
 
-- Added in version ?.?.?.
+- Added in version 3.12.0.

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -21,7 +21,7 @@ The default value for `CustomBaseClass` is `void`. In this case an empty base cl
 #### Limitations
 
 The type `CustomBaseClass` has to be a default-constructible class.
-`basic_json` only supports  copy/move construction/assignment if `CustomBaseClass` does so as well.
+`basic_json` only supports copy/move construction/assignment if `CustomBaseClass` does so as well.
 
 ## Examples
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -5,7 +5,7 @@ using json_base_class_t = detail::json_base_class<CustomBaseClass>;
 ```
 
 The base class used to inject custom functionality into each instance of `basic_json`.
-Examples of such functionality might be metadata, additional member functions (e.g. visitors), or other application-specific code.
+Examples of such functionality might be metadata, additional member functions (e.g., visitors), or other application-specific code.
 
 ## Template parameters
 

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
         - 'is_string': api/basic_json/is_string.md
         - 'is_structured': api/basic_json/is_structured.md
         - 'items': api/basic_json/items.md
+        - 'json_base_class_t': api/basic_json/json_base_class_t.md
         - 'json_serializer': api/basic_json/json_serializer.md
         - 'max_size': api/basic_json/max_size.md
         - 'meta': api/basic_json/meta.md

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -10,11 +10,11 @@ namespace detail
 struct json_default_base {};
 
 template<class T>
-using json_base_class = typename std::conditional<
-        std::is_same<T, void>::value,
-        json_default_base,
-        T
-    >::type;
+using json_base_class = typename std::conditional <
+                        std::is_same<T, void>::value,
+                        json_default_base,
+                        T
+                        >::type;
 
 }  // namespace detail
 }  // namespace nlohmann

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -12,13 +12,6 @@ namespace detail
 
 So that the correct implementation of the copy / move ctors / assign operators
 of @ref basic_json does not require complex case distinctions
-(no base class / custom base class), @ref basic_json always a base class.
-By default this class is used, since empty and thus has no effect on the
-behaviour of @ref basic_json.
-
-
-So that the correct implementation of the copy / move ctors / assign operators
-of @ref basic_json does not require complex case distinctions
 (no base class / custom base class used as customization point),
 @ref basic_json always has a base class.
 By default, this class is used because it is empty and thus has no effect

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -7,6 +7,23 @@ namespace nlohmann
 namespace detail
 {
 
+/*!
+@brief Default base class of the @ref basic_json class.
+
+So that the correct implementation of the copy / move ctors / assign operators
+of @ref basic_json does not require complex case distinctions
+(no base class / custom base class), @ref basic_json always a base class.
+By default this class is used, since empty and thus has no effect on the
+behaviour of @ref basic_json.
+
+
+So that the correct implementation of the copy / move ctors / assign operators
+of @ref basic_json does not require complex case distinctions
+(no base class / custom base class used as customization point),
+@ref basic_json always has a base class.
+By default, this class is used because it is empty and thus has no effect
+on the behavior of @ref basic_json.
+*/
 struct json_default_base {};
 
 template<class T>

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <type_traits>
+
+namespace nlohmann
+{
+namespace detail
+{
+
+struct json_default_base {};
+
+template<class T>
+using json_base_class = typename std::conditional<
+        std::is_same<T, void>::value,
+        json_default_base,
+        T
+    >::type;
+
+}  // namespace detail
+}  // namespace nlohmann

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <type_traits>
+#include <type_traits> // conditional, is_same
 
 namespace nlohmann
 {

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -26,4 +26,4 @@ using json_base_class = typename std::conditional <
                         >::type;
 
 }  // namespace detail
-}  // namespace nlohmann
+NLOHMANN_JSON_NAMESPACE_END

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -9,7 +9,7 @@ namespace detail
 /*!
 @brief Default base class of the @ref basic_json class.
 
-So that the correct implementation of the copy / move ctors / assign operators
+So that the correct implementations of the copy / move ctors / assign operators
 of @ref basic_json do not require complex case distinctions
 (no base class / custom base class used as customization point),
 @ref basic_json always has a base class.

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -2,8 +2,7 @@
 
 #include <type_traits> // conditional, is_same
 
-namespace nlohmann
-{
+NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {
 

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -10,7 +10,7 @@ namespace detail
 @brief Default base class of the @ref basic_json class.
 
 So that the correct implementation of the copy / move ctors / assign operators
-of @ref basic_json does not require complex case distinctions
+of @ref basic_json do not require complex case distinctions
 (no base class / custom base class used as customization point),
 @ref basic_json always has a base class.
 By default, this class is used because it is empty and thus has no effect

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -2,6 +2,8 @@
 
 #include <type_traits> // conditional, is_same
 
+#include <nlohmann/detail/abi_macros.hpp>
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -240,12 +240,13 @@
              class NumberUnsignedType, class NumberFloatType,              \
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer,     \
-             class BinaryType>
+             class BinaryType,                                             \
+             class CustomBaseClass>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
     basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer, BinaryType>
+    AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>
 
 // Macros to simplify conversion from/to types
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1204,12 +1204,12 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief move constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(basic_json&& other) noexcept
-        : json_base_class_t(static_cast < json_base_class_t&& > (other)),
+        : json_base_class_t(std::move(other)),
           m_type(std::move(other.m_type)),
           m_value(std::move(other.m_value))
     {
         // check that passed value is valid
-        other.assert_invariant(false);
+        other.assert_invariant(false); // NOLINT(bugprone-use-after-move,hicpp-invalid-access-moved)
 
         // invalidate payload
         other.m_type = value_t::null;

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -47,6 +47,7 @@
 #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 #include <nlohmann/detail/iterators/json_reverse_iterator.hpp>
 #include <nlohmann/detail/iterators/primitive_iterator.hpp>
+#include <nlohmann/detail/json_custom_base_class.hpp>
 #include <nlohmann/detail/json_pointer.hpp>
 #include <nlohmann/detail/json_ref.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
@@ -93,6 +94,7 @@ The invariants are checked by member function assert_invariant().
 */
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
 class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+    : public ::nlohmann::detail::json_base_class<CustomBaseClass>
 {
   private:
     template<detail::value_t> friend struct detail::external_constructor;
@@ -119,6 +121,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// workaround type for MSVC
     using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
+    using json_base_class_t = ::nlohmann::detail::json_base_class<CustomBaseClass>;
 
   JSON_PRIVATE_UNLESS_TESTED:
     // convenience aliases for types residing in namespace detail;
@@ -1132,7 +1135,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief copy constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(const basic_json& other)
-        : m_type(other.m_type)
+        : json_base_class_t(other),
+          m_type(other.m_type)
     {
         // check of passed value is valid
         other.assert_invariant();
@@ -1200,7 +1204,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief move constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(basic_json&& other) noexcept
-        : m_type(std::move(other.m_type)),
+        : json_base_class_t(std::move(other)),
+          m_type(std::move(other.m_type)),
           m_value(std::move(other.m_value))
     {
         // check that passed value is valid
@@ -1220,7 +1225,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         std::is_nothrow_move_constructible<value_t>::value&&
         std::is_nothrow_move_assignable<value_t>::value&&
         std::is_nothrow_move_constructible<json_value>::value&&
-        std::is_nothrow_move_assignable<json_value>::value
+        std::is_nothrow_move_assignable<json_value>::value&&
+        std::is_nothrow_move_assignable<json_base_class_t>::value
     )
     {
         // check that passed value is valid
@@ -1229,6 +1235,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         using std::swap;
         swap(m_type, other.m_type);
         swap(m_value, other.m_value);
+        json_base_class_t::operator=(std::move(other));
 
         set_parents();
         assert_invariant();

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1204,7 +1204,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief move constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(basic_json&& other) noexcept
-        : json_base_class_t(std::move(other)),
+        : json_base_class_t(static_cast < json_base_class_t&& > (other)),
           m_type(std::move(other.m_type)),
           m_value(std::move(other.m_value))
     {

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -46,7 +46,8 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename U> class AllocatorType = std::allocator,
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>>
+         class BinaryType = std::vector<std::uint8_t>,
+         class CustomBaseClass = void>
 class basic_json;
 
 /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -46,7 +46,7 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename U> class AllocatorType = std::allocator,
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
          class CustomBaseClass = void>
 class basic_json;
 

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -46,7 +46,7 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename U> class AllocatorType = std::allocator,
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class BinaryType = std::vector<std::uint8_t>,
          class CustomBaseClass = void>
 class basic_json;
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2590,12 +2590,13 @@ JSON_HEDLEY_DIAGNOSTIC_POP
              class NumberUnsignedType, class NumberFloatType,              \
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer,     \
-             class BinaryType>
+             class BinaryType,                                             \
+             class CustomBaseClass>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
     basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer, BinaryType>
+    AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>
 
 // Macros to simplify conversion from/to types
 
@@ -3389,7 +3390,8 @@ NLOHMANN_JSON_NAMESPACE_END
     template<typename U> class AllocatorType = std::allocator,
     template<typename T, typename SFINAE = void> class JSONSerializer =
     adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>>
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
     class basic_json;
 
     /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
@@ -13673,6 +13675,38 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/iterators/primitive_iterator.hpp>
 
+// #include <nlohmann/detail/json_custom_base_class.hpp>
+
+
+#include <type_traits> // conditional, is_same
+
+namespace nlohmann
+{
+namespace detail
+{
+
+/*!
+@brief Default base class of the @ref basic_json class.
+
+So that the correct implementation of the copy / move ctors / assign operators
+of @ref basic_json does not require complex case distinctions
+(no base class / custom base class used as customization point),
+@ref basic_json always has a base class.
+By default, this class is used because it is empty and thus has no effect
+on the behavior of @ref basic_json.
+*/
+struct json_default_base {};
+
+template<class T>
+using json_base_class = typename std::conditional <
+                        std::is_same<T, void>::value,
+                        json_default_base,
+                        T
+                        >::type;
+
+}  // namespace detail
+}  // namespace nlohmann
+
 // #include <nlohmann/detail/json_pointer.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
@@ -19271,6 +19305,7 @@ The invariants are checked by member function assert_invariant().
 */
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
 class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+    : public ::nlohmann::detail::json_base_class<CustomBaseClass>
 {
   private:
     template<detail::value_t> friend struct detail::external_constructor;
@@ -19297,6 +19332,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// workaround type for MSVC
     using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
+    using json_base_class_t = ::nlohmann::detail::json_base_class<CustomBaseClass>;
 
   JSON_PRIVATE_UNLESS_TESTED:
     // convenience aliases for types residing in namespace detail;
@@ -20310,7 +20346,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief copy constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(const basic_json& other)
-        : m_type(other.m_type)
+        : json_base_class_t(other),
+          m_type(other.m_type)
     {
         // check of passed value is valid
         other.assert_invariant();
@@ -20378,11 +20415,12 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief move constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(basic_json&& other) noexcept
-        : m_type(std::move(other.m_type)),
+        : json_base_class_t(std::move(other)),
+          m_type(std::move(other.m_type)),
           m_value(std::move(other.m_value))
     {
         // check that passed value is valid
-        other.assert_invariant(false);
+        other.assert_invariant(false); // NOLINT(bugprone-use-after-move,hicpp-invalid-access-moved)
 
         // invalidate payload
         other.m_type = value_t::null;
@@ -20398,7 +20436,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         std::is_nothrow_move_constructible<value_t>::value&&
         std::is_nothrow_move_assignable<value_t>::value&&
         std::is_nothrow_move_constructible<json_value>::value&&
-        std::is_nothrow_move_assignable<json_value>::value
+        std::is_nothrow_move_assignable<json_value>::value&&
+        std::is_nothrow_move_assignable<json_base_class_t>::value
     )
     {
         // check that passed value is valid
@@ -20407,6 +20446,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         using std::swap;
         swap(m_type, other.m_type);
         swap(m_value, other.m_value);
+        json_base_class_t::operator=(std::move(other));
 
         set_parents();
         assert_invariant();

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13688,7 +13688,7 @@ namespace detail
 @brief Default base class of the @ref basic_json class.
 
 So that the correct implementation of the copy / move ctors / assign operators
-of @ref basic_json does not require complex case distinctions
+of @ref basic_json do not require complex case distinctions
 (no base class / custom base class used as customization point),
 @ref basic_json always has a base class.
 By default, this class is used because it is empty and thus has no effect

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13704,7 +13704,7 @@ using json_base_class = typename std::conditional <
                         >::type;
 
 }  // namespace detail
-}  // namespace nlohmann
+NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/json_pointer.hpp>
 //     __ _____ _____ _____

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13680,8 +13680,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 #include <type_traits> // conditional, is_same
 
-namespace nlohmann
-{
+NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13680,6 +13680,9 @@ NLOHMANN_JSON_NAMESPACE_END
 
 #include <type_traits> // conditional, is_same
 
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13687,7 +13687,7 @@ namespace detail
 /*!
 @brief Default base class of the @ref basic_json class.
 
-So that the correct implementation of the copy / move ctors / assign operators
+So that the correct implementations of the copy / move ctors / assign operators
 of @ref basic_json do not require complex case distinctions
 (no base class / custom base class used as customization point),
 @ref basic_json always has a base class.

--- a/single_include/nlohmann/json_fwd.hpp
+++ b/single_include/nlohmann/json_fwd.hpp
@@ -147,7 +147,8 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename U> class AllocatorType = std::allocator,
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>>
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
 class basic_json;
 
 /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -173,7 +173,7 @@ TEST_CASE("JSON Node Metadata")
     {
         using json = json_with_metadata<std::unique_ptr<int>>;
         json value;
-        value.metadata() = std::make_unique<int>(42);
+        value.metadata().reset(new int(42));
         auto moved = std::move(value);
 
         CHECK(moved.metadata() != nullptr);

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -35,6 +35,8 @@ SOFTWARE.
 
 #include <nlohmann/json.hpp>
 
+// Test extending nlohmann::json by using a custom base class.
+// Add some metadata to each node ant test the behaviour of copy / move
 template<class MetaDataType>
 class json_metadata
 {
@@ -201,6 +203,8 @@ TEST_CASE("JSON Node Metadata")
     }
 }
 
+// Test extending nlohmann::json by using a custom base class.
+// Add a custom member function template iterating over the whole json tree.
 class visitor_adaptor
 {
   public:

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -307,7 +307,7 @@ TEST_CASE("JSON Visit Node")
                const json_with_visitor_t& j)
         {
             std::stringstream str;
-            str << p << " - " ;
+            str << p.to_string() << " - " ;
              using value_t = nlohmann::detail::value_t;
             switch(j.type())
             {

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -36,7 +36,7 @@ SOFTWARE.
 #include <nlohmann/json.hpp>
 
 // Test extending nlohmann::json by using a custom base class.
-// Add some metadata to each node ant test the behaviour of copy / move
+// Add some metadata to each node and test the behaviour of copy / move
 template<class MetaDataType>
 class json_metadata
 {

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -66,7 +66,7 @@ using json_with_metadata =
     nlohmann::adl_serializer,
     std::vector<std::uint8_t>,
     json_metadata<T>
->;
+    >;
 
 TEST_CASE("JSON Node Metadata")
 {
@@ -216,18 +216,18 @@ class visitor_adaptor
 };
 
 using json_with_visitor_t = nlohmann::basic_json <
-    std::map,
-    std::vector,
-    std::string,
-    bool,
-    std::int64_t,
-    std::uint64_t,
-    double,
-    std::allocator,
-    nlohmann::adl_serializer,
-    std::vector<std::uint8_t>,
-    visitor_adaptor
->;
+                            std::map,
+                            std::vector,
+                            std::string,
+                            bool,
+                            std::int64_t,
+                            std::uint64_t,
+                            double,
+                            std::allocator,
+                            nlohmann::adl_serializer,
+                            std::vector<std::uint8_t>,
+                            visitor_adaptor
+                            >;
 
 
 template <class Fnc>
@@ -241,30 +241,45 @@ void visitor_adaptor::do_visit(const Ptr& ptr, const Fnc& fnc) const
 {
     using value_t = nlohmann::detail::value_t;
     const json_with_visitor_t& json = *static_cast<const json_with_visitor_t*>(this);
-    switch(json.type())
+    switch (json.type())
     {
-    case value_t::object:
-        for(const auto& entry : json.items())
-        {
-            entry.value().do_visit(ptr/entry.key(), fnc);
-        }
-        break;
-    case value_t::array:
-        for(std::size_t i = 0; i < json.size(); ++i)
-        {
-            json.at(i).do_visit(ptr/std::to_string(i), fnc);
-        }
-        break;
-    case value_t::discarded: break;
-    case value_t::null: fnc(ptr, json); break;
-    case value_t::string: fnc(ptr, json); break;
-    case value_t::boolean: fnc(ptr, json); break;
-    case value_t::number_integer: fnc(ptr, json); break;
-    case value_t::number_unsigned: fnc(ptr, json); break;
-    case value_t::number_float: fnc(ptr, json); break;
-    case value_t::binary: fnc(ptr, json); break;
-    default:
-        fnc(ptr, json);
+        case value_t::object:
+            for (const auto& entry : json.items())
+            {
+                entry.value().do_visit(ptr / entry.key(), fnc);
+            }
+            break;
+        case value_t::array:
+            for (std::size_t i = 0; i < json.size(); ++i)
+            {
+                json.at(i).do_visit(ptr / std::to_string(i), fnc);
+            }
+            break;
+        case value_t::discarded:
+            break;
+        case value_t::null:
+            fnc(ptr, json);
+            break;
+        case value_t::string:
+            fnc(ptr, json);
+            break;
+        case value_t::boolean:
+            fnc(ptr, json);
+            break;
+        case value_t::number_integer:
+            fnc(ptr, json);
+            break;
+        case value_t::number_unsigned:
+            fnc(ptr, json);
+            break;
+        case value_t::number_float:
+            fnc(ptr, json);
+            break;
+        case value_t::binary:
+            fnc(ptr, json);
+            break;
+        default:
+            fnc(ptr, json);
     }
 }
 
@@ -303,32 +318,54 @@ TEST_CASE("JSON Visit Node")
     };
 
     json.visit(
-                [&](const json_with_visitor_t::json_pointer& p,
-               const json_with_visitor_t& j)
+        [&](const json_with_visitor_t::json_pointer & p,
+            const json_with_visitor_t& j)
+    {
+        std::stringstream str;
+        str << p.to_string() << " - " ;
+        using value_t = nlohmann::detail::value_t;
+        switch (j.type())
         {
-            std::stringstream str;
-            str << p.to_string() << " - " ;
-             using value_t = nlohmann::detail::value_t;
-            switch(j.type())
-            {
-            case value_t::object: str << "object"; break;
-            case value_t::array: str << "array"; break;
-            case value_t::discarded: str << "discarded"; break;
-            case value_t::null: str << "null"; break;
-            case value_t::string: str << "string"; break;
-            case value_t::boolean: str << "boolean"; break;
-            case value_t::number_integer: str << "number_integer"; break;
-            case value_t::number_unsigned: str << "number_unsigned"; break;
-            case value_t::number_float: str << "number_float"; break;
-            case value_t::binary: str << "binary"; break;
-            default: str << "error"; break;
-            }
-            str << " - "  << j.dump();
-            CHECK(json.at(p) == j);
-            INFO(str.str());
-            CHECK(expected.count(str.str()) == 1);
-            expected.erase(str.str());
+            case value_t::object:
+                str << "object";
+                break;
+            case value_t::array:
+                str << "array";
+                break;
+            case value_t::discarded:
+                str << "discarded";
+                break;
+            case value_t::null:
+                str << "null";
+                break;
+            case value_t::string:
+                str << "string";
+                break;
+            case value_t::boolean:
+                str << "boolean";
+                break;
+            case value_t::number_integer:
+                str << "number_integer";
+                break;
+            case value_t::number_unsigned:
+                str << "number_unsigned";
+                break;
+            case value_t::number_float:
+                str << "number_float";
+                break;
+            case value_t::binary:
+                str << "binary";
+                break;
+            default:
+                str << "error";
+                break;
         }
+        str << " - "  << j.dump();
+        CHECK(json.at(p) == j);
+        INFO(str.str());
+        CHECK(expected.count(str.str()) == 1);
+        expected.erase(str.str());
+    }
     );
     CHECK(expected.empty());
 }

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -173,7 +173,7 @@ TEST_CASE("JSON Node Metadata")
     {
         using json = json_with_metadata<std::unique_ptr<int>>;
         json value;
-        value.metadata().reset(new int(42));
+        value.metadata().reset(new int(42)); // NOLINT
         auto moved = std::move(value);
 
         CHECK(moved.metadata() != nullptr);

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -130,12 +130,9 @@ TEST_CASE("JSON Node Metadata")
 
         const json moved = std::move(value);
 
-        const json copy_after_moved_from{value};
-
         CHECK(moved.metadata().size()  == 2);
         CHECK(moved.metadata().at(0)   == 1);
         CHECK(moved.metadata().at(1)   == 2);
-        CHECK(copy_after_moved_from.metadata().size()  == 0);
     }
     SECTION("move assign")
     {
@@ -150,7 +147,6 @@ TEST_CASE("JSON Node Metadata")
         CHECK(moved.metadata().size()  == 2);
         CHECK(moved.metadata().at(0)   == 1);
         CHECK(moved.metadata().at(1)   == 2);
-        CHECK(value.metadata().size()  == 0);
     }
     SECTION("copy assign")
     {
@@ -177,11 +173,9 @@ TEST_CASE("JSON Node Metadata")
     {
         using json = json_with_metadata<std::unique_ptr<int>>;
         json value;
-        value.metadata().reset(new int);
-        (*value.metadata()) = 42;
+        value.metadata() = std::make_unique<int>(42);
         auto moved = std::move(value);
 
-        CHECK(value.metadata() == nullptr); // NOLINT
         CHECK(moved.metadata() != nullptr);
         CHECK(*moved.metadata() == 42);
     }

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -130,10 +130,12 @@ TEST_CASE("JSON Node Metadata")
 
         const json moved = std::move(value);
 
+        const json copy_after_moved_from{value};
+
         CHECK(moved.metadata().size()  == 2);
         CHECK(moved.metadata().at(0)   == 1);
         CHECK(moved.metadata().at(1)   == 2);
-        CHECK(value.metadata().size()  == 0);
+        CHECK(copy_after_moved_from.metadata().size()  == 0);
     }
     SECTION("move assign")
     {
@@ -179,7 +181,7 @@ TEST_CASE("JSON Node Metadata")
         (*value.metadata()) = 42;
         auto moved = std::move(value);
 
-        CHECK(value.metadata() == nullptr);
+        CHECK(value.metadata() == nullptr); // NOLINT
         CHECK(moved.metadata() != nullptr);
         CHECK(*moved.metadata() == 42);
     }
@@ -258,26 +260,12 @@ void visitor_adaptor::do_visit(const Ptr& ptr, const Fnc& fnc) const
         case value_t::discarded:
             break;
         case value_t::null:
-            fnc(ptr, json);
-            break;
         case value_t::string:
-            fnc(ptr, json);
-            break;
         case value_t::boolean:
-            fnc(ptr, json);
-            break;
         case value_t::number_integer:
-            fnc(ptr, json);
-            break;
         case value_t::number_unsigned:
-            fnc(ptr, json);
-            break;
         case value_t::number_float:
-            fnc(ptr, json);
-            break;
         case value_t::binary:
-            fnc(ptr, json);
-            break;
         default:
             fnc(ptr, json);
     }

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -283,23 +283,23 @@ TEST_CASE("JSON Visit Node")
 
     std::set<std::string> expected
     {
-        "\"/null\" - null - null",
-        "\"/int\" - number_integer - -1",
-        "\"/uint\" - number_unsigned - 1",
-        "\"/float\" - number_float - 1.0",
-        "\"/boolean\" - boolean - true",
-        "\"/string\" - string - \"string\"",
-        "\"/array/0\" - number_integer - 0",
-        "\"/array/1\" - number_integer - 1",
+        "/null - null - null",
+        "/int - number_integer - -1",
+        "/uint - number_unsigned - 1",
+        "/float - number_float - 1.0",
+        "/boolean - boolean - true",
+        "/string - string - \"string\"",
+        "/array/0 - number_integer - 0",
+        "/array/1 - number_integer - 1",
 
-        "\"/array/2/null\" - null - null",
-        "\"/array/2/int\" - number_integer - -1",
-        "\"/array/2/uint\" - number_unsigned - 1",
-        "\"/array/2/float\" - number_float - 1.0",
-        "\"/array/2/boolean\" - boolean - true",
-        "\"/array/2/string\" - string - \"string\"",
-        "\"/array/2/array/0\" - number_integer - 0",
-        "\"/array/2/array/1\" - number_integer - 1"
+        "/array/2/null - null - null",
+        "/array/2/int - number_integer - -1",
+        "/array/2/uint - number_unsigned - 1",
+        "/array/2/float - number_float - 1.0",
+        "/array/2/boolean - boolean - true",
+        "/array/2/string - string - \"string\"",
+        "/array/2/array/0 - number_integer - 0",
+        "/array/2/array/1 - number_integer - 1"
     };
 
     json.visit(
@@ -325,6 +325,7 @@ TEST_CASE("JSON Visit Node")
             }
             str << " - "  << j.dump();
             CHECK(json.at(p) == j);
+            INFO(str.str());
             CHECK(expected.count(str.str()) == 1);
             expected.erase(str.str());
         }

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -1,0 +1,333 @@
+/*
+    __ _____ _____ _____
+ __|  |   __|     |   | |  JSON for Modern C++ (test suite)
+|  |  |__   |  |  | | | |  version 3.10.2
+|_____|_____|_____|_|___|  https://github.com/nlohmann/json
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+SPDX-License-Identifier: MIT
+Copyright (c) 2013-2019 Niels Lohmann <http://nlohmann.me>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "doctest_compatibility.h"
+
+#include <nlohmann/json.hpp>
+
+template<class MetaDataType>
+class json_metadata
+{
+  public:
+    using metadata_t = MetaDataType;
+    metadata_t& metadata()
+    {
+        return m_metadata;
+    }
+    const metadata_t& metadata() const
+    {
+        return m_metadata;
+    }
+  private:
+    metadata_t m_metadata = {};
+};
+
+template<class T>
+using json_with_metadata =
+    nlohmann::basic_json <
+    std::map,
+    std::vector,
+    std::string,
+    bool,
+    std::int64_t,
+    std::uint64_t,
+    double,
+    std::allocator,
+    nlohmann::adl_serializer,
+    std::vector<std::uint8_t>,
+    json_metadata<T>
+>;
+
+TEST_CASE("JSON Node Metadata")
+{
+    SECTION("type int")
+    {
+        using json = json_with_metadata<int>;
+        json null;
+        auto obj   = json::object();
+        auto array = json::array();
+
+        null.metadata()  = 1;
+        obj.metadata()   = 2;
+        array.metadata() = 3;
+        auto copy = array;
+
+        CHECK(null.metadata()  == 1);
+        CHECK(obj.metadata()   == 2);
+        CHECK(array.metadata() == 3);
+        CHECK(copy.metadata()  == 3);
+    }
+    SECTION("type vector<int>")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        auto copy = value;
+        value.metadata().emplace_back(2);
+
+        CHECK(copy.metadata().size()  == 1);
+        CHECK(copy.metadata().at(0)   == 1);
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+    }
+    SECTION("copy ctor")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json copy = value;
+
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(copy.metadata().at(0)   == 1);
+        CHECK(copy.metadata().at(1)   == 2);
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+
+        value.metadata().clear();
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(value.metadata().size() == 0);
+    }
+    SECTION("move ctor")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        const json moved = std::move(value);
+
+        CHECK(moved.metadata().size()  == 2);
+        CHECK(moved.metadata().at(0)   == 1);
+        CHECK(moved.metadata().at(1)   == 2);
+        CHECK(value.metadata().size()  == 0);
+    }
+    SECTION("move assign")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json moved;
+        moved = std::move(value);
+
+        CHECK(moved.metadata().size()  == 2);
+        CHECK(moved.metadata().at(0)   == 1);
+        CHECK(moved.metadata().at(1)   == 2);
+        CHECK(value.metadata().size()  == 0);
+    }
+    SECTION("copy assign")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json copy;
+        copy = value;
+
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(copy.metadata().at(0)   == 1);
+        CHECK(copy.metadata().at(1)   == 2);
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+
+        value.metadata().clear();
+        CHECK(copy.metadata().size()  == 2);
+        CHECK(value.metadata().size() == 0);
+    }
+    SECTION("type unique_ptr<int>")
+    {
+        using json = json_with_metadata<std::unique_ptr<int>>;
+        json value;
+        value.metadata().reset(new int);
+        (*value.metadata()) = 42;
+        auto moved = std::move(value);
+
+        CHECK(value.metadata() == nullptr);
+        CHECK(moved.metadata() != nullptr);
+        CHECK(*moved.metadata() == 42);
+    }
+    SECTION("type vector<int> in json array")
+    {
+        using json = json_with_metadata<std::vector<int>>;
+        json value;
+        value.metadata().emplace_back(1);
+        value.metadata().emplace_back(2);
+
+        json array(10, value);
+
+        CHECK(value.metadata().size() == 2);
+        CHECK(value.metadata().at(0)  == 1);
+        CHECK(value.metadata().at(1)  == 2);
+
+        for (const auto& val : array)
+        {
+            CHECK(val.metadata().size() == 2);
+            CHECK(val.metadata().at(0)  == 1);
+            CHECK(val.metadata().at(1)  == 2);
+        }
+    }
+}
+
+class visitor_adaptor
+{
+  public:
+    template <class Fnc>
+    void visit(const Fnc& fnc) const;
+  private:
+    template <class Ptr, class Fnc>
+    void do_visit(const Ptr& ptr, const Fnc& fnc) const;
+};
+
+using json_with_visitor_t = nlohmann::basic_json <
+    std::map,
+    std::vector,
+    std::string,
+    bool,
+    std::int64_t,
+    std::uint64_t,
+    double,
+    std::allocator,
+    nlohmann::adl_serializer,
+    std::vector<std::uint8_t>,
+    visitor_adaptor
+>;
+
+
+template <class Fnc>
+void visitor_adaptor::visit(const Fnc& fnc) const
+{
+    do_visit(json_with_visitor_t::json_pointer{}, fnc);
+}
+
+template <class Ptr, class Fnc>
+void visitor_adaptor::do_visit(const Ptr& ptr, const Fnc& fnc) const
+{
+    using value_t = nlohmann::detail::value_t;
+    const json_with_visitor_t& json = *static_cast<const json_with_visitor_t*>(this);
+    switch(json.type())
+    {
+    case value_t::object:
+        for(const auto& entry : json.items())
+        {
+            entry.value().do_visit(ptr/entry.key(), fnc);
+        }
+        break;
+    case value_t::array:
+        for(std::size_t i = 0; i < json.size(); ++i)
+        {
+            json.at(i).do_visit(ptr/std::to_string(i), fnc);
+        }
+        break;
+    case value_t::discarded: break;
+    case value_t::null: fnc(ptr, json); break;
+    case value_t::string: fnc(ptr, json); break;
+    case value_t::boolean: fnc(ptr, json); break;
+    case value_t::number_integer: fnc(ptr, json); break;
+    case value_t::number_unsigned: fnc(ptr, json); break;
+    case value_t::number_float: fnc(ptr, json); break;
+    case value_t::binary: fnc(ptr, json); break;
+    default:
+        fnc(ptr, json);
+    }
+}
+
+TEST_CASE("JSON Visit Node")
+{
+    json_with_visitor_t json;
+    json["null"];
+    json["int"]  = -1;
+    json["uint"] = 1U;
+    json["float"] = 1.0;
+    json["boolean"] = true;
+    json["string"] = "string";
+    json["array"].push_back(0);
+    json["array"].push_back(1);
+    json["array"].push_back(json);
+
+    std::set<std::string> expected
+    {
+        "\"/null\" - null - null",
+        "\"/int\" - number_integer - -1",
+        "\"/uint\" - number_unsigned - 1",
+        "\"/float\" - number_float - 1.0",
+        "\"/boolean\" - boolean - true",
+        "\"/string\" - string - \"string\"",
+        "\"/array/0\" - number_integer - 0",
+        "\"/array/1\" - number_integer - 1",
+
+        "\"/array/2/null\" - null - null",
+        "\"/array/2/int\" - number_integer - -1",
+        "\"/array/2/uint\" - number_unsigned - 1",
+        "\"/array/2/float\" - number_float - 1.0",
+        "\"/array/2/boolean\" - boolean - true",
+        "\"/array/2/string\" - string - \"string\"",
+        "\"/array/2/array/0\" - number_integer - 0",
+        "\"/array/2/array/1\" - number_integer - 1"
+    };
+
+    json.visit(
+                [&](const json_with_visitor_t::json_pointer& p,
+               const json_with_visitor_t& j)
+        {
+            std::stringstream str;
+            str << p << " - " ;
+             using value_t = nlohmann::detail::value_t;
+            switch(j.type())
+            {
+            case value_t::object: str << "object"; break;
+            case value_t::array: str << "array"; break;
+            case value_t::discarded: str << "discarded"; break;
+            case value_t::null: str << "null"; break;
+            case value_t::string: str << "string"; break;
+            case value_t::boolean: str << "boolean"; break;
+            case value_t::number_integer: str << "number_integer"; break;
+            case value_t::number_unsigned: str << "number_unsigned"; break;
+            case value_t::number_float: str << "number_float"; break;
+            case value_t::binary: str << "binary"; break;
+            default: str << "error"; break;
+            }
+            str << " - "  << j.dump();
+            CHECK(json.at(p) == j);
+            CHECK(expected.count(str.str()) == 1);
+            expected.erase(str.str());
+        }
+    );
+    CHECK(expected.empty());
+}

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -175,7 +175,7 @@ TEST_CASE("JSON Node Metadata")
     {
         using json = json_with_metadata<std::unique_ptr<int>>;
         json value;
-        value.metadata().reset(new int(42)); // NOLINT
+        value.metadata().reset(new int(42)); // NOLINT(cppcoreguidelines-owning-memory)
         auto moved = std::move(value);
 
         CHECK(moved.metadata() != nullptr);


### PR DESCRIPTION
This PR adds an additional template parameter which allows to set a custom base class for `nlohmann::json`. This class serves as an extension point and allows to add functionality to json node. Examples for such functionality might be metadata or additional member functions (e.g. visitors) or other application specific code.
By default the parameter is set to void and an empty base class is used. In this case the library behaves as it already did.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src). (should be. will update state aver coverall is done)
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
