### PR TITLE
Restore disabled check for #3070 (except on MSVC)

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -464,8 +464,7 @@ void from_json(const BasicJsonType& j, std_fs::path& p)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_string()))
     {
-        // Not tested because of #3377 (related #3070)
-        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name()), j)); // LCOV_EXCL_LINE
+        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name()), j));
     }
     p = *j.template get_ptr<const typename BasicJsonType::string_t*>();
 }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4279,8 +4279,7 @@ void from_json(const BasicJsonType& j, std_fs::path& p)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_string()))
     {
-        // Not tested because of #3377 (related #3070)
-        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name()), j)); // LCOV_EXCL_LINE
+        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name()), j));
     }
     p = *j.template get_ptr<const typename BasicJsonType::string_t*>();
 }

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -748,8 +748,10 @@ TEST_CASE("regression tests 2")
         const auto j_path = j.get<nlohmann::detail::std_fs::path>();
         CHECK(j_path == text_path);
 
-        // Disabled pending resolution of #3377
-        // CHECK_THROWS_WITH_AS(nlohmann::detail::std_fs::path(json(1)), "[json.exception.type_error.302] type must be string, but is number", json::type_error);
+#ifndef _MSC_VER
+        // works everywhere but on MSVC
+        CHECK_THROWS_WITH_AS(nlohmann::detail::std_fs::path(json(1)), "[json.exception.type_error.302] type must be string, but is number", json::type_error);
+#endif
     }
 #endif
 


### PR DESCRIPTION
Restore the previously disabled check for regression #3070 on all compilers but MSVC.

To summarize the issue:
Given `namespace fs = std::filesystem`.
On MSVC attempting to construct an `fs::path` from `json` results in an ambiguous overload resolution because `fs::path` can be constructed from both a `std::string` as well as another `fs::path`. To the best of my knowledge there is no way to fix an ambiguous overload situation involving a type we do not control and with `json` implicitly converting to both `std::string` and `fs::path`.

Re-enabling the check where it compiles and keeping it disabled for MSVC is the best we can do.

Closes #3377 and #3382.
