### PR TITLE
Fix FAQ hyperlink typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 - [Design goals](#design-goals)
 - [Sponsors](#sponsors)
-- [Support](#support) ([documentation](https://json.nlohmann.me), [FAQ](http://127.0.0.1:8000/home/faq/), [discussions](https://github.com/nlohmann/json/discussions), [API](https://json.nlohmann.me/api/basic_json/), [bug issues](https://github.com/nlohmann/json/issues))
+- [Support](#support) ([documentation](https://json.nlohmann.me), [FAQ](https://json.nlohmann.me/home/faq/), [discussions](https://github.com/nlohmann/json/discussions), [API](https://json.nlohmann.me/api/basic_json/), [bug issues](https://github.com/nlohmann/json/issues))
 - [Examples](#examples)
   - [JSON as first-class data type](#json-as-first-class-data-type)
   - [Serialization / Deserialization](#serialization--deserialization)


### PR DESCRIPTION
Hello! To begin with, thank you very much for this amazing library! While going through the readme, I noticed this small typo and thus, the PR to fix it. Please, have a look. 😄 

There was a minor typo in the readme where the hyperlink to the FAQ section was linked to localhost. This PR fixes this issue. No changes in the code itself have been made. As far as I've searched through, this seems to be the only occurrence of this issue in the project.

Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>