### PR TITLE
change bjdata ndarray flag to detect negative size, as part of #3475

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2430,7 +2430,7 @@ class binary_reader
                 {'m', "uint32"}, {'l', "int32"}, {'M', "uint64"}, {'L', "int64"}, {'d', "single"}, {'D', "double"}, {'C', "char"}
             };
 
-            size_and_type.second &= ~(256);
+            size_and_type.second -= 256;
 
             string_t key = "_ArrayType_";
             if (JSON_HEDLEY_UNLIKELY(bjdtype.count(size_and_type.second) == 0 || !sax->key(key) || !sax->string(bjdtype[size_and_type.second]) ))

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -1938,7 +1938,7 @@ class binary_reader
     {
         std::pair<std::size_t, char_int_type> size_and_type;
         size_t dimlen = 0;
-        bool isndarray = false;
+        bool is_ndarray = false;
 
         if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type)))
         {
@@ -1953,7 +1953,7 @@ class binary_reader
                 {
                     for (std::size_t i = 0; i < size_and_type.first; ++i)
                     {
-                        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, isndarray, size_and_type.second)))
+                        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, is_ndarray, size_and_type.second)))
                         {
                             return false;
                         }
@@ -1965,7 +1965,7 @@ class binary_reader
             {
                 for (std::size_t i = 0; i < size_and_type.first; ++i)
                 {
-                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, isndarray)))
+                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, is_ndarray)))
                     {
                         return false;
                     }
@@ -1977,7 +1977,7 @@ class binary_reader
         {
             while (current != ']')
             {
-                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, isndarray, current)))
+                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, is_ndarray, current)))
                 {
                     return false;
                 }
@@ -1992,9 +1992,9 @@ class binary_reader
     @param[out] result  determined size
     @return whether size determination completed
     */
-    bool get_ubjson_size_value(std::size_t& result, bool& isndarray, char_int_type prefix = 0)
+    bool get_ubjson_size_value(std::size_t& result, bool& is_ndarray, char_int_type prefix = 0)
     {
-        isndarray = false;
+        is_ndarray = false;
         if (prefix == 0)
         {
             prefix = get_ignore_noop();
@@ -2134,7 +2134,7 @@ class binary_reader
                             return false;
                         }
                     }
-                    isndarray = true;
+                    is_ndarray = true;
                     return sax->end_array();
                 }
                 result = 0;
@@ -2170,7 +2170,7 @@ class binary_reader
     */
     bool get_ubjson_size_type(std::pair<std::size_t, char_int_type>& result)
     {
-        bool isndarray = false;
+        bool is_ndarray = false;
         result.first = string_t::npos; // size
         result.second = 0; // type
 
@@ -2205,22 +2205,22 @@ class binary_reader
                                         exception_message(input_format, concat("expected '#' after type information; last byte: 0x", last_token), "size"), nullptr));
             }
 
-            bool iserr = get_ubjson_size_value(result.first, isndarray);
-            if (input_format == input_format_t::bjdata && isndarray)
+            bool is_error = get_ubjson_size_value(result.first, is_ndarray);
+            if (input_format == input_format_t::bjdata && is_ndarray)
             {
-                result.second |= 256; // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
+                result.second |= (1 << 8); // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
             }
-            return iserr;
+            return is_error;
         }
 
         if (current == '#')
         {
-            bool iserr = get_ubjson_size_value(result.first, isndarray);
-            if (input_format == input_format_t::bjdata && isndarray)
+            bool is_error = get_ubjson_size_value(result.first, is_ndarray);
+            if (input_format == input_format_t::bjdata && is_ndarray)
             {
-                result.second |= 256; // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
+                result.second |= (1 << 8); // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
             }
-            return iserr;
+            return is_error;
         }
 
         return true;
@@ -2424,16 +2424,23 @@ class binary_reader
         // detect and encode bjdata ndarray as an object in JData annotated array format (https://github.com/NeuroJSON/jdata):
         // {"_ArrayType_" : "typeid", "_ArraySize_" : [n1, n2, ...], "_ArrayData_" : [v1, v2, ...]}
 
