### PR TITLE
Refactor unit tests to use more convenient doctest assertion macros

### DIFF
--- a/test/src/unit-algorithms.cpp
+++ b/test/src/unit-algorithms.cpp
@@ -241,9 +241,7 @@ TEST_CASE("algorithms")
             SECTION("sorting an object")
             {
                 json j({{"one", 1}, {"two", 2}});
-                CHECK_THROWS_AS(std::sort(j.begin(), j.end()), json::invalid_iterator&);
-                CHECK_THROWS_WITH(std::sort(j.begin(), j.end()),
-                                  "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                CHECK_THROWS_WITH_AS(std::sort(j.begin(), j.end()), "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
             }
         }
 

--- a/test/src/unit-bson.cpp
+++ b/test/src/unit-bson.cpp
@@ -44,8 +44,7 @@ TEST_CASE("BSON")
         SECTION("null")
         {
             json j = nullptr;
-            CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-            CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is null");
+            CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is null", json::type_error&);
         }
 
         SECTION("boolean")
@@ -53,44 +52,38 @@ TEST_CASE("BSON")
             SECTION("true")
             {
                 json j = true;
-                CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-                CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is boolean");
+                CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is boolean", json::type_error&);
             }
 
             SECTION("false")
             {
                 json j = false;
-                CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-                CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is boolean");
+                CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is boolean", json::type_error&);
             }
         }
 
         SECTION("number")
         {
             json j = 42;
-            CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-            CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is number");
+            CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is number", json::type_error&);
         }
 
         SECTION("float")
         {
             json j = 4.2;
-            CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-            CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is number");
+            CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is number", json::type_error&);
         }
 
         SECTION("string")
         {
             json j = "not supported";
-            CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-            CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is string");
+            CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is string", json::type_error&);
         }
 
         SECTION("array")
         {
             json j = std::vector<int> {1, 2, 3, 4, 5, 6, 7};
-            CHECK_THROWS_AS(json::to_bson(j), json::type_error&);
-            CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is array");
+            CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.type_error.317] to serialize to BSON, top-level type must be object, but is array", json::type_error&);
         }
     }
 
@@ -100,11 +93,10 @@ TEST_CASE("BSON")
         {
             { std::string("en\0try", 6), true }
         };
-        CHECK_THROWS_AS(json::to_bson(j), json::out_of_range&);
 #if JSON_DIAGNOSTICS
-        CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.out_of_range.409] (/en) BSON key cannot contain code point U+0000 (at byte 2)");
+        CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.out_of_range.409] (/en) BSON key cannot contain code point U+0000 (at byte 2)", json::out_of_range&);
 #else
-        CHECK_THROWS_WITH(json::to_bson(j), "[json.exception.out_of_range.409] BSON key cannot contain code point U+0000 (at byte 2)");
+        CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.out_of_range.409] BSON key cannot contain code point U+0000 (at byte 2)", json::out_of_range&);
 #endif
     }
 
@@ -119,8 +111,7 @@ TEST_CASE("BSON")
             0x00, 0x00, 0x00, 0x80
         };
         json _;
-        CHECK_THROWS_AS(_ = json::from_bson(v), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_bson(v), "[json.exception.parse_error.112] parse error at byte 10: syntax error while parsing BSON string: string length must be at least 1, is -2147483648");
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(v), "[json.exception.parse_error.112] parse error at byte 10: syntax error while parsing BSON string: string length must be at least 1, is -2147483648", json::parse_error&);
     }
 
     SECTION("objects")
@@ -764,9 +755,7 @@ TEST_CASE("Incomplete BSON Input")
         };
 
         json _;
-        CHECK_THROWS_AS(_ = json::from_bson(incomplete_bson), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_bson(incomplete_bson),
-                          "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing BSON cstring: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(incomplete_bson), "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing BSON cstring: unexpected end of input", json::parse_error&);
 
         CHECK(json::from_bson(incomplete_bson, true, false).is_discarded());
 
@@ -783,9 +772,7 @@ TEST_CASE("Incomplete BSON Input")
         };
 
         json _;
-        CHECK_THROWS_AS(_ = json::from_bson(incomplete_bson), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_bson(incomplete_bson),
-                          "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing BSON cstring: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(incomplete_bson), "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing BSON cstring: unexpected end of input", json::parse_error&);
         CHECK(json::from_bson(incomplete_bson, true, false).is_discarded());
 
         SaxCountdown scp(0);
@@ -807,9 +794,7 @@ TEST_CASE("Incomplete BSON Input")
         };
 
         json _;
-        CHECK_THROWS_AS(_ = json::from_bson(incomplete_bson), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_bson(incomplete_bson),
-                          "[json.exception.parse_error.110] parse error at byte 28: syntax error while parsing BSON element list: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(incomplete_bson), "[json.exception.parse_error.110] parse error at byte 28: syntax error while parsing BSON element list: unexpected end of input", json::parse_error&);
         CHECK(json::from_bson(incomplete_bson, true, false).is_discarded());
 
         SaxCountdown scp(1);
@@ -824,9 +809,7 @@ TEST_CASE("Incomplete BSON Input")
         };
 
         json _;
-        CHECK_THROWS_AS(_ = json::from_bson(incomplete_bson), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_bson(incomplete_bson),
-                          "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing BSON number: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(incomplete_bson), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing BSON number: unexpected end of input", json::parse_error&);
         CHECK(json::from_bson(incomplete_bson, true, false).is_discarded());
 
         SaxCountdown scp(0);
@@ -872,8 +855,7 @@ TEST_CASE("Negative size of binary value")
         0x00 // end marker
     };
     json _;
-    CHECK_THROWS_AS(_ = json::from_bson(input), json::parse_error);
-    CHECK_THROWS_WITH(_ = json::from_bson(input), "[json.exception.parse_error.112] parse error at byte 15: syntax error while parsing BSON binary: byte array length cannot be negative, is -1");
+    CHECK_THROWS_WITH_AS(_ = json::from_bson(input), "[json.exception.parse_error.112] parse error at byte 15: syntax error while parsing BSON binary: byte array length cannot be negative, is -1", json::parse_error);
 }
 
 TEST_CASE("Unsupported BSON input")
@@ -887,9 +869,7 @@ TEST_CASE("Unsupported BSON input")
     };
 
     json _;
-    CHECK_THROWS_AS(_ = json::from_bson(bson), json::parse_error&);
-    CHECK_THROWS_WITH(_ = json::from_bson(bson),
-                      "[json.exception.parse_error.114] parse error at byte 5: Unsupported BSON record type 0xFF");
+    CHECK_THROWS_WITH_AS(_ = json::from_bson(bson), "[json.exception.parse_error.114] parse error at byte 5: Unsupported BSON record type 0xFF", json::parse_error&);
     CHECK(json::from_bson(bson, true, false).is_discarded());
 
     SaxCountdown scp(0);

--- a/test/src/unit-cbor.cpp
+++ b/test/src/unit-cbor.cpp
@@ -991,17 +991,13 @@ TEST_CASE("CBOR")
                     SECTION("no byte follows")
                     {
                         json _;
-                        CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xf9})), json::parse_error&);
-                        CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xf9})),
-                                          "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input");
+                        CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xf9})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
                         CHECK(json::from_cbor(std::vector<uint8_t>({0xf9}), true, false).is_discarded());
                     }
                     SECTION("only one byte follows")
                     {
                         json _;
-                        CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xf9, 0x7c})), json::parse_error&);
-                        CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xf9, 0x7c})),
-                                          "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input");
+                        CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xf9, 0x7c})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
                         CHECK(json::from_cbor(std::vector<uint8_t>({0xf9, 0x7c}), true, false).is_discarded());
                     }
                 }
@@ -1671,97 +1667,40 @@ TEST_CASE("CBOR")
         SECTION("empty byte vector")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>()), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>()),
-                              "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing CBOR value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>()), "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
             CHECK(json::from_cbor(std::vector<uint8_t>(), true, false).is_discarded());
         }
 
         SECTION("too short byte vector")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x18})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x19})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x19, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x62})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x62, 0x60})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x7F})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x7F, 0x60})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x82, 0x01})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x9F, 0x01})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0x61, 0xF5})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xA1, 0x61, 0X61})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0X61})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x5F})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x5F, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x41})), json::parse_error&);
-
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x18})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x19})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x19, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1a})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing CBOR number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x62})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x62, 0x60})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x7F})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x7F, 0x60})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x82, 0x01})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR value: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x9F, 0x01})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR value: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0x61, 0xF5})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xA1, 0x61, 0x61})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR value: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0x61})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR value: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x5F})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR binary: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x5F, 0x00})),
-                              "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing CBOR binary: expected length specification (0x40-0x5B) or indefinite binary array type (0x5F); last byte: 0x00");
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x41})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR binary: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x18})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x19})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x19, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1a, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x62})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x62, 0x60})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x7F})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x7F, 0x60})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x82, 0x01})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x9F, 0x01})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0x61, 0xF5})), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xA1, 0x61, 0X61})), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0X61})), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x5F})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR binary: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x5F, 0x00})), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing CBOR binary: expected length specification (0x40-0x5B) or indefinite binary array type (0x5F); last byte: 0x00", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x41})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR binary: unexpected end of input", json::parse_error&);
 
             CHECK(json::from_cbor(std::vector<uint8_t>({0x18}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x19}), true, false).is_discarded());
@@ -1797,14 +1736,10 @@ TEST_CASE("CBOR")
             SECTION("concrete examples")
             {
                 json _;
-                CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1c})), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0x1c})),
-                                  "[json.exception.parse_error.112] parse error at byte 1: syntax error while parsing CBOR value: invalid byte: 0x1C");
+                CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1c})), "[json.exception.parse_error.112] parse error at byte 1: syntax error while parsing CBOR value: invalid byte: 0x1C", json::parse_error&);
                 CHECK(json::from_cbor(std::vector<uint8_t>({0x1c}), true, false).is_discarded());
 
-                CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xf8})), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xf8})),
-                                  "[json.exception.parse_error.112] parse error at byte 1: syntax error while parsing CBOR value: invalid byte: 0xF8");
+                CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xf8})), "[json.exception.parse_error.112] parse error at byte 1: syntax error while parsing CBOR value: invalid byte: 0xF8", json::parse_error&);
                 CHECK(json::from_cbor(std::vector<uint8_t>({0xf8}), true, false).is_discarded());
             }
 
@@ -1858,9 +1793,7 @@ TEST_CASE("CBOR")
         SECTION("invalid string in map")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_cbor(std::vector<uint8_t>({0xa1, 0xff, 0x01})), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_cbor(std::vector<uint8_t>({0xa1, 0xff, 0x01})),
-                              "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0xFF");
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0xa1, 0xff, 0x01})), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0xFF", json::parse_error&);
             CHECK(json::from_cbor(std::vector<uint8_t>({0xa1, 0xff, 0x01}), true, false).is_discarded());
         }
 
@@ -1877,9 +1810,7 @@ TEST_CASE("CBOR")
             SECTION("strict mode")
             {
                 json _;
-                CHECK_THROWS_AS(_ = json::from_cbor(vec), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_cbor(vec),
-                                  "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR value: expected end of input; last byte: 0xF6");
+                CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR value: expected end of input; last byte: 0xF6", json::parse_error&);
                 CHECK(json::from_cbor(vec, true, false).is_discarded());
             }
         }
@@ -2746,8 +2677,7 @@ TEST_CASE("Tagged values")
 
         // parse error when parsing tagged value
         json _;
-        CHECK_THROWS_AS(_ = json::from_cbor(vec), json::parse_error);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec), "[json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: invalid byte: 0xD8");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec), "[json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: invalid byte: 0xD8", json::parse_error);
 
         // binary without subtype when tags are ignored
         json jb = json::from_cbor(vec, true, true, json::cbor_tag_handler_t::ignore);

