### PR TITLE
prevent ndarray dimension vector from recusive array, nlohmann/json#3500

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -1938,7 +1938,7 @@ class binary_reader
     {
         std::pair<std::size_t, char_int_type> size_and_type;
         size_t dimlen = 0;
-        bool is_ndarray = false;
+        bool is_ndarray = true;
 
         if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type)))
         {
@@ -1994,7 +1994,6 @@ class binary_reader
     */
     bool get_ubjson_size_value(std::size_t& result, bool& is_ndarray, char_int_type prefix = 0)
     {
-        is_ndarray = false;
         if (prefix == 0)
         {
             prefix = get_ignore_noop();
@@ -2107,6 +2106,10 @@ class binary_reader
                 if (input_format != input_format_t::bjdata)
                 {
                     break;
+                }
+                if (is_ndarray) // ndarray dimensional vector can only contain integers, and can not embed another array
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimention vector can only contain integers", "size"), nullptr));
                 }
                 std::vector<size_t> dim;
                 if (JSON_HEDLEY_UNLIKELY(!get_ubjson_ndarray_size(dim)))

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10412,7 +10412,7 @@ class binary_reader
     {
         std::pair<std::size_t, char_int_type> size_and_type;
         size_t dimlen = 0;
-        bool is_ndarray = false;
+        bool is_ndarray = true;
 
         if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type)))
         {
@@ -10468,7 +10468,6 @@ class binary_reader
     */
     bool get_ubjson_size_value(std::size_t& result, bool& is_ndarray, char_int_type prefix = 0)
     {
-        is_ndarray = false;
         if (prefix == 0)
         {
             prefix = get_ignore_noop();
@@ -10581,6 +10580,10 @@ class binary_reader
                 if (input_format != input_format_t::bjdata)
                 {
                     break;
+                }
+                if (is_ndarray) // ndarray dimensional vector can only contain integers, and can not embed another array
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimention vector can only contain integers", "size"), nullptr));
                 }
                 std::vector<size_t> dim;
                 if (JSON_HEDLEY_UNLIKELY(!get_ubjson_ndarray_size(dim)))

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2784,6 +2784,14 @@ TEST_CASE("BJData")
 
             std::vector<uint8_t> vh = {'[', '$', 'h', '#', '[', '$', 'i', '#', 'i', 2, 2, 3};
             CHECK(json::from_bjdata(vh, true, false).is_discarded());
+
+            std::vector<uint8_t> vR = {'[', '$', 'i', '#', '[', 'i', 1, '[', ']', ']', 1};
+            CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vR), "[json.exception.parse_error.113] parse error at byte 8: syntax error while parsing BJData size: ndarray dimention vector can only contain integers", json::parse_error&);
+            CHECK(json::from_bjdata(vR, true, false).is_discarded());
+
+            std::vector<uint8_t> vRo = {'[', '$', 'i', '#', '[', 'i', 0, '{', '}', ']', 1};
+            CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vRo), "[json.exception.parse_error.113] parse error at byte 8: syntax error while parsing BJData size: expected length type specification (U, i, u, I, m, l, M, L) after '#'; last byte: 0x7B", json::parse_error&);
+            CHECK(json::from_bjdata(vRo, true, false).is_discarded());
         }
 
         SECTION("objects")


### PR DESCRIPTION
I believe the issue @nlohmann found in https://github.com/nlohmann/json/pull/3500#issuecomment-1130464847 is because the ndarray dimension vector parsing is too relax - permitting embedded arrays (which can result in unpredictable results).

I am adding an exception here to avoid such case. let me know if you still see errors.