### PR TITLE
Refactor unit tests to use more convenient doctest assertion macros (Part 2)

### DIFF
--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -771,7 +771,7 @@ TEST_CASE("regression tests 1")
             ss << "   ";
             json j;
             CHECK_THROWS_WITH_AS(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+                                 "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("one value")
@@ -794,7 +794,7 @@ TEST_CASE("regression tests 1")
             CHECK(j == 222);
 
             CHECK_THROWS_WITH_AS(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 2, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
+                                 "[json.exception.parse_error.101] parse error at line 2, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("whitespace + one value")
@@ -1412,13 +1412,13 @@ TEST_CASE("regression tests 1")
                        "from": "/one/two/three",
                        "path": "/a/b/c"}])"_json;
         CHECK_THROWS_WITH_AS(model.patch(p1),
-                          "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
+                             "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
 
         auto p2 = R"([{"op": "copy",
                        "from": "/one/two/three",
                        "path": "/a/b/c"}])"_json;
         CHECK_THROWS_WITH_AS(model.patch(p2),
-                          "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
+                             "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
     }
 
     SECTION("issue #961 - incorrect parsing of indefinite length CBOR strings")

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -793,9 +793,8 @@ TEST_CASE("regression tests 1")
             CHECK_NOTHROW(ss >> j);
             CHECK(j == 222);
 
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j,
+                              "[json.exception.parse_error.101] parse error at line 2, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("whitespace + one value")

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -1417,13 +1417,8 @@ TEST_CASE("regression tests 1")
         auto p3 = R"([{"op": "copy",
                        "from": "/one/two/three",
                        "path": "/a/b/c"}])"_json;
-        CHECK_THROWS_AS(model.patch(p3), json::out_of_range&);
-
-        auto p4 = R"([{"op": "copy",
-                                 "from": "/one/two/three",
-                                 "path": "/a/b/c"}])"_json;
-        CHECK_THROWS_WITH(model.patch(p4),
-                          "[json.exception.out_of_range.403] key 'a' not found");
+        CHECK_THROWS_WITH_AS(model.patch(p3),
+                          "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
     }
 
     SECTION("issue #961 - incorrect parsing of indefinite length CBOR strings")

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -1414,10 +1414,10 @@ TEST_CASE("regression tests 1")
         CHECK_THROWS_WITH_AS(model.patch(p1),
                           "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
 
-        auto p3 = R"([{"op": "copy",
+        auto p2 = R"([{"op": "copy",
                        "from": "/one/two/three",
                        "path": "/a/b/c"}])"_json;
-        CHECK_THROWS_WITH_AS(model.patch(p3),
+        CHECK_THROWS_WITH_AS(model.patch(p2),
                           "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
     }
 

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -770,9 +770,8 @@ TEST_CASE("regression tests 1")
             std::stringstream ss;
             ss << "   ";
             json j;
-            CHECK_THROWS_AS(ss >> j, json::parse_error&);
-            CHECK_THROWS_WITH(ss >> j,
-                              "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal");
+            CHECK_THROWS_WITH_AS(ss >> j,
+                              "[json.exception.parse_error.101] parse error at line 1, column 4: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal", json::parse_error&);
         }
 
         SECTION("one value")

--- a/test/src/unit-regression1.cpp
+++ b/test/src/unit-regression1.cpp
@@ -1411,13 +1411,8 @@ TEST_CASE("regression tests 1")
         auto p1 = R"([{"op": "move",
                        "from": "/one/two/three",
                        "path": "/a/b/c"}])"_json;
-        CHECK_THROWS_AS(model.patch(p1), json::out_of_range&);
-
-        auto p2 = R"([{"op": "move",
-                       "from": "/one/two/three",
-                       "path": "/a/b/c"}])"_json;
-        CHECK_THROWS_WITH(model.patch(p2),
-                          "[json.exception.out_of_range.403] key 'a' not found");
+        CHECK_THROWS_WITH_AS(model.patch(p1),
+                          "[json.exception.out_of_range.403] key 'a' not found", json::out_of_range&);
 
         auto p3 = R"([{"op": "copy",
                        "from": "/one/two/three",


### PR DESCRIPTION
Also, removed some now redundant code and adjusted the expected error messages. The new messages reflect what would be communicated if the old assertion macros were reordered (first `CHECK_THROWS_WITH` and then `CHECK_THROWS_AS`).