### PR TITLE
Separate number-to/from-string logic into their own classes

### DIFF
--- a/include/nlohmann/detail/input/numerizer.hpp
+++ b/include/nlohmann/detail/input/numerizer.hpp
@@ -27,13 +27,13 @@ struct numerizer
     }
     
     JSON_HEDLEY_NON_NULL(2)
-    static auto strtoull(const char* str, char** endptr, int base)
+    static unsigned long long int strtoull(const char* str, char** endptr, int base)
     {
         return std::strtoull(str, endptr, base);
     }
     
     JSON_HEDLEY_NON_NULL(2)
-    static auto strtoll(const char* str, char** endptr, int base)
+    static long long int strtoll(const char* str, char** endptr, int base)
     {
         return std::strtoll(str, endptr, base);
     }

--- a/include/nlohmann/detail/input/numerizer.hpp
+++ b/include/nlohmann/detail/input/numerizer.hpp
@@ -1,0 +1,44 @@
+
+#include <cstdlib> // strtof, strtod, strtold, strtoll, strtoull
+
+namespace nlohmann
+{
+namespace detail
+{
+  
+struct numerizer
+{
+    JSON_HEDLEY_NON_NULL(2)
+    static void strtof(float& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtof(str, endptr);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    static void strtof(double& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtod(str, endptr);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    static void strtof(long double& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtold(str, endptr);
+    }
+    
+    JSON_HEDLEY_NON_NULL(2)
+    static auto strtoull(const char* str, char** endptr, int base)
+    {
+        return std::strtoull(str, endptr, base);
+    }
+    
+    JSON_HEDLEY_NON_NULL(2)
+    static auto strtoll(const char* str, char** endptr, int base)
+    {
+        return std::strtoll(str, endptr, base);
+    }
+};
+
+ 
+}
+}

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -48,14 +48,14 @@ using parser_callback_t =
 
 This class implements a recursive descent parser.
 */
-template<typename BasicJsonType, typename InputAdapterType>
+template<template<typename, typename> class LexerType, typename BasicJsonType, typename InputAdapterType>
 class parser
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
     using string_t = typename BasicJsonType::string_t;
-    using lexer_t = lexer<BasicJsonType, InputAdapterType>;
+    using lexer_t = LexerType<BasicJsonType, InputAdapterType>;
     using token_type = typename lexer_t::token_type;
 
   public:

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -132,12 +132,13 @@
              class NumberUnsignedType, class NumberFloatType,              \
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer,     \
-             class BinaryType>
+             class BinaryType,                                             \
+             template<typename, typename> class LexerType>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
     basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer, BinaryType>
+    AllocatorType, JSONSerializer, BinaryType, LexerType>
 
 // Macros to simplify conversion from/to types
 

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -133,12 +133,13 @@
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer,     \
              class BinaryType,                                             \
-             template<typename, typename> class LexerType>
+             template<typename, typename> class LexerType,                 \
+             template<typename> class SerializerType>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
     basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer, BinaryType, LexerType>
+    AllocatorType, JSONSerializer, BinaryType, LexerType, SerializerType>
 
 // Macros to simplify conversion from/to types
 

--- a/include/nlohmann/detail/output/denumerizer.hpp
+++ b/include/nlohmann/detail/output/denumerizer.hpp
@@ -20,7 +20,7 @@ namespace nlohmann
 namespace detail
 {
 
-struct symbolifier
+struct denumerizer
 {   
     using number_buffer_t = std::array<char, 64>;
     

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -21,7 +21,7 @@
 #include <nlohmann/detail/output/binary_writer.hpp>
 #include <nlohmann/detail/output/output_adapters.hpp>
 #include <nlohmann/detail/value_t.hpp>
-#include <nlohmann/detail/output/symbolifier.hpp>
+#include <nlohmann/detail/output/denumerizer.hpp>
 
 namespace nlohmann
 {
@@ -39,7 +39,7 @@ enum class error_handler_t
     ignore   ///< ignore invalid UTF-8 sequences
 };
 
-template<typename BasicJsonType, typename SymbolifierType = symbolifier>
+template<typename BasicJsonType, typename DenumerizerType = denumerizer>
 class serializer
 {
     using string_t = typename BasicJsonType::string_t;
@@ -263,10 +263,10 @@ class serializer
                         for (auto i = val.m_value.binary->cbegin();
                                 i != val.m_value.binary->cend() - 1; ++i)
                         {
-                            SymbolifierType::dump_integer(o, *i);
+                            DenumerizerType::dump_integer(o, *i);
                             o->write_characters(", ", 2);
                         }
-                        SymbolifierType::dump_integer(o, val.m_value.binary->back());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->back());
                     }
 
                     o->write_characters("],\n", 3);
@@ -275,7 +275,7 @@ class serializer
                     o->write_characters("\"subtype\": ", 11);
                     if (val.m_value.binary->has_subtype())
                     {
-                        SymbolifierType::dump_integer(o, val.m_value.binary->subtype());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->subtype());
                     }
                     else
                     {
@@ -294,16 +294,16 @@ class serializer
                         for (auto i = val.m_value.binary->cbegin();
                                 i != val.m_value.binary->cend() - 1; ++i)
                         {
-                            SymbolifierType::dump_integer(o, *i);
+                            DenumerizerType::dump_integer(o, *i);
                             o->write_character(',');
                         }
-                        SymbolifierType::dump_integer(o, val.m_value.binary->back());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->back());
                     }
 
                     o->write_characters("],\"subtype\":", 12);
                     if (val.m_value.binary->has_subtype())
                     {
-                        SymbolifierType::dump_integer(o, val.m_value.binary->subtype());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->subtype());
                         o->write_character('}');
                     }
                     else