--- a/test/src/unit-class_const_iterator.cpp
+++ b/test/src/unit-class_const_iterator.cpp
@@ -148,8 +148,7 @@ TEST_CASE("const_iterator class")
             {
                 json j(json::value_t::null);
                 json::const_iterator it = j.cbegin();
-                CHECK_THROWS_AS(*it, json::invalid_iterator&);
-                CHECK_THROWS_WITH(*it, "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(*it, "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("number")
@@ -158,8 +157,7 @@ TEST_CASE("const_iterator class")
                 json::const_iterator it = j.cbegin();
                 CHECK(*it == json(17));
                 it = j.cend();
-                CHECK_THROWS_AS(*it, json::invalid_iterator&);
-                CHECK_THROWS_WITH(*it, "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(*it, "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("object")
@@ -183,8 +181,7 @@ TEST_CASE("const_iterator class")
             {
                 json j(json::value_t::null);
                 json::const_iterator it = j.cbegin();
-                CHECK_THROWS_AS(std::string(it->type_name()), json::invalid_iterator&);
-                CHECK_THROWS_WITH(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("number")
@@ -193,8 +190,7 @@ TEST_CASE("const_iterator class")
                 json::const_iterator it = j.cbegin();
                 CHECK(std::string(it->type_name()) == "number");
                 it = j.cend();
-                CHECK_THROWS_AS(std::string(it->type_name()), json::invalid_iterator&);
-                CHECK_THROWS_WITH(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("object")

--- a/test/src/unit-class_iterator.cpp
+++ b/test/src/unit-class_iterator.cpp
@@ -138,8 +138,7 @@ TEST_CASE("iterator class")
             {
                 json j(json::value_t::null);
                 json::iterator it = j.begin();
-                CHECK_THROWS_AS(*it, json::invalid_iterator&);
-                CHECK_THROWS_WITH(*it, "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(*it, "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("number")
@@ -148,8 +147,7 @@ TEST_CASE("iterator class")
                 json::iterator it = j.begin();
                 CHECK(*it == json(17));
                 it = j.end();
-                CHECK_THROWS_AS(*it, json::invalid_iterator&);
-                CHECK_THROWS_WITH(*it, "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(*it, "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("object")
@@ -173,8 +171,7 @@ TEST_CASE("iterator class")
             {
                 json j(json::value_t::null);
                 json::iterator it = j.begin();
-                CHECK_THROWS_AS(std::string(it->type_name()), json::invalid_iterator&);
-                CHECK_THROWS_WITH(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("number")
@@ -183,8 +180,7 @@ TEST_CASE("iterator class")
                 json::iterator it = j.begin();
                 CHECK(std::string(it->type_name()) == "number");
                 it = j.end();
-                CHECK_THROWS_AS(std::string(it->type_name()), json::invalid_iterator&);
-                CHECK_THROWS_WITH(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(std::string(it->type_name()), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
 
             SECTION("object")

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -610,39 +610,39 @@ TEST_CASE("parser class")
                 CHECK_THROWS_AS(parser_helper("+0"), json::parse_error&);
 
                 CHECK_THROWS_WITH_AS(parser_helper("01"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected number literal; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected number literal; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-01"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - unexpected number literal; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - unexpected number literal; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("--1"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("1."),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("1E"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("1E-"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '1E-'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '1E-'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("1.E1"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.E'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.E'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-1E"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-1E'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-1E'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0E#"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-0E#'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-0E#'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0E-#"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0E-#'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0E-#'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0#"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: '-0#'; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: '-0#'; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0.0:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - unexpected ':'; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - unexpected ':'; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0.0Z"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: '-0.0Z'; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: '-0.0Z'; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0E123:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - unexpected ':'; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - unexpected ':'; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0e0-:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'; expected end of input", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0e-:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0e-:'", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0e-:'", json::parse_error&);
                 CHECK_THROWS_WITH_AS(parser_helper("-0f"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: '-0f'; expected end of input", json::parse_error&);
+                                     "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: '-0f'; expected end of input", json::parse_error&);
             }
         }
     }
@@ -913,119 +913,119 @@ TEST_CASE("parser class")
     {
         // unexpected end of number
         CHECK_THROWS_WITH_AS(parser_helper("0."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("-"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("--"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("-0."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after '.'; last read: '-0.'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after '.'; last read: '-0.'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("-."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-.'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-.'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("-:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("0.:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.:'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.:'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("e."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'e'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'e'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("1e."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e.'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e.'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("1e/"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e/'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e/'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("1e:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e:'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e:'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("1E."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E.'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E.'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("1E/"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E/'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E/'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("1E:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E:'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E:'", json::parse_error&);
 
         // unexpected end of null
         CHECK_THROWS_WITH_AS(parser_helper("n"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'n'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'n'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("nu"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'nu'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'nu'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("nul"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nul'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nul'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("nulk"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulk'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulk'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("nulm"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulm'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulm'", json::parse_error&);
 
         // unexpected end of true
         CHECK_THROWS_WITH_AS(parser_helper("t"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 't'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 't'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("tr"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'tr'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'tr'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("tru"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'tru'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'tru'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("trud"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'trud'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'trud'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("truf"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'truf'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'truf'", json::parse_error&);
 
         // unexpected end of false
         CHECK_THROWS_WITH_AS(parser_helper("f"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'f'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'f'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("fa"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'fa'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'fa'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("fal"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'fal'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'fal'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("fals"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'fals'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'fals'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("falsd"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsd'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsd'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("falsf"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsf'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsf'", json::parse_error&);
 
         // missing/unexpected end of array
         CHECK_THROWS_WITH_AS(parser_helper("["),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("[1"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("[1,"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("[1,]"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("]"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal", json::parse_error&);
 
         // missing/unexpected end of object
         CHECK_THROWS_WITH_AS(parser_helper("{"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing object key - unexpected end of input; expected string literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing object key - unexpected end of input; expected string literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("{\"foo\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing object separator - unexpected end of input; expected ':'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing object separator - unexpected end of input; expected ':'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("{\"foo\":"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("{\"foo\":}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("{\"foo\":1,}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 10: syntax error while parsing object key - unexpected '}'; expected string literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 10: syntax error while parsing object key - unexpected '}'; expected string literal", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal", json::parse_error&);
 
         // missing/unexpected end of string
         CHECK_THROWS_WITH_AS(parser_helper("\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: missing closing quote; last read: '\"'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: missing closing quote; last read: '\"'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: missing closing quote; last read: '\"\\\"'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: missing closing quote; last read: '\"\\\"'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u\"'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u\"'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u0\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0\"'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0\"'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u01\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01\"'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01\"'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u012\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012\"'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012\"'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u0"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u01"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01'", json::parse_error&);
         CHECK_THROWS_WITH_AS(parser_helper("\"\\u012"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012'", json::parse_error&);
 
         // invalid escapes
         for (int c = 1; c < 128; ++c)
@@ -1177,11 +1177,11 @@ TEST_CASE("parser class")
         CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\""), "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\"'", json::parse_error&);
         // invalid surrogate pair
         CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\\uD80C\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uD80C'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uD80C'", json::parse_error&);
         CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\\u0000\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\u0000'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\u0000'", json::parse_error&);
         CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\\uFFFF\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uFFFF'", json::parse_error&);
+                             "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uFFFF'", json::parse_error&);
     }
 
     SECTION("parse errors (accept)")

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -377,88 +377,48 @@ TEST_CASE("parser class")
             SECTION("errors")
             {
                 // error: tab in string
-                CHECK_THROWS_AS(parser_helper("\"\t\""), json::parse_error&);
-                CHECK_THROWS_WITH(parser_helper("\"\t\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t; last read: '\"<U+0009>'");
+                CHECK_THROWS_WITH_AS(parser_helper("\"\t\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t; last read: '\"<U+0009>'", json::parse_error&);
                 // error: newline in string
-                CHECK_THROWS_AS(parser_helper("\"\n\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\r\""), json::parse_error&);
-                CHECK_THROWS_WITH(parser_helper("\"\n\""),
-                                  "[json.exception.parse_error.101] parse error at line 2, column 0: syntax error while parsing value - invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n; last read: '\"<U+000A>'");
-                CHECK_THROWS_WITH(parser_helper("\"\r\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r; last read: '\"<U+000D>'");
+                CHECK_THROWS_WITH_AS(parser_helper("\"\n\""), "[json.exception.parse_error.101] parse error at line 2, column 0: syntax error while parsing value - invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n; last read: '\"<U+000A>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\r\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r; last read: '\"<U+000D>'", json::parse_error&);
                 // error: backspace in string
-                CHECK_THROWS_AS(parser_helper("\"\b\""), json::parse_error&);
-                CHECK_THROWS_WITH(parser_helper("\"\b\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b; last read: '\"<U+0008>'");
+                CHECK_THROWS_WITH_AS(parser_helper("\"\b\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b; last read: '\"<U+0008>'", json::parse_error&);
                 // improve code coverage
                 CHECK_THROWS_AS(parser_helper("\uFF01"), json::parse_error&);
                 CHECK_THROWS_AS(parser_helper("[-4:1,]"), json::parse_error&);
                 // unescaped control characters
-                CHECK_THROWS_AS(parser_helper("\"\x00\""), json::parse_error&); // NOLINT(bugprone-string-literal-with-embedded-nul)
-                CHECK_THROWS_AS(parser_helper("\"\x01\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x02\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x03\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x04\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x05\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x06\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x07\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x08\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x09\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x0a\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x0b\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x0c\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x0d\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x0e\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x0f\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x10\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x11\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x12\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x13\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x14\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x15\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x16\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x17\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x18\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x19\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x1a\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x1b\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x1c\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x1d\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x1e\""), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("\"\x1f\""), json::parse_error&);
-                CHECK_THROWS_WITH(parser_helper("\"\x00\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: missing closing quote; last read: '\"'"); // NOLINT(bugprone-string-literal-with-embedded-nul)
-                CHECK_THROWS_WITH(parser_helper("\"\x01\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0001 (SOH) must be escaped to \\u0001; last read: '\"<U+0001>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x02\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0002 (STX) must be escaped to \\u0002; last read: '\"<U+0002>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x03\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0003 (ETX) must be escaped to \\u0003; last read: '\"<U+0003>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x04\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0004 (EOT) must be escaped to \\u0004; last read: '\"<U+0004>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x05\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0005 (ENQ) must be escaped to \\u0005; last read: '\"<U+0005>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x06\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0006 (ACK) must be escaped to \\u0006; last read: '\"<U+0006>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x07\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0007 (BEL) must be escaped to \\u0007; last read: '\"<U+0007>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x08\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b; last read: '\"<U+0008>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x09\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t; last read: '\"<U+0009>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x0a\""), "[json.exception.parse_error.101] parse error at line 2, column 0: syntax error while parsing value - invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n; last read: '\"<U+000A>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x0b\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000B (VT) must be escaped to \\u000B; last read: '\"<U+000B>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x0c\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000C (FF) must be escaped to \\u000C or \\f; last read: '\"<U+000C>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x0d\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r; last read: '\"<U+000D>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x0e\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000E (SO) must be escaped to \\u000E; last read: '\"<U+000E>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x0f\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000F (SI) must be escaped to \\u000F; last read: '\"<U+000F>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x10\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0010 (DLE) must be escaped to \\u0010; last read: '\"<U+0010>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x11\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0011 (DC1) must be escaped to \\u0011; last read: '\"<U+0011>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x12\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0012 (DC2) must be escaped to \\u0012; last read: '\"<U+0012>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x13\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0013 (DC3) must be escaped to \\u0013; last read: '\"<U+0013>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x14\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0014 (DC4) must be escaped to \\u0014; last read: '\"<U+0014>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x15\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0015 (NAK) must be escaped to \\u0015; last read: '\"<U+0015>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x16\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0016 (SYN) must be escaped to \\u0016; last read: '\"<U+0016>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x17\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0017 (ETB) must be escaped to \\u0017; last read: '\"<U+0017>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x18\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0018 (CAN) must be escaped to \\u0018; last read: '\"<U+0018>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x19\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0019 (EM) must be escaped to \\u0019; last read: '\"<U+0019>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x1a\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001A (SUB) must be escaped to \\u001A; last read: '\"<U+001A>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x1b\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001B (ESC) must be escaped to \\u001B; last read: '\"<U+001B>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x1c\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001C (FS) must be escaped to \\u001C; last read: '\"<U+001C>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x1d\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001D (GS) must be escaped to \\u001D; last read: '\"<U+001D>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x1e\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001E (RS) must be escaped to \\u001E; last read: '\"<U+001E>'");
-                CHECK_THROWS_WITH(parser_helper("\"\x1f\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001F (US) must be escaped to \\u001F; last read: '\"<U+001F>'");
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x00\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: missing closing quote; last read: '\"'", json::parse_error&); // NOLINT(bugprone-string-literal-with-embedded-nul)
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x01\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0001 (SOH) must be escaped to \\u0001; last read: '\"<U+0001>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x02\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0002 (STX) must be escaped to \\u0002; last read: '\"<U+0002>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x03\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0003 (ETX) must be escaped to \\u0003; last read: '\"<U+0003>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x04\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0004 (EOT) must be escaped to \\u0004; last read: '\"<U+0004>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x05\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0005 (ENQ) must be escaped to \\u0005; last read: '\"<U+0005>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x06\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0006 (ACK) must be escaped to \\u0006; last read: '\"<U+0006>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x07\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0007 (BEL) must be escaped to \\u0007; last read: '\"<U+0007>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x08\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b; last read: '\"<U+0008>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x09\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t; last read: '\"<U+0009>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x0a\""), "[json.exception.parse_error.101] parse error at line 2, column 0: syntax error while parsing value - invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n; last read: '\"<U+000A>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x0b\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000B (VT) must be escaped to \\u000B; last read: '\"<U+000B>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x0c\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000C (FF) must be escaped to \\u000C or \\f; last read: '\"<U+000C>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x0d\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r; last read: '\"<U+000D>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x0e\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000E (SO) must be escaped to \\u000E; last read: '\"<U+000E>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x0f\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+000F (SI) must be escaped to \\u000F; last read: '\"<U+000F>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x10\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0010 (DLE) must be escaped to \\u0010; last read: '\"<U+0010>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x11\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0011 (DC1) must be escaped to \\u0011; last read: '\"<U+0011>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x12\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0012 (DC2) must be escaped to \\u0012; last read: '\"<U+0012>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x13\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0013 (DC3) must be escaped to \\u0013; last read: '\"<U+0013>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x14\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0014 (DC4) must be escaped to \\u0014; last read: '\"<U+0014>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x15\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0015 (NAK) must be escaped to \\u0015; last read: '\"<U+0015>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x16\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0016 (SYN) must be escaped to \\u0016; last read: '\"<U+0016>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x17\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0017 (ETB) must be escaped to \\u0017; last read: '\"<U+0017>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x18\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0018 (CAN) must be escaped to \\u0018; last read: '\"<U+0018>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x19\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0019 (EM) must be escaped to \\u0019; last read: '\"<U+0019>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x1a\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001A (SUB) must be escaped to \\u001A; last read: '\"<U+001A>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x1b\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001B (ESC) must be escaped to \\u001B; last read: '\"<U+001B>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x1c\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001C (FS) must be escaped to \\u001C; last read: '\"<U+001C>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x1d\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001D (GS) must be escaped to \\u001D; last read: '\"<U+001D>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x1e\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001E (RS) must be escaped to \\u001E; last read: '\"<U+001E>'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("\"\x1f\""), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+001F (US) must be escaped to \\u001F; last read: '\"<U+001F>'", json::parse_error&);
 
                 SECTION("additional test for null byte")
                 {
@@ -469,8 +429,7 @@ TEST_CASE("parser class")
                     std::string s = "\"1\"";
                     s[1] = '\0';
                     json _;
-                    CHECK_THROWS_AS(_ = json::parse(s.begin(), s.end()), json::parse_error&);
-                    CHECK_THROWS_WITH(_ = json::parse(s.begin(), s.end()), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0000 (NUL) must be escaped to \\u0000; last read: '\"<U+0000>'");
+                    CHECK_THROWS_WITH_AS(_ = json::parse(s.begin(), s.end()), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: control character U+0000 (NUL) must be escaped to \\u0000; last read: '\"<U+0000>'", json::parse_error&);
                 }
             }
 
@@ -641,69 +600,49 @@ TEST_CASE("parser class")
             SECTION("overflow")
             {
                 // overflows during parsing yield an exception
-                CHECK_THROWS_AS(parser_helper("1.18973e+4932").empty(), json::out_of_range&);
-                CHECK_THROWS_WITH(parser_helper("1.18973e+4932").empty(),
-                                  "[json.exception.out_of_range.406] number overflow parsing '1.18973e+4932'");
+                CHECK_THROWS_WITH_AS(parser_helper("1.18973e+4932").empty(), "[json.exception.out_of_range.406] number overflow parsing '1.18973e+4932'", json::out_of_range&);
             }
 
             SECTION("invalid numbers")
             {
-                CHECK_THROWS_AS(parser_helper("01"),      json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-01"),     json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("--1"),     json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("1."),      json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("1E"),      json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("1E-"),     json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("1.E1"),    json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-1E"),     json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0E#"),    json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0E-#"),   json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0#"),     json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0.0:"),   json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0.0Z"),   json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0E123:"), json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0e0-:"),  json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0e-:"),   json::parse_error&);
-                CHECK_THROWS_AS(parser_helper("-0f"),     json::parse_error&);
-
                 // numbers must not begin with "+"
                 CHECK_THROWS_AS(parser_helper("+1"), json::parse_error&);
                 CHECK_THROWS_AS(parser_helper("+0"), json::parse_error&);
 
-                CHECK_THROWS_WITH(parser_helper("01"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected number literal; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("-01"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - unexpected number literal; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("--1"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'");
-                CHECK_THROWS_WITH(parser_helper("1."),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.'");
-                CHECK_THROWS_WITH(parser_helper("1E"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E'");
-                CHECK_THROWS_WITH(parser_helper("1E-"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '1E-'");
-                CHECK_THROWS_WITH(parser_helper("1.E1"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.E'");
-                CHECK_THROWS_WITH(parser_helper("-1E"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-1E'");
-                CHECK_THROWS_WITH(parser_helper("-0E#"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-0E#'");
-                CHECK_THROWS_WITH(parser_helper("-0E-#"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0E-#'");
-                CHECK_THROWS_WITH(parser_helper("-0#"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: '-0#'; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("-0.0:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - unexpected ':'; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("-0.0Z"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: '-0.0Z'; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("-0E123:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - unexpected ':'; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("-0e0-:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'; expected end of input");
-                CHECK_THROWS_WITH(parser_helper("-0e-:"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0e-:'");
-                CHECK_THROWS_WITH(parser_helper("-0f"),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: '-0f'; expected end of input");
+                CHECK_THROWS_WITH_AS(parser_helper("01"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected number literal; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-01"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - unexpected number literal; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("--1"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("1."),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("1E"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("1E-"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '1E-'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("1.E1"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '1.E'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-1E"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-1E'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0E#"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '-0E#'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0E-#"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0E-#'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0#"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: '-0#'; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0.0:"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - unexpected ':'; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0.0Z"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: '-0.0Z'; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0E123:"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - unexpected ':'; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0e0-:"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'; expected end of input", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0e-:"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid number; expected digit after exponent sign; last read: '-0e-:'", json::parse_error&);
+                CHECK_THROWS_WITH_AS(parser_helper("-0f"),
+                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: '-0f'; expected end of input", json::parse_error&);
             }
         }
     }
@@ -973,171 +912,120 @@ TEST_CASE("parser class")
     SECTION("parse errors")
     {
         // unexpected end of number
-        CHECK_THROWS_AS(parser_helper("0."),  json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("-"),   json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("--"),  json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("-0."), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("-."),  json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("-:"),  json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("0.:"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("e."),  json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("1e."), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("1e/"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("1e:"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("1E."), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("1E/"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("1E:"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("0."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.'");
-        CHECK_THROWS_WITH(parser_helper("-"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-'");
-        CHECK_THROWS_WITH(parser_helper("--"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'");
-        CHECK_THROWS_WITH(parser_helper("-0."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after '.'; last read: '-0.'");
-        CHECK_THROWS_WITH(parser_helper("-."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-.'");
-        CHECK_THROWS_WITH(parser_helper("-:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'");
-        CHECK_THROWS_WITH(parser_helper("0.:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.:'");
-        CHECK_THROWS_WITH(parser_helper("e."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'e'");
-        CHECK_THROWS_WITH(parser_helper("1e."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e.'");
-        CHECK_THROWS_WITH(parser_helper("1e/"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e/'");
-        CHECK_THROWS_WITH(parser_helper("1e:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e:'");
-        CHECK_THROWS_WITH(parser_helper("1E."),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E.'");
-        CHECK_THROWS_WITH(parser_helper("1E/"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E/'");
-        CHECK_THROWS_WITH(parser_helper("1E:"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E:'");
+        CHECK_THROWS_WITH_AS(parser_helper("0."),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("-"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("--"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '--'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("-0."),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid number; expected digit after '.'; last read: '-0.'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("-."),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-.'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("-:"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid number; expected digit after '-'; last read: '-:'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("0.:"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected digit after '.'; last read: '0.:'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("e."),
+                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'e'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("1e."),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e.'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("1e/"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e/'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("1e:"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1e:'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("1E."),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E.'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("1E/"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E/'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("1E:"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid number; expected '+', '-', or digit after exponent; last read: '1E:'", json::parse_error&);
 
         // unexpected end of null
-        CHECK_THROWS_AS(parser_helper("n"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("nu"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("nul"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("nulk"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("nulm"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("n"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'n'");
-        CHECK_THROWS_WITH(parser_helper("nu"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'nu'");
-        CHECK_THROWS_WITH(parser_helper("nul"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nul'");
-        CHECK_THROWS_WITH(parser_helper("nulk"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulk'");
-        CHECK_THROWS_WITH(parser_helper("nulm"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulm'");
+        CHECK_THROWS_WITH_AS(parser_helper("n"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'n'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("nu"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'nu'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("nul"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nul'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("nulk"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulk'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("nulm"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'nulm'", json::parse_error&);
 
         // unexpected end of true
-        CHECK_THROWS_AS(parser_helper("t"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("tr"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("tru"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("trud"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("truf"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("t"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 't'");
-        CHECK_THROWS_WITH(parser_helper("tr"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'tr'");
-        CHECK_THROWS_WITH(parser_helper("tru"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'tru'");
-        CHECK_THROWS_WITH(parser_helper("trud"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'trud'");
-        CHECK_THROWS_WITH(parser_helper("truf"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'truf'");
+        CHECK_THROWS_WITH_AS(parser_helper("t"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 't'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("tr"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'tr'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("tru"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'tru'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("trud"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'trud'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("truf"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'truf'", json::parse_error&);
 
         // unexpected end of false
-        CHECK_THROWS_AS(parser_helper("f"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("fa"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("fal"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("fals"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("falsd"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("falsf"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("f"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'f'");
-        CHECK_THROWS_WITH(parser_helper("fa"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'fa'");
-        CHECK_THROWS_WITH(parser_helper("fal"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'fal'");
-        CHECK_THROWS_WITH(parser_helper("fals"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'fals'");
-        CHECK_THROWS_WITH(parser_helper("falsd"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsd'");
-        CHECK_THROWS_WITH(parser_helper("falsf"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsf'");
+        CHECK_THROWS_WITH_AS(parser_helper("f"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid literal; last read: 'f'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("fa"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid literal; last read: 'fa'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("fal"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid literal; last read: 'fal'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("fals"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'fals'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("falsd"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsd'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("falsf"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'falsf'", json::parse_error&);
 
         // missing/unexpected end of array
-        CHECK_THROWS_AS(parser_helper("["), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("[1"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("[1,"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("[1,]"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("]"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("["),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(parser_helper("[1"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing array - unexpected end of input; expected ']'");
-        CHECK_THROWS_WITH(parser_helper("[1,"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(parser_helper("[1,]"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(parser_helper("]"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal");
+        CHECK_THROWS_WITH_AS(parser_helper("["),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("[1"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("[1,"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("[1,]"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("]"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal", json::parse_error&);
 
         // missing/unexpected end of object
-        CHECK_THROWS_AS(parser_helper("{"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("{\"foo\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("{\"foo\":"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("{\"foo\":}"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("{\"foo\":1,}"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("}"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("{"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing object key - unexpected end of input; expected string literal");
-        CHECK_THROWS_WITH(parser_helper("{\"foo\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing object separator - unexpected end of input; expected ':'");
-        CHECK_THROWS_WITH(parser_helper("{\"foo\":"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(parser_helper("{\"foo\":}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal");
-        CHECK_THROWS_WITH(parser_helper("{\"foo\":1,}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 10: syntax error while parsing object key - unexpected '}'; expected string literal");
-        CHECK_THROWS_WITH(parser_helper("}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal");
+        CHECK_THROWS_WITH_AS(parser_helper("{"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing object key - unexpected end of input; expected string literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("{\"foo\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing object separator - unexpected end of input; expected ':'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("{\"foo\":"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("{\"foo\":}"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("{\"foo\":1,}"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 10: syntax error while parsing object key - unexpected '}'; expected string literal", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("}"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected '}'; expected '[', '{', or a literal", json::parse_error&);
 
         // missing/unexpected end of string
-        CHECK_THROWS_AS(parser_helper("\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u0\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u01\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u012\""), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u0"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u01"), json::parse_error&);
-        CHECK_THROWS_AS(parser_helper("\"\\u012"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: missing closing quote; last read: '\"'");
-        CHECK_THROWS_WITH(parser_helper("\"\\\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: missing closing quote; last read: '\"\\\"'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u\"'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u0\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0\"'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u01\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01\"'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u012\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012\"'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u0"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u01"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01'");
-        CHECK_THROWS_WITH(parser_helper("\"\\u012"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012'");
+        CHECK_THROWS_WITH_AS(parser_helper("\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: missing closing quote; last read: '\"'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: missing closing quote; last read: '\"\\\"'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u\"'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u0\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0\"'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u01\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01\"'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u012\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012\"'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u0"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u0'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u01"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 6: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u01'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(parser_helper("\"\\u012"),
+                          "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\u012'", json::parse_error&);
 
         // invalid escapes
         for (int c = 1; c < 128; ++c)
@@ -1286,19 +1174,14 @@ TEST_CASE("parser class")
         json _;
 
         // missing part of a surrogate pair
-        CHECK_THROWS_AS(_ = json::parse("\"\\uD80C\""), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::parse("\"\\uD80C\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\"'");
+        CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\""), "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\"'", json::parse_error&);
         // invalid surrogate pair
-        CHECK_THROWS_AS(_ = json::parse("\"\\uD80C\\uD80C\""), json::parse_error&);
-        CHECK_THROWS_AS(_ = json::parse("\"\\uD80C\\u0000\""), json::parse_error&);
-        CHECK_THROWS_AS(_ = json::parse("\"\\uD80C\\uFFFF\""), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::parse("\"\\uD80C\\uD80C\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uD80C'");
-        CHECK_THROWS_WITH(_ = json::parse("\"\\uD80C\\u0000\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\u0000'");
-        CHECK_THROWS_WITH(_ = json::parse("\"\\uD80C\\uFFFF\""),
-                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uFFFF'");
+        CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\\uD80C\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uD80C'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\\u0000\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\u0000'", json::parse_error&);
+        CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD80C\\uFFFF\""),
+                          "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD80C\\uFFFF'", json::parse_error&);
     }
 
     SECTION("parse errors (accept)")
@@ -1490,13 +1373,9 @@ TEST_CASE("parser class")
     SECTION("tests found by mutate++")
     {
         // test case to make sure no comma precedes the first key
-        CHECK_THROWS_AS(parser_helper("{,\"key\": false}"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("{,\"key\": false}"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing object key - unexpected ','; expected string literal");
+        CHECK_THROWS_WITH_AS(parser_helper("{,\"key\": false}"), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing object key - unexpected ','; expected string literal", json::parse_error&);
         // test case to make sure an object is properly closed
-        CHECK_THROWS_AS(parser_helper("[{\"key\": false true]"), json::parse_error&);
-        CHECK_THROWS_WITH(parser_helper("[{\"key\": false true]"),
-                          "[json.exception.parse_error.101] parse error at line 1, column 19: syntax error while parsing object - unexpected true literal; expected '}'");
+        CHECK_THROWS_WITH_AS(parser_helper("[{\"key\": false true]"), "[json.exception.parse_error.101] parse error at line 1, column 19: syntax error while parsing object - unexpected true literal; expected '}'", json::parse_error&);
 
         // test case to make sure the callback is properly evaluated after reading a key
         {
@@ -1740,13 +1619,9 @@ TEST_CASE("parser class")
             CHECK(json::parse("{\"foo\": true:", cb, false).is_discarded());
 
             json _;
-            CHECK_THROWS_AS(_ = json::parse("{\"foo\": true:", cb), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse("{\"foo\": true:", cb),
-                              "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing object - unexpected ':'; expected '}'");
+            CHECK_THROWS_WITH_AS(_ = json::parse("{\"foo\": true:", cb), "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing object - unexpected ':'; expected '}'", json::parse_error&);
 
-            CHECK_THROWS_AS(_ = json::parse("1.18973e+4932", cb), json::out_of_range&);
-            CHECK_THROWS_WITH(_ = json::parse("1.18973e+4932", cb),
-                              "[json.exception.out_of_range.406] number overflow parsing '1.18973e+4932'");
+            CHECK_THROWS_WITH_AS(_ = json::parse("1.18973e+4932", cb), "[json.exception.out_of_range.406] number overflow parsing '1.18973e+4932'", json::out_of_range&);
         }
 
         SECTION("SAX parser")

--- a/test/src/unit-class_parser.cpp
+++ b/test/src/unit-class_parser.cpp
@@ -649,6 +649,7 @@ TEST_CASE("parser class")
             SECTION("invalid numbers")
             {
                 CHECK_THROWS_AS(parser_helper("01"),      json::parse_error&);
+                CHECK_THROWS_AS(parser_helper("-01"),     json::parse_error&);
                 CHECK_THROWS_AS(parser_helper("--1"),     json::parse_error&);
                 CHECK_THROWS_AS(parser_helper("1."),      json::parse_error&);
                 CHECK_THROWS_AS(parser_helper("1E"),      json::parse_error&);

--- a/test/src/unit-constructor1.cpp
+++ b/test/src/unit-constructor1.cpp
@@ -305,12 +305,9 @@ TEST_CASE("constructors")
         {
             json j{1};
 
-            CHECK_THROWS_AS((j.get<std::pair<int, int>>()), json::out_of_range&);
-            CHECK_THROWS_WITH((j.get<std::pair<int, int>>()), "[json.exception.out_of_range.401] array index 1 is out of range");
-            CHECK_THROWS_AS((j.get<std::tuple<int, int>>()), json::out_of_range&);
-            CHECK_THROWS_WITH((j.get<std::tuple<int, int>>()), "[json.exception.out_of_range.401] array index 1 is out of range");
-            CHECK_THROWS_AS((j.get<std::array<int, 3>>()), json::out_of_range&);
-            CHECK_THROWS_WITH((j.get<std::array<int, 3>>()), "[json.exception.out_of_range.401] array index 1 is out of range");
+            CHECK_THROWS_WITH_AS((j.get<std::pair<int, int>>()), "[json.exception.out_of_range.401] array index 1 is out of range", json::out_of_range&);
+            CHECK_THROWS_WITH_AS((j.get<std::tuple<int, int>>()), "[json.exception.out_of_range.401] array index 1 is out of range", json::out_of_range&);
+            CHECK_THROWS_WITH_AS((j.get<std::array<int, 3>>()), "[json.exception.out_of_range.401] array index 1 is out of range", json::out_of_range&);
         }
 
         SECTION("std::forward_list<json>")
@@ -1091,10 +1088,7 @@ TEST_CASE("constructors")
             SECTION("object with error")
             {
                 json _;
-                CHECK_THROWS_AS(_ = json::object({ {"one", 1}, {"two", 1u}, {"three", 2.2}, {"four", false}, 13 }),
-                json::type_error&);
-                CHECK_THROWS_WITH(_ = json::object({ {"one", 1}, {"two", 1u}, {"three", 2.2}, {"four", false}, 13 }),
-                "[json.exception.type_error.301] cannot create object from initializer list");
+                CHECK_THROWS_WITH_AS(_ = json::object({ {"one", 1}, {"two", 1u}, {"three", 2.2}, {"four", false}, 13 }), "[json.exception.type_error.301] cannot create object from initializer list", json::type_error&);
             }
 
             SECTION("empty array")
@@ -1340,18 +1334,14 @@ TEST_CASE("constructors")
                 {
                     json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
                     json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                    CHECK_THROWS_AS(json(jobject.begin(), jobject2.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(json(jobject2.begin(), jobject.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(json(jobject.begin(), jobject2.end()), "[json.exception.invalid_iterator.201] iterators are not compatible");
-                    CHECK_THROWS_WITH(json(jobject2.begin(), jobject.end()), "[json.exception.invalid_iterator.201] iterators are not compatible");
+                    CHECK_THROWS_WITH_AS(json(jobject.begin(), jobject2.end()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(json(jobject2.begin(), jobject.end()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
                 }
                 {
                     json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
                     json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                    CHECK_THROWS_AS(json(jobject.cbegin(), jobject2.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(json(jobject2.cbegin(), jobject.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(json(jobject.cbegin(), jobject2.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible");
-                    CHECK_THROWS_WITH(json(jobject2.cbegin(), jobject.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible");
+                    CHECK_THROWS_WITH_AS(json(jobject.cbegin(), jobject2.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(json(jobject2.cbegin(), jobject.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
                 }
             }
         }
@@ -1405,18 +1395,14 @@ TEST_CASE("constructors")
                 {
                     json jarray = {1, 2, 3, 4};
                     json jarray2 = {2, 3, 4, 5};
-                    CHECK_THROWS_AS(json(jarray.begin(), jarray2.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(json(jarray2.begin(), jarray.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(json(jarray.begin(), jarray2.end()), "[json.exception.invalid_iterator.201] iterators are not compatible");
-                    CHECK_THROWS_WITH(json(jarray2.begin(), jarray.end()), "[json.exception.invalid_iterator.201] iterators are not compatible");
+                    CHECK_THROWS_WITH_AS(json(jarray.begin(), jarray2.end()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(json(jarray2.begin(), jarray.end()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
                 }
                 {
                     json jarray = {1, 2, 3, 4};
                     json jarray2 = {2, 3, 4, 5};
-                    CHECK_THROWS_AS(json(jarray.cbegin(), jarray2.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(json(jarray2.cbegin(), jarray.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(json(jarray.cbegin(), jarray2.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible");
-                    CHECK_THROWS_WITH(json(jarray2.cbegin(), jarray.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible");
+                    CHECK_THROWS_WITH_AS(json(jarray.cbegin(), jarray2.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(json(jarray2.cbegin(), jarray.cend()), "[json.exception.invalid_iterator.201] iterators are not compatible", json::invalid_iterator&);
                 }
             }
         }
@@ -1429,15 +1415,11 @@ TEST_CASE("constructors")
                 {
                     {
                         json j;
-                        CHECK_THROWS_AS(json(j.begin(), j.end()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.begin(), j.end()),
-                                          "[json.exception.invalid_iterator.206] cannot construct with iterators from null");
+                        CHECK_THROWS_WITH_AS(json(j.begin(), j.end()), "[json.exception.invalid_iterator.206] cannot construct with iterators from null", json::invalid_iterator&);
                     }
                     {
                         json j;
-                        CHECK_THROWS_AS(json(j.cbegin(), j.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.cbegin(), j.cend()),
-                                          "[json.exception.invalid_iterator.206] cannot construct with iterators from null");
+                        CHECK_THROWS_WITH_AS(json(j.cbegin(), j.cend()), "[json.exception.invalid_iterator.206] cannot construct with iterators from null", json::invalid_iterator&);
                     }
                 }
 
@@ -1532,17 +1514,13 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = "foo";
-                        CHECK_THROWS_AS(json(j.end(), j.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.begin(), j.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                     {
                         json j = "bar";
-                        CHECK_THROWS_AS(json(j.cend(), j.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                 }
 
@@ -1550,17 +1528,13 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = false;
-                        CHECK_THROWS_AS(json(j.end(), j.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.begin(), j.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                     {
                         json j = true;
-                        CHECK_THROWS_AS(json(j.cend(), j.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                 }
 
@@ -1568,17 +1542,13 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = 17;
-                        CHECK_THROWS_AS(json(j.end(), j.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.begin(), j.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                     {
                         json j = 17;
-                        CHECK_THROWS_AS(json(j.cend(), j.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                 }
 
@@ -1586,17 +1556,13 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = 17u;
-                        CHECK_THROWS_AS(json(j.end(), j.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.begin(), j.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                     {
                         json j = 17u;
-                        CHECK_THROWS_AS(json(j.cend(), j.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                 }
 
@@ -1604,17 +1570,13 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = 23.42;
-                        CHECK_THROWS_AS(json(j.end(), j.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.begin(), j.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                     {
                         json j = 23.42;
-                        CHECK_THROWS_AS(json(j.cend(), j.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(json(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                        CHECK_THROWS_WITH(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                        CHECK_THROWS_WITH_AS(json(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(json(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                     }
                 }
             }

--- a/test/src/unit-convenience.cpp
+++ b/test/src/unit-convenience.cpp
@@ -106,12 +106,8 @@ TEST_CASE("convenience functions")
         check_escaped("\x1f", "\\u001f");
 
         // invalid UTF-8 characters
-        CHECK_THROWS_AS(check_escaped("ä\xA9ü"), json::type_error&);
-        CHECK_THROWS_WITH(check_escaped("ä\xA9ü"),
-                          "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9");
+        CHECK_THROWS_WITH_AS(check_escaped("ä\xA9ü"), "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9", json::type_error&);
 
-        CHECK_THROWS_AS(check_escaped("\xC2"), json::type_error&);
-        CHECK_THROWS_WITH(check_escaped("\xC2"),
-                          "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2");
+        CHECK_THROWS_WITH_AS(check_escaped("\xC2"), "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2", json::type_error&);
     }
 }

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -111,8 +111,8 @@ TEST_CASE("value conversion")
                 json(json::value_t::string).get<json::object_t>(),
                 "[json.exception.type_error.302] type must be object, but is string", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<json::object_t>(),
-                              "[json.exception.type_error.302] type must be object, "
-                              "but is boolean", json::type_error&);
+                                 "[json.exception.type_error.302] type must be object, "
+                                 "but is boolean", json::type_error&);
             CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::object_t>(),
                 "[json.exception.type_error.302] type must be object, but is number", json::type_error&);
@@ -447,8 +447,8 @@ TEST_CASE("value conversion")
                 json(json::value_t::array).get<json::string_t>(),
                 "[json.exception.type_error.302] type must be string, but is array", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<json::string_t>(),
-                              "[json.exception.type_error.302] type must be string, "
-                              "but is boolean", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, "
+                                 "but is boolean", json::type_error&);
             CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::string_t>(),
                 "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
@@ -464,19 +464,19 @@ TEST_CASE("value conversion")
         SECTION("exception in case of a non-string type using string_view")
         {
             CHECK_THROWS_WITH_AS(json(json::value_t::null).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::object).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is object", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is object", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::array).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is array", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is array", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is boolean", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is boolean", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::number_integer).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::number_unsigned).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::number_float).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+                                 "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
         }
 #endif
     }
@@ -519,19 +519,19 @@ TEST_CASE("value conversion")
         CHECK(n2 == n);
 
         CHECK_THROWS_WITH_AS(json(json::value_t::string).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is string", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is string", json::type_error&);
         CHECK_THROWS_WITH_AS(json(json::value_t::object).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is object", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is object", json::type_error&);
         CHECK_THROWS_WITH_AS(json(json::value_t::array).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is array", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is array", json::type_error&);
         CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is boolean", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is boolean", json::type_error&);
         CHECK_THROWS_WITH_AS(json(json::value_t::number_integer).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
         CHECK_THROWS_WITH_AS(json(json::value_t::number_unsigned).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
         CHECK_THROWS_WITH_AS(json(json::value_t::number_float).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
+                             "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
     }
 
 #if JSON_USE_IMPLICIT_CONVERSIONS
@@ -594,14 +594,14 @@ TEST_CASE("value conversion")
                 json(json::value_t::null).get<json::boolean_t>(),
                 "[json.exception.type_error.302] type must be boolean, but is null", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::object).get<json::boolean_t>(),
-                              "[json.exception.type_error.302] type must be boolean, "
-                              "but is object", json::type_error&);
+                                 "[json.exception.type_error.302] type must be boolean, "
+                                 "but is object", json::type_error&);
             CHECK_THROWS_WITH_AS(
                 json(json::value_t::array).get<json::boolean_t>(),
                 "[json.exception.type_error.302] type must be boolean, but is array", json::type_error&);
             CHECK_THROWS_WITH_AS(json(json::value_t::string).get<json::boolean_t>(),
-                              "[json.exception.type_error.302] type must be boolean, "
-                              "but is string", json::type_error&);
+                                 "[json.exception.type_error.302] type must be boolean, "
+                                 "but is string", json::type_error&);
             CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::boolean_t>(),
                 "[json.exception.type_error.302] type must be boolean, but is "
@@ -1387,7 +1387,7 @@ TEST_CASE("value conversion")
                 {
                     std::array<int, 6> arr6 = {{1, 2, 3, 4, 5, 6}};
                     CHECK_THROWS_WITH_AS(j1.get_to(arr6), "[json.exception.out_of_range.401] "
-                                      "array index 4 is out of range", json::out_of_range&);
+                                         "array index 4 is out of range", json::out_of_range&);
                 }
 
                 SECTION("std::array is smaller than JSON")
@@ -1455,11 +1455,11 @@ TEST_CASE("value conversion")
                 json j7 = {0, 1, 2, 3};
                 json j8 = 2;
                 CHECK_THROWS_WITH_AS((j7.get<std::map<int, int>>()),
-                                  "[json.exception.type_error.302] type must be array, "
-                                  "but is number", json::type_error&);
+                                     "[json.exception.type_error.302] type must be array, "
+                                     "but is number", json::type_error&);
                 CHECK_THROWS_WITH_AS((j8.get<std::map<int, int>>()),
-                                  "[json.exception.type_error.302] type must be array, "
-                                  "but is number", json::type_error&);
+                                     "[json.exception.type_error.302] type must be array, "
+                                     "but is number", json::type_error&);
 
                 SECTION("superfluous entries")
                 {
@@ -1480,11 +1480,11 @@ TEST_CASE("value conversion")
                 json j7 = {0, 1, 2, 3};
                 json j8 = 2;
                 CHECK_THROWS_WITH_AS((j7.get<std::unordered_map<int, int>>()),
-                                  "[json.exception.type_error.302] type must be array, "
-                                  "but is number", json::type_error&);
+                                     "[json.exception.type_error.302] type must be array, "
+                                     "but is number", json::type_error&);
                 CHECK_THROWS_WITH_AS((j8.get<std::unordered_map<int, int>>()),
-                                  "[json.exception.type_error.302] type must be array, "
-                                  "but is number", json::type_error&);
+                                     "[json.exception.type_error.302] type must be array, "
+                                     "but is number", json::type_error&);
 
                 SECTION("superfluous entries")
                 {

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -101,43 +101,27 @@ TEST_CASE("value conversion")
 
         SECTION("exception in case of a non-object type")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::object_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::array).get<json::object_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::string).get<json::object_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::boolean).get<json::object_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_integer).get<json::object_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(
-                json(json::value_t::number_unsigned).get<json::object_t>(),
-                json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_float).get<json::object_t>(),
-                            json::type_error&);
-
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<json::object_t>(),
-                "[json.exception.type_error.302] type must be object, but is null");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be object, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::array).get<json::object_t>(),
-                "[json.exception.type_error.302] type must be object, but is array");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be object, but is array", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::string).get<json::object_t>(),
-                "[json.exception.type_error.302] type must be object, but is string");
-            CHECK_THROWS_WITH(json(json::value_t::boolean).get<json::object_t>(),
+                "[json.exception.type_error.302] type must be object, but is string", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<json::object_t>(),
                               "[json.exception.type_error.302] type must be object, "
-                              "but is boolean");
-            CHECK_THROWS_WITH(
+                              "but is boolean", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::object_t>(),
-                "[json.exception.type_error.302] type must be object, but is number");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be object, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_unsigned).get<json::object_t>(),
-                "[json.exception.type_error.302] type must be object, but is number");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be object, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_float).get<json::object_t>(),
-                "[json.exception.type_error.302] type must be object, but is number");
+                "[json.exception.type_error.302] type must be object, but is number", json::type_error&);
         }
     }
 
@@ -255,11 +239,9 @@ TEST_CASE("value conversion")
             std::forward_list<json> a = j.get<std::forward_list<json>>();
             CHECK(json(a) == j);
 
-            CHECK_THROWS_AS(json(json::value_t::null).get<std::forward_list<json>>(),
-                            json::type_error&);
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<std::forward_list<json>>(),
-                "[json.exception.type_error.302] type must be array, but is null");
+                "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
         }
 
         SECTION("std::vector<json>")
@@ -267,11 +249,9 @@ TEST_CASE("value conversion")
             std::vector<json> a = j.get<std::vector<json>>();
             CHECK(json(a) == j);
 
-            CHECK_THROWS_AS(json(json::value_t::null).get<std::vector<json>>(),
-                            json::type_error&);
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<std::vector<json>>(),
-                "[json.exception.type_error.302] type must be array, but is null");
+                "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
 
 #if !defined(JSON_NOEXCEPTION)
             SECTION("reserve is called on containers that supports it")
@@ -306,45 +286,30 @@ TEST_CASE("value conversion")
 
         SECTION("exception in case of a non-array type")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::array_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::object).get<json::array_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::string).get<json::array_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::boolean).get<json::array_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_integer).get<json::array_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_unsigned).get<json::array_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_float).get<json::array_t>(),
-                            json::type_error&);
-
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::object).get<std::vector<int>>(),
-                "[json.exception.type_error.302] type must be array, but is object");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is null");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::object).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is object");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::string).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is string");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is string", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::boolean).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is boolean");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is boolean", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is number");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_unsigned).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is number");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be array, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_float).get<json::array_t>(),
-                "[json.exception.type_error.302] type must be array, but is number");
+                "[json.exception.type_error.302] type must be array, but is number", json::type_error&);
         }
     }
 
@@ -472,70 +437,46 @@ TEST_CASE("value conversion")
 
         SECTION("exception in case of a non-string type")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::string_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::object).get<json::string_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::array).get<json::string_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::boolean).get<json::string_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_integer).get<json::string_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(
-                json(json::value_t::number_unsigned).get<json::string_t>(),
-                json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_float).get<json::string_t>(),
-                            json::type_error&);
-
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<json::string_t>(),
-                "[json.exception.type_error.302] type must be string, but is null");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::object).get<json::string_t>(),
-                "[json.exception.type_error.302] type must be string, but is object");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be string, but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::array).get<json::string_t>(),
-                "[json.exception.type_error.302] type must be string, but is array");
-            CHECK_THROWS_WITH(json(json::value_t::boolean).get<json::string_t>(),
+                "[json.exception.type_error.302] type must be string, but is array", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<json::string_t>(),
                               "[json.exception.type_error.302] type must be string, "
-                              "but is boolean");
-            CHECK_THROWS_WITH(
+                              "but is boolean", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::string_t>(),
-                "[json.exception.type_error.302] type must be string, but is number");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_unsigned).get<json::string_t>(),
-                "[json.exception.type_error.302] type must be string, but is number");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_float).get<json::string_t>(),
-                "[json.exception.type_error.302] type must be string, but is number");
+                "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
         }
 
 #if defined(JSON_HAS_CPP_17)
         SECTION("exception in case of a non-string type using string_view")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<std::string_view>(), json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::object).get<std::string_view>(), json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::array).get<std::string_view>(), json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::boolean).get<std::string_view>(), json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_integer).get<std::string_view>(), json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_unsigned).get<std::string_view>(), json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_float).get<std::string_view>(), json::type_error&);
-
-            CHECK_THROWS_WITH(json(json::value_t::null).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is null");
-            CHECK_THROWS_WITH(json(json::value_t::object).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is object");
-            CHECK_THROWS_WITH(json(json::value_t::array).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is array");
-            CHECK_THROWS_WITH(json(json::value_t::boolean).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is boolean");
-            CHECK_THROWS_WITH(json(json::value_t::number_integer).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is number");
-            CHECK_THROWS_WITH(json(json::value_t::number_unsigned).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is number");
-            CHECK_THROWS_WITH(json(json::value_t::number_float).get<std::string_view>(),
-                              "[json.exception.type_error.302] type must be string, but is number");
+            CHECK_THROWS_WITH_AS(json(json::value_t::null).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::object).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::array).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is array", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is boolean", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::number_integer).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::number_unsigned).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::number_float).get<std::string_view>(),
+                              "[json.exception.type_error.302] type must be string, but is number", json::type_error&);
         }
 #endif
     }
@@ -577,29 +518,20 @@ TEST_CASE("value conversion")
         auto n2 = j.get<std::nullptr_t>();
         CHECK(n2 == n);
 
-        CHECK_THROWS_AS(json(json::value_t::string).get<std::nullptr_t>(), json::type_error&);
-        CHECK_THROWS_AS(json(json::value_t::object).get<std::nullptr_t>(), json::type_error&);
-        CHECK_THROWS_AS(json(json::value_t::array).get<std::nullptr_t>(), json::type_error&);
-        CHECK_THROWS_AS(json(json::value_t::boolean).get<std::nullptr_t>(), json::type_error&);
-        CHECK_THROWS_AS(json(json::value_t::number_integer).get<std::nullptr_t>(), json::type_error&);
-        CHECK_THROWS_AS(json(json::value_t::number_unsigned).get<std::nullptr_t>(), json::type_error&);
-        CHECK_THROWS_AS(json(json::value_t::number_float).get<std::nullptr_t>(), json::type_error&);
-
-        CHECK_THROWS_WITH(json(json::value_t::string).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is string");
-        CHECK_THROWS_WITH(json(json::value_t::object).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is object");
-        CHECK_THROWS_WITH(json(json::value_t::array).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is array");
-        CHECK_THROWS_WITH(json(json::value_t::boolean).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is boolean");
-        CHECK_THROWS_WITH(json(json::value_t::number_integer).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is number");
-        CHECK_THROWS_WITH(json(json::value_t::number_unsigned).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is number");
-        CHECK_THROWS_WITH(json(json::value_t::number_float).get<std::nullptr_t>(),
-                          "[json.exception.type_error.302] type must be null, but is number");
-
+        CHECK_THROWS_WITH_AS(json(json::value_t::string).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is string", json::type_error&);
+        CHECK_THROWS_WITH_AS(json(json::value_t::object).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is object", json::type_error&);
+        CHECK_THROWS_WITH_AS(json(json::value_t::array).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is array", json::type_error&);
+        CHECK_THROWS_WITH_AS(json(json::value_t::boolean).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is boolean", json::type_error&);
+        CHECK_THROWS_WITH_AS(json(json::value_t::number_integer).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(json(json::value_t::number_unsigned).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(json(json::value_t::number_float).get<std::nullptr_t>(),
+                          "[json.exception.type_error.302] type must be null, but is number", json::type_error&);
     }
 
 #if JSON_USE_IMPLICIT_CONVERSIONS
@@ -655,49 +587,33 @@ TEST_CASE("value conversion")
 
         SECTION("exception in case of a non-number type")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::boolean_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::object).get<json::boolean_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::array).get<json::boolean_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::string).get<json::boolean_t>(),
-                            json::type_error&);
             CHECK_THROWS_AS(json(json::value_t::string).get<uint8_t>(),
                             json::type_error&);
-            CHECK_THROWS_AS(
-                json(json::value_t::number_integer).get<json::boolean_t>(),
-                json::type_error&);
-            CHECK_THROWS_AS(
-                json(json::value_t::number_unsigned).get<json::boolean_t>(),
-                json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::number_float).get<json::boolean_t>(),
-                            json::type_error&);
 
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<json::boolean_t>(),
-                "[json.exception.type_error.302] type must be boolean, but is null");
-            CHECK_THROWS_WITH(json(json::value_t::object).get<json::boolean_t>(),
+                "[json.exception.type_error.302] type must be boolean, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::object).get<json::boolean_t>(),
                               "[json.exception.type_error.302] type must be boolean, "
-                              "but is object");
-            CHECK_THROWS_WITH(
+                              "but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::array).get<json::boolean_t>(),
-                "[json.exception.type_error.302] type must be boolean, but is array");
-            CHECK_THROWS_WITH(json(json::value_t::string).get<json::boolean_t>(),
+                "[json.exception.type_error.302] type must be boolean, but is array", json::type_error&);
+            CHECK_THROWS_WITH_AS(json(json::value_t::string).get<json::boolean_t>(),
                               "[json.exception.type_error.302] type must be boolean, "
-                              "but is string");
-            CHECK_THROWS_WITH(
+                              "but is string", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_integer).get<json::boolean_t>(),
                 "[json.exception.type_error.302] type must be boolean, but is "
-                "number");
-            CHECK_THROWS_WITH(
+                "number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_unsigned).get<json::boolean_t>(),
                 "[json.exception.type_error.302] type must be boolean, but is "
-                "number");
-            CHECK_THROWS_WITH(
+                "number", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::number_float).get<json::boolean_t>(),
                 "[json.exception.type_error.302] type must be boolean, but is "
-                "number");
+                "number", json::type_error&);
         }
     }
 
@@ -934,34 +850,22 @@ TEST_CASE("value conversion")
 
         SECTION("exception in case of a non-number type")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::number_integer_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::object).get<json::number_integer_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::array).get<json::number_integer_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::string).get<json::number_integer_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(
-                json(json::value_t::boolean).get<json::number_integer_t>(),
-                json::type_error&);
-
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<json::number_integer_t>(),
-                "[json.exception.type_error.302] type must be number, but is null");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::object).get<json::number_integer_t>(),
-                "[json.exception.type_error.302] type must be number, but is object");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::array).get<json::number_integer_t>(),
-                "[json.exception.type_error.302] type must be number, but is array");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is array", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::string).get<json::number_integer_t>(),
-                "[json.exception.type_error.302] type must be number, but is string");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is string", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::boolean).get<json::number_integer_t>(),
                 "[json.exception.type_error.302] type must be number, but is "
-                "boolean");
+                "boolean", json::type_error&);
 
             CHECK_NOTHROW(
                 json(json::value_t::number_float).get<json::number_integer_t>());
@@ -1209,33 +1113,22 @@ TEST_CASE("value conversion")
 
         SECTION("exception in case of a non-string type")
         {
-            CHECK_THROWS_AS(json(json::value_t::null).get<json::number_float_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::object).get<json::number_float_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::array).get<json::number_float_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::string).get<json::number_float_t>(),
-                            json::type_error&);
-            CHECK_THROWS_AS(json(json::value_t::boolean).get<json::number_float_t>(),
-                            json::type_error&);
-
-            CHECK_THROWS_WITH(
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::null).get<json::number_float_t>(),
-                "[json.exception.type_error.302] type must be number, but is null");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is null", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::object).get<json::number_float_t>(),
-                "[json.exception.type_error.302] type must be number, but is object");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is object", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::array).get<json::number_float_t>(),
-                "[json.exception.type_error.302] type must be number, but is array");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is array", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::string).get<json::number_float_t>(),
-                "[json.exception.type_error.302] type must be number, but is string");
-            CHECK_THROWS_WITH(
+                "[json.exception.type_error.302] type must be number, but is string", json::type_error&);
+            CHECK_THROWS_WITH_AS(
                 json(json::value_t::boolean).get<json::number_float_t>(),
                 "[json.exception.type_error.302] type must be number, but is "
-                "boolean");
+                "boolean", json::type_error&);
 
             CHECK_NOTHROW(
                 json(json::value_t::number_integer).get<json::number_float_t>());
@@ -1450,11 +1343,9 @@ TEST_CASE("value conversion")
 
             SECTION("exception in case of a non-object type")
             {
-                CHECK_THROWS_AS((json().get<std::map<std::string, int>>()),
-                                json::type_error&);
-                CHECK_THROWS_WITH(
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::map<std::string, int>>()),
-                    "[json.exception.type_error.302] type must be object, but is null");
+                    "[json.exception.type_error.302] type must be object, but is null", json::type_error&);
             }
         }
 
@@ -1495,9 +1386,8 @@ TEST_CASE("value conversion")
                 SECTION("std::array is larger than JSON")
                 {
                     std::array<int, 6> arr6 = {{1, 2, 3, 4, 5, 6}};
-                    CHECK_THROWS_AS(j1.get_to(arr6), json::out_of_range&);
-                    CHECK_THROWS_WITH(j1.get_to(arr6), "[json.exception.out_of_range.401] "
-                                      "array index 4 is out of range");
+                    CHECK_THROWS_WITH_AS(j1.get_to(arr6), "[json.exception.out_of_range.401] "
+                                      "array index 4 is out of range", json::out_of_range&);
                 }
 
                 SECTION("std::array is smaller than JSON")
@@ -1564,14 +1454,12 @@ TEST_CASE("value conversion")
 
                 json j7 = {0, 1, 2, 3};
                 json j8 = 2;
-                CHECK_THROWS_AS((j7.get<std::map<int, int>>()), json::type_error&);
-                CHECK_THROWS_AS((j8.get<std::map<int, int>>()), json::type_error&);
-                CHECK_THROWS_WITH((j7.get<std::map<int, int>>()),
+                CHECK_THROWS_WITH_AS((j7.get<std::map<int, int>>()),
                                   "[json.exception.type_error.302] type must be array, "
-                                  "but is number");
-                CHECK_THROWS_WITH((j8.get<std::map<int, int>>()),
+                                  "but is number", json::type_error&);
+                CHECK_THROWS_WITH_AS((j8.get<std::map<int, int>>()),
                                   "[json.exception.type_error.302] type must be array, "
-                                  "but is number");
+                                  "but is number", json::type_error&);
 
                 SECTION("superfluous entries")
                 {
@@ -1591,14 +1479,12 @@ TEST_CASE("value conversion")
 
                 json j7 = {0, 1, 2, 3};
                 json j8 = 2;
-                CHECK_THROWS_AS((j7.get<std::unordered_map<int, int>>()), json::type_error&);
-                CHECK_THROWS_AS((j8.get<std::unordered_map<int, int>>()), json::type_error&);
-                CHECK_THROWS_WITH((j7.get<std::unordered_map<int, int>>()),
+                CHECK_THROWS_WITH_AS((j7.get<std::unordered_map<int, int>>()),
                                   "[json.exception.type_error.302] type must be array, "
-                                  "but is number");
-                CHECK_THROWS_WITH((j8.get<std::unordered_map<int, int>>()),
+                                  "but is number", json::type_error&);
+                CHECK_THROWS_WITH_AS((j8.get<std::unordered_map<int, int>>()),
                                   "[json.exception.type_error.302] type must be array, "
-                                  "but is number");
+                                  "but is number", json::type_error&);
 
                 SECTION("superfluous entries")
                 {
@@ -1610,32 +1496,26 @@ TEST_CASE("value conversion")
 
             SECTION("exception in case of a non-object type")
             {
-                CHECK_THROWS_AS((json().get<std::list<int>>()), json::type_error&);
-                CHECK_THROWS_AS((json().get<std::vector<int>>()), json::type_error&);
-                CHECK_THROWS_AS((json().get<std::vector<json>>()), json::type_error&);
-                CHECK_THROWS_AS((json().get<std::list<json>>()), json::type_error&);
-                CHECK_THROWS_AS((json().get<std::valarray<int>>()), json::type_error&);
-
                 // does type really must be an array? or it rather must not be null?
                 // that's what I thought when other test like this one broke
-                CHECK_THROWS_WITH(
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::list<int>>()),
-                    "[json.exception.type_error.302] type must be array, but is null");
-                CHECK_THROWS_WITH(
+                    "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::vector<int>>()),
-                    "[json.exception.type_error.302] type must be array, but is null");
-                CHECK_THROWS_WITH(
+                    "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::vector<json>>()),
-                    "[json.exception.type_error.302] type must be array, but is null");
-                CHECK_THROWS_WITH(
+                    "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::list<json>>()),
-                    "[json.exception.type_error.302] type must be array, but is null");
-                CHECK_THROWS_WITH(
+                    "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::valarray<int>>()),
-                    "[json.exception.type_error.302] type must be array, but is null");
-                CHECK_THROWS_WITH(
+                    "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
+                CHECK_THROWS_WITH_AS(
                     (json().get<std::map<int, int>>()),
-                    "[json.exception.type_error.302] type must be array, but is null");
+                    "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
             }
         }
     }

--- a/test/src/unit-deserialization.cpp
+++ b/test/src/unit-deserialization.cpp
@@ -281,20 +281,16 @@ TEST_CASE("deserialization")
         SECTION("stream")
         {
             std::stringstream ss1;
-            std::stringstream ss2;
             std::stringstream ss3;
             std::stringstream ss4;
             std::stringstream ss5;
             ss1 << R"(["foo",1,2,3,false,{"one":1})";
-            ss2 << R"(["foo",1,2,3,false,{"one":1})";
             ss3 << R"(["foo",1,2,3,false,{"one":1})";
             ss4 << R"(["foo",1,2,3,false,{"one":1})";
             ss5 << R"(["foo",1,2,3,false,{"one":1})";
 
             json _;
-            CHECK_THROWS_AS(_ = json::parse(ss1), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(ss2),
-                              "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'");
+            CHECK_THROWS_WITH_AS(_ = json::parse(ss1), "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
             CHECK(!json::accept(ss3));
 
             json j_error;
@@ -317,9 +313,7 @@ TEST_CASE("deserialization")
         {
             json::string_t s = R"(["foo",1,2,3,false,{"one":1})";
             json _;
-            CHECK_THROWS_AS(_ = json::parse(s), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(s),
-                              "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'");
+            CHECK_THROWS_WITH_AS(_ = json::parse(s), "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
             CHECK(!json::accept(s));
 
             json j_error;
@@ -340,33 +334,23 @@ TEST_CASE("deserialization")
 
         SECTION("operator<<")
         {
-            std::stringstream ss1;
-            std::stringstream ss2;
-            ss1 << R"(["foo",1,2,3,false,{"one":1})";
-            ss2 << R"(["foo",1,2,3,false,{"one":1})";
+            std::stringstream ss;
+            ss << R"(["foo",1,2,3,false,{"one":1})";
             json j;
-            CHECK_THROWS_AS(j << ss1, json::parse_error&);
-            CHECK_THROWS_WITH(j << ss2,
-                              "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'");
+            CHECK_THROWS_WITH_AS(j << ss, "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
         }
 
         SECTION("operator>>")
         {
-            std::stringstream ss1;
-            std::stringstream ss2;
-            ss1 << R"(["foo",1,2,3,false,{"one":1})";
-            ss2 << R"(["foo",1,2,3,false,{"one":1})";
+            std::stringstream ss;
+            ss << R"(["foo",1,2,3,false,{"one":1})";
             json j;
-            CHECK_THROWS_AS(ss1 >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss2 >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
         }
 
         SECTION("user-defined string literal")
         {
-            CHECK_THROWS_AS("[\"foo\",1,2,3,false,{\"one\":1}"_json, json::parse_error&);
-            CHECK_THROWS_WITH("[\"foo\",1,2,3,false,{\"one\":1}"_json,
-                              "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'");
+            CHECK_THROWS_WITH_AS("[\"foo\",1,2,3,false,{\"one\":1}"_json, "[json.exception.parse_error.101] parse error at line 1, column 29: syntax error while parsing array - unexpected end of input; expected ']'", json::parse_error&);
         }
     }
 
@@ -648,9 +632,7 @@ TEST_CASE("deserialization")
             {
                 std::array<std::uint8_t, 4> v = {{'\"', 0x7F, 0xDF, 0x7F}};
                 json _;
-                CHECK_THROWS_AS(_ = json::parse(std::begin(v), std::end(v)), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse(std::begin(v), std::end(v)),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\x7f\xdf\x7f'");
+                CHECK_THROWS_WITH_AS(_ = json::parse(std::begin(v), std::end(v)), "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\x7f\xdf\x7f'", json::parse_error&);
                 CHECK(!json::accept(std::begin(v), std::end(v)));
 
                 json j_error;
@@ -846,13 +828,9 @@ TEST_CASE("deserialization")
         SECTION("BOM only")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::parse(bom), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(bom),
-                              "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(_ = json::parse(bom), "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
 
-            CHECK_THROWS_AS(_ = json::parse(std::istringstream(bom)), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(std::istringstream(bom)),
-                              "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::istringstream(bom)), "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
 
             SaxEventLogger l;
             CHECK(!json::sax_parse(bom, &l));
@@ -887,13 +865,9 @@ TEST_CASE("deserialization")
         SECTION("2 byte of BOM")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::parse(bom.substr(0, 2)), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(bom.substr(0, 2)),
-                              "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF\xBB'");
+            CHECK_THROWS_WITH_AS(_ = json::parse(bom.substr(0, 2)), "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF\xBB'", json::parse_error&);
 
-            CHECK_THROWS_AS(_ = json::parse(std::istringstream(bom.substr(0, 2))), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(std::istringstream(bom.substr(0, 2))),
-                              "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF\xBB'");
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::istringstream(bom.substr(0, 2))), "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF\xBB'", json::parse_error&);
 
             SaxEventLogger l1;
             SaxEventLogger l2;
@@ -914,13 +888,9 @@ TEST_CASE("deserialization")
         SECTION("1 byte of BOM")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::parse(bom.substr(0, 1)), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(bom.substr(0, 1)),
-                              "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF'");
+            CHECK_THROWS_WITH_AS(_ = json::parse(bom.substr(0, 1)), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF'", json::parse_error&);
 
-            CHECK_THROWS_AS(_ = json::parse(std::istringstream(bom.substr(0, 1))), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::parse(std::istringstream(bom.substr(0, 1))),
-                              "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF'");
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::istringstream(bom.substr(0, 1))), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid BOM; must be 0xEF 0xBB 0xBF if given; last read: '\xEF'", json::parse_error&);
 
             SaxEventLogger l1;
             SaxEventLogger l2;

--- a/test/src/unit-element_access1.cpp
+++ b/test/src/unit-element_access1.cpp
@@ -65,9 +65,9 @@ TEST_CASE("element access 1")
             SECTION("access outside bounds")
             {
                 CHECK_THROWS_WITH_AS(j.at(8),
-                                  "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
+                                     "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
                 CHECK_THROWS_WITH_AS(j_const.at(8),
-                                  "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
+                                     "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
             }
 
             SECTION("access on non-array type")
@@ -379,26 +379,26 @@ TEST_CASE("element access 1")
                         json jarray2 = {"foo", "bar"};
 
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray2.begin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray.begin(), jarray2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray2.begin(), jarray.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray2.begin(), jarray2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                     {
                         json jarray = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
                         json jarray2 = {"foo", "bar"};
 
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray2.cbegin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray.cbegin(), jarray2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray2.cbegin(), jarray.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jarray.erase(jarray2.cbegin(), jarray2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                 }
             }
@@ -550,7 +550,7 @@ TEST_CASE("element access 1")
                 {
                     json j;
                     CHECK_THROWS_WITH_AS(j.erase(j.begin()),
-                                      "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
+                                         "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
             }
 

--- a/test/src/unit-element_access1.cpp
+++ b/test/src/unit-element_access1.cpp
@@ -64,13 +64,10 @@ TEST_CASE("element access 1")
 
             SECTION("access outside bounds")
             {
-                CHECK_THROWS_AS(j.at(8), json::out_of_range&);
-                CHECK_THROWS_AS(j_const.at(8), json::out_of_range&);
-
-                CHECK_THROWS_WITH(j.at(8),
-                                  "[json.exception.out_of_range.401] array index 8 is out of range");
-                CHECK_THROWS_WITH(j_const.at(8),
-                                  "[json.exception.out_of_range.401] array index 8 is out of range");
+                CHECK_THROWS_WITH_AS(j.at(8),
+                                  "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const.at(8),
+                                  "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
             }
 
             SECTION("access on non-array type")
@@ -79,77 +76,63 @@ TEST_CASE("element access 1")
                 {
                     json j_nonarray(json::value_t::null);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with null");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with null");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
                 }
 
                 SECTION("boolean")
                 {
                     json j_nonarray(json::value_t::boolean);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with boolean");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with boolean");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
                 }
 
                 SECTION("string")
                 {
                     json j_nonarray(json::value_t::string);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with string");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with string");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
                 }
 
                 SECTION("object")
                 {
                     json j_nonarray(json::value_t::object);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with object");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with object");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with object", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with object", json::type_error&);
                 }
 
                 SECTION("number (integer)")
                 {
                     json j_nonarray(json::value_t::number_integer);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with number");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with number");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
                 }
 
                 SECTION("number (unsigned)")
                 {
                     json j_nonarray(json::value_t::number_unsigned);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with number");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with number");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
                 {
                     json j_nonarray(json::value_t::number_float);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray.at(0), json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const.at(0), json::type_error&);
 
-                    CHECK_THROWS_WITH(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with number");
-                    CHECK_THROWS_WITH(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with number");
+                    CHECK_THROWS_WITH_AS(j_nonarray.at(0), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const.at(0), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
                 }
             }
         }
@@ -194,8 +177,7 @@ TEST_CASE("element access 1")
                         json j_nonarray(json::value_t::null);
                         const json j_nonarray_const(j_nonarray);
                         CHECK_NOTHROW(j_nonarray[0]);
-                        CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                        CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with null");
+                        CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with null", json::type_error&);
                     }
 
                     SECTION("implicit transformation to properly filled array")
@@ -210,60 +192,48 @@ TEST_CASE("element access 1")
                 {
                     json j_nonarray(json::value_t::boolean);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray[0], json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with boolean");
-                    CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with boolean");
+                    CHECK_THROWS_WITH_AS(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with boolean", json::type_error&);
                 }
 
                 SECTION("string")
                 {
                     json j_nonarray(json::value_t::string);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray[0], json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with string");
-                    CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with string");
+                    CHECK_THROWS_WITH_AS(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with string", json::type_error&);
                 }
 
                 SECTION("object")
                 {
                     json j_nonarray(json::value_t::object);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray[0], json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with object");
-                    CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with object");
+                    CHECK_THROWS_WITH_AS(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with object", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with object", json::type_error&);
                 }
 
                 SECTION("number (integer)")
                 {
                     json j_nonarray(json::value_t::number_integer);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray[0], json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number");
-                    CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number");
+                    CHECK_THROWS_WITH_AS(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number", json::type_error&);
                 }
 
                 SECTION("number (unsigned)")
                 {
                     json j_nonarray(json::value_t::number_unsigned);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray[0], json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number");
-                    CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number");
+                    CHECK_THROWS_WITH_AS(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
                 {
                     json j_nonarray(json::value_t::number_float);
                     const json j_nonarray_const(j_nonarray);
-                    CHECK_THROWS_AS(j_nonarray[0], json::type_error&);
-                    CHECK_THROWS_AS(j_nonarray_const[0], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number");
-                    CHECK_THROWS_WITH(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number");
+                    CHECK_THROWS_WITH_AS(j_nonarray[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonarray_const[0], "[json.exception.type_error.305] cannot use operator[] with a numeric argument with number", json::type_error&);
                 }
             }
         }
@@ -314,9 +284,7 @@ TEST_CASE("element access 1")
                 }
                 {
                     json jarray = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
-                    CHECK_THROWS_AS(jarray.erase(8), json::out_of_range&);
-                    CHECK_THROWS_WITH(jarray.erase(8),
-                                      "[json.exception.out_of_range.401] array index 8 is out of range");
+                    CHECK_THROWS_WITH_AS(jarray.erase(8), "[json.exception.out_of_range.401] array index 8 is out of range", json::out_of_range&);
                 }
             }
 
@@ -409,36 +377,28 @@ TEST_CASE("element access 1")
                     {
                         json jarray = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
                         json jarray2 = {"foo", "bar"};
-                        CHECK_THROWS_AS(jarray.erase(jarray2.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jarray.erase(jarray.begin(), jarray2.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jarray.erase(jarray2.begin(), jarray.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jarray.erase(jarray2.begin(), jarray2.end()), json::invalid_iterator&);
 
-                        CHECK_THROWS_WITH(jarray.erase(jarray2.begin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value");
-                        CHECK_THROWS_WITH(jarray.erase(jarray.begin(), jarray2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jarray.erase(jarray2.begin(), jarray.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jarray.erase(jarray2.begin(), jarray2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray2.begin()),
+                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray.begin(), jarray2.end()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray2.begin(), jarray.end()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray2.begin(), jarray2.end()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                     {
                         json jarray = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
                         json jarray2 = {"foo", "bar"};
-                        CHECK_THROWS_AS(jarray.erase(jarray2.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jarray.erase(jarray.cbegin(), jarray2.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jarray.erase(jarray2.cbegin(), jarray.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jarray.erase(jarray2.cbegin(), jarray2.cend()), json::invalid_iterator&);
 
-                        CHECK_THROWS_WITH(jarray.erase(jarray2.cbegin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value");
-                        CHECK_THROWS_WITH(jarray.erase(jarray.cbegin(), jarray2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jarray.erase(jarray2.cbegin(), jarray.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jarray.erase(jarray2.cbegin(), jarray2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray2.cbegin()),
+                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray.cbegin(), jarray2.cend()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray2.cbegin(), jarray.cend()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jarray.erase(jarray2.cbegin(), jarray2.cend()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                 }
             }
@@ -448,57 +408,43 @@ TEST_CASE("element access 1")
                 SECTION("null")
                 {
                     json j_nonobject(json::value_t::null);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with null");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
 
                 SECTION("boolean")
                 {
                     json j_nonobject(json::value_t::boolean);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with boolean");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with boolean", json::type_error&);
                 }
 
                 SECTION("string")
                 {
                     json j_nonobject(json::value_t::string);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with string");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with string", json::type_error&);
                 }
 
                 SECTION("object")
                 {
                     json j_nonobject(json::value_t::object);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with object");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with object", json::type_error&);
                 }
 
                 SECTION("number (integer)")
                 {
                     json j_nonobject(json::value_t::number_integer);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
                 }
 
                 SECTION("number (unsigned)")
                 {
                     json j_nonobject(json::value_t::number_unsigned);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
                 {
                     json j_nonobject(json::value_t::number_float);
-                    CHECK_THROWS_AS(j_nonobject.erase(0), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase(0),
-                                      "[json.exception.type_error.307] cannot use erase() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(0), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
                 }
             }
         }
@@ -512,17 +458,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j;
-                    CHECK_THROWS_AS(j.front(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.back(), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.front(), "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(j.back(), "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(j.front(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.back(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
                 {
                     const json j{};
-                    CHECK_THROWS_AS(j.front(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.back(), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.front(), "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(j.back(), "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(j.front(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.back(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
             }
 
@@ -603,15 +545,12 @@ TEST_CASE("element access 1")
             {
                 {
                     json j;
-                    CHECK_THROWS_AS(j.erase(j.begin()), json::type_error&);
-                    CHECK_THROWS_WITH(j.erase(j.begin()),
-                                      "[json.exception.type_error.307] cannot use erase() with null");
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin()), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
                 {
                     json j;
-                    CHECK_THROWS_AS(j.erase(j.cbegin()), json::type_error&);
-                    CHECK_THROWS_WITH(j.erase(j.begin()),
-                                      "[json.exception.type_error.307] cannot use erase() with null");
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin()),
+                                      "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
             }
 
@@ -718,15 +657,11 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = "foo";
-                    CHECK_THROWS_AS(j.erase(j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
                 {
                     json j = "bar";
-                    CHECK_THROWS_AS(j.erase(j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
             }
 
@@ -734,15 +669,11 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = false;
-                    CHECK_THROWS_AS(j.erase(j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
                 {
                     json j = true;
-                    CHECK_THROWS_AS(j.erase(j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
             }
 
@@ -750,15 +681,11 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17;
-                    CHECK_THROWS_AS(j.erase(j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
                 {
                     json j = 17;
-                    CHECK_THROWS_AS(j.erase(j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
             }
 
@@ -766,15 +693,11 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17u;
-                    CHECK_THROWS_AS(j.erase(j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
                 {
                     json j = 17u;
-                    CHECK_THROWS_AS(j.erase(j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
             }
 
@@ -782,15 +705,11 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 23.42;
-                    CHECK_THROWS_AS(j.erase(j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
                 {
                     json j = 23.42;
-                    CHECK_THROWS_AS(j.erase(j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend()),
-                                      "[json.exception.invalid_iterator.205] iterator out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend()), "[json.exception.invalid_iterator.205] iterator out of range", json::invalid_iterator&);
                 }
             }
         }
@@ -801,15 +720,11 @@ TEST_CASE("element access 1")
             {
                 {
                     json j;
-                    CHECK_THROWS_AS(j.erase(j.begin(), j.end()), json::type_error&);
-                    CHECK_THROWS_WITH(j.erase(j.begin(), j.end()),
-                                      "[json.exception.type_error.307] cannot use erase() with null");
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin(), j.end()), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
                 {
                     json j;
-                    CHECK_THROWS_AS(j.erase(j.cbegin(), j.cend()), json::type_error&);
-                    CHECK_THROWS_WITH(j.erase(j.cbegin(), j.cend()),
-                                      "[json.exception.type_error.307] cannot use erase() with null");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cbegin(), j.cend()), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
             }
 
@@ -916,17 +831,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = "foo";
-                    CHECK_THROWS_AS(j.erase(j.end(), j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.begin(), j.begin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
                 {
                     json j = "bar";
-                    CHECK_THROWS_AS(j.erase(j.cend(), j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
             }
 
@@ -934,17 +845,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = false;
-                    CHECK_THROWS_AS(j.erase(j.end(), j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.begin(), j.begin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
                 {
                     json j = true;
-                    CHECK_THROWS_AS(j.erase(j.cend(), j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
             }
 
@@ -952,17 +859,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17;
-                    CHECK_THROWS_AS(j.erase(j.end(), j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.begin(), j.begin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
                 {
                     json j = 17;
-                    CHECK_THROWS_AS(j.erase(j.cend(), j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
             }
 
@@ -970,17 +873,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17u;
-                    CHECK_THROWS_AS(j.erase(j.end(), j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.begin(), j.begin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
                 {
                     json j = 17u;
-                    CHECK_THROWS_AS(j.erase(j.cend(), j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
             }
 
@@ -988,17 +887,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 23.42;
-                    CHECK_THROWS_AS(j.erase(j.end(), j.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.begin(), j.begin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.end(), j.end()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.begin(), j.begin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
                 {
                     json j = 23.42;
-                    CHECK_THROWS_AS(j.erase(j.cend(), j.cend()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.erase(j.cbegin(), j.cbegin()), json::invalid_iterator&);
-                    CHECK_THROWS_WITH(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range");
-                    CHECK_THROWS_WITH(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range");
+                    CHECK_THROWS_WITH_AS(j.erase(j.cend(), j.cend()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.erase(j.cbegin(), j.cbegin()), "[json.exception.invalid_iterator.204] iterators out of range", json::invalid_iterator&);
                 }
             }
         }

--- a/test/src/unit-element_access2.cpp
+++ b/test/src/unit-element_access2.cpp
@@ -408,13 +408,13 @@ TEST_CASE("element access 2")
                     json j_nonobject(json::value_t::boolean);
                     const json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
                 }
 
                 SECTION("string")
@@ -422,13 +422,13 @@ TEST_CASE("element access 2")
                     json j_nonobject(json::value_t::string);
                     const json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
                 }
 
                 SECTION("array")
@@ -436,12 +436,12 @@ TEST_CASE("element access 2")
                     json j_nonobject(json::value_t::array);
                     const json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
                 }
 
                 SECTION("number (integer)")
@@ -449,13 +449,13 @@ TEST_CASE("element access 2")
                     json j_nonobject(json::value_t::number_integer);
                     const json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                 }
 
                 SECTION("number (unsigned)")
@@ -463,13 +463,13 @@ TEST_CASE("element access 2")
                     json j_nonobject(json::value_t::number_unsigned);
                     const json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
@@ -477,13 +477,13 @@ TEST_CASE("element access 2")
                     json j_nonobject(json::value_t::number_float);
                     const json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                 }
             }
         }
@@ -623,25 +623,25 @@ TEST_CASE("element access 2")
                         json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
                         json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject.begin(), jobject2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin(), jobject.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin(), jobject2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                     {
                         json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
                         json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject.cbegin(), jobject2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin(), jobject.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin(), jobject2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                 }
             }

--- a/test/src/unit-element_access2.cpp
+++ b/test/src/unit-element_access2.cpp
@@ -64,12 +64,8 @@ TEST_CASE("element access 2")
 
             SECTION("access outside bounds")
             {
-                CHECK_THROWS_AS(j.at("foo"), json::out_of_range&);
-                CHECK_THROWS_AS(j_const.at("foo"), json::out_of_range&);
-                CHECK_THROWS_WITH(j.at("foo"),
-                                  "[json.exception.out_of_range.403] key 'foo' not found");
-                CHECK_THROWS_WITH(j_const.at("foo"),
-                                  "[json.exception.out_of_range.403] key 'foo' not found");
+                CHECK_THROWS_WITH_AS(j.at("foo"), "[json.exception.out_of_range.403] key 'foo' not found", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const.at("foo"), "[json.exception.out_of_range.403] key 'foo' not found", json::out_of_range&);
             }
 
             SECTION("access on non-object type")
@@ -78,70 +74,56 @@ TEST_CASE("element access 2")
                 {
                     json j_nonobject(json::value_t::null);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with null");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with null");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
                 }
 
                 SECTION("boolean")
                 {
                     json j_nonobject(json::value_t::boolean);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
                 }
 
                 SECTION("string")
                 {
                     json j_nonobject(json::value_t::string);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with string");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with string");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
                 }
 
                 SECTION("array")
                 {
                     json j_nonobject(json::value_t::array);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with array");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with array");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with array", json::type_error&);
                 }
 
                 SECTION("number (integer)")
                 {
                     json j_nonobject(json::value_t::number_integer);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
                 }
 
                 SECTION("number (unsigned)")
                 {
                     json j_nonobject(json::value_t::number_unsigned);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
                 {
                     json j_nonobject(json::value_t::number_float);
                     const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject.at("foo"), json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject_const.at("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number");
-                    CHECK_THROWS_WITH(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
                 }
             }
         }
@@ -203,84 +185,56 @@ TEST_CASE("element access 2")
                     {
                         json j_nonobject(json::value_t::null);
                         const json j_nonobject_const(json::value_t::null);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with null");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with null");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
                     }
 
                     SECTION("boolean")
                     {
                         json j_nonobject(json::value_t::boolean);
                         const json j_nonobject_const(json::value_t::boolean);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with boolean");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with boolean");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
                     }
 
                     SECTION("string")
                     {
                         json j_nonobject(json::value_t::string);
                         const json j_nonobject_const(json::value_t::string);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with string");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with string");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
                     }
 
                     SECTION("array")
                     {
                         json j_nonobject(json::value_t::array);
                         const json j_nonobject_const(json::value_t::array);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with array");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with array");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
                     }
 
                     SECTION("number (integer)")
                     {
                         json j_nonobject(json::value_t::number_integer);
                         const json j_nonobject_const(json::value_t::number_integer);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
                     }
 
                     SECTION("number (unsigned)")
                     {
                         json j_nonobject(json::value_t::number_unsigned);
                         const json j_nonobject_const(json::value_t::number_unsigned);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
                     }
 
                     SECTION("number (floating-point)")
                     {
                         json j_nonobject(json::value_t::number_float);
                         const json j_nonobject_const(json::value_t::number_float);
-                        CHECK_THROWS_AS(j_nonobject.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("foo", 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("foo", 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
                     }
                 }
             }
@@ -321,84 +275,56 @@ TEST_CASE("element access 2")
                     {
                         json j_nonobject(json::value_t::null);
                         const json j_nonobject_const(json::value_t::null);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with null");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with null");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
                     }
 
                     SECTION("boolean")
                     {
                         json j_nonobject(json::value_t::boolean);
                         const json j_nonobject_const(json::value_t::boolean);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with boolean");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with boolean");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
                     }
 
                     SECTION("string")
                     {
                         json j_nonobject(json::value_t::string);
                         const json j_nonobject_const(json::value_t::string);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with string");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with string");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
                     }
 
                     SECTION("array")
                     {
                         json j_nonobject(json::value_t::array);
                         const json j_nonobject_const(json::value_t::array);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with array");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with array");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
                     }
 
                     SECTION("number (integer)")
                     {
                         json j_nonobject(json::value_t::number_integer);
                         const json j_nonobject_const(json::value_t::number_integer);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
                     }
 
                     SECTION("number (unsigned)")
                     {
                         json j_nonobject(json::value_t::number_unsigned);
                         const json j_nonobject_const(json::value_t::number_unsigned);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
                     }
 
                     SECTION("number (floating-point)")
                     {
                         json j_nonobject(json::value_t::number_float);
                         const json j_nonobject_const(json::value_t::number_float);
-                        CHECK_THROWS_AS(j_nonobject.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_AS(j_nonobject_const.value("/foo"_json_pointer, 1), json::type_error&);
-                        CHECK_THROWS_WITH(j_nonobject.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
-                        CHECK_THROWS_WITH(j_nonobject_const.value("/foo"_json_pointer, 1),
-                                          "[json.exception.type_error.306] cannot use value() with number");
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
                     }
                 }
             }
@@ -473,118 +399,91 @@ TEST_CASE("element access 2")
                     const json j_const_nonobject(j_nonobject);
                     CHECK_NOTHROW(j_nonobject["foo"]);
                     CHECK_NOTHROW(j_nonobject2[json::object_t::key_type("foo")]);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"], "[json.exception.type_error.305] cannot use operator[] with a string argument with null");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with null");
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", json::type_error&);
                 }
 
                 SECTION("boolean")
                 {
                     json j_nonobject(json::value_t::boolean);
                     const json j_const_nonobject(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean");
-                    CHECK_THROWS_WITH(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean");
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean");
+                    CHECK_THROWS_WITH_AS(j_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
                 }
 
                 SECTION("string")
                 {
                     json j_nonobject(json::value_t::string);
                     const json j_const_nonobject(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string");
-                    CHECK_THROWS_WITH(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string");
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string");
+                    CHECK_THROWS_WITH_AS(j_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
                 }
 
                 SECTION("array")
                 {
                     json j_nonobject(json::value_t::array);
                     const json j_const_nonobject(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array");
-                    CHECK_THROWS_WITH(j_nonobject[json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array");
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array");
+                    CHECK_THROWS_WITH_AS(j_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
                 }
 
                 SECTION("number (integer)")
                 {
                     json j_nonobject(json::value_t::number_integer);
                     const json j_const_nonobject(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                 }
 
                 SECTION("number (unsigned)")
                 {
                     json j_nonobject(json::value_t::number_unsigned);
                     const json j_const_nonobject(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
                 {
                     json j_nonobject(json::value_t::number_float);
                     const json j_const_nonobject(j_nonobject);
-                    CHECK_THROWS_AS(j_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject["foo"], json::type_error&);
-                    CHECK_THROWS_AS(j_const_nonobject[json::object_t::key_type("foo")], json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_const_nonobject["foo"],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
-                    CHECK_THROWS_WITH(j_const_nonobject[json::object_t::key_type("foo")],
-                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
+                                      "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
                 }
             }
         }
@@ -723,34 +622,26 @@ TEST_CASE("element access 2")
                     {
                         json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
                         json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        CHECK_THROWS_AS(jobject.erase(jobject2.begin()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jobject.erase(jobject.begin(), jobject2.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jobject.erase(jobject2.begin(), jobject.end()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jobject.erase(jobject2.begin(), jobject2.end()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(jobject.erase(jobject2.begin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value");
-                        CHECK_THROWS_WITH(jobject.erase(jobject.begin(), jobject2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jobject.erase(jobject2.begin(), jobject.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jobject.erase(jobject2.begin(), jobject2.end()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin()),
+                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject.begin(), jobject2.end()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin(), jobject.end()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin(), jobject2.end()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                     {
                         json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
                         json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        CHECK_THROWS_AS(jobject.erase(jobject2.cbegin()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jobject.erase(jobject.cbegin(), jobject2.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jobject.erase(jobject2.cbegin(), jobject.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_AS(jobject.erase(jobject2.cbegin(), jobject2.cend()), json::invalid_iterator&);
-                        CHECK_THROWS_WITH(jobject.erase(jobject2.cbegin()),
-                                          "[json.exception.invalid_iterator.202] iterator does not fit current value");
-                        CHECK_THROWS_WITH(jobject.erase(jobject.cbegin(), jobject2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jobject.erase(jobject2.cbegin(), jobject.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
-                        CHECK_THROWS_WITH(jobject.erase(jobject2.cbegin(), jobject2.cend()),
-                                          "[json.exception.invalid_iterator.203] iterators do not fit current value");
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin()),
+                                          "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject.cbegin(), jobject2.cend()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin(), jobject.cend()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                        CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin(), jobject2.cend()),
+                                          "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
                     }
                 }
             }
@@ -760,49 +651,37 @@ TEST_CASE("element access 2")
                 SECTION("null")
                 {
                     json j_nonobject(json::value_t::null);
-                    CHECK_THROWS_AS(j_nonobject.erase("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase("foo"),
-                                      "[json.exception.type_error.307] cannot use erase() with null");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
                 }
 
                 SECTION("boolean")
                 {
                     json j_nonobject(json::value_t::boolean);
-                    CHECK_THROWS_AS(j_nonobject.erase("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase("foo"),
-                                      "[json.exception.type_error.307] cannot use erase() with boolean");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with boolean", json::type_error&);
                 }
 
                 SECTION("string")
                 {
                     json j_nonobject(json::value_t::string);
-                    CHECK_THROWS_AS(j_nonobject.erase("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase("foo"),
-                                      "[json.exception.type_error.307] cannot use erase() with string");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with string", json::type_error&);
                 }
 
                 SECTION("array")
                 {
                     json j_nonobject(json::value_t::array);
-                    CHECK_THROWS_AS(j_nonobject.erase("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase("foo"),
-                                      "[json.exception.type_error.307] cannot use erase() with array");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with array", json::type_error&);
                 }
 
                 SECTION("number (integer)")
                 {
                     json j_nonobject(json::value_t::number_integer);
-                    CHECK_THROWS_AS(j_nonobject.erase("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase("foo"),
-                                      "[json.exception.type_error.307] cannot use erase() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
                 }
 
                 SECTION("number (floating-point)")
                 {
                     json j_nonobject(json::value_t::number_float);
-                    CHECK_THROWS_AS(j_nonobject.erase("foo"), json::type_error&);
-                    CHECK_THROWS_WITH(j_nonobject.erase("foo"),
-                                      "[json.exception.type_error.307] cannot use erase() with number");
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
                 }
             }
         }

--- a/test/src/unit-iterators1.cpp
+++ b/test/src/unit-iterators1.cpp
@@ -338,23 +338,17 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(it.value() == json(true));
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(cit.value() == json(true));
 
                 auto rit = j.rend();
                 auto crit = j.crend();
-                CHECK_THROWS_AS(rit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(rit.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(rit.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(crit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(rit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
         }
 
@@ -542,23 +536,17 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(it.value() == json("hello world"));
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(cit.value() == json("hello world"));
 
                 auto rit = j.rend();
                 auto crit = j.crend();
-                CHECK_THROWS_AS(rit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(rit.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(rit.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(crit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(rit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
         }
 
@@ -739,11 +727,9 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(it.value() == json(1));
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(cit.value() == json(1));
             }
         }
@@ -1116,23 +1102,17 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(it.value() == json(23));
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(cit.value() == json(23));
 
                 auto rit = j.rend();
                 auto crit = j.crend();
-                CHECK_THROWS_AS(rit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(rit.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(rit.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(crit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(rit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
         }
 
@@ -1320,23 +1300,17 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(it.value() == json(23));
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(cit.value() == json(23));
 
                 auto rit = j.rend();
                 auto crit = j.crend();
-                CHECK_THROWS_AS(rit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(rit.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(rit.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(crit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(rit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
         }
 
@@ -1524,23 +1498,17 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(it.value() == json(23.42));
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
                 CHECK(cit.value() == json(23.42));
 
                 auto rit = j.rend();
                 auto crit = j.crend();
-                CHECK_THROWS_AS(rit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(rit.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(rit.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(crit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(rit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
         }
 
@@ -1598,25 +1566,17 @@ TEST_CASE("iterators 1")
             {
                 auto it = j.begin();
                 auto cit = j_const.cbegin();
-                CHECK_THROWS_AS(it.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(it.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(cit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(cit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(it.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(cit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(it.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(it.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(cit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(cit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
 
                 auto rit = j.rend();
                 auto crit = j.crend();
-                CHECK_THROWS_AS(rit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(rit.value(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.key(), json::invalid_iterator&);
-                CHECK_THROWS_AS(crit.value(), json::invalid_iterator&);
-                CHECK_THROWS_WITH(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(rit.value(), "[json.exception.invalid_iterator.214] cannot get value");
-                CHECK_THROWS_WITH(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators");
-                CHECK_THROWS_WITH(crit.value(), "[json.exception.invalid_iterator.214] cannot get value");
+                CHECK_THROWS_WITH_AS(rit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(rit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.key(), "[json.exception.invalid_iterator.207] cannot use key() for non-object iterators", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(crit.value(), "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
             }
         }
     }

--- a/test/src/unit-iterators2.cpp
+++ b/test/src/unit-iterators2.cpp
@@ -82,32 +82,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 < it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 < it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 < it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 < it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c < it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c < it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c < it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c < it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 < it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 < it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 < it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 < it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -127,32 +119,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 <= it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 <= it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 <= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 <= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c <= it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c <= it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c <= it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c <= it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 <= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 <= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 <= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 <= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -173,32 +157,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 > it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 > it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 > it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 > it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c > it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c > it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c > it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c > it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 > it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 > it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 > it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 > it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -219,32 +195,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 >= it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 >= it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 >= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 >= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c >= it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c >= it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c >= it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c >= it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 >= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 >= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 >= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 >= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -269,17 +237,13 @@ TEST_CASE("iterators 2")
             {
                 if (j != k)
                 {
-                    CHECK_THROWS_AS(j.begin() == k.begin(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.cbegin() == k.cbegin(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.begin() < k.begin(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.cbegin() < k.cbegin(), json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
                     // the output differs in each loop, so we cannot fix a string for the expected exception
 #else
-                    CHECK_THROWS_WITH(j.begin() == k.begin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
-                    CHECK_THROWS_WITH(j.cbegin() == k.cbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
-                    CHECK_THROWS_WITH(j.begin() < k.begin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
-                    CHECK_THROWS_WITH(j.cbegin() < k.cbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
+                    CHECK_THROWS_WITH_AS(j.begin() == k.begin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.cbegin() == k.cbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.begin() < k.begin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.cbegin() < k.cbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
 #endif
                 }
             }
@@ -299,63 +263,51 @@ TEST_CASE("iterators 2")
             {
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(it += 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(it += 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(it + 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(it + 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(1 + it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(1 + it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(it -= 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(it -= 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(it - 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(it - 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(it - it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(it - it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
             }
 
@@ -444,17 +396,13 @@ TEST_CASE("iterators 2")
             {
                 {
                     auto it = j_object.begin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.cbegin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.208] cannot use operator[] for object iterators", json::invalid_iterator&);
                 }
             }
 
@@ -484,17 +432,13 @@ TEST_CASE("iterators 2")
             {
                 {
                     auto it = j_null.begin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
                 {
                     auto it = j_null.cbegin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
             }
 
@@ -503,14 +447,12 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_value.begin();
                     CHECK(it[0] == json(42));
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
                 {
                     auto it = j_value.cbegin();
                     CHECK(it[0] == json(42));
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
             }
         }
@@ -564,32 +506,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 < it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 < it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 < it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 < it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c < it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c < it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c < it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c < it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 < it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 < it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 < it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 < it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 < it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c < it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -609,32 +543,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 <= it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 <= it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 <= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 <= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c <= it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c <= it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c <= it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c <= it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 <= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 <= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 <= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 <= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 <= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c <= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -655,32 +581,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 > it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 > it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 > it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 > it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c > it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c > it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c > it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c > it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 > it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 > it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 > it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 > it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 > it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c > it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -701,32 +619,24 @@ TEST_CASE("iterators 2")
             {
                 if (j.type() == json::value_t::object)
                 {
-                    CHECK_THROWS_AS(it1 >= it1, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 >= it2, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2 >= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1 >= it3, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c >= it1_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c >= it2_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it2_c >= it3_c, json::invalid_iterator&);
-                    CHECK_THROWS_AS(it1_c >= it3_c, json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
-                    CHECK_THROWS_WITH(it1 >= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 >= it1, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it2, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it3, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it1_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it2_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it3_c, "[json.exception.invalid_iterator.213] (/5) cannot compare order of object iterators", json::invalid_iterator&);
 #else
-                    CHECK_THROWS_WITH(it1 >= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it2_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
-                    CHECK_THROWS_WITH(it1_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators");
+                    CHECK_THROWS_WITH_AS(it1 >= it1, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it2, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1 >= it3, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it1_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it2_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it2_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it1_c >= it3_c, "[json.exception.invalid_iterator.213] cannot compare order of object iterators", json::invalid_iterator&);
 #endif
                 }
                 else
@@ -751,17 +661,13 @@ TEST_CASE("iterators 2")
             {
                 if (j != k)
                 {
-                    CHECK_THROWS_AS(j.rbegin() == k.rbegin(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.crbegin() == k.crbegin(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.rbegin() < k.rbegin(), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j.crbegin() < k.crbegin(), json::invalid_iterator&);
 #if JSON_DIAGNOSTICS
                     // the output differs in each loop, so we cannot fix a string for the expected exception
 #else
-                    CHECK_THROWS_WITH(j.rbegin() == k.rbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
-                    CHECK_THROWS_WITH(j.crbegin() == k.crbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
-                    CHECK_THROWS_WITH(j.rbegin() < k.rbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
-                    CHECK_THROWS_WITH(j.crbegin() < k.crbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers");
+                    CHECK_THROWS_WITH_AS(j.rbegin() == k.rbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.crbegin() == k.crbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.rbegin() < k.rbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j.crbegin() < k.crbegin(), "[json.exception.invalid_iterator.212] cannot compare iterators of different containers", json::invalid_iterator&);
 #endif
                 }
             }
@@ -781,63 +687,51 @@ TEST_CASE("iterators 2")
             {
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(it += 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(it += 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it += 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(it + 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(it + 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it + 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(1 + it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(1 + it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(1 + it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(it -= 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(it -= 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it -= 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(it - 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(it - 1, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - 1, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(it - it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(it - it, json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it - it, "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
             }
 
@@ -926,17 +820,13 @@ TEST_CASE("iterators 2")
             {
                 {
                     auto it = j_object.rbegin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
                 {
                     auto it = j_object.crbegin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.209] cannot use offsets with object iterators", json::invalid_iterator&);
                 }
             }
 
@@ -966,17 +856,13 @@ TEST_CASE("iterators 2")
             {
                 {
                     auto it = j_null.rbegin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
                 {
                     auto it = j_null.crbegin();
-                    CHECK_THROWS_AS(it[0], json::invalid_iterator&);
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[0], "[json.exception.invalid_iterator.214] cannot get value");
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[0], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
             }
 
@@ -985,14 +871,12 @@ TEST_CASE("iterators 2")
                 {
                     auto it = j_value.rbegin();
                     CHECK(it[0] == json(42));
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
                 {
                     auto it = j_value.crbegin();
                     CHECK(it[0] == json(42));
-                    CHECK_THROWS_AS(it[1], json::invalid_iterator&);
-                    CHECK_THROWS_WITH(it[1], "[json.exception.invalid_iterator.214] cannot get value");
+                    CHECK_THROWS_WITH_AS(it[1], "[json.exception.invalid_iterator.214] cannot get value", json::invalid_iterator&);
                 }
             }
         }

--- a/test/src/unit-json_patch.cpp
+++ b/test/src/unit-json_patch.cpp
@@ -80,9 +80,7 @@ TEST_CASE("JSON patch")
             json doc2 = R"({ "q": { "bar": 2 } })"_json;
 
             // because "a" does not exist.
-            CHECK_THROWS_AS(doc2.patch(patch), json::out_of_range&);
-            CHECK_THROWS_WITH(doc2.patch(patch),
-                              "[json.exception.out_of_range.403] key 'a' not found");
+            CHECK_THROWS_WITH_AS(doc2.patch(patch), "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
         }
 
         SECTION("4.2 remove")
@@ -430,9 +428,7 @@ TEST_CASE("JSON patch")
             // references neither the root of the document, nor a member of
             // an existing object, nor a member of an existing array.
 
-            CHECK_THROWS_AS(doc.patch(patch), json::out_of_range&);
-            CHECK_THROWS_WITH(doc.patch(patch),
-                              "[json.exception.out_of_range.403] key 'baz' not found");
+            CHECK_THROWS_WITH_AS(doc.patch(patch), "[json.exception.out_of_range.403] key 'baz' not found", json::out_of_range&);
         }
 
         // A.13. Invalid JSON Patch Document
@@ -681,20 +677,17 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{"op", "add"}, {"path", ""}, {"value", 1}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.parse_error.104] parse error: JSON patch must be an array of objects");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.104] parse error: JSON patch must be an array of objects", json::parse_error&);
             }
 
             SECTION("not an array of objects")
             {
                 json j;
                 json patch = {"op", "add", "path", "", "value", 1};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.104] parse error: (/0) JSON patch must be an array of objects");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.104] parse error: (/0) JSON patch must be an array of objects", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.104] parse error: JSON patch must be an array of objects");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.104] parse error: JSON patch must be an array of objects", json::parse_error&);
 #endif
             }
 
@@ -702,11 +695,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"foo", "bar"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation must have member 'op'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation must have member 'op'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation must have member 'op'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation must have member 'op'", json::parse_error&);
 #endif
             }
 
@@ -714,11 +706,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation must have string member 'op'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation must have string member 'op'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation must have string member 'op'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation must have string member 'op'", json::parse_error&);
 #endif
             }
 
@@ -726,11 +717,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "foo"}, {"path", ""}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation value 'foo' is invalid");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation value 'foo' is invalid", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation value 'foo' is invalid");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation value 'foo' is invalid", json::parse_error&);
 #endif
             }
         }
@@ -741,11 +731,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "add"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'add' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'add' must have member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'add' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'add' must have member 'path'", json::parse_error&);
 #endif
             }
 
@@ -753,11 +742,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "add"}, {"path", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'add' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'add' must have string member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'add' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'add' must have string member 'path'", json::parse_error&);
 #endif
             }
 
@@ -765,11 +753,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "add"}, {"path", ""}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'add' must have member 'value'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'add' must have member 'value'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'add' must have member 'value'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'add' must have member 'value'", json::parse_error&);
 #endif
             }
 
@@ -777,9 +764,7 @@ TEST_CASE("JSON patch")
             {
                 json j = {1, 2};
                 json patch = {{{"op", "add"}, {"path", "/4"}, {"value", 4}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.401] array index 4 is out of range");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.401] array index 4 is out of range", json::out_of_range&);
             }
         }
 
@@ -789,11 +774,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "remove"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'remove' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'remove' must have member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'remove' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'remove' must have member 'path'", json::parse_error&);
 #endif
             }
 
@@ -801,11 +785,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "remove"}, {"path", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'remove' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'remove' must have string member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'remove' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'remove' must have string member 'path'", json::parse_error&);
 #endif
             }
 
@@ -813,27 +796,21 @@ TEST_CASE("JSON patch")
             {
                 json j = {1, 2, 3};
                 json patch = {{{"op", "remove"}, {"path", "/17"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.401] array index 17 is out of range");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.401] array index 17 is out of range", json::out_of_range&);
             }
 
             SECTION("nonexisting target location (object)")
             {
                 json j = {{"foo", 1}, {"bar", 2}};
                 json patch = {{{"op", "remove"}, {"path", "/baz"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.403] key 'baz' not found");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.403] key 'baz' not found", json::out_of_range&);
             }
 
             SECTION("root element as target location")
             {
                 json j = "string";
                 json patch = {{{"op", "remove"}, {"path", ""}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.405] JSON pointer has no parent");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
             }
         }
 
@@ -843,11 +820,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "replace"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'replace' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'replace' must have member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'replace' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'replace' must have member 'path'", json::parse_error&);
 #endif
             }
 
@@ -855,11 +831,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "replace"}, {"path", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'replace' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'replace' must have string member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'replace' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'replace' must have string member 'path'", json::parse_error&);
 #endif
             }
 
@@ -867,11 +842,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "replace"}, {"path", ""}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'replace' must have member 'value'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'replace' must have member 'value'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'replace' must have member 'value'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'replace' must have member 'value'", json::parse_error&);
 #endif
             }
 
@@ -879,18 +853,14 @@ TEST_CASE("JSON patch")
             {
                 json j = {1, 2, 3};
                 json patch = {{{"op", "replace"}, {"path", "/17"}, {"value", 19}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.401] array index 17 is out of range");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.401] array index 17 is out of range", json::out_of_range&);
             }
 
             SECTION("nonexisting target location (object)")
             {
                 json j = {{"foo", 1}, {"bar", 2}};
                 json patch = {{{"op", "replace"}, {"path", "/baz"}, {"value", 3}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.403] key 'baz' not found");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.403] key 'baz' not found", json::out_of_range&);
             }
         }
 
@@ -900,11 +870,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "move"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have member 'path'", json::parse_error&);
 #endif
             }
 
@@ -912,11 +881,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "move"}, {"path", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have string member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have string member 'path'", json::parse_error&);
 #endif
             }
 
@@ -926,9 +894,9 @@ TEST_CASE("JSON patch")
                 json patch = {{{"op", "move"}, {"path", ""}}};
                 CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have member 'from'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have member 'from'", json::parse_error&);
 #endif
             }
 
@@ -938,9 +906,9 @@ TEST_CASE("JSON patch")
                 json patch = {{{"op", "move"}, {"path", ""}, {"from", 1}}};
                 CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have string member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'move' must have string member 'from'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have string member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'move' must have string member 'from'", json::parse_error&);
 #endif
             }
 
@@ -948,18 +916,14 @@ TEST_CASE("JSON patch")
             {
                 json j = {1, 2, 3};
                 json patch = {{{"op", "move"}, {"path", "/0"}, {"from", "/5"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.401] array index 5 is out of range");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
             }
 
             SECTION("nonexisting from location (object)")
             {
                 json j = {{"foo", 1}, {"bar", 2}};
                 json patch = {{{"op", "move"}, {"path", "/baz"}, {"from", "/baz"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.403] key 'baz' not found");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.403] key 'baz' not found", json::out_of_range&);
             }
         }
 
@@ -969,11 +933,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "copy"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have member 'path'", json::parse_error&);
 #endif
             }
 
@@ -981,11 +944,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "copy"}, {"path", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have string member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have string member 'path'", json::parse_error&);
 #endif
             }
 
@@ -993,11 +955,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "copy"}, {"path", ""}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have member 'from'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have member 'from'", json::parse_error&);
 #endif
             }
 
@@ -1005,11 +966,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "copy"}, {"path", ""}, {"from", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have string member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'copy' must have string member 'from'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have string member 'from'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'copy' must have string member 'from'", json::parse_error&);
 #endif
             }
 
@@ -1017,18 +977,14 @@ TEST_CASE("JSON patch")
             {
                 json j = {1, 2, 3};
                 json patch = {{{"op", "copy"}, {"path", "/0"}, {"from", "/5"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.401] array index 5 is out of range");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
             }
 
             SECTION("nonexisting from location (object)")
             {
                 json j = {{"foo", 1}, {"bar", 2}};
                 json patch = {{{"op", "copy"}, {"path", "/fob"}, {"from", "/baz"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::out_of_range&);
-                CHECK_THROWS_WITH(j.patch(patch),
-                                  "[json.exception.out_of_range.403] key 'baz' not found");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.out_of_range.403] key 'baz' not found", json::out_of_range&);
             }
         }
 
@@ -1038,11 +994,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "test"}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'test' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'test' must have member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'test' must have member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'test' must have member 'path'", json::parse_error&);
 #endif
             }
 
@@ -1050,11 +1005,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "test"}, {"path", 1}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'test' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'test' must have string member 'path'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'test' must have string member 'path'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'test' must have string member 'path'", json::parse_error&);
 #endif
             }
 
@@ -1062,11 +1016,10 @@ TEST_CASE("JSON patch")
             {
                 json j;
                 json patch = {{{"op", "test"}, {"path", ""}}};
-                CHECK_THROWS_AS(j.patch(patch), json::parse_error&);
 #if JSON_DIAGNOSTICS
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'test' must have member 'value'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: (/0) operation 'test' must have member 'value'", json::parse_error&);
 #else
-                CHECK_THROWS_WITH(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'test' must have member 'value'");
+                CHECK_THROWS_WITH_AS(j.patch(patch), "[json.exception.parse_error.105] parse error: operation 'test' must have member 'value'", json::parse_error&);
 #endif
             }
         }

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -37,33 +37,27 @@ TEST_CASE("JSON pointers")
 {
     SECTION("errors")
     {
-        CHECK_THROWS_AS(json::json_pointer("foo"), json::parse_error&);
-        CHECK_THROWS_WITH(json::json_pointer("foo"),
-                          "[json.exception.parse_error.107] parse error at byte 1: JSON pointer must be empty or begin with '/' - was: 'foo'");
+        CHECK_THROWS_WITH_AS(json::json_pointer("foo"),
+                          "[json.exception.parse_error.107] parse error at byte 1: JSON pointer must be empty or begin with '/' - was: 'foo'", json::parse_error&);
 
-        CHECK_THROWS_AS(json::json_pointer("/~~"), json::parse_error&);
-        CHECK_THROWS_WITH(json::json_pointer("/~~"),
-                          "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'");
+        CHECK_THROWS_WITH_AS(json::json_pointer("/~~"),
+                          "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
 
-        CHECK_THROWS_AS(json::json_pointer("/~"), json::parse_error&);
-        CHECK_THROWS_WITH(json::json_pointer("/~"),
-                          "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'");
+        CHECK_THROWS_WITH_AS(json::json_pointer("/~"),
+                          "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
 
         json::json_pointer p;
-        CHECK_THROWS_AS(p.top(), json::out_of_range&);
-        CHECK_THROWS_WITH(p.top(),
-                          "[json.exception.out_of_range.405] JSON pointer has no parent");
-        CHECK_THROWS_AS(p.pop_back(), json::out_of_range&);
-        CHECK_THROWS_WITH(p.pop_back(),
-                          "[json.exception.out_of_range.405] JSON pointer has no parent");
+        CHECK_THROWS_WITH_AS(p.top(),
+                          "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
+        CHECK_THROWS_WITH_AS(p.pop_back(),
+                          "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
 
         SECTION("array index error")
         {
             json v = {1, 2, 3, 4};
             json::json_pointer ptr("/10e");
-            CHECK_THROWS_AS(v[ptr], json::out_of_range&);
-            CHECK_THROWS_WITH(v[ptr],
-                              "[json.exception.out_of_range.404] unresolved reference token '10e'");
+            CHECK_THROWS_WITH_AS(v[ptr],
+                              "[json.exception.out_of_range.404] unresolved reference token '10e'", json::out_of_range&);
         }
     }
 
@@ -165,12 +159,10 @@ TEST_CASE("JSON pointers")
 
             // unresolved access
             json j_primitive = 1;
-            CHECK_THROWS_AS(j_primitive["/foo"_json_pointer], json::out_of_range&);
-            CHECK_THROWS_WITH(j_primitive["/foo"_json_pointer],
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'");
-            CHECK_THROWS_AS(j_primitive.at("/foo"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j_primitive.at("/foo"_json_pointer),
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'");
+            CHECK_THROWS_WITH_AS(j_primitive["/foo"_json_pointer],
+                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
+            CHECK_THROWS_WITH_AS(j_primitive.at("/foo"_json_pointer),
+                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
             CHECK(!j_primitive.contains(json::json_pointer("/foo")));
         }
 
@@ -229,18 +221,15 @@ TEST_CASE("JSON pointers")
             CHECK(j[json::json_pointer("/m~0n")] == j["m~n"]);
 
             // unescaped access
-            CHECK_THROWS_AS(j.at(json::json_pointer("/a/b")), json::out_of_range&);
-            CHECK_THROWS_WITH(j.at(json::json_pointer("/a/b")),
-                              "[json.exception.out_of_range.403] key 'a' not found");
+            CHECK_THROWS_WITH_AS(j.at(json::json_pointer("/a/b")),
+                              "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
 
             // unresolved access
             const json j_primitive = 1;
-            CHECK_THROWS_AS(j_primitive["/foo"_json_pointer], json::out_of_range&);
-            CHECK_THROWS_WITH(j_primitive["/foo"_json_pointer],
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'");
-            CHECK_THROWS_AS(j_primitive.at("/foo"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j_primitive.at("/foo"_json_pointer),
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'");
+            CHECK_THROWS_WITH_AS(j_primitive["/foo"_json_pointer],
+                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
+            CHECK_THROWS_WITH_AS(j_primitive.at("/foo"_json_pointer),
+                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
         }
 
         SECTION("user-defined string literal")
@@ -300,18 +289,14 @@ TEST_CASE("JSON pointers")
             CHECK(j == json({1, 13, 3, 33, nullptr, 55}));
 
             // error with leading 0
-            CHECK_THROWS_AS(j["/01"_json_pointer], json::parse_error&);
-            CHECK_THROWS_WITH(j["/01"_json_pointer],
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
-            CHECK_THROWS_AS(j_const["/01"_json_pointer], json::parse_error&);
-            CHECK_THROWS_WITH(j_const["/01"_json_pointer],
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
-            CHECK_THROWS_AS(j.at("/01"_json_pointer), json::parse_error&);
-            CHECK_THROWS_WITH(j.at("/01"_json_pointer),
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
-            CHECK_THROWS_AS(j_const.at("/01"_json_pointer), json::parse_error&);
-            CHECK_THROWS_WITH(j_const.at("/01"_json_pointer),
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
+            CHECK_THROWS_WITH_AS(j["/01"_json_pointer],
+                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j_const["/01"_json_pointer],
+                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j.at("/01"_json_pointer),
+                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j_const.at("/01"_json_pointer),
+                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
 
             CHECK(!j.contains("/01"_json_pointer));
             CHECK(!j.contains("/01"_json_pointer));
@@ -319,43 +304,33 @@ TEST_CASE("JSON pointers")
             CHECK(!j_const.contains("/01"_json_pointer));
 
             // error with incorrect numbers
-            CHECK_THROWS_AS(j["/one"_json_pointer] = 1, json::parse_error&);
-            CHECK_THROWS_WITH(j["/one"_json_pointer] = 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
-            CHECK_THROWS_AS(j_const["/one"_json_pointer] == 1, json::parse_error&);
-            CHECK_THROWS_WITH(j_const["/one"_json_pointer] == 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
+            CHECK_THROWS_WITH_AS(j["/one"_json_pointer] = 1,
+                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j_const["/one"_json_pointer] == 1,
+                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
 
-            CHECK_THROWS_AS(j.at("/one"_json_pointer) = 1, json::parse_error&);
-            CHECK_THROWS_WITH(j.at("/one"_json_pointer) = 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
-            CHECK_THROWS_AS(j_const.at("/one"_json_pointer) == 1, json::parse_error&);
-            CHECK_THROWS_WITH(j_const.at("/one"_json_pointer) == 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
+            CHECK_THROWS_WITH_AS(j.at("/one"_json_pointer) = 1,
+                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j_const.at("/one"_json_pointer) == 1,
+                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
 
-            CHECK_THROWS_AS(j["/+1"_json_pointer] = 1, json::parse_error&);
-            CHECK_THROWS_WITH(j["/+1"_json_pointer] = 1,
-                              "[json.exception.parse_error.109] parse error: array index '+1' is not a number");
-            CHECK_THROWS_AS(j_const["/+1"_json_pointer] == 1, json::parse_error&);
-            CHECK_THROWS_WITH(j_const["/+1"_json_pointer] == 1,
-                              "[json.exception.parse_error.109] parse error: array index '+1' is not a number");
+            CHECK_THROWS_WITH_AS(j["/+1"_json_pointer] = 1,
+                              "[json.exception.parse_error.109] parse error: array index '+1' is not a number", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j_const["/+1"_json_pointer] == 1,
+                              "[json.exception.parse_error.109] parse error: array index '+1' is not a number", json::parse_error&);
 
-            CHECK_THROWS_AS(j["/1+1"_json_pointer] = 1, json::out_of_range&);
-            CHECK_THROWS_WITH(j["/1+1"_json_pointer] = 1,
-                              "[json.exception.out_of_range.404] unresolved reference token '1+1'");
-            CHECK_THROWS_AS(j_const["/1+1"_json_pointer] == 1, json::out_of_range&);
-            CHECK_THROWS_WITH(j_const["/1+1"_json_pointer] == 1,
-                              "[json.exception.out_of_range.404] unresolved reference token '1+1'");
+            CHECK_THROWS_WITH_AS(j["/1+1"_json_pointer] = 1,
+                              "[json.exception.out_of_range.404] unresolved reference token '1+1'", json::out_of_range&);
+            CHECK_THROWS_WITH_AS(j_const["/1+1"_json_pointer] == 1,
+                              "[json.exception.out_of_range.404] unresolved reference token '1+1'", json::out_of_range&);
 
             {
                 auto too_large_index = std::to_string((std::numeric_limits<unsigned long long>::max)()) + "1";
                 json::json_pointer jp(std::string("/") + too_large_index);
                 std::string throw_msg = std::string("[json.exception.out_of_range.404] unresolved reference token '") + too_large_index + "'";
 
-                CHECK_THROWS_AS(j[jp] = 1, json::out_of_range&);
-                CHECK_THROWS_WITH(j[jp] = 1, throw_msg.c_str());
-                CHECK_THROWS_AS(j_const[jp] == 1, json::out_of_range&);
-                CHECK_THROWS_WITH(j_const[jp] == 1, throw_msg.c_str());
+                CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const[jp] == 1, throw_msg.c_str(), json::out_of_range&);
             }
 
             // on some machines, the check below is not constant
@@ -369,47 +344,39 @@ TEST_CASE("JSON pointers")
                 json::json_pointer jp(std::string("/") + too_large_index);
                 std::string throw_msg = std::string("[json.exception.out_of_range.410] array index ") + too_large_index + " exceeds size_type";
 
-                CHECK_THROWS_AS(j[jp] = 1, json::out_of_range&);
-                CHECK_THROWS_WITH(j[jp] = 1, throw_msg.c_str());
-                CHECK_THROWS_AS(j_const[jp] == 1, json::out_of_range&);
-                CHECK_THROWS_WITH(j_const[jp] == 1, throw_msg.c_str());
+                CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const[jp] == 1, throw_msg.c_str(), json::out_of_range&);
             }
 
             DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-            CHECK_THROWS_AS(j.at("/one"_json_pointer) = 1, json::parse_error&);
-            CHECK_THROWS_WITH(j.at("/one"_json_pointer) = 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
-            CHECK_THROWS_AS(j_const.at("/one"_json_pointer) == 1, json::parse_error&);
-            CHECK_THROWS_WITH(j_const.at("/one"_json_pointer) == 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
+            CHECK_THROWS_WITH_AS(j.at("/one"_json_pointer) = 1,
+                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j_const.at("/one"_json_pointer) == 1,
+                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
 
             CHECK(!j.contains("/one"_json_pointer));
             CHECK(!j.contains("/one"_json_pointer));
             CHECK(!j_const.contains("/one"_json_pointer));
             CHECK(!j_const.contains("/one"_json_pointer));
 
-            CHECK_THROWS_AS(json({{"/list/0", 1}, {"/list/1", 2}, {"/list/three", 3}}).unflatten(), json::parse_error&);
-            CHECK_THROWS_WITH(json({{"/list/0", 1}, {"/list/1", 2}, {"/list/three", 3}}).unflatten(),
-            "[json.exception.parse_error.109] parse error: array index 'three' is not a number");
+            CHECK_THROWS_WITH_AS(json({{"/list/0", 1}, {"/list/1", 2}, {"/list/three", 3}}).unflatten(),
+            "[json.exception.parse_error.109] parse error: array index 'three' is not a number", json::parse_error&);
 
             // assign to "-"
             j["/-"_json_pointer] = 99;
             CHECK(j == json({1, 13, 3, 33, nullptr, 55, 99}));
 
             // error when using "-" in const object
-            CHECK_THROWS_AS(j_const["/-"_json_pointer], json::out_of_range&);
-            CHECK_THROWS_WITH(j_const["/-"_json_pointer],
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range");
+            CHECK_THROWS_WITH_AS(j_const["/-"_json_pointer],
+                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK(!j_const.contains("/-"_json_pointer));
 
             // error when using "-" with at
-            CHECK_THROWS_AS(j.at("/-"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j.at("/-"_json_pointer),
-                              "[json.exception.out_of_range.402] array index '-' (7) is out of range");
-            CHECK_THROWS_AS(j_const.at("/-"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j_const.at("/-"_json_pointer),
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range");
+            CHECK_THROWS_WITH_AS(j.at("/-"_json_pointer),
+                              "[json.exception.out_of_range.402] array index '-' (7) is out of range", json::out_of_range&);
+            CHECK_THROWS_WITH_AS(j_const.at("/-"_json_pointer),
+                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK(!j_const.contains("/-"_json_pointer));
         }
 
@@ -423,24 +390,20 @@ TEST_CASE("JSON pointers")
             CHECK(j["/2"_json_pointer] == j[2]);
 
             // assign to nonexisting index
-            CHECK_THROWS_AS(j.at("/3"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j.at("/3"_json_pointer),
-                              "[json.exception.out_of_range.401] array index 3 is out of range");
+            CHECK_THROWS_WITH_AS(j.at("/3"_json_pointer),
+                              "[json.exception.out_of_range.401] array index 3 is out of range", json::out_of_range&);
             CHECK(!j.contains("/3"_json_pointer));
 
             // assign to nonexisting index (with gap)
-            CHECK_THROWS_AS(j.at("/5"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j.at("/5"_json_pointer),
-                              "[json.exception.out_of_range.401] array index 5 is out of range");
+            CHECK_THROWS_WITH_AS(j.at("/5"_json_pointer),
+                              "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
             CHECK(!j.contains("/5"_json_pointer));
 
             // assign to "-"
-            CHECK_THROWS_AS(j["/-"_json_pointer], json::out_of_range&);
-            CHECK_THROWS_WITH(j["/-"_json_pointer],
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range");
-            CHECK_THROWS_AS(j.at("/-"_json_pointer), json::out_of_range&);
-            CHECK_THROWS_WITH(j.at("/-"_json_pointer),
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range");
+            CHECK_THROWS_WITH_AS(j["/-"_json_pointer],
+                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
+            CHECK_THROWS_WITH_AS(j.at("/-"_json_pointer),
+                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK(!j.contains("/-"_json_pointer));
         }
     }
@@ -496,23 +459,20 @@ TEST_CASE("JSON pointers")
         CHECK(j_flatten.unflatten() == j);
 
         // error for nonobjects
-        CHECK_THROWS_AS(json(1).unflatten(), json::type_error&);
-        CHECK_THROWS_WITH(json(1).unflatten(),
-                          "[json.exception.type_error.314] only objects can be unflattened");
+        CHECK_THROWS_WITH_AS(json(1).unflatten(),
+                          "[json.exception.type_error.314] only objects can be unflattened", json::type_error&);
 
         // error for nonprimitve values
-        CHECK_THROWS_AS(json({{"/1", {1, 2, 3}}}).unflatten(), json::type_error&);
 #if JSON_DIAGNOSTICS
-        CHECK_THROWS_WITH(json({{"/1", {1, 2, 3}}}).unflatten(), "[json.exception.type_error.315] (/~11) values in object must be primitive");
+        CHECK_THROWS_WITH_AS(json({{"/1", {1, 2, 3}}}).unflatten(), "[json.exception.type_error.315] (/~11) values in object must be primitive", json::type_error&);
 #else
-        CHECK_THROWS_WITH(json({{"/1", {1, 2, 3}}}).unflatten(), "[json.exception.type_error.315] values in object must be primitive");
+        CHECK_THROWS_WITH_AS(json({{"/1", {1, 2, 3}}}).unflatten(), "[json.exception.type_error.315] values in object must be primitive", json::type_error&);
 #endif
 
         // error for conflicting values
         json j_error = {{"", 42}, {"/foo", 17}};
-        CHECK_THROWS_AS(j_error.unflatten(), json::type_error&);
-        CHECK_THROWS_WITH(j_error.unflatten(),
-                          "[json.exception.type_error.313] invalid value to unflatten");
+        CHECK_THROWS_WITH_AS(j_error.unflatten(),
+                          "[json.exception.type_error.313] invalid value to unflatten", json::type_error&);
 
         // explicit roundtrip check
         CHECK(j.flatten().unflatten() == j);

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -38,26 +38,26 @@ TEST_CASE("JSON pointers")
     SECTION("errors")
     {
         CHECK_THROWS_WITH_AS(json::json_pointer("foo"),
-                          "[json.exception.parse_error.107] parse error at byte 1: JSON pointer must be empty or begin with '/' - was: 'foo'", json::parse_error&);
+                             "[json.exception.parse_error.107] parse error at byte 1: JSON pointer must be empty or begin with '/' - was: 'foo'", json::parse_error&);
 
         CHECK_THROWS_WITH_AS(json::json_pointer("/~~"),
-                          "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
+                             "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
 
         CHECK_THROWS_WITH_AS(json::json_pointer("/~"),
-                          "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
+                             "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
 
         json::json_pointer p;
         CHECK_THROWS_WITH_AS(p.top(),
-                          "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
+                             "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
         CHECK_THROWS_WITH_AS(p.pop_back(),
-                          "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
+                             "[json.exception.out_of_range.405] JSON pointer has no parent", json::out_of_range&);
 
         SECTION("array index error")
         {
             json v = {1, 2, 3, 4};
             json::json_pointer ptr("/10e");
             CHECK_THROWS_WITH_AS(v[ptr],
-                              "[json.exception.out_of_range.404] unresolved reference token '10e'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token '10e'", json::out_of_range&);
         }
     }
 
@@ -160,9 +160,9 @@ TEST_CASE("JSON pointers")
             // unresolved access
             json j_primitive = 1;
             CHECK_THROWS_WITH_AS(j_primitive["/foo"_json_pointer],
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j_primitive.at("/foo"_json_pointer),
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
             CHECK(!j_primitive.contains(json::json_pointer("/foo")));
         }
 
@@ -222,14 +222,14 @@ TEST_CASE("JSON pointers")
 
             // unescaped access
             CHECK_THROWS_WITH_AS(j.at(json::json_pointer("/a/b")),
-                              "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
+                                 "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
 
             // unresolved access
             const json j_primitive = 1;
             CHECK_THROWS_WITH_AS(j_primitive["/foo"_json_pointer],
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j_primitive.at("/foo"_json_pointer),
-                              "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token 'foo'", json::out_of_range&);
         }
 
         SECTION("user-defined string literal")
@@ -290,13 +290,13 @@ TEST_CASE("JSON pointers")
 
             // error with leading 0
             CHECK_THROWS_WITH_AS(j["/01"_json_pointer],
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+                                 "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
             CHECK_THROWS_WITH_AS(j_const["/01"_json_pointer],
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+                                 "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
             CHECK_THROWS_WITH_AS(j.at("/01"_json_pointer),
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+                                 "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
             CHECK_THROWS_WITH_AS(j_const.at("/01"_json_pointer),
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+                                 "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
 
             CHECK(!j.contains("/01"_json_pointer));
             CHECK(!j.contains("/01"_json_pointer));
@@ -305,24 +305,24 @@ TEST_CASE("JSON pointers")
 
             // error with incorrect numbers
             CHECK_THROWS_WITH_AS(j["/one"_json_pointer] = 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
             CHECK_THROWS_WITH_AS(j_const["/one"_json_pointer] == 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
 
             CHECK_THROWS_WITH_AS(j.at("/one"_json_pointer) = 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
             CHECK_THROWS_WITH_AS(j_const.at("/one"_json_pointer) == 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
 
             CHECK_THROWS_WITH_AS(j["/+1"_json_pointer] = 1,
-                              "[json.exception.parse_error.109] parse error: array index '+1' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index '+1' is not a number", json::parse_error&);
             CHECK_THROWS_WITH_AS(j_const["/+1"_json_pointer] == 1,
-                              "[json.exception.parse_error.109] parse error: array index '+1' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index '+1' is not a number", json::parse_error&);
 
             CHECK_THROWS_WITH_AS(j["/1+1"_json_pointer] = 1,
-                              "[json.exception.out_of_range.404] unresolved reference token '1+1'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token '1+1'", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j_const["/1+1"_json_pointer] == 1,
-                              "[json.exception.out_of_range.404] unresolved reference token '1+1'", json::out_of_range&);
+                                 "[json.exception.out_of_range.404] unresolved reference token '1+1'", json::out_of_range&);
 
             {
                 auto too_large_index = std::to_string((std::numeric_limits<unsigned long long>::max)()) + "1";
@@ -351,9 +351,9 @@ TEST_CASE("JSON pointers")
             DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
             CHECK_THROWS_WITH_AS(j.at("/one"_json_pointer) = 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
             CHECK_THROWS_WITH_AS(j_const.at("/one"_json_pointer) == 1,
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
+                                 "[json.exception.parse_error.109] parse error: array index 'one' is not a number", json::parse_error&);
 
             CHECK(!j.contains("/one"_json_pointer));
             CHECK(!j.contains("/one"_json_pointer));
@@ -369,14 +369,14 @@ TEST_CASE("JSON pointers")
 
             // error when using "-" in const object
             CHECK_THROWS_WITH_AS(j_const["/-"_json_pointer],
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK(!j_const.contains("/-"_json_pointer));
 
             // error when using "-" with at
             CHECK_THROWS_WITH_AS(j.at("/-"_json_pointer),
-                              "[json.exception.out_of_range.402] array index '-' (7) is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.402] array index '-' (7) is out of range", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j_const.at("/-"_json_pointer),
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK(!j_const.contains("/-"_json_pointer));
         }
 
@@ -391,19 +391,19 @@ TEST_CASE("JSON pointers")
 
             // assign to nonexisting index
             CHECK_THROWS_WITH_AS(j.at("/3"_json_pointer),
-                              "[json.exception.out_of_range.401] array index 3 is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.401] array index 3 is out of range", json::out_of_range&);
             CHECK(!j.contains("/3"_json_pointer));
 
             // assign to nonexisting index (with gap)
             CHECK_THROWS_WITH_AS(j.at("/5"_json_pointer),
-                              "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
             CHECK(!j.contains("/5"_json_pointer));
 
             // assign to "-"
             CHECK_THROWS_WITH_AS(j["/-"_json_pointer],
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j.at("/-"_json_pointer),
-                              "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
+                                 "[json.exception.out_of_range.402] array index '-' (3) is out of range", json::out_of_range&);
             CHECK(!j.contains("/-"_json_pointer));
         }
     }
@@ -460,7 +460,7 @@ TEST_CASE("JSON pointers")
 
         // error for nonobjects
         CHECK_THROWS_WITH_AS(json(1).unflatten(),
-                          "[json.exception.type_error.314] only objects can be unflattened", json::type_error&);
+                             "[json.exception.type_error.314] only objects can be unflattened", json::type_error&);
 
         // error for nonprimitve values
 #if JSON_DIAGNOSTICS
@@ -472,7 +472,7 @@ TEST_CASE("JSON pointers")
         // error for conflicting values
         json j_error = {{"", 42}, {"/foo", 17}};
         CHECK_THROWS_WITH_AS(j_error.unflatten(),
-                          "[json.exception.type_error.313] invalid value to unflatten", json::type_error&);
+                             "[json.exception.type_error.313] invalid value to unflatten", json::type_error&);
 
         // explicit roundtrip check
         CHECK(j.flatten().unflatten() == j);

--- a/test/src/unit-modifiers.cpp
+++ b/test/src/unit-modifiers.cpp
@@ -658,9 +658,9 @@ TEST_CASE("modifiers")
                 json j_other_array2 = {"first", "second"};
 
                 CHECK_THROWS_WITH_AS(j_array.insert(j_array.end(), j_array.begin(), j_array.end()), "[json.exception.invalid_iterator.211] passed iterators may not belong to container",
-                                json::invalid_iterator&);
+                                     json::invalid_iterator&);
                 CHECK_THROWS_WITH_AS(j_array.insert(j_array.end(), j_other_array.begin(), j_other_array2.end()), "[json.exception.invalid_iterator.210] iterators do not fit",
-                                json::invalid_iterator&);
+                                     json::invalid_iterator&);
             }
         }
 

--- a/test/src/unit-modifiers.cpp
+++ b/test/src/unit-modifiers.cpp
@@ -198,8 +198,7 @@ TEST_CASE("modifiers")
                 SECTION("other type")
                 {
                     json j = 1;
-                    CHECK_THROWS_AS(j.push_back("Hello"), json::type_error&);
-                    CHECK_THROWS_WITH(j.push_back("Hello"), "[json.exception.type_error.308] cannot use push_back() with number");
+                    CHECK_THROWS_WITH_AS(j.push_back("Hello"), "[json.exception.type_error.308] cannot use push_back() with number", json::type_error&);
                 }
             }
 
@@ -228,8 +227,7 @@ TEST_CASE("modifiers")
                 {
                     json j = 1;
                     json k("Hello");
-                    CHECK_THROWS_AS(j.push_back(k), json::type_error&);
-                    CHECK_THROWS_WITH(j.push_back(k), "[json.exception.type_error.308] cannot use push_back() with number");
+                    CHECK_THROWS_WITH_AS(j.push_back(k), "[json.exception.type_error.308] cannot use push_back() with number", json::type_error&);
                 }
             }
         }
@@ -261,9 +259,7 @@ TEST_CASE("modifiers")
             {
                 json j = 1;
                 json k("Hello");
-                CHECK_THROWS_AS(j.push_back(json::object_t::value_type({"one", 1})), json::type_error&);
-                CHECK_THROWS_WITH(j.push_back(json::object_t::value_type({"one", 1})),
-                                  "[json.exception.type_error.308] cannot use push_back() with number");
+                CHECK_THROWS_WITH_AS(j.push_back(json::object_t::value_type({"one", 1})), "[json.exception.type_error.308] cannot use push_back() with number", json::type_error&);
             }
         }
 
@@ -298,12 +294,9 @@ TEST_CASE("modifiers")
                 CHECK(j == json({{"key1", 1}, {"key2", "bar"}}));
 
                 // invalid values (no string/val pair)
-                CHECK_THROWS_AS(j.push_back({1}), json::type_error&);
-                CHECK_THROWS_WITH(j.push_back({1}), "[json.exception.type_error.308] cannot use push_back() with object");
-                CHECK_THROWS_AS(j.push_back({1, 2}), json::type_error&);
-                CHECK_THROWS_WITH(j.push_back({1, 2}), "[json.exception.type_error.308] cannot use push_back() with object");
-                CHECK_THROWS_AS(j.push_back({1, 2, 3, 4}), json::type_error&);
-                CHECK_THROWS_WITH(j.push_back({1, 2, 3, 4}), "[json.exception.type_error.308] cannot use push_back() with object");
+                CHECK_THROWS_WITH_AS(j.push_back({1}), "[json.exception.type_error.308] cannot use push_back() with object", json::type_error&);
+                CHECK_THROWS_WITH_AS(j.push_back({1, 2}), "[json.exception.type_error.308] cannot use push_back() with object", json::type_error&);
+                CHECK_THROWS_WITH_AS(j.push_back({1, 2, 3, 4}), "[json.exception.type_error.308] cannot use push_back() with object", json::type_error&);
             }
         }
     }
@@ -345,9 +338,7 @@ TEST_CASE("modifiers")
         SECTION("other type")
         {
             json j = 1;
-            CHECK_THROWS_AS(j.emplace_back("Hello"), json::type_error&);
-            CHECK_THROWS_WITH(j.emplace_back("Hello"),
-                              "[json.exception.type_error.311] cannot use emplace_back() with number");
+            CHECK_THROWS_WITH_AS(j.emplace_back("Hello"), "[json.exception.type_error.311] cannot use emplace_back() with number", json::type_error&);
         }
     }
 
@@ -405,9 +396,7 @@ TEST_CASE("modifiers")
         SECTION("other type")
         {
             json j = 1;
-            CHECK_THROWS_AS(j.emplace("foo", "bar"), json::type_error&);
-            CHECK_THROWS_WITH(j.emplace("foo", "bar"),
-                              "[json.exception.type_error.311] cannot use emplace() with number");
+            CHECK_THROWS_WITH_AS(j.emplace("foo", "bar"), "[json.exception.type_error.311] cannot use emplace() with number", json::type_error&);
         }
     }
 
@@ -437,8 +426,7 @@ TEST_CASE("modifiers")
                 SECTION("other type")
                 {
                     json j = 1;
-                    CHECK_THROWS_AS(j += "Hello", json::type_error&);
-                    CHECK_THROWS_WITH(j += "Hello", "[json.exception.type_error.308] cannot use push_back() with number");
+                    CHECK_THROWS_WITH_AS(j += "Hello", "[json.exception.type_error.308] cannot use push_back() with number", json::type_error&);
                 }
             }
 
@@ -467,8 +455,7 @@ TEST_CASE("modifiers")
                 {
                     json j = 1;
                     json k("Hello");
-                    CHECK_THROWS_AS(j += k, json::type_error&);
-                    CHECK_THROWS_WITH(j += k, "[json.exception.type_error.308] cannot use push_back() with number");
+                    CHECK_THROWS_WITH_AS(j += k, "[json.exception.type_error.308] cannot use push_back() with number", json::type_error&);
                 }
             }
         }
@@ -500,9 +487,7 @@ TEST_CASE("modifiers")
             {
                 json j = 1;
                 json k("Hello");
-                CHECK_THROWS_AS(j += json::object_t::value_type({"one", 1}), json::type_error&);
-                CHECK_THROWS_WITH(j += json::object_t::value_type({"one", 1}),
-                                  "[json.exception.type_error.308] cannot use push_back() with number");
+                CHECK_THROWS_WITH_AS(j += json::object_t::value_type({"one", 1}), "[json.exception.type_error.308] cannot use push_back() with number", json::type_error&);
             }
         }
 
@@ -537,8 +522,7 @@ TEST_CASE("modifiers")
                 CHECK(j == json({{"key1", 1}, {"key2", "bar"}}));
 
                 json k = {{"key1", 1}};
-                CHECK_THROWS_AS((k += {1, 2, 3, 4}), json::type_error&);
-                CHECK_THROWS_WITH((k += {1, 2, 3, 4}), "[json.exception.type_error.308] cannot use push_back() with object");
+                CHECK_THROWS_WITH_AS((k += {1, 2, 3, 4}), "[json.exception.type_error.308] cannot use push_back() with object", json::type_error&);
             }
         }
     }
@@ -673,15 +657,10 @@ TEST_CASE("modifiers")
             {
                 json j_other_array2 = {"first", "second"};
 
-                CHECK_THROWS_AS(j_array.insert(j_array.end(), j_array.begin(), j_array.end()),
+                CHECK_THROWS_WITH_AS(j_array.insert(j_array.end(), j_array.begin(), j_array.end()), "[json.exception.invalid_iterator.211] passed iterators may not belong to container",
                                 json::invalid_iterator&);
-                CHECK_THROWS_AS(j_array.insert(j_array.end(), j_other_array.begin(), j_other_array2.end()),
+                CHECK_THROWS_WITH_AS(j_array.insert(j_array.end(), j_other_array.begin(), j_other_array2.end()), "[json.exception.invalid_iterator.210] iterators do not fit",
                                 json::invalid_iterator&);
-
-                CHECK_THROWS_WITH(j_array.insert(j_array.end(), j_array.begin(), j_array.end()),
-                                  "[json.exception.invalid_iterator.211] passed iterators may not belong to container");
-                CHECK_THROWS_WITH(j_array.insert(j_array.end(), j_other_array.begin(), j_other_array2.end()),
-                                  "[json.exception.invalid_iterator.210] iterators do not fit");
             }
         }
 
@@ -706,16 +685,9 @@ TEST_CASE("modifiers")
             {
                 json j_other_array2 = {"first", "second"};
 
-                CHECK_THROWS_AS(j_array.insert(j_object2.begin(), j_object2.end()), json::type_error&);
-                CHECK_THROWS_AS(j_object1.insert(j_object1.begin(), j_object2.end()), json::invalid_iterator&);
-                CHECK_THROWS_AS(j_object1.insert(j_array.begin(), j_array.end()), json::invalid_iterator&);
-
-                CHECK_THROWS_WITH(j_array.insert(j_object2.begin(), j_object2.end()),
-                                  "[json.exception.type_error.309] cannot use insert() with array");
-                CHECK_THROWS_WITH(j_object1.insert(j_object1.begin(), j_object2.end()),
-                                  "[json.exception.invalid_iterator.210] iterators do not fit");
-                CHECK_THROWS_WITH(j_object1.insert(j_array.begin(), j_array.end()),
-                                  "[json.exception.invalid_iterator.202] iterators first and last must point to objects");
+                CHECK_THROWS_WITH_AS(j_array.insert(j_object2.begin(), j_object2.end()), "[json.exception.type_error.309] cannot use insert() with array", json::type_error&);
+                CHECK_THROWS_WITH_AS(j_object1.insert(j_object1.begin(), j_object2.end()), "[json.exception.invalid_iterator.210] iterators do not fit", json::invalid_iterator&);
+                CHECK_THROWS_WITH_AS(j_object1.insert(j_array.begin(), j_array.end()), "[json.exception.invalid_iterator.202] iterators first and last must point to objects", json::invalid_iterator&);
             }
         }
 
@@ -754,22 +726,11 @@ TEST_CASE("modifiers")
             // pass iterator to a different array
             json j_another_array = {1, 2};
             json j_yet_another_array = {"first", "second"};
-            CHECK_THROWS_AS(j_array.insert(j_another_array.end(), 10), json::invalid_iterator&);
-            CHECK_THROWS_AS(j_array.insert(j_another_array.end(), j_value), json::invalid_iterator&);
-            CHECK_THROWS_AS(j_array.insert(j_another_array.end(), 10, 11), json::invalid_iterator&);
-            CHECK_THROWS_AS(j_array.insert(j_another_array.end(), j_yet_another_array.begin(), j_yet_another_array.end()), json::invalid_iterator&);
-            CHECK_THROWS_AS(j_array.insert(j_another_array.end(), {1, 2, 3, 4}), json::invalid_iterator&);
-
-            CHECK_THROWS_WITH(j_array.insert(j_another_array.end(), 10),
-                              "[json.exception.invalid_iterator.202] iterator does not fit current value");
-            CHECK_THROWS_WITH(j_array.insert(j_another_array.end(), j_value),
-                              "[json.exception.invalid_iterator.202] iterator does not fit current value");
-            CHECK_THROWS_WITH(j_array.insert(j_another_array.end(), 10, 11),
-                              "[json.exception.invalid_iterator.202] iterator does not fit current value");
-            CHECK_THROWS_WITH(j_array.insert(j_another_array.end(), j_yet_another_array.begin(), j_yet_another_array.end()),
-                              "[json.exception.invalid_iterator.202] iterator does not fit current value");
-            CHECK_THROWS_WITH(j_array.insert(j_another_array.end(), {1, 2, 3, 4}),
-                              "[json.exception.invalid_iterator.202] iterator does not fit current value");
+            CHECK_THROWS_WITH_AS(j_array.insert(j_another_array.end(), 10), "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+            CHECK_THROWS_WITH_AS(j_array.insert(j_another_array.end(), j_value), "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+            CHECK_THROWS_WITH_AS(j_array.insert(j_another_array.end(), 10, 11), "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+            CHECK_THROWS_WITH_AS(j_array.insert(j_another_array.end(), j_yet_another_array.begin(), j_yet_another_array.end()), "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+            CHECK_THROWS_WITH_AS(j_array.insert(j_another_array.end(), {1, 2, 3, 4}), "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
         }
 
         SECTION("non-array type")
@@ -777,20 +738,11 @@ TEST_CASE("modifiers")
             // call insert on a non-array type
             json j_nonarray = 3;
             json j_yet_another_array = {"first", "second"};
-            CHECK_THROWS_AS(j_nonarray.insert(j_nonarray.end(), 10), json::type_error&);
-            CHECK_THROWS_AS(j_nonarray.insert(j_nonarray.end(), j_value), json::type_error&);
-            CHECK_THROWS_AS(j_nonarray.insert(j_nonarray.end(), 10, 11), json::type_error&);
-            CHECK_THROWS_AS(j_nonarray.insert(j_nonarray.end(), j_yet_another_array.begin(),
-                                              j_yet_another_array.end()), json::type_error&);
-            CHECK_THROWS_AS(j_nonarray.insert(j_nonarray.end(), {1, 2, 3, 4}), json::type_error&);
-
-            CHECK_THROWS_WITH(j_nonarray.insert(j_nonarray.end(), 10), "[json.exception.type_error.309] cannot use insert() with number");
-            CHECK_THROWS_WITH(j_nonarray.insert(j_nonarray.end(), j_value), "[json.exception.type_error.309] cannot use insert() with number");
-            CHECK_THROWS_WITH(j_nonarray.insert(j_nonarray.end(), 10, 11), "[json.exception.type_error.309] cannot use insert() with number");
-            CHECK_THROWS_WITH(j_nonarray.insert(j_nonarray.end(), j_yet_another_array.begin(),
-                                                j_yet_another_array.end()), "[json.exception.type_error.309] cannot use insert() with number");
-            CHECK_THROWS_WITH(j_nonarray.insert(j_nonarray.end(), {1, 2, 3, 4}),
-                              "[json.exception.type_error.309] cannot use insert() with number");
+            CHECK_THROWS_WITH_AS(j_nonarray.insert(j_nonarray.end(), 10), "[json.exception.type_error.309] cannot use insert() with number", json::type_error&);
+            CHECK_THROWS_WITH_AS(j_nonarray.insert(j_nonarray.end(), j_value), "[json.exception.type_error.309] cannot use insert() with number", json::type_error&);
+            CHECK_THROWS_WITH_AS(j_nonarray.insert(j_nonarray.end(), 10, 11), "[json.exception.type_error.309] cannot use insert() with number", json::type_error&);
+            CHECK_THROWS_WITH_AS(j_nonarray.insert(j_nonarray.end(), j_yet_another_array.begin(), j_yet_another_array.end()), "[json.exception.type_error.309] cannot use insert() with number", json::type_error&);
+            CHECK_THROWS_WITH_AS(j_nonarray.insert(j_nonarray.end(), {1, 2, 3, 4}), "[json.exception.type_error.309] cannot use insert() with number", json::type_error&);
         }
     }
 
@@ -816,11 +768,9 @@ TEST_CASE("modifiers")
 
                 SECTION("wrong types")
                 {
-                    CHECK_THROWS_AS(j_array.update(j_object1), json::type_error&);
-                    CHECK_THROWS_WITH(j_array.update(j_object1), "[json.exception.type_error.312] cannot use update() with array");
+                    CHECK_THROWS_WITH_AS(j_array.update(j_object1), "[json.exception.type_error.312] cannot use update() with array", json::type_error&);
 
-                    CHECK_THROWS_AS(j_object1.update(j_array), json::type_error&);
-                    CHECK_THROWS_WITH(j_object1.update(j_array), "[json.exception.type_error.312] cannot use update() with array");
+                    CHECK_THROWS_WITH_AS(j_object1.update(j_array), "[json.exception.type_error.312] cannot use update() with array", json::type_error&);
                 }
             }
 
@@ -846,16 +796,9 @@ TEST_CASE("modifiers")
                 {
                     json j_other_array2 = {"first", "second"};
 
-                    CHECK_THROWS_AS(j_array.update(j_object2.begin(), j_object2.end()), json::type_error&);
-                    CHECK_THROWS_AS(j_object1.update(j_object1.begin(), j_object2.end()), json::invalid_iterator&);
-                    CHECK_THROWS_AS(j_object1.update(j_array.begin(), j_array.end()), json::type_error&);
-
-                    CHECK_THROWS_WITH(j_array.update(j_object2.begin(), j_object2.end()),
-                                      "[json.exception.type_error.312] cannot use update() with array");
-                    CHECK_THROWS_WITH(j_object1.update(j_object1.begin(), j_object2.end()),
-                                      "[json.exception.invalid_iterator.210] iterators do not fit");
-                    CHECK_THROWS_WITH(j_object1.update(j_array.begin(), j_array.end()),
-                                      "[json.exception.type_error.312] cannot use update() with array");
+                    CHECK_THROWS_WITH_AS(j_array.update(j_object2.begin(), j_object2.end()), "[json.exception.type_error.312] cannot use update() with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_object1.update(j_object1.begin(), j_object2.end()), "[json.exception.invalid_iterator.210] iterators do not fit", json::invalid_iterator&);
+                    CHECK_THROWS_WITH_AS(j_object1.update(j_array.begin(), j_array.end()), "[json.exception.type_error.312] cannot use update() with array", json::type_error&);
                 }
             }
         }
@@ -932,8 +875,7 @@ TEST_CASE("modifiers")
                 json j = 17;
                 json::array_t a = {"foo", "bar", "baz"};
 
-                CHECK_THROWS_AS(j.swap(a), json::type_error&);
-                CHECK_THROWS_WITH(j.swap(a), "[json.exception.type_error.310] cannot use swap() with number");
+                CHECK_THROWS_WITH_AS(j.swap(a), "[json.exception.type_error.310] cannot use swap() with number", json::type_error&);
             }
         }
 
@@ -958,8 +900,7 @@ TEST_CASE("modifiers")
                 json j = 17;
                 json::object_t o = {{"cow", "Kuh"}, {"chicken", "Huhn"}};
 
-                CHECK_THROWS_AS(j.swap(o), json::type_error&);
-                CHECK_THROWS_WITH(j.swap(o), "[json.exception.type_error.310] cannot use swap() with number");
+                CHECK_THROWS_WITH_AS(j.swap(o), "[json.exception.type_error.310] cannot use swap() with number", json::type_error&);
             }
         }
 
@@ -984,8 +925,7 @@ TEST_CASE("modifiers")
                 json j = 17;
                 json::string_t s = "Hallo Welt";
 
-                CHECK_THROWS_AS(j.swap(s), json::type_error&);
-                CHECK_THROWS_WITH(j.swap(s), "[json.exception.type_error.310] cannot use swap() with number");
+                CHECK_THROWS_WITH_AS(j.swap(s), "[json.exception.type_error.310] cannot use swap() with number", json::type_error&);
             }
         }
 

--- a/test/src/unit-msgpack.cpp
+++ b/test/src/unit-msgpack.cpp
@@ -1425,76 +1425,54 @@ TEST_CASE("MessagePack")
         SECTION("empty byte vector")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>()), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>()),
-                              "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>()), "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
             CHECK(json::from_msgpack(std::vector<uint8_t>(), true, false).is_discarded());
         }
 
         SECTION("too short byte vector")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x87})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcc})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcd})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcd, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xa5, 0x68, 0x65})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x92, 0x01})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xa1, 0x61})), json::parse_error&);
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xc4, 0x02})), json::parse_error&);
 
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0x87})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcc})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcd})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcd, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xce})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing MessagePack number: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xa5, 0x68, 0x65})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack string: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0x92, 0x01})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack value: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xa1, 0x61})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack value: unexpected end of input");
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xc4, 0x02})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack binary: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x87})),
+                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcc})),
+                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcd})),
+                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcd, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce})),
+                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf})),
+                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
+                              "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xa5, 0x68, 0x65})),
+                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x92, 0x01})),
+                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xa1, 0x61})),
+                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xc4, 0x02})),
+                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack binary: unexpected end of input", json::parse_error&);
 
             CHECK(json::from_msgpack(std::vector<uint8_t>({0x87}), true, false).is_discarded());
             CHECK(json::from_msgpack(std::vector<uint8_t>({0xcc}), true, false).is_discarded());
@@ -1524,9 +1502,7 @@ TEST_CASE("MessagePack")
             SECTION("concrete examples")
             {
                 json _;
-                CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xc1})), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0xc1})),
-                                  "[json.exception.parse_error.112] parse error at byte 1: syntax error while parsing MessagePack value: invalid byte: 0xC1");
+                CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xc1})), "[json.exception.parse_error.112] parse error at byte 1: syntax error while parsing MessagePack value: invalid byte: 0xC1", json::parse_error&);
             }
 
             SECTION("all unsupported bytes")
@@ -1547,9 +1523,7 @@ TEST_CASE("MessagePack")
         SECTION("invalid string in map")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xff, 0x01})), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xff, 0x01})),
-                              "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing MessagePack string: expected length specification (0xA0-0xBF, 0xD9-0xDB); last byte: 0xFF");
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xff, 0x01})), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing MessagePack string: expected length specification (0xA0-0xBF, 0xD9-0xDB); last byte: 0xFF", json::parse_error&);
             CHECK(json::from_msgpack(std::vector<uint8_t>({0x81, 0xff, 0x01}), true, false).is_discarded());
         }
 
@@ -1565,9 +1539,7 @@ TEST_CASE("MessagePack")
             SECTION("strict mode")
             {
                 json _;
-                CHECK_THROWS_AS(_ = json::from_msgpack(vec), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_msgpack(vec),
-                                  "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack value: expected end of input; last byte: 0xC0");
+                CHECK_THROWS_WITH_AS(_ = json::from_msgpack(vec), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack value: expected end of input; last byte: 0xC0", json::parse_error&);
                 CHECK(json::from_msgpack(vec, true, false).is_discarded());
             }
         }

--- a/test/src/unit-msgpack.cpp
+++ b/test/src/unit-msgpack.cpp
@@ -1434,45 +1434,45 @@ TEST_CASE("MessagePack")
             json _;
 
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x87})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcc})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcd})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcd, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xce, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf})),
-                              "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xcf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
-                              "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xa5, 0x68, 0x65})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x92, 0x01})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0x81, 0xa1, 0x61})),
-                              "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::vector<uint8_t>({0xc4, 0x02})),
-                              "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack binary: unexpected end of input", json::parse_error&);
+                                 "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing MessagePack binary: unexpected end of input", json::parse_error&);
 
             CHECK(json::from_msgpack(std::vector<uint8_t>({0x87}), true, false).is_discarded());
             CHECK(json::from_msgpack(std::vector<uint8_t>({0xcc}), true, false).is_discarded());

--- a/test/src/unit-reference_access.cpp
+++ b/test/src/unit-reference_access.cpp
@@ -66,17 +66,17 @@ TEST_CASE("reference access")
         // check if mismatching references throw correctly
         CHECK_NOTHROW(value.get_ref<json::object_t&>());
         CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
     }
 
     SECTION("const reference access to const object_t")
@@ -109,18 +109,18 @@ TEST_CASE("reference access")
 
         // check if mismatching references throw correctly
         CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::array_t&>());
         CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
     }
 
     SECTION("reference access to string_t")
@@ -139,18 +139,18 @@ TEST_CASE("reference access")
 
         // check if mismatching references throw correctly
         CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::string_t&>());
         CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
     }
 
     SECTION("reference access to boolean_t")
@@ -169,18 +169,18 @@ TEST_CASE("reference access")
 
         // check if mismatching references throw correctly
         CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::boolean_t&>());
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
     }
 
     SECTION("reference access to number_integer_t")
@@ -199,18 +199,18 @@ TEST_CASE("reference access")
 
         // check if mismatching references throw correctly
         CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::number_integer_t&>());
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
     }
 
     SECTION("reference access to number_unsigned_t")
@@ -229,13 +229,13 @@ TEST_CASE("reference access")
 
         // check if mismatching references throw correctly
         CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+                             "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         //CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
         //    "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::number_unsigned_t&>());

--- a/test/src/unit-reference_access.cpp
+++ b/test/src/unit-reference_access.cpp
@@ -65,24 +65,18 @@ TEST_CASE("reference access")
 
         // check if mismatching references throw correctly
         CHECK_NOTHROW(value.get_ref<json::object_t&>());
-        CHECK_THROWS_AS(value.get_ref<json::array_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object");
-        CHECK_THROWS_AS(value.get_ref<json::string_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object");
-        CHECK_THROWS_AS(value.get_ref<json::boolean_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object");
-        CHECK_THROWS_AS(value.get_ref<json::number_integer_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object");
-        CHECK_THROWS_AS(value.get_ref<json::number_unsigned_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object");
-        CHECK_THROWS_AS(value.get_ref<json::number_float_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is object", json::type_error&);
     }
 
     SECTION("const reference access to const object_t")
@@ -114,25 +108,19 @@ TEST_CASE("reference access")
         CHECK(p2 == value.get<test_type>());
 
         // check if mismatching references throw correctly
-        CHECK_THROWS_AS(value.get_ref<json::object_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::array_t&>());
-        CHECK_THROWS_AS(value.get_ref<json::string_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array");
-        CHECK_THROWS_AS(value.get_ref<json::boolean_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array");
-        CHECK_THROWS_AS(value.get_ref<json::number_integer_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array");
-        CHECK_THROWS_AS(value.get_ref<json::number_unsigned_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array");
-        CHECK_THROWS_AS(value.get_ref<json::number_float_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is array", json::type_error&);
     }
 
     SECTION("reference access to string_t")
@@ -150,25 +138,19 @@ TEST_CASE("reference access")
         CHECK(p2 == value.get<test_type>());
 
         // check if mismatching references throw correctly
-        CHECK_THROWS_AS(value.get_ref<json::object_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string");
-        CHECK_THROWS_AS(value.get_ref<json::array_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::string_t&>());
-        CHECK_THROWS_AS(value.get_ref<json::boolean_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string");
-        CHECK_THROWS_AS(value.get_ref<json::number_integer_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string");
-        CHECK_THROWS_AS(value.get_ref<json::number_unsigned_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string");
-        CHECK_THROWS_AS(value.get_ref<json::number_float_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is string", json::type_error&);
     }
 
     SECTION("reference access to boolean_t")
@@ -186,25 +168,19 @@ TEST_CASE("reference access")
         CHECK(p2 == value.get<test_type>());
 
         // check if mismatching references throw correctly
-        CHECK_THROWS_AS(value.get_ref<json::object_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean");
-        CHECK_THROWS_AS(value.get_ref<json::array_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean");
-        CHECK_THROWS_AS(value.get_ref<json::string_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::boolean_t&>());
-        CHECK_THROWS_AS(value.get_ref<json::number_integer_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean");
-        CHECK_THROWS_AS(value.get_ref<json::number_unsigned_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean");
-        CHECK_THROWS_AS(value.get_ref<json::number_float_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is boolean", json::type_error&);
     }
 
     SECTION("reference access to number_integer_t")
@@ -222,25 +198,19 @@ TEST_CASE("reference access")
         CHECK(p2 == value.get<test_type>());
 
         // check if mismatching references throw correctly
-        CHECK_THROWS_AS(value.get_ref<json::object_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::array_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::string_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::boolean_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::number_integer_t&>());
-        CHECK_THROWS_AS(value.get_ref<json::number_unsigned_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::number_float_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
     }
 
     SECTION("reference access to number_unsigned_t")
@@ -258,25 +228,18 @@ TEST_CASE("reference access")
         CHECK(p2 == value.get<test_type>());
 
         // check if mismatching references throw correctly
-        CHECK_THROWS_AS(value.get_ref<json::object_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::array_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::string_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::boolean_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        //CHECK_THROWS_AS(value.get_ref<json::number_integer_t&>(), json::type_error&);
-        //CHECK_THROWS_WITH(value.get_ref<json::number_integer_t&>(),
-        //    "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(),
+                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        //CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(),
+        //    "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::number_unsigned_t&>());
-        CHECK_THROWS_AS(value.get_ref<json::number_float_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_float_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_float_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
     }
 
     SECTION("reference access to number_float_t")
@@ -294,24 +257,12 @@ TEST_CASE("reference access")
         CHECK(p2 == value.get<test_type>());
 
         // check if mismatching references throw correctly
-        CHECK_THROWS_AS(value.get_ref<json::object_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::object_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::array_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::array_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::string_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::string_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::boolean_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::boolean_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::number_integer_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_integer_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
-        CHECK_THROWS_AS(value.get_ref<json::number_unsigned_t&>(), json::type_error&);
-        CHECK_THROWS_WITH(value.get_ref<json::number_unsigned_t&>(),
-                          "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number");
+        CHECK_THROWS_WITH_AS(value.get_ref<json::object_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::array_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::string_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::boolean_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_integer_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
+        CHECK_THROWS_WITH_AS(value.get_ref<json::number_unsigned_t&>(), "[json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is number", json::type_error&);
         CHECK_NOTHROW(value.get_ref<json::number_float_t&>());
     }
 }

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -395,11 +395,10 @@ TEST_CASE("regression tests 1")
 
         // improve coverage
         o["int"] = 1;
-        CHECK_THROWS_AS(s2 = o["int"], json::type_error);
 #if JSON_DIAGNOSTICS
-        CHECK_THROWS_WITH(s2 = o["int"], "[json.exception.type_error.302] (/int) type must be string, but is number");
+        CHECK_THROWS_WITH_AS(s2 = o["int"], "[json.exception.type_error.302] (/int) type must be string, but is number", json::type_error);
 #else
-        CHECK_THROWS_WITH(s2 = o["int"], "[json.exception.type_error.302] type must be string, but is number");
+        CHECK_THROWS_WITH_AS(s2 = o["int"], "[json.exception.type_error.302] type must be string, but is number", json::type_error);
 #endif
     }
 #endif
@@ -679,9 +678,7 @@ TEST_CASE("regression tests 1")
     SECTION("issue #329 - serialized value not always can be parsed")
     {
         json _;
-        CHECK_THROWS_AS(_ = json::parse("22e2222"), json::out_of_range&);
-        CHECK_THROWS_WITH(_ = json::parse("22e2222"),
-                          "[json.exception.out_of_range.406] number overflow parsing '22e2222'");
+        CHECK_THROWS_WITH_AS(_ = json::parse("22e2222"), "[json.exception.out_of_range.406] number overflow parsing '22e2222'", json::out_of_range&);
     }
 
     SECTION("issue #360 - Loss of precision when serializing <double>")
@@ -746,8 +743,7 @@ TEST_CASE("regression tests 1")
     {
         std::ifstream f("file_not_found.json");
         json _;
-        CHECK_THROWS_AS(_ = json::parse(f), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::parse(f), "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+        CHECK_THROWS_WITH_AS(_ = json::parse(f), "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
     }
 
     SECTION("issue #367 - calling stream at EOF")
@@ -761,9 +757,7 @@ TEST_CASE("regression tests 1")
         // ss is not at EOF; this yielded an error before the fix
         // (threw basic_string::append). No, it should just throw
         // a parse error because of the EOF.
-        CHECK_THROWS_AS(ss >> j, json::parse_error&);
-        CHECK_THROWS_WITH(ss >> j,
-                          "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+        CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
     }
 
     SECTION("issue #367 - behavior of operator>> should more closely resemble that of built-in overloads")
@@ -772,9 +766,7 @@ TEST_CASE("regression tests 1")
         {
             std::stringstream ss;
             json j;
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("(whitespace)")
@@ -795,9 +787,7 @@ TEST_CASE("regression tests 1")
             CHECK_NOTHROW(ss >> j);
             CHECK(j == 111);
 
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("one value + whitespace")
@@ -821,9 +811,7 @@ TEST_CASE("regression tests 1")
             CHECK_NOTHROW(ss >> j);
             CHECK(j == 333);
 
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("three values")
@@ -838,9 +826,7 @@ TEST_CASE("regression tests 1")
             CHECK_NOTHROW(ss >> j);
             CHECK(j == 333);
 
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("literals without whitespace")
@@ -857,9 +843,7 @@ TEST_CASE("regression tests 1")
             CHECK_NOTHROW(ss >> j);
             CHECK(j == "");
 
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("example from #529")
@@ -872,9 +856,7 @@ TEST_CASE("regression tests 1")
             CHECK_NOTHROW(ss >> j);
             CHECK(j == json({{"three", 3}}));
 
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j, "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("second example from #529")
@@ -943,9 +925,7 @@ TEST_CASE("regression tests 1")
         // original test case
         std::vector<uint8_t> vec {0x65, 0xf5, 0x0a, 0x48, 0x21};
         json _;
-        CHECK_THROWS_AS(_ = json::from_cbor(vec), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec),
-                          "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing CBOR string: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec), "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
     }
 
     SECTION("issue #407 - Heap-buffer-overflow (OSS-Fuzz issue 343)")
@@ -954,33 +934,23 @@ TEST_CASE("regression tests 1")
 
         // original test case: incomplete float64
         std::vector<uint8_t> vec1 {0xcb, 0x8f, 0x0a};
-        CHECK_THROWS_AS(_ = json::from_msgpack(vec1), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_msgpack(vec1),
-                          "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_msgpack(vec1), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
 
         // related test case: incomplete float32
         std::vector<uint8_t> vec2 {0xca, 0x8f, 0x0a};
-        CHECK_THROWS_AS(_ = json::from_msgpack(vec2), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_msgpack(vec2),
-                          "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_msgpack(vec2), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
 
         // related test case: incomplete Half-Precision Float (CBOR)
         std::vector<uint8_t> vec3 {0xf9, 0x8f};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec3), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec3),
-                          "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec3), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
 
         // related test case: incomplete Single-Precision Float (CBOR)
         std::vector<uint8_t> vec4 {0xfa, 0x8f, 0x0a};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec4), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec4),
-                          "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec4), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
 
         // related test case: incomplete Double-Precision Float (CBOR)
         std::vector<uint8_t> vec5 {0xfb, 0x8f, 0x0a};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec5), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec5),
-                          "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec5), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
     }
 
     SECTION("issue #408 - Heap-buffer-overflow (OSS-Fuzz issue 344)")
@@ -989,9 +959,7 @@ TEST_CASE("regression tests 1")
 
         // original test case
         std::vector<uint8_t> vec1 {0x87};
-        CHECK_THROWS_AS(_ = json::from_msgpack(vec1), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_msgpack(vec1),
-                          "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack string: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_msgpack(vec1), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing MessagePack string: unexpected end of input", json::parse_error&);
 
         // more test cases for MessagePack
         for (auto b :
@@ -1023,12 +991,8 @@ TEST_CASE("regression tests 1")
 
         // special case: empty input
         std::vector<uint8_t> vec2;
-        CHECK_THROWS_AS(_ = json::from_cbor(vec2), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec2),
-                          "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing CBOR value: unexpected end of input");
-        CHECK_THROWS_AS(_ = json::from_msgpack(vec2), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_msgpack(vec2),
-                          "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec2), "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
+        CHECK_THROWS_WITH_AS(_ = json::from_msgpack(vec2), "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input", json::parse_error&);
     }
 
     SECTION("issue #411 - Heap-buffer-overflow (OSS-Fuzz issue 366)")
@@ -1037,21 +1001,15 @@ TEST_CASE("regression tests 1")
 
         // original test case: empty UTF-8 string (indefinite length)
         std::vector<uint8_t> vec1 {0x7f};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec1), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec1),
-                          "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec1), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
 
         // related test case: empty array (indefinite length)
         std::vector<uint8_t> vec2 {0x9f};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec2), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec2),
-                          "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR value: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec2), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
 
         // related test case: empty map (indefinite length)
         std::vector<uint8_t> vec3 {0xbf};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec3), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec3),
-                          "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec3), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
     }
 
     SECTION("issue #412 - Heap-buffer-overflow (OSS-Fuzz issue 367)")
@@ -1079,27 +1037,19 @@ TEST_CASE("regression tests 1")
         };
 
         json _;
-        CHECK_THROWS_AS(_ = json::from_cbor(vec), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec),
-                          "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0x98");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0x98", json::parse_error&);
 
         // related test case: nonempty UTF-8 string (indefinite length)
         std::vector<uint8_t> vec1 {0x7f, 0x61, 0x61};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec1), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec1),
-                          "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR string: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec1), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
 
         // related test case: nonempty array (indefinite length)
         std::vector<uint8_t> vec2 {0x9f, 0x01};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec2), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec2),
-                          "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR value: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec2), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR value: unexpected end of input", json::parse_error&);
 
         // related test case: nonempty map (indefinite length)
         std::vector<uint8_t> vec3 {0xbf, 0x61, 0x61, 0x01};
-        CHECK_THROWS_AS(_ = json::from_cbor(vec3), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec3),
-                          "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR string: unexpected end of input");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec3), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
     }
 
     SECTION("issue #414 - compare with literal 0)")
@@ -1134,9 +1084,7 @@ TEST_CASE("regression tests 1")
         };
 
         json _;
-        CHECK_THROWS_AS(_ = json::from_cbor(vec1), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec1),
-                          "[json.exception.parse_error.113] parse error at byte 13: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0xB4");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec1), "[json.exception.parse_error.113] parse error at byte 13: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0xB4", json::parse_error&);
 
         // related test case: double-precision
         std::vector<uint8_t> vec2
@@ -1148,9 +1096,7 @@ TEST_CASE("regression tests 1")
             0x96, 0x96, 0xb4, 0xb4, 0xfa, 0x94, 0x94, 0x61,
             0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0xfb
         };
-        CHECK_THROWS_AS(_ = json::from_cbor(vec2), json::parse_error&);
-        CHECK_THROWS_WITH(_ = json::from_cbor(vec2),
-                          "[json.exception.parse_error.113] parse error at byte 13: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0xB4");
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(vec2), "[json.exception.parse_error.113] parse error at byte 13: syntax error while parsing CBOR string: expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0xB4", json::parse_error&);
     }
 
     SECTION("issue #452 - Heap-buffer-overflow (OSS-Fuzz issue 585)")
@@ -1200,10 +1146,8 @@ TEST_CASE("regression tests 1")
             };
 
             CHECK_NOTHROW(create(j_array));
-            CHECK_THROWS_AS(create(j_number), json::type_error&);
-            CHECK_THROWS_WITH(create(j_number), "[json.exception.type_error.302] type must be array, but is number");
-            CHECK_THROWS_AS(create(j_null), json::type_error&);
-            CHECK_THROWS_WITH(create(j_null), "[json.exception.type_error.302] type must be array, but is null");
+            CHECK_THROWS_WITH_AS(create(j_number), "[json.exception.type_error.302] type must be array, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(create(j_null), "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
         }
 
         SECTION("std::list")
@@ -1214,10 +1158,8 @@ TEST_CASE("regression tests 1")
             };
 
             CHECK_NOTHROW(create(j_array));
-            CHECK_THROWS_AS(create(j_number), json::type_error&);
-            CHECK_THROWS_WITH(create(j_number), "[json.exception.type_error.302] type must be array, but is number");
-            CHECK_THROWS_AS(create(j_null), json::type_error&);
-            CHECK_THROWS_WITH(create(j_null), "[json.exception.type_error.302] type must be array, but is null");
+            CHECK_THROWS_WITH_AS(create(j_number), "[json.exception.type_error.302] type must be array, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(create(j_null), "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
         }
 
         SECTION("std::forward_list")
@@ -1228,10 +1170,8 @@ TEST_CASE("regression tests 1")
             };
 
             CHECK_NOTHROW(create(j_array));
-            CHECK_THROWS_AS(create(j_number), json::type_error&);
-            CHECK_THROWS_WITH(create(j_number), "[json.exception.type_error.302] type must be array, but is number");
-            CHECK_THROWS_AS(create(j_null), json::type_error&);
-            CHECK_THROWS_WITH(create(j_null), "[json.exception.type_error.302] type must be array, but is null");
+            CHECK_THROWS_WITH_AS(create(j_number), "[json.exception.type_error.302] type must be array, but is number", json::type_error&);
+            CHECK_THROWS_WITH_AS(create(j_null), "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
         }
     }
 #endif
@@ -1380,9 +1320,7 @@ TEST_CASE("regression tests 1")
                 CHECK(v[i] == j[i]);
             }
 
-            CHECK_THROWS_AS(json().get<std::valarray<double>>(), json::type_error&);
-            CHECK_THROWS_WITH(json().get<std::valarray<double>>(),
-                              "[json.exception.type_error.302] type must be array, but is null");
+            CHECK_THROWS_WITH_AS(json().get<std::valarray<double>>(), "[json.exception.type_error.302] type must be array, but is null", json::type_error&);
         }
     }
 #endif
@@ -1452,8 +1390,7 @@ TEST_CASE("regression tests 1")
         std::array<uint8_t, 28> key1 = {{ 103, 92, 117, 48, 48, 48, 55, 92, 114, 215, 126, 214, 95, 92, 34, 174, 40, 71, 38, 174, 40, 71, 38, 223, 134, 247, 127, 0 }};
         std::string key1_str(reinterpret_cast<char*>(key1.data()));
         json j = key1_str;
-        CHECK_THROWS_AS(j.dump(), json::type_error&);
-        CHECK_THROWS_WITH(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 10: 0x7E");
+        CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 10: 0x7E", json::type_error&);
     }
 
 #if JSON_USE_IMPLICIT_CONVERSIONS

--- a/test/src/unit-serialization.cpp
+++ b/test/src/unit-serialization.cpp
@@ -104,10 +104,8 @@ TEST_CASE("serialization")
         {
             json j = "ä\xA9ü";
 
-            CHECK_THROWS_AS(j.dump(), json::type_error&);
-            CHECK_THROWS_WITH(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9");
-            CHECK_THROWS_AS(j.dump(1, ' ', false, json::error_handler_t::strict), json::type_error&);
-            CHECK_THROWS_WITH(j.dump(1, ' ', false, json::error_handler_t::strict), "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9");
+            CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9", json::type_error&);
+            CHECK_THROWS_WITH_AS(j.dump(1, ' ', false, json::error_handler_t::strict), "[json.exception.type_error.316] invalid UTF-8 byte at index 2: 0xA9", json::type_error&);
             CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"äü\"");
             CHECK(j.dump(-1, ' ', false, json::error_handler_t::replace) == "\"ä\xEF\xBF\xBDü\"");
             CHECK(j.dump(-1, ' ', true, json::error_handler_t::replace) == "\"\\u00e4\\ufffd\\u00fc\"");
@@ -117,8 +115,7 @@ TEST_CASE("serialization")
         {
             json j = "123\xC2";
 
-            CHECK_THROWS_AS(j.dump(), json::type_error&);
-            CHECK_THROWS_WITH(j.dump(), "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2");
+            CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] incomplete UTF-8 string; last byte: 0xC2", json::type_error&);
             CHECK_THROWS_AS(j.dump(1, ' ', false, json::error_handler_t::strict), json::type_error&);
             CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"123\"");
             CHECK(j.dump(-1, ' ', false, json::error_handler_t::replace) == "\"123\xEF\xBF\xBD\"");
@@ -129,8 +126,7 @@ TEST_CASE("serialization")
         {
             json j = "123\xF1\xB0\x34\x35\x36";
 
-            CHECK_THROWS_AS(j.dump(), json::type_error&);
-            CHECK_THROWS_WITH(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 5: 0x34");
+            CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 5: 0x34", json::type_error&);
             CHECK_THROWS_AS(j.dump(1, ' ', false, json::error_handler_t::strict), json::type_error&);
             CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"123456\"");
             CHECK(j.dump(-1, ' ', false, json::error_handler_t::replace) == "\"123\xEF\xBF\xBD\x34\x35\x36\"");

--- a/test/src/unit-ubjson.cpp
+++ b/test/src/unit-ubjson.cpp
@@ -1595,9 +1595,7 @@ TEST_CASE("UBJSON")
             SECTION("strict mode")
             {
                 json _;
-                CHECK_THROWS_AS(_ = json::from_ubjson(vec), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_ubjson(vec),
-                                  "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: expected end of input; last byte: 0x5A");
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vec), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: expected end of input; last byte: 0x5A", json::parse_error&);
             }
         }
 
@@ -1820,9 +1818,7 @@ TEST_CASE("UBJSON")
         SECTION("empty byte vector")
         {
             json _;
-            CHECK_THROWS_AS(_ = json::from_ubjson(std::vector<uint8_t>()), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(std::vector<uint8_t>()),
-                              "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(std::vector<uint8_t>()), "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
         }
 
         SECTION("char")
@@ -1831,16 +1827,14 @@ TEST_CASE("UBJSON")
             {
                 std::vector<uint8_t> v = {'C'};
                 json _;
-                CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON char: unexpected end of input");
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON char: unexpected end of input", json::parse_error&);
             }
 
             SECTION("byte out of range")
             {
                 std::vector<uint8_t> v = {'C', 130};
                 json _;
-                CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON char: byte after 'C' must be in range 0x00..0x7F; last byte: 0x82");
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON char: byte after 'C' must be in range 0x00..0x7F; last byte: 0x82", json::parse_error&);
             }
         }
 
@@ -1850,16 +1844,14 @@ TEST_CASE("UBJSON")
             {
                 std::vector<uint8_t> v = {'S'};
                 json _;
-                CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: unexpected end of input");
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             }
 
             SECTION("invalid byte")
             {
                 std::vector<uint8_t> v = {'S', '1', 'a'};
                 json _;
-                CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON string: expected length type specification (U, i, I, l, L); last byte: 0x31");
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON string: expected length type specification (U, i, I, l, L); last byte: 0x31", json::parse_error&);
             }
         }
 
@@ -1869,8 +1861,7 @@ TEST_CASE("UBJSON")
             {
                 std::vector<uint8_t> v = {'[', '$', 'i', 2};
                 json _;
-                CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.112] parse error at byte 4: syntax error while parsing UBJSON size: expected '#' after type information; last byte: 0x02");
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.112] parse error at byte 4: syntax error while parsing UBJSON size: expected '#' after type information; last byte: 0x02", json::parse_error&);
             }
         }
 
@@ -1878,18 +1869,15 @@ TEST_CASE("UBJSON")
         {
             std::vector<uint8_t> vS = {'S'};
             json _;
-            CHECK_THROWS_AS(_ = json::from_ubjson(vS), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vS), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vS), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vS, true, false).is_discarded());
 
             std::vector<uint8_t> v = {'S', 'i', '2', 'a'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing UBJSON string: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing UBJSON string: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(v, true, false).is_discarded());
 
             std::vector<uint8_t> vC = {'C'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vC), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vC), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON char: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vC), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON char: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vC, true, false).is_discarded());
         }
 
@@ -1897,33 +1885,27 @@ TEST_CASE("UBJSON")
         {
             std::vector<uint8_t> vU = {'[', '#', 'U'};
             json _;
-            CHECK_THROWS_AS(_ = json::from_ubjson(vU), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vU), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vU), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vU, true, false).is_discarded());
 
             std::vector<uint8_t> vi = {'[', '#', 'i'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vi), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vi), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vi), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vi, true, false).is_discarded());
 
             std::vector<uint8_t> vI = {'[', '#', 'I'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vI), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vI), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vI), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vI, true, false).is_discarded());
 
             std::vector<uint8_t> vl = {'[', '#', 'l'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vl), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vl), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vl), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vl, true, false).is_discarded());
 
             std::vector<uint8_t> vL = {'[', '#', 'L'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vL), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vL), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vL), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vL, true, false).is_discarded());
 
             std::vector<uint8_t> v0 = {'[', '#', 'T', ']'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(v0), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v0), "[json.exception.parse_error.113] parse error at byte 3: syntax error while parsing UBJSON size: expected length type specification (U, i, I, l, L) after '#'; last byte: 0x54");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v0), "[json.exception.parse_error.113] parse error at byte 3: syntax error while parsing UBJSON size: expected length type specification (U, i, I, l, L) after '#'; last byte: 0x54", json::parse_error&);
             CHECK(json::from_ubjson(v0, true, false).is_discarded());
         }
 
@@ -1931,18 +1913,15 @@ TEST_CASE("UBJSON")
         {
             std::vector<uint8_t> v0 = {'[', '$'};
             json _;
-            CHECK_THROWS_AS(_ = json::from_ubjson(v0), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v0), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing UBJSON type: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v0), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing UBJSON type: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(v0, true, false).is_discarded());
 
             std::vector<uint8_t> vi = {'[', '$', '#'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vi), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vi), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vi), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vi, true, false).is_discarded());
 
             std::vector<uint8_t> vT = {'[', '$', 'T'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vT), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vT), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vT), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vT, true, false).is_discarded());
         }
 
@@ -1950,18 +1929,15 @@ TEST_CASE("UBJSON")
         {
             std::vector<uint8_t> vST = {'[', '$', 'i', '#', 'i', 2, 1};
             json _;
-            CHECK_THROWS_AS(_ = json::from_ubjson(vST), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vST), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vST), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vST, true, false).is_discarded());
 
             std::vector<uint8_t> vS = {'[', '#', 'i', 2, 'i', 1};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vS), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vS), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vS), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vS, true, false).is_discarded());
 
             std::vector<uint8_t> v = {'[', 'i', 2, 'i', 1};
-            CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 6: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(v, true, false).is_discarded());
         }
 
@@ -1969,43 +1945,35 @@ TEST_CASE("UBJSON")
         {
             std::vector<uint8_t> vST = {'{', '$', 'i', '#', 'i', 2, 'i', 1, 'a', 1};
             json _;
-            CHECK_THROWS_AS(_ = json::from_ubjson(vST), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vST), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vST), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vST, true, false).is_discarded());
 
             std::vector<uint8_t> vT = {'{', '$', 'i', 'i', 1, 'a', 1};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vT), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vT), "[json.exception.parse_error.112] parse error at byte 4: syntax error while parsing UBJSON size: expected '#' after type information; last byte: 0x69");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vT), "[json.exception.parse_error.112] parse error at byte 4: syntax error while parsing UBJSON size: expected '#' after type information; last byte: 0x69", json::parse_error&);
             CHECK(json::from_ubjson(vT, true, false).is_discarded());
 
             std::vector<uint8_t> vS = {'{', '#', 'i', 2, 'i', 1, 'a', 'i', 1};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vS), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vS), "[json.exception.parse_error.110] parse error at byte 10: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vS), "[json.exception.parse_error.110] parse error at byte 10: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vS, true, false).is_discarded());
 
             std::vector<uint8_t> v = {'{', 'i', 1, 'a', 'i', 1};
-            CHECK_THROWS_AS(_ = json::from_ubjson(v), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(v, true, false).is_discarded());
 
             std::vector<uint8_t> v2 = {'{', 'i', 1, 'a', 'i', 1, 'i'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(v2), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v2), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v2), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(v2, true, false).is_discarded());
 
             std::vector<uint8_t> v3 = {'{', 'i', 1, 'a'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(v3), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(v3), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v3), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(v3, true, false).is_discarded());
 
             std::vector<uint8_t> vST1 = {'{', '$', 'd', '#', 'i', 2, 'i', 1, 'a'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vST1), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vST1), "[json.exception.parse_error.110] parse error at byte 10: syntax error while parsing UBJSON number: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vST1), "[json.exception.parse_error.110] parse error at byte 10: syntax error while parsing UBJSON number: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vST1, true, false).is_discarded());
 
             std::vector<uint8_t> vST2 = {'{', '#', 'i', 2, 'i', 1, 'a'};
-            CHECK_THROWS_AS(_ = json::from_ubjson(vST2), json::parse_error&);
-            CHECK_THROWS_WITH(_ = json::from_ubjson(vST2), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing UBJSON value: unexpected end of input");
+            CHECK_THROWS_WITH_AS(_ = json::from_ubjson(vST2), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing UBJSON value: unexpected end of input", json::parse_error&);
             CHECK(json::from_ubjson(vST2, true, false).is_discarded());
         }
     }

--- a/test/src/unit-unicode1.cpp
+++ b/test/src/unit-unicode1.cpp
@@ -107,33 +107,19 @@ TEST_CASE("Unicode (1/5)" * doctest::skip())
             {
                 json _;
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uDC00\\uDC00\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uDC00\\uDC00\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF; last read: '\"\\uDC00'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uDC00\\uDC00\""), "[json.exception.parse_error.101] parse error at line 1, column 7: syntax error while parsing value - invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF; last read: '\"\\uDC00'", json::parse_error&);
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uD7FF\\uDC00\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uD7FF\\uDC00\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF; last read: '\"\\uD7FF\\uDC00'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD7FF\\uDC00\""), "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF; last read: '\"\\uD7FF\\uDC00'", json::parse_error&);
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uD800]\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uD800]\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800]'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD800]\""), "[json.exception.parse_error.101] parse error at line 1, column 8: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800]'", json::parse_error&);
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uD800\\v\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uD800\\v\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 9: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800\\v'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD800\\v\""), "[json.exception.parse_error.101] parse error at line 1, column 9: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800\\v'", json::parse_error&);
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uD800\\u123\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uD800\\u123\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\uD800\\u123\"'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD800\\u123\""), "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\uD800\\u123\"'", json::parse_error&);
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uD800\\uDBFF\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uD800\\uDBFF\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800\\uDBFF'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD800\\uDBFF\""), "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800\\uDBFF'", json::parse_error&);
 
-                CHECK_THROWS_AS(_ = json::parse("\"\\uD800\\uE000\""), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::parse("\"\\uD800\\uE000\""),
-                                  "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800\\uE000'");
+                CHECK_THROWS_WITH_AS(_ = json::parse("\"\\uD800\\uE000\""), "[json.exception.parse_error.101] parse error at line 1, column 13: syntax error while parsing value - invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF; last read: '\"\\uD800\\uE000'", json::parse_error&);
             }
         }
 


### PR DESCRIPTION
This PR refactors unit tests to use more convenient doctest assertion macros, as discussed in issue #3365.

The bulk of the change was done automatically, using a regexp replace, with some manual adjustments.

In the process, I found several unit tests that rely on the side effects of running two assertion macros and got broken by running a single one. Those tests are left untouched, to keep them passing. I think I will try to address those is a separate PR.