-        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= 256)
+        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= (1 << 8))
         {
             std::map<char_int_type, string_t> bjdtype = {{'U', "uint8"},  {'i', "int8"},  {'u', "uint16"}, {'I', "int16"},
                 {'m', "uint32"}, {'l', "int32"}, {'M', "uint64"}, {'L', "int64"}, {'d', "single"}, {'D', "double"}, {'C', "char"}
             };
 
-            size_and_type.second -= 256;
+            size_and_type.second &= ~(1 << 8);  // use bit 8 to indicate ndarray, here we remove the bit to restore the type marker
 
             string_t key = "_ArrayType_";
-            if (JSON_HEDLEY_UNLIKELY(bjdtype.count(size_and_type.second) == 0 || !sax->key(key) || !sax->string(bjdtype[size_and_type.second]) ))
+            if (JSON_HEDLEY_UNLIKELY(bjdtype.count(size_and_type.second) == 0))
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                        exception_message(input_format, "invalid byte: 0x" + last_token, "type"), nullptr));
+            }
+
+            if (JSON_HEDLEY_UNLIKELY(!sax->key(key) || !sax->string(bjdtype[size_and_type.second]) ))
             {
                 return false;
             }
@@ -2522,9 +2529,11 @@ class binary_reader
             return false;
         }
 
-        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= 256)
+        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= (1 << 8))
         {
-            return false;
+            auto last_token = get_token_string();
+            return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                    exception_message(input_format, "BJData object does not support ND-array size in optimized format", "object"), nullptr));
         }
 
         string_t key;
@@ -2598,8 +2607,8 @@ class binary_reader
     {
         // get size of following number string
         std::size_t size{};
-        bool isndarray = false;
-        auto res = get_ubjson_size_value(size, isndarray);
+        bool is_ndarray = false;
+        auto res = get_ubjson_size_value(size, is_ndarray);
         if (JSON_HEDLEY_UNLIKELY(!res))
         {
             return res;

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2421,16 +2421,16 @@ class binary_reader
             return false;
         }
 
-        // detect and encode bjdata ndarray as an object in JData annotated array format (https://github.com/NeuroJSON/jdata):
+        // if bit-8 of size_and_type.second is set to 1, encode bjdata ndarray as an object in JData annotated array format (https://github.com/NeuroJSON/jdata):
         // {"_ArrayType_" : "typeid", "_ArraySize_" : [n1, n2, ...], "_ArrayData_" : [v1, v2, ...]}
 
-        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= (1 << 8))
+        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && (size_and_type.second & (1 << 8)) != 0)
         {
             std::map<char_int_type, string_t> bjdtype = {{'U', "uint8"},  {'i', "int8"},  {'u', "uint16"}, {'I', "int16"},
                 {'m', "uint32"}, {'l', "int32"}, {'M', "uint64"}, {'L', "int64"}, {'d', "single"}, {'D', "double"}, {'C', "char"}
             };
 
-            size_and_type.second &= ~(1 << 8);  // use bit 8 to indicate ndarray, here we remove the bit to restore the type marker
+            size_and_type.second &= ~(static_cast<char_int_type>(1) << 8);  // use bit 8 to indicate ndarray, here we remove the bit to restore the type marker
 
             string_t key = "_ArrayType_";
             if (JSON_HEDLEY_UNLIKELY(bjdtype.count(size_and_type.second) == 0))
@@ -2529,7 +2529,8 @@ class binary_reader
             return false;
         }
 
-        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= (1 << 8))
+        // do not accept ND-array size in objects in BJData
+        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && (size_and_type.second & (1 << 8)) != 0)
         {
             auto last_token = get_token_string();
             return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10904,7 +10904,7 @@ class binary_reader
                 {'m', "uint32"}, {'l', "int32"}, {'M', "uint64"}, {'L', "int64"}, {'d', "single"}, {'D', "double"}, {'C', "char"}
             };
 
-            size_and_type.second &= ~(256);
+            size_and_type.second -= 256;
 
             string_t key = "_ArrayType_";
             if (JSON_HEDLEY_UNLIKELY(bjdtype.count(size_and_type.second) == 0 || !sax->key(key) || !sax->string(bjdtype[size_and_type.second]) ))

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10412,6 +10412,7 @@ class binary_reader
     {
         std::pair<std::size_t, char_int_type> size_and_type;
         size_t dimlen = 0;
+        bool isndarray = false;
 
         if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type)))
         {
@@ -10426,7 +10427,7 @@ class binary_reader
                 {
                     for (std::size_t i = 0; i < size_and_type.first; ++i)
                     {
-                        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, size_and_type.second)))
+                        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, isndarray, size_and_type.second)))
                         {
                             return false;
                         }