@@ -329,19 +329,19 @@ class serializer
 
             case value_t::number_integer:
             {
-                SymbolifierType::dump_integer(o, val.m_value.number_integer);
+                DenumerizerType::dump_integer(o, val.m_value.number_integer);
                 return;
             }
 
             case value_t::number_unsigned:
             {
-                SymbolifierType::dump_integer(o, val.m_value.number_unsigned);
+                DenumerizerType::dump_integer(o, val.m_value.number_unsigned);
                 return;
             }
 
             case value_t::number_float:
             {
-                SymbolifierType::dump_float(o, val.m_value.number_float);
+                DenumerizerType::dump_float(o, val.m_value.number_float);
                 return;
             }
 

--- a/include/nlohmann/detail/output/symbolifier.hpp
+++ b/include/nlohmann/detail/output/symbolifier.hpp
@@ -1,0 +1,247 @@
+
+
+#include <algorithm> // reverse, remove, fill, find, none_of
+#include <array> // array
+#include <clocale> // localeconv, lconv
+#include <cmath> // labs, isfinite, isnan, signbit
+#include <cstddef> // size_t, ptrdiff_t
+#include <cstdint> // uint8_t
+#include <cstdio> // snprintf
+#include <limits> // numeric_limits
+#include <string> // string, char_traits
+#include <iomanip> // setfill, setw
+#include <sstream> // stringstream
+#include <type_traits> // is_same
+#include <utility> // move
+
+
+namespace nlohmann
+{
+namespace detail
+{
+
+struct symbolifier
+{   
+    using number_buffer_t = std::array<char, 64>;
+    
+    template <typename number_unsigned_t>
+    static unsigned int count_digits(number_unsigned_t x) noexcept
+    {
+        unsigned int n_digits = 1;
+        for (;;)
+        {
+            if (x < 10)
+            {
+                return n_digits;
+            }
+            if (x < 100)
+            {
+                return n_digits + 1;
+            }
+            if (x < 1000)
+            {
+                return n_digits + 2;
+            }
+            if (x < 10000)
+            {
+                return n_digits + 3;
+            }
+            x = x / 10000u;
+            n_digits += 4;
+        }
+    }
+    
+    template <typename number_integral_t, typename number_unsigned_t =
+        typename std::make_unsigned<
+            number_integral_t>::type>
+    static number_unsigned_t remove_sign(number_integral_t x) noexcept
+    {
+        JSON_ASSERT(x < 0 && x < (std::numeric_limits<number_integral_t>::max)()); // NOLINT(misc-redundant-expression)
+        return static_cast<number_unsigned_t>(-(x + 1)) + 1;
+    }
+    
+    template <typename OutputAdapterType, typename number_integral_t,
+        typename number_unsigned_t = typename std::make_unsigned<
+            number_integral_t>::type>
+    static void dump_integer(OutputAdapterType& o, number_integral_t x)
+    {
+        static constexpr std::array<std::array<char, 2>, 100> digits_to_99
+        {
+            {
+                {{'0', '0'}}, {{'0', '1'}}, {{'0', '2'}}, {{'0', '3'}}, {{'0', '4'}}, {{'0', '5'}}, {{'0', '6'}}, {{'0', '7'}}, {{'0', '8'}}, {{'0', '9'}},
+                {{'1', '0'}}, {{'1', '1'}}, {{'1', '2'}}, {{'1', '3'}}, {{'1', '4'}}, {{'1', '5'}}, {{'1', '6'}}, {{'1', '7'}}, {{'1', '8'}}, {{'1', '9'}},
+                {{'2', '0'}}, {{'2', '1'}}, {{'2', '2'}}, {{'2', '3'}}, {{'2', '4'}}, {{'2', '5'}}, {{'2', '6'}}, {{'2', '7'}}, {{'2', '8'}}, {{'2', '9'}},
+                {{'3', '0'}}, {{'3', '1'}}, {{'3', '2'}}, {{'3', '3'}}, {{'3', '4'}}, {{'3', '5'}}, {{'3', '6'}}, {{'3', '7'}}, {{'3', '8'}}, {{'3', '9'}},
+                {{'4', '0'}}, {{'4', '1'}}, {{'4', '2'}}, {{'4', '3'}}, {{'4', '4'}}, {{'4', '5'}}, {{'4', '6'}}, {{'4', '7'}}, {{'4', '8'}}, {{'4', '9'}},
+                {{'5', '0'}}, {{'5', '1'}}, {{'5', '2'}}, {{'5', '3'}}, {{'5', '4'}}, {{'5', '5'}}, {{'5', '6'}}, {{'5', '7'}}, {{'5', '8'}}, {{'5', '9'}},
+                {{'6', '0'}}, {{'6', '1'}}, {{'6', '2'}}, {{'6', '3'}}, {{'6', '4'}}, {{'6', '5'}}, {{'6', '6'}}, {{'6', '7'}}, {{'6', '8'}}, {{'6', '9'}},
+                {{'7', '0'}}, {{'7', '1'}}, {{'7', '2'}}, {{'7', '3'}}, {{'7', '4'}}, {{'7', '5'}}, {{'7', '6'}}, {{'7', '7'}}, {{'7', '8'}}, {{'7', '9'}},
+                {{'8', '0'}}, {{'8', '1'}}, {{'8', '2'}}, {{'8', '3'}}, {{'8', '4'}}, {{'8', '5'}}, {{'8', '6'}}, {{'8', '7'}}, {{'8', '8'}}, {{'8', '9'}},
+                {{'9', '0'}}, {{'9', '1'}}, {{'9', '2'}}, {{'9', '3'}}, {{'9', '4'}}, {{'9', '5'}}, {{'9', '6'}}, {{'9', '7'}}, {{'9', '8'}}, {{'9', '9'}},
+            }
+        };
+
+        // special case for "0"
+        if (x == 0)
+        {
+            o->write_character('0');
+            return;
+        }
+        
+        number_buffer_t number_buffer{{}};
+
+        // use a pointer to fill the buffer
+        auto buffer_ptr = number_buffer.begin(); // NOLINT(llvm-qualified-auto,readability-qualified-auto,cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+
+        const bool is_negative = std::is_signed<number_integral_t>::value && !(x >= 0); // see issue #755
+        number_unsigned_t abs_value;
+
+        unsigned int n_chars{};
+
+        if (is_negative)
+        {
+            *buffer_ptr = '-';
+            abs_value = remove_sign(static_cast<number_integral_t>(x));
+
+            // account one more byte for the minus sign
+            n_chars = 1 + count_digits(abs_value);
+        }
+        else
+        {
+            abs_value = static_cast<number_unsigned_t>(x);
+            n_chars = count_digits(abs_value);
+        }
+
+        // spare 1 byte for '\0'
+        JSON_ASSERT(n_chars < number_buffer.size() - 1);
+
+        // jump to the end to generate the string from backward
+        // so we later avoid reversing the result
+        buffer_ptr += n_chars;
+
+        // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
+        // See: https://www.youtube.com/watch?v=o4-CwDo2zpg
+        while (abs_value >= 100)
+        {
+            const auto digits_index = static_cast<unsigned>((abs_value % 100));
+            abs_value /= 100;
+            *(--buffer_ptr) = digits_to_99[digits_index][1];
+            *(--buffer_ptr) = digits_to_99[digits_index][0];
+        }
+
+        if (abs_value >= 10)
+        {
+            const auto digits_index = static_cast<unsigned>(abs_value);
+            *(--buffer_ptr) = digits_to_99[digits_index][1];
+            *(--buffer_ptr) = digits_to_99[digits_index][0];
+        }
+        else
+        {
+            *(--buffer_ptr) = static_cast<char>('0' + abs_value);
+        }
+
+        o->write_characters(number_buffer.data(), n_chars);
+    }
+    
+    
+    template <typename OutputAdapterType, typename number_float_t,
+        detail::enable_if_t<
+            std::is_floating_point<number_float_t>::value, int> = 0>
+    static void dump_float(OutputAdapterType& o, number_float_t x)
+    {
+        // NaN / inf
+        if (!std::isfinite(x))
+        {
+            o->write_characters("null", 4);
+            return;
+        }
+
+        // If number_float_t is an IEEE-754 single or double precision number,
+        // use the Grisu2 algorithm to produce short numbers which are
+        // guaranteed to round-trip, using strtof and strtod, resp.
+        //
+        // NB: The test below works if <long double> == <double>.
+        static constexpr bool is_ieee_single_or_double
+            = (std::numeric_limits<number_float_t>::is_iec559 && std::numeric_limits<number_float_t>::digits == 24 && std::numeric_limits<number_float_t>::max_exponent == 128) ||
+              (std::numeric_limits<number_float_t>::is_iec559 && std::numeric_limits<number_float_t>::digits == 53 && std::numeric_limits<number_float_t>::max_exponent == 1024);
+
+        dump_float(o, x, std::integral_constant<bool, is_ieee_single_or_double>());
+    }
+    
+    template <typename OutputAdapterType, typename number_float_t,
+        detail::enable_if_t<
+            std::is_floating_point<number_float_t>::value, int> = 0>
+    static void dump_float(OutputAdapterType& o, number_float_t x, std::true_type /*is_ieee_single_or_double*/)
+    {
+        number_buffer_t number_buffer{{}};
+      
+        auto* begin = number_buffer.data();
+        auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
+
+        o->write_characters(begin, static_cast<size_t>(end - begin));
+    }
+    
+    template <typename OutputAdapterType, typename number_float_t,
+        detail::enable_if_t<
+            std::is_floating_point<number_float_t>::value, int> = 0>
+    static void dump_float(OutputAdapterType& o, number_float_t x, std::false_type /*is_ieee_single_or_double*/)
+    {
+        number_buffer_t number_buffer{{}};
+        
+        const std::lconv* loc(std::localeconv());
+        const char thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)));
+        const char decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)));
+        
+        // get number of digits for a float -> text -> float round-trip
+        static constexpr auto d = std::numeric_limits<number_float_t>::max_digits10;
+
+        // the actual conversion
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        std::ptrdiff_t len = (std::snprintf)(number_buffer.data(), number_buffer.size(), "%.*g", d, x);
+
+        // negative value indicates an error
+        JSON_ASSERT(len > 0);
+        // check if buffer was large enough
+        JSON_ASSERT(static_cast<std::size_t>(len) < number_buffer.size());
+
+        // erase thousands separator
+        if (thousands_sep != '\0')
+        {
+            // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::remove returns an iterator, see https://github.com/nlohmann/json/issues/3081
+            const auto end = std::remove(number_buffer.begin(), number_buffer.begin() + len, thousands_sep);
+            std::fill(end, number_buffer.end(), '\0');
+            JSON_ASSERT((end - number_buffer.begin()) <= len);
+            len = (end - number_buffer.begin());
+        }
+
+        // convert decimal point to '.'
+        if (decimal_point != '\0' && decimal_point != '.')
+        {
+            // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::find returns an iterator, see https://github.com/nlohmann/json/issues/3081
+            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), decimal_point);
+            if (dec_pos != number_buffer.end())
+            {
+                *dec_pos = '.';
+            }
+        }
+
+        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+
+        // determine if need to append ".0"
+        const bool value_is_int_like =
+            std::none_of(number_buffer.begin(), number_buffer.begin() + len + 1,
+                         [](char c)
+        {
+            return c == '.' || c == 'e';
+        });
+
+        if (value_is_int_like)
+        {
+            o->write_characters(".0", 2);
+        }
+    }
+  
+};
+  
+}
+}

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -199,17 +199,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
   JSON_PRIVATE_UNLESS_TESTED:
     // convenience aliases for types residing in namespace detail;
