### PR TITLE
CI: Remove -Wstrict-overflow

### DIFF
--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -343,8 +343,6 @@ set(GCC_CXXFLAGS
     -Wstrict-aliasing
     -Wstrict-aliasing=3
     -Wstrict-null-sentinel
-    -Wstrict-overflow
-    -Wstrict-overflow=5
     -Wstring-compare
     -Wstringop-overflow=4
     -Wstringop-overread


### PR DESCRIPTION
Starting in GCC 12, `ci_test_gcc` generates the following error (in most if not all unit tests):
```
tests/src/unit-constructor1.cpp: In function ‘nlohmann::detail::dtoa_impl::cached_power nlohmann::detail::dtoa_impl::get_cached_power_for_binary_exponent(int)’:
unit-constructor1.cpp:1585:1: error: assuming signed overflow does not occur when changing X +- C1 cmp C2 to X cmp C2 -+ C1 [-Werror=strict-overflow]
```

Neither rewriting the offending line nor suppressing the warning in `get_cached_power_for_binary_exponent(int)` is possible.

This PR removes `-Wstrict-overflow` from the CI warning flags, which is of dubious value anyway.