@@ -10438,7 +10439,7 @@ class binary_reader
             {
                 for (std::size_t i = 0; i < size_and_type.first; ++i)
                 {
-                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen)))
+                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, isndarray)))
                     {
                         return false;
                     }
@@ -10450,7 +10451,7 @@ class binary_reader
         {
             while (current != ']')
             {
-                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, current)))
+                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, isndarray, current)))
                 {
                     return false;
                 }
@@ -10465,8 +10466,9 @@ class binary_reader
     @param[out] result  determined size
     @return whether size determination completed
     */
-    bool get_ubjson_size_value(std::size_t& result, char_int_type prefix = 0)
+    bool get_ubjson_size_value(std::size_t& result, bool& isndarray, char_int_type prefix = 0)
     {
+        isndarray = false;
         if (prefix == 0)
         {
             prefix = get_ignore_noop();
@@ -10606,7 +10608,7 @@ class binary_reader
                             return false;
                         }
                     }
-                    result |= (1ull << (sizeof(result) * 8 - 1)); // low 63 bit of result stores the total element count, sign-bit indicates ndarray
+                    isndarray = true;
                     return sax->end_array();
                 }
                 result = 0;
@@ -10642,6 +10644,7 @@ class binary_reader
     */
     bool get_ubjson_size_type(std::pair<std::size_t, char_int_type>& result)
     {
+        bool isndarray = false;
         result.first = string_t::npos; // size
         result.second = 0; // type
 
@@ -10659,7 +10662,7 @@ class binary_reader
                                         exception_message(input_format, concat("marker 0x", last_token, " is not a permitted optimized array type"), "type"), nullptr));
             }
 
-            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "type") || (input_format == input_format_t::bjdata && std::find(bjdx.begin(), bjdx.end(), result.second) != bjdx.end() )))
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "type")))
             {
                 return false;
             }
@@ -10676,12 +10679,22 @@ class binary_reader
                                         exception_message(input_format, concat("expected '#' after type information; last byte: 0x", last_token), "size"), nullptr));
             }
 
-            return get_ubjson_size_value(result.first);
+            bool iserr = get_ubjson_size_value(result.first, isndarray);
+            if (input_format == input_format_t::bjdata && isndarray)
+            {
+                result.second |= 256; // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
+            }
+            return iserr;
         }
 
         if (current == '#')
         {
-            return get_ubjson_size_value(result.first);
+            bool iserr = get_ubjson_size_value(result.first, isndarray);
+            if (input_format == input_format_t::bjdata && isndarray)
+            {
+                result.second |= 256; // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
+            }
+            return iserr;
         }
 
         return true;
@@ -10885,11 +10898,13 @@ class binary_reader
         // detect and encode bjdata ndarray as an object in JData annotated array format (https://github.com/NeuroJSON/jdata):
         // {"_ArrayType_" : "typeid", "_ArraySize_" : [n1, n2, ...], "_ArrayData_" : [v1, v2, ...]}
 
-        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.first >= (1ull << (sizeof(std::size_t) * 8 - 1)))
+        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= 256)
         {
             std::map<char_int_type, string_t> bjdtype = {{'U', "uint8"},  {'i', "int8"},  {'u', "uint16"}, {'I', "int16"},
                 {'m', "uint32"}, {'l', "int32"}, {'M', "uint64"}, {'L', "int64"}, {'d', "single"}, {'D', "double"}, {'C', "char"}
             };
+
+            size_and_type.second &= ~(256);
 
             string_t key = "_ArrayType_";
             if (JSON_HEDLEY_UNLIKELY(bjdtype.count(size_and_type.second) == 0 || !sax->key(key) || !sax->string(bjdtype[size_and_type.second]) ))
@@ -10902,7 +10917,6 @@ class binary_reader
                 size_and_type.second = 'U';
             }
 
-            size_and_type.first &= ~(1ull << (sizeof(std::size_t) * 8 - 1));
             key = "_ArrayData_";
             if (JSON_HEDLEY_UNLIKELY(!sax->key(key) || !sax->start_array(size_and_type.first) ))
             {
@@ -10982,7 +10996,7 @@ class binary_reader
             return false;
         }
 
-        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.first >= (1ull << (sizeof(std::size_t) * 8 - 1)))
+        if (input_format == input_format_t::bjdata && size_and_type.first != string_t::npos && size_and_type.second >= 256)
         {
             return false;
         }