-    using lexer = ::nlohmann::detail::lexer_base<basic_json>;
+    // using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType> parser(
+    static ::nlohmann::detail::parser<LexerType, basic_json, InputAdapterType> parser(
         InputAdapterType adapter,
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
     )
     {
-        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
+        return ::nlohmann::detail::parser<LexerType, basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);
     }
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -231,7 +231,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     template<typename CharType> using binary_writer = ::nlohmann::detail::binary_writer<basic_json, CharType>;
 
   JSON_PRIVATE_UNLESS_TESTED:
-    using serializer = ::nlohmann::detail::serializer<basic_json>;
+    // using serializer = ::nlohmann::detail::serializer<basic_json>;
+    using serializer = SerializerType<basic_json>;
 
   public:
     using value_t = detail::value_t;

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -199,7 +199,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
   JSON_PRIVATE_UNLESS_TESTED:
     // convenience aliases for types residing in namespace detail;
-    // using lexer = ::nlohmann::detail::lexer_base<basic_json>;
+    using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
     static ::nlohmann::detail::parser<LexerType, basic_json, InputAdapterType> parser(

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -34,13 +34,13 @@ struct numerizer;
 template<typename BasicJsonType, typename InputAdapterType>
 using basic_lexer = lexer<BasicJsonType, InputAdapterType, numerizer>;
 
-struct symbolifier;
+struct denumerizer;
 
-template<typename BasicJsonType, typename SymbolifierType>
+template<typename BasicJsonType, typename DenumerizerType>
 class serializer;
 
 template<typename BasicJsonType>
-using basic_serializer = serializer<BasicJsonType, symbolifier>;
+using basic_serializer = serializer<BasicJsonType, denumerizer>;
 }
 
 template<template<typename U, typename V, typename... Args> class ObjectType =

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -34,8 +34,13 @@ struct numerizer;
 template<typename BasicJsonType, typename InputAdapterType>
 using basic_lexer = lexer<BasicJsonType, InputAdapterType, numerizer>;
 
