### PR TITLE
Fix ordered_map ctor with initializer_list (fixes #3343)

### DIFF
--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -34,7 +34,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
     template <class It>
     ordered_map(It first, It last, const Allocator& alloc = Allocator())
         : Container{first, last, alloc} {}
-    ordered_map(std::initializer_list<T> init, const Allocator& alloc = Allocator() )
+    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
         : Container{init, alloc} {}
 
     std::pair<iterator, bool> emplace(const key_type& key, T&& t)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -17070,7 +17070,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
     template <class It>
     ordered_map(It first, It last, const Allocator& alloc = Allocator())
         : Container{first, last, alloc} {}
-    ordered_map(std::initializer_list<T> init, const Allocator& alloc = Allocator() )
+    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
         : Container{init, alloc} {}
 
     std::pair<iterator, bool> emplace(const key_type& key, T&& t)

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -835,6 +835,18 @@ TEST_CASE("regression tests 2")
 
         CHECK(j.dump() == "[1,4]");
     }
+
+    SECTION("issue #3343 - json and ordered_json are not interchangable")
+    {
+        json::object_t jobj({ { "product", "one" } });
+        ordered_json::object_t ojobj({{"product", "one"}});
+
+        auto jit = jobj.begin();
+        auto ojit = ojobj.begin();
+
+        CHECK(jit->first == ojit->first);
+        CHECK(jit->second.get<std::string>() == ojit->second.get<std::string>());
+    }
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
One of the `ordered_map` constructors was incorrectly accepting a
`std::initializer_list<T>` instead of `std::initializer_list<value_type>`.

Add regression test.

Fixes #3343.