@@ -11058,7 +11072,8 @@ class binary_reader
     {
         // get size of following number string
         std::size_t size{};
-        auto res = get_ubjson_size_value(size);
+        bool isndarray = false;
+        auto res = get_ubjson_size_value(size, isndarray);
         if (JSON_HEDLEY_UNLIKELY(!res))
         {
             return res;

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2499,21 +2499,29 @@ TEST_CASE("BJData")
 
                 json _;
                 CHECK_THROWS_AS(_ = json::from_bjdata(v1), json::out_of_range&);
-                CHECK_THROWS_WITH(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 18446744073709551601");
-
                 CHECK_THROWS_AS(_ = json::from_bjdata(v2), json::out_of_range&);
-                CHECK_THROWS_WITH(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 18446744073709551602");
+                CHECK_THROWS_AS(_ = json::from_bjdata(v4), json::out_of_range&);
+                CHECK_THROWS_AS(_ = json::from_bjdata(v6), json::out_of_range&);
+
+                if (sizeof(size_t) == 8)
+                {
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 18446744073709551601");
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 18446744073709551602");
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 18446744073709551592");
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v6), "[json.exception.out_of_range.408] excessive array size: 18446744073709551607");
+                }
+                else
+                {
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 4294967281");
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 4294967282");
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 4294967272");
+                    CHECK_THROWS_WITH(_ = json::from_bjdata(v6), "[json.exception.out_of_range.408] excessive array size: 4294967287");
+                }
 
                 CHECK(json::from_bjdata(v3, true, false).is_discarded());
 
-                CHECK_THROWS_AS(_ = json::from_bjdata(v4), json::out_of_range&);
-                CHECK_THROWS_WITH(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 18446744073709551592");
-
                 CHECK_THROWS_AS(_ = json::from_bjdata(v5), json::parse_error&);
                 CHECK_THROWS_WITH(_ = json::from_bjdata(v5), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing BJData number: unexpected end of input");
-
-                CHECK_THROWS_AS(_ = json::from_bjdata(v6), json::out_of_range&);
-                CHECK_THROWS_WITH(_ = json::from_bjdata(v6), "[json.exception.out_of_range.408] excessive array size: 18446744073709551607");
             }
 
             SECTION("do not accept NTFZ markers in ndarray optimized type")

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2094,6 +2094,20 @@ TEST_CASE("BJData")
             CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
+        SECTION("key() in ndarray _ArrayType_")
+        {
+            std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
+            SaxCountdown scp(9);
+            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+        }
+
+        SECTION("key() in ndarray _ArrayType_")
+        {
+            std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
+            SaxCountdown scp(10);
+            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+        }
+
         SECTION("string() in ndarray _ArrayType_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'i', '#', 'i', 2, 3, 2, 6, 5, 4, 3, 2, 1};

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2498,13 +2498,23 @@ TEST_CASE("BJData")
                 std::vector<uint8_t> v6 = {'[', '#', '[', 'i', 0xF3, 'i', 0x02, ']'};
 
                 json _;
-                CHECK_THROWS_AS(_ = json::from_bjdata(v1), json::out_of_range&);
-                CHECK_THROWS_AS(_ = json::from_bjdata(v2), json::out_of_range&);
-                CHECK_THROWS_AS(_ = json::from_bjdata(v3), json::out_of_range&);
-                CHECK_THROWS_AS(_ = json::from_bjdata(v4), json::out_of_range&);
+                static bool is_64bit = (sizeof(size_t) == 8);
 
-                CHECK_THROWS_AS(_ = json::from_bjdata(v5), json::parse_error&);
-                CHECK_THROWS_WITH(_ = json::from_bjdata(v5), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing BJData number: unexpected end of input");
+                if (is_64bit)
+                {
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 18446744073709551601", json::out_of_range&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 18446744073709551602", json::out_of_range&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v3), "[json.exception.out_of_range.408] excessive array size: 18446744073709551592", json::out_of_range&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 18446744073709551607", json::out_of_range&);
+                }
+                else
+                {
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 4294967281", json::out_of_range&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 4294967282", json::out_of_range&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v3), "[json.exception.out_of_range.408] excessive array size: 4294967272", json::out_of_range&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 4294967287", json::out_of_range&);
+                }
+                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v5), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing BJData number: unexpected end of input", json::parse_error&);
 
                 CHECK(json::from_bjdata(v6, true, false).is_discarded());
             }

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2492,36 +2492,21 @@ TEST_CASE("BJData")
             {
                 std::vector<uint8_t> v1 = {'[', '#', 'i', 0xF1};
                 std::vector<uint8_t> v2 = {'[', '$', 'I', '#', 'i', 0xF2};
-                std::vector<uint8_t> v3 = {'[', '#', '[', 'i', 0xF3, 'i', 0x02, ']'};
-                std::vector<uint8_t> v4 = {'[', '$', 'I', '#', '[', 'i', 0xF4, 'i', 0x02, ']'};
+                std::vector<uint8_t> v3 = {'[', '$', 'I', '#', '[', 'i', 0xF4, 'i', 0x02, ']'};
+                std::vector<uint8_t> v4 = {'[', '$', 0xF6, '#', 'i', 0xF7};
                 std::vector<uint8_t> v5 = {'[', '$', 'I', '#', '[', 'i', 0xF5, 'i', 0xF1, ']'};
-                std::vector<uint8_t> v6 = {'[', '$', 0xF6, '#', 'i', 0xF7};
+                std::vector<uint8_t> v6 = {'[', '#', '[', 'i', 0xF3, 'i', 0x02, ']'};
 
                 json _;
                 CHECK_THROWS_AS(_ = json::from_bjdata(v1), json::out_of_range&);
                 CHECK_THROWS_AS(_ = json::from_bjdata(v2), json::out_of_range&);
+                CHECK_THROWS_AS(_ = json::from_bjdata(v3), json::out_of_range&);
                 CHECK_THROWS_AS(_ = json::from_bjdata(v4), json::out_of_range&);
-                CHECK_THROWS_AS(_ = json::from_bjdata(v6), json::out_of_range&);
-
-                if (sizeof(size_t) == 8)
-                {
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 18446744073709551601");
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 18446744073709551602");
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 18446744073709551592");
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v6), "[json.exception.out_of_range.408] excessive array size: 18446744073709551607");
-                }
-                else
-                {
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 4294967281");
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 4294967282");
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 4294967272");
-                    CHECK_THROWS_WITH(_ = json::from_bjdata(v6), "[json.exception.out_of_range.408] excessive array size: 4294967287");
-                }
-
-                CHECK(json::from_bjdata(v3, true, false).is_discarded());
 
                 CHECK_THROWS_AS(_ = json::from_bjdata(v5), json::parse_error&);
                 CHECK_THROWS_WITH(_ = json::from_bjdata(v5), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing BJData number: unexpected end of input");
+
+                CHECK(json::from_bjdata(v6, true, false).is_discarded());
             }
 
             SECTION("do not accept NTFZ markers in ndarray optimized type")

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2488,6 +2488,34 @@ TEST_CASE("BJData")
                 CHECK_THROWS_WITH(_ = json::from_bjdata(v), "[json.exception.parse_error.112] parse error at byte 4: syntax error while parsing BJData size: expected '#' after type information; last byte: 0x02");
             }
 