-template<typename BasicJsonType>
+struct symbolifier;
+
+template<typename BasicJsonType, typename SymbolifierType>
 class serializer;
+
+template<typename BasicJsonType>
+using basic_serializer = serializer<BasicJsonType, symbolifier>;
 }
 
 template<template<typename U, typename V, typename... Args> class ObjectType =
@@ -50,7 +55,7 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          adl_serializer,
          class BinaryType = std::vector<std::uint8_t>,
          template<typename BasicJsonType, typename InputAdapterType> class LexerType = detail::basic_lexer,
-         template<typename BasicJsonType> class SerializerType = detail::serializer>
+         template<typename BasicJsonType> class SerializerType = detail::basic_serializer>
 class basic_json;
 
 /*!

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -28,6 +28,9 @@ namespace detail
 {
 template<typename BasicJsonType, typename InputAdapterType>
 class lexer;
+
+template<typename BasicJsonType>
+class serializer;
 }
 
 template<template<typename U, typename V, typename... Args> class ObjectType =
@@ -41,7 +44,8 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
          class BinaryType = std::vector<std::uint8_t>,
-         template<typename BasicJsonType, typename InputAdapterType> class LexerType = detail::lexer>
+         template<typename BasicJsonType, typename InputAdapterType> class LexerType = detail::lexer,
+         template<typename BasicJsonType> class SerializerType = detail::serializer>
 class basic_json;
 
 /*!

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -24,6 +24,12 @@ for serialization.
 template<typename T = void, typename SFINAE = void>
 struct adl_serializer;
 
+namespace detail
+{
+template<typename BasicJsonType, typename InputAdapterType>
+class lexer;
+}
+
 template<template<typename U, typename V, typename... Args> class ObjectType =
          std::map,
          template<typename U, typename... Args> class ArrayType = std::vector,
@@ -34,7 +40,8 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename U> class AllocatorType = std::allocator,
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>>
+         class BinaryType = std::vector<std::uint8_t>,
+         template<typename BasicJsonType, typename InputAdapterType> class LexerType = detail::lexer>
 class basic_json;
 
 /*!

--- a/include/nlohmann/json_fwd.hpp
+++ b/include/nlohmann/json_fwd.hpp
@@ -26,8 +26,13 @@ struct adl_serializer;
 
 namespace detail
 {
-template<typename BasicJsonType, typename InputAdapterType>
+template<typename BasicJsonType, typename InputAdapterType, typename NumerizerType>
 class lexer;
+
+struct numerizer;
+
+template<typename BasicJsonType, typename InputAdapterType>
+using basic_lexer = lexer<BasicJsonType, InputAdapterType, numerizer>;
 
 template<typename BasicJsonType>
 class serializer;
@@ -44,7 +49,7 @@ template<template<typename U, typename V, typename... Args> class ObjectType =
          template<typename T, typename SFINAE = void> class JSONSerializer =
          adl_serializer,
          class BinaryType = std::vector<std::uint8_t>,
-         template<typename BasicJsonType, typename InputAdapterType> class LexerType = detail::lexer,
+         template<typename BasicJsonType, typename InputAdapterType> class LexerType = detail::basic_lexer,
          template<typename BasicJsonType> class SerializerType = detail::serializer>
 class basic_json;
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -17784,7 +17784,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
   JSON_PRIVATE_UNLESS_TESTED:
     // convenience aliases for types residing in namespace detail;
-    // using lexer = ::nlohmann::detail::lexer_base<basic_json>;
+    using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
     static ::nlohmann::detail::parser<LexerType, basic_json, InputAdapterType> parser(

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3446,13 +3446,13 @@ struct numerizer;
 template<typename BasicJsonType, typename InputAdapterType>
 using basic_lexer = lexer<BasicJsonType, InputAdapterType, numerizer>;
 
-struct symbolifier;
+struct denumerizer;
 
-template<typename BasicJsonType, typename SymbolifierType>
+template<typename BasicJsonType, typename DenumerizerType>
 class serializer;
 
 template<typename BasicJsonType>
-using basic_serializer = serializer<BasicJsonType, symbolifier>;
+using basic_serializer = serializer<BasicJsonType, denumerizer>;
 }
 
 template<template<typename U, typename V, typename... Args> class ObjectType =
@@ -16495,7 +16495,7 @@ char* to_chars(char* first, const char* last, FloatType value)
 
 // #include <nlohmann/detail/value_t.hpp>
 
-// #include <nlohmann/detail/output/symbolifier.hpp>
+// #include <nlohmann/detail/output/denumerizer.hpp>
 
 
 #include <algorithm> // reverse, remove, fill, find, none_of
@@ -16518,7 +16518,7 @@ namespace nlohmann
 namespace detail
 {
 
-struct symbolifier
+struct denumerizer
 {   
     using number_buffer_t = std::array<char, 64>;
     
@@ -16760,7 +16760,7 @@ enum class error_handler_t
     ignore   ///< ignore invalid UTF-8 sequences
 };
 
-template<typename BasicJsonType, typename SymbolifierType = symbolifier>
+template<typename BasicJsonType, typename DenumerizerType = denumerizer>
 class serializer
 {
     using string_t = typename BasicJsonType::string_t;
@@ -16984,10 +16984,10 @@ class serializer
                         for (auto i = val.m_value.binary->cbegin();
                                 i != val.m_value.binary->cend() - 1; ++i)
                         {
-                            SymbolifierType::dump_integer(o, *i);
+                            DenumerizerType::dump_integer(o, *i);
                             o->write_characters(", ", 2);
                         }
-                        SymbolifierType::dump_integer(o, val.m_value.binary->back());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->back());
                     }
 
                     o->write_characters("],\n", 3);
@@ -16996,7 +16996,7 @@ class serializer
                     o->write_characters("\"subtype\": ", 11);
                     if (val.m_value.binary->has_subtype())
                     {
-                        SymbolifierType::dump_integer(o, val.m_value.binary->subtype());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->subtype());
                     }
                     else
                     {
@@ -17015,16 +17015,16 @@ class serializer
                         for (auto i = val.m_value.binary->cbegin();
                                 i != val.m_value.binary->cend() - 1; ++i)
                         {
-                            SymbolifierType::dump_integer(o, *i);
+                            DenumerizerType::dump_integer(o, *i);
                             o->write_character(',');
                         }
-                        SymbolifierType::dump_integer(o, val.m_value.binary->back());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->back());
                     }
 
                     o->write_characters("],\"subtype\":", 12);
                     if (val.m_value.binary->has_subtype())
                     {
-                        SymbolifierType::dump_integer(o, val.m_value.binary->subtype());
+                        DenumerizerType::dump_integer(o, val.m_value.binary->subtype());
                         o->write_character('}');
                     }
                     else
@@ -17050,19 +17050,19 @@ class serializer
 
             case value_t::number_integer:
             {
-                SymbolifierType::dump_integer(o, val.m_value.number_integer);
+                DenumerizerType::dump_integer(o, val.m_value.number_integer);
                 return;
             }
 
             case value_t::number_unsigned:
             {
-                SymbolifierType::dump_integer(o, val.m_value.number_unsigned);
+                DenumerizerType::dump_integer(o, val.m_value.number_unsigned);
                 return;
             }
 
             case value_t::number_float:
             {
-                SymbolifierType::dump_float(o, val.m_value.number_float);
+                DenumerizerType::dump_float(o, val.m_value.number_float);
                 return;
             }
 


### PR DESCRIPTION
Hello. This is a feature request:

**Changes**
The code that performs conversions between numbers and strings was moved into separate classes.

Originally, the code was inside the `lexer` and `serializer` classes. Now, the code lives inside new classes `numerizer` and `denumerizer` which are passed as template args to the former.

`numerizer` converts strings to numbers (strtof, strtoull, ...)
`denumerizer` converts numbers to strings (dump_integer, dump_float, ...)

**Reasoning**
- this enables customization of the number parsing/dumping behavior
- this enables custom numeric types to be used

To do this, users can replace or inherit from `numerizer` / `denumerizer`. After implementing the static functions to their liking, they pass their custom classes as template args

**Notes**
- In order to create an 'interface' for the classes, template arguments were added to `serializer` and `lexer`.
- Furthermore, two template arguments were added to `basic_json`: `LexerType` and `SerializerType`. (Should we create a config template class to avoid too many template args?)
- `number_buffer` and locale information is allocated on-demand rather than inside an object, which might impact performance


* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).