### PR TITLE
Exclude std::any from implicit conversion (fixes #3428)

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -94,6 +94,7 @@ SOFTWARE.
 #include <nlohmann/ordered_map.hpp>
 
 #if defined(JSON_HAS_CPP_17)
+    #include <any>
     #include <string_view>
 #endif
 
@@ -1891,6 +1892,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
 #if defined(JSON_HAS_CPP_17) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER <= 1914))
                                                 detail::negation<std::is_same<ValueType, std::string_view>>,
+#endif
+#if defined(JSON_HAS_CPP_17)
+                                                detail::negation < std::is_same<ValueType, std::any>>,
 #endif
                                                 detail::is_detected_lazy<detail::get_template_function, const basic_json_t&, ValueType>
                                                 >::value, int >::type = 0 >

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1894,7 +1894,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                                 detail::negation<std::is_same<ValueType, std::string_view>>,
 #endif
 #if defined(JSON_HAS_CPP_17)
-                                                detail::negation < std::is_same<ValueType, std::any>>,
+                                                detail::negation<std::is_same<ValueType, std::any>>,
 #endif
                                                 detail::is_detected_lazy<detail::get_template_function, const basic_json_t&, ValueType>
                                                 >::value, int >::type = 0 >

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -17287,6 +17287,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
 
 #if defined(JSON_HAS_CPP_17)
+    #include <any>
     #include <string_view>
 #endif
 
@@ -19084,6 +19085,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
 #if defined(JSON_HAS_CPP_17) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER <= 1914))
                                                 detail::negation<std::is_same<ValueType, std::string_view>>,
+#endif
+#if defined(JSON_HAS_CPP_17)
+                                                detail::negation < std::is_same<ValueType, std::any>>,
 #endif
                                                 detail::is_detected_lazy<detail::get_template_function, const basic_json_t&, ValueType>
                                                 >::value, int >::type = 0 >

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19087,7 +19087,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                                 detail::negation<std::is_same<ValueType, std::string_view>>,
 #endif
 #if defined(JSON_HAS_CPP_17)
-                                                detail::negation < std::is_same<ValueType, std::any>>,
+                                                detail::negation<std::is_same<ValueType, std::any>>,
 #endif
                                                 detail::is_detected_lazy<detail::get_template_function, const basic_json_t&, ValueType>
                                                 >::value, int >::type = 0 >

--- a/test/src/unit-regression2.cpp
+++ b/test/src/unit-regression2.cpp
@@ -43,6 +43,7 @@ using ordered_json = nlohmann::ordered_json;
 #include <utility>
 
 #ifdef JSON_HAS_CPP_17
+    #include <any>
     #include <variant>
 #endif
 
@@ -858,6 +859,18 @@ TEST_CASE("regression tests 2")
         j.get_to(obj);
 
         CHECK(obj.name == "class");
+    }
+#endif
+
+#if defined(JSON_HAS_CPP_17) && JSON_USE_IMPLICIT_CONVERSIONS
+    SECTION("issue #3428 - Error occurred when converting nlohmann::json to std::any")
+    {
+        json j;
+        std::any a1 = j;
+        std::any&& a2 = j;
+
+        CHECK(a1.type() == typeid(j));
+        CHECK(a2.type() == typeid(j));
     }
 #endif
 }


### PR DESCRIPTION
Fixes #3428 (MSVC) and silences compiler warning on GCC (-Wconversion).