+            SECTION("optimized array: negative size")
+            {
+                std::vector<uint8_t> v1 = {'[', '#', 'i', 0xF1};
+                std::vector<uint8_t> v2 = {'[', '$', 'I', '#', 'i', 0xF2};
+                std::vector<uint8_t> v3 = {'[', '#', '[', 'i', 0xF3, 'i', 0x02, ']'};
+                std::vector<uint8_t> v4 = {'[', '$', 'I', '#', '[', 'i', 0xF4, 'i', 0x02, ']'};
+                std::vector<uint8_t> v5 = {'[', '$', 'I', '#', '[', 'i', 0xF5, 'i', 0xF1, ']'};
+                std::vector<uint8_t> v6 = {'[', '$', 0xF6, '#', 'i', 0xF7};
+
+                json _;
+                CHECK_THROWS_AS(_ = json::from_bjdata(v1), json::out_of_range&);
+                CHECK_THROWS_WITH(_ = json::from_bjdata(v1), "[json.exception.out_of_range.408] excessive array size: 18446744073709551601");
+
+                CHECK_THROWS_AS(_ = json::from_bjdata(v2), json::out_of_range&);
+                CHECK_THROWS_WITH(_ = json::from_bjdata(v2), "[json.exception.out_of_range.408] excessive array size: 18446744073709551602");
+
+                CHECK(json::from_bjdata(v3, true, false).is_discarded());
+
+                CHECK_THROWS_AS(_ = json::from_bjdata(v4), json::out_of_range&);
+                CHECK_THROWS_WITH(_ = json::from_bjdata(v4), "[json.exception.out_of_range.408] excessive array size: 18446744073709551592");
+
+                CHECK_THROWS_AS(_ = json::from_bjdata(v5), json::parse_error&);
+                CHECK_THROWS_WITH(_ = json::from_bjdata(v5), "[json.exception.parse_error.110] parse error at byte 11: syntax error while parsing BJData number: unexpected end of input");
+
+                CHECK_THROWS_AS(_ = json::from_bjdata(v6), json::out_of_range&);
+                CHECK_THROWS_WITH(_ = json::from_bjdata(v6), "[json.exception.out_of_range.408] excessive array size: 18446744073709551607");
+            }
+
             SECTION("do not accept NTFZ markers in ndarray optimized type")
             {
                 json _;

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -1130,7 +1130,7 @@ TEST_CASE("BJData")
                 {
                     json j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0x7c}));
                     json::number_float_t d{j};
