### PR TITLE
CI: windows-2016 has been deprecated; remove jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,41 +29,6 @@ jobs:
       - name: test
         run: cd build ; ctest -j 10 -C Debug --output-on-failure
 
-  msvc2017:
-    runs-on: windows-2016
-    strategy:
-      matrix:
-        build_type: [Debug, Release]
-        architecture: [Win32, x64]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
-      if: matrix.build_type == 'Release' && matrix.architecture == 'x64'
-    - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
-      if: matrix.build_type == 'Release' && matrix.architecture != 'x64'
-    - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
-      if: matrix.build_type == 'Debug'
-    - name: build
-      run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
-    - name: test
-      run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
-
-  msvc2017_latest:
-    runs-on: windows-2016
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: cmake
-      run: cmake -S . -B build -G "Visual Studio 15 2017" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
-    - name: build
-      run: cmake --build build --config Release --parallel 10
-    - name: test
-      run: cd build ; ctest -j 10 -C Release --output-on-failure
-
   msvc2019:
     runs-on: windows-2019
     strategy:

--- a/README.md
+++ b/README.md
@@ -1117,7 +1117,6 @@ The following compilers are currently used in continuous integration at [AppVeyo
 | NVCC 11.0.221                                                                                          | Ubuntu 20.04.3 LTS | GitHub Actions |
 | Visual Studio 14 2015 MSVC 19.0.24241.7 (Build Engine version 14.0.25420.1)                            | Windows-6.3.9600   | AppVeyor       |
 | Visual Studio 15 2017 MSVC 19.16.27035.0 (Build Engine version 15.9.21+g9802d43bc3 for .NET Framework) | Windows-10.0.14393 | AppVeyor       |
-| Visual Studio 15 2017 MSVC 19.16.27045.0 (Build Engine version 15.9.21+g9802d43bc3 for .NET Framework) | Windows-10.0.14393 | GitHub Actions |
 | Visual Studio 16 2019 MSVC 19.28.29912.0 (Build Engine version 16.9.0+57a23d249 for .NET Framework)    | Windows-10.0.17763 | GitHub Actions |
 | Visual Studio 16 2019 MSVC 19.28.29912.0 (Build Engine version 16.9.0+57a23d249 for .NET Framework)    | Windows-10.0.17763 | AppVeyor       |
 | Visual Studio 17 2022 MSVC 19.30.30709.0 (Build Engine version 17.0.31804.368 for .NET Framework)      | Windows-10.0.20348 | GitHub Actions |


### PR DESCRIPTION
As previously mentioned windows-2016 is now deprecated. Remove msvc2017* jobs from the workflow.
GH offers no replacement for jobs requiring "Visual Studio 15 2017".