### PR TITLE
Fix and update CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 19 * * 1'
+  workflow_dispatch:
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,7 @@ on:
       - master
       - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   xcode:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,7 @@ on:
       - master
       - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci_test_clang:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
       run: cd build ; ctest -j 10 -C Release --output-on-failure
 
   msvc2019:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         build_type: [Debug, Release]
@@ -85,7 +85,7 @@ jobs:
       run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
 
   msvc2019_latest:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
       run: cd build ; ctest -j 10 -C Release --output-on-failure
 
   clang:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         version: [11, 12]
@@ -146,7 +146,7 @@ jobs:
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure
 
   clang-cl-11:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         architecture: [Win32, x64]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,7 @@ on:
       - master
       - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   mingw:


### PR DESCRIPTION
Per GitHub's announcement [1] the windows-latest runner has migrated to Windows Server 2022 and ships with different tool versions. Specifically, it no longer includes MSVC 2019. Use windows-2019 instead.

The manual trigger `workflow_dispatch` has been added to all workflows allowing them to be manually triggered from the Actions tab (via the "Run Workflow" drop-down). This can be used to trigger a CI run on branches other than `develop`, `master`, or `release/*`, and by forks prior to creating a PR.

Add `topic/*` to the list of push triggers. Again, this is useful to run CI more easily during development. I've chosen a neutral name without a common prefix with other branches to not interfere with tab completion (e.g., `devel/` and `develop`).

<hr/>

[1] https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/
[2] https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#language-and-runtime