-                    CHECK(!std::isfinite(d));
+                    CHECK_FALSE(std::isfinite(d));
                     CHECK(j.dump() == "null");
                 }
 
@@ -2035,91 +2035,84 @@ TEST_CASE("BJData")
         {
             std::vector<uint8_t> v = {'[', 'T', 'F', ']'};
             SaxCountdown scp(0);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("start_object()")
         {
             std::vector<uint8_t> v = {'{', 'i', 3, 'f', 'o', 'o', 'F', '}'};
             SaxCountdown scp(0);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("key() in object")
         {
             std::vector<uint8_t> v = {'{', 'i', 3, 'f', 'o', 'o', 'F', '}'};
             SaxCountdown scp(1);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("start_array(len)")
         {
             std::vector<uint8_t> v = {'[', '#', 'i', '2', 'T', 'F'};
             SaxCountdown scp(0);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("start_object(len)")
         {
             std::vector<uint8_t> v = {'{', '#', 'i', '1', 3, 'f', 'o', 'o', 'F'};
             SaxCountdown scp(0);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("key() in object with length")
         {
             std::vector<uint8_t> v = {'{', 'i', 3, 'f', 'o', 'o', 'F', '}'};
             SaxCountdown scp(1);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("start_array() in ndarray _ArraySize_")
         {
             std::vector<uint8_t> v = {'[', '$', 'i', '#', '[', '$', 'i', '#', 'i', 2, 2, 1, 1, 2};
             SaxCountdown scp(2);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("number_integer() in ndarray _ArraySize_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'i', '#', 'i', 2, 2, 1, 1, 2};
             SaxCountdown scp(3);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("key() in ndarray _ArrayType_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
-            SaxCountdown scp(8);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            SaxCountdown scp(6);
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("key() in ndarray _ArrayType_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
-            SaxCountdown scp(9);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
-        }
-
-        SECTION("key() in ndarray _ArrayType_")
-        {
-            std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
-            SaxCountdown scp(10);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            SaxCountdown scp(7);
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("string() in ndarray _ArrayType_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'i', '#', 'i', 2, 3, 2, 6, 5, 4, 3, 2, 1};
             SaxCountdown scp(11);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
         SECTION("start_array() in ndarray _ArrayData_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', 'i', 2, 'i', 3, ']', 6, 5, 4, 3, 2, 1};
             SaxCountdown scp(13);
-            CHECK(!json::sax_parse(v, &scp, json::input_format_t::bjdata));
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
     }
 

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2094,10 +2094,24 @@ TEST_CASE("BJData")
             CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 
-        SECTION("key() in ndarray _ArrayType_")
+        SECTION("string() in ndarray _ArrayType_")
         {
             std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
             SaxCountdown scp(7);
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
+        }
+
+        SECTION("key() in ndarray _ArrayData_")
+        {
+            std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
+            SaxCountdown scp(8);
+            CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
+        }
+
+        SECTION("string() in ndarray _ArrayData_")
+        {
+            std::vector<uint8_t> v = {'[', '$', 'U', '#', '[', '$', 'U', '#', 'i', 2, 2, 2, 1, 2, 3, 4};
+            SaxCountdown scp(9);
             CHECK_FALSE(json::sax_parse(v, &scp, json::input_format_t::bjdata));
         }
 


### PR DESCRIPTION
here is the fix to #3475. I took @falbrechtskirchinger's suggestion, and use size_and_type.second's bit 8 (all BJData nd UBJSON markers are ASCII letters) as an ND array indicator, this allows negative sizes to be thrown as `json.exception.out_of_range` error.

This should fix the detected fuzzer errors. Let me know if you still see anything.