### PR TITLE
Allow disabling std::filesystem support

### DIFF
--- a/doc/mkdocs/docs/features/macros.md
+++ b/doc/mkdocs/docs/features/macros.md
@@ -38,6 +38,10 @@ Note the explanatory [`what()`](https://en.cppreference.com/w/cpp/error/exceptio
 
 When defined, headers `<cstdio>`, `<ios>`, `<iosfwd>`, `<istream>`, and `<ostream>` are not included and parse functions relying on these headers are excluded. This is relevant for environment where these I/O functions are disallowed for security reasons (e.g., Intel Software Guard Extensions (SGX)).
 
+## `JSON_NO_STD_FILESYSTEM`
+
+When defined, `<filesystem>` header is not included, even for C++17 compilers, and `std::filesystem::path` support is not available. This can be useful to disable automatically-detected `std::filesystem` support if its implementation in the standard library is suboptimal or even missing.
+
 ## `JSON_SKIP_UNSUPPORTED_COMPILER_CHECK`
 
 When defined, the library will not create a compile error when a known unsupported compiler is detected. This allows to use the library with compilers that do not fully support C++11 and may only work if unsupported features are not used.

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -19,7 +19,7 @@
 #include <nlohmann/detail/meta/type_traits.hpp>
 #include <nlohmann/detail/value_t.hpp>
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
     #include <filesystem>
 #endif
 
@@ -448,7 +448,7 @@ void from_json(const BasicJsonType& j, std::unordered_map<Key, Value, Hash, KeyE
     }
 }
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
 template<typename BasicJsonType>
 void from_json(const BasicJsonType& j, std::filesystem::path& p)
 {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -15,7 +15,7 @@
 #include <nlohmann/detail/meta/type_traits.hpp>
 #include <nlohmann/detail/value_t.hpp>
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
     #include <filesystem>
 #endif
 
@@ -391,7 +391,7 @@ void to_json(BasicJsonType& j, const T& t)
     to_json_tuple_impl(j, t, make_index_sequence<std::tuple_size<T>::value> {});
 }
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
 template<typename BasicJsonType>
 void to_json(BasicJsonType& j, const std::filesystem::path& p)
 {

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -37,6 +37,13 @@
     #define JSON_HAS_CPP_11
 #endif
 
+// Optimistically assume that all compilers providing C++17 support also
+// provide std::filesystem in their standard library. Realistically allow
+// overriding this because this is not the case in practice.
+#if defined(JSON_HAS_CPP_17) && !defined(JSON_NO_STD_FILESYSTEM)
+    #define JSON_HAS_STD_FILESYSTEM
+#endif
+
 // disable documentation warnings on clang
 #if defined(__clang__)
     #pragma clang diagnostic push

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2325,6 +2325,13 @@ using is_detected_convertible =
     #define JSON_HAS_CPP_11
 #endif
 
+// Optimistically assume that all compilers providing C++17 support also
+// provide std::filesystem in their standard library. Realistically allow
+// overriding this because this is not the case in practice.
+#if defined(JSON_HAS_CPP_17) && !defined(JSON_NO_STD_FILESYSTEM)
+    #define JSON_HAS_STD_FILESYSTEM
+#endif
+
 // disable documentation warnings on clang
 #if defined(__clang__)
     #pragma clang diagnostic push
@@ -3950,7 +3957,7 @@ T conditional_static_cast(U value)
 // #include <nlohmann/detail/value_t.hpp>
 
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
     #include <filesystem>
 #endif
 
@@ -4379,7 +4386,7 @@ void from_json(const BasicJsonType& j, std::unordered_map<Key, Value, Hash, KeyE
     }
 }
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
 template<typename BasicJsonType>
 void from_json(const BasicJsonType& j, std::filesystem::path& p)
 {
@@ -4626,7 +4633,7 @@ class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
 // #include <nlohmann/detail/value_t.hpp>
 
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
     #include <filesystem>
 #endif
 
@@ -5002,7 +5009,7 @@ void to_json(BasicJsonType& j, const T& t)
     to_json_tuple_impl(j, t, make_index_sequence<std::tuple_size<T>::value> {});
 }
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
 template<typename BasicJsonType>
 void to_json(BasicJsonType& j, const std::filesystem::path& p)
 {
@@ -17747,7 +17754,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -46,8 +46,10 @@ using ordered_json = nlohmann::ordered_json;
     #define JSON_HAS_CPP_17
 #endif
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
     #include <filesystem>
+#endif
+#ifdef JSON_HAS_CPP_17
     #include <variant>
 #endif
 
@@ -728,7 +730,7 @@ TEST_CASE("regression tests 2")
         CHECK(j == k);
     }
 
-#ifdef JSON_HAS_CPP_17
+#ifdef JSON_HAS_STD_FILESYSTEM
     SECTION("issue #3070 - Version 3.10.3 breaks backward-compatibility with 3.10.2 ")
     {
         std::filesystem::path text_path("/tmp/text.txt");


### PR DESCRIPTION
This can be useful when the compiler claims C++17 support, but standard
library std::filesystem implementation is unavailable (MinGW) or can't
be used because the current macOS target is too low to allow it (#3156).

See #3090.

---

I think it could be useful to disable this by default when macOS min version target is lower than 10.15 and will add a commit doing this if there are no objections.