### PR TITLE
Fix basic_json converting constructor yielding wrong value type and mark constructor JSON_EXPLICIT

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -937,7 +937,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     template < typename BasicJsonType,
                detail::enable_if_t <
                    detail::is_basic_json<BasicJsonType>::value&& !std::is_same<basic_json, BasicJsonType>::value, int > = 0 >
-    basic_json(const BasicJsonType& val)
+    JSON_EXPLICIT basic_json(const BasicJsonType& val)
     {
         using other_boolean_t = typename BasicJsonType::boolean_t;
         using other_number_float_t = typename BasicJsonType::number_float_t;
@@ -1760,7 +1760,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    int > = 0 >
     BasicJsonType get_impl(detail::priority_tag<2> /*unused*/) const
     {
-        return *this;
+        return BasicJsonType(*this);
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5113,6 +5113,16 @@ template<>
 struct external_constructor<value_t::object>
 {
     template<typename BasicJsonType>
+    static void construct(BasicJsonType& j)
+    {
+        j.m_value.destroy(j.m_type);
+        j.m_type = value_t::object;
+        j.m_value.object = j.template create<typename BasicJsonType::object_t>();
+        j.set_parents();
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType>
     static void construct(BasicJsonType& j, const typename BasicJsonType::object_t& obj)
     {
         j.m_value.destroy(j.m_type);
@@ -5147,6 +5157,28 @@ struct external_constructor<value_t::object>
     }
 };
 
+//////////////
+// wrappers //
+//////////////
+
+template<typename ArrayType>
+struct array_type_wrapper
+{
+    const ArrayType& array;
+};
+
+template<typename ObjectType>
+struct object_type_wrapper
+{
+    const ObjectType& object;
+};
+
+template<typename StringType>
+struct string_type_wrapper
+{
+    const StringType& string;
+};
+
 /////////////
 // to_json //
 /////////////
@@ -5169,6 +5201,17 @@ template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, typename BasicJsonType::string_t&& s)
 {
     external_constructor<value_t::string>::construct(j, std::move(s));
+}
+
+template<typename BasicJsonType, typename StringType>
+using string_type_constructible_from_data_and_size = decltype(typename BasicJsonType::string_t(
+            std::declval<const StringType&>().data(), std::declval<const StringType&>().size()));
+
+template<typename BasicJsonType, typename StringType, detail::enable_if_t<
+             detail::is_detected<string_type_constructible_from_data_and_size, BasicJsonType, StringType>::value, int> = 0>
+void to_json(BasicJsonType& j, detail::string_type_wrapper<StringType> s)
+{
+    external_constructor<value_t::string>::construct(j, typename BasicJsonType::string_t(s.string.data(), s.string.size()));
 }
 
 template<typename BasicJsonType, typename FloatType,
@@ -5219,6 +5262,18 @@ inline void to_json(BasicJsonType& j, const CompatibleArrayType& arr)
     external_constructor<value_t::array>::construct(j, arr);
 }
 
+template<typename BasicJsonType, typename ArrayType>
+using array_type_constructible_from_iter = decltype(typename BasicJsonType::array_t(
+            std::declval<result_of_begin<const ArrayType&>>(), std::declval<result_of_end<const ArrayType&>>()));
+
+template<typename BasicJsonType, typename ArrayType, detail::enable_if_t<
+             detail::is_detected<array_type_constructible_from_iter, BasicJsonType, ArrayType>::value, int> = 0>
+void to_json(BasicJsonType& j, detail::array_type_wrapper<ArrayType> a)
+{
+    external_constructor<value_t::array>::construct(j,
+            typename BasicJsonType::array_t(a.array.begin(), a.array.end()));
+}
+
 template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, const typename BasicJsonType::binary_t& bin)
 {
@@ -5249,6 +5304,43 @@ template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, typename BasicJsonType::object_t&& obj)
 {
     external_constructor<value_t::object>::construct(j, std::move(obj));
+}
+
+template < typename BasicJsonType, typename ObjectType,
+           enable_if_t < is_compatible_object_type<BasicJsonType, ObjectType>::value
+                         || is_basic_json<ObjectType>::value, int > = 0 >
+void to_json(BasicJsonType& j, const object_type_wrapper<ObjectType>& obj)
+{
+    external_constructor<value_t::object>::construct(j, obj.object);
+}
+
+template<typename BasicJsonType, typename ObjectType>
+using object_type_key_constructible_from_data_and_size = decltype(
+            typename BasicJsonType::object_t::key_type(
+                std::declval<const typename ObjectType::key_type&>().data(),
+                std::declval<const typename ObjectType::key_type&>().size()));
+
+template < typename BasicJsonType, typename ObjectType,
+           enable_if_t < !is_compatible_object_type<BasicJsonType, ObjectType>::value
+                         && !is_basic_json<ObjectType>::value
+                         && detail::is_detected<object_type_key_constructible_from_data_and_size,
+                                 BasicJsonType, ObjectType>::value, int > = 0 >
+void to_json(BasicJsonType& j, const object_type_wrapper<ObjectType>& o)
+{
+    using std::begin;
+    using std::end;
+
+    external_constructor<value_t::object>::construct(j);
+
+    auto& obj = j.template get_ref<typename BasicJsonType::object_t&>();
+    std::transform(begin(o.object), end(o.object), std::inserter(obj, obj.end()),
+                   [](const typename ObjectType::value_type & val)
+    {
+        return typename BasicJsonType::object_t::value_type
+        {
+            typename BasicJsonType::object_t::key_type(val.first.data(), val.first.size()),
+            BasicJsonType(val.second)};
+    });
 }
 
 template <
@@ -19139,6 +19231,73 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         assert_invariant();
     }
 
+  private:
+    template<typename BasicJsonType, class Serializer, typename SerializedType,
+             class WrapperType>
+    using serializer_has_to_json_with_type_wrapper = decltype(Serializer::to_json(
+                std::declval<BasicJsonType&>(), std::declval<const WrapperType&>()));
+
+    template <typename OtherStringType,
+              detail::enable_if_t <
+                  detail::is_detected<serializer_has_to_json_with_type_wrapper,
+                                      basic_json_t, JSONSerializer<OtherStringType>, OtherStringType,
+                                      detail::string_type_wrapper<OtherStringType>>::value, int > = 0 >
+    void other_string_to_json(const OtherStringType& str)
+    {
+        JSONSerializer<OtherStringType>::to_json(*this, detail::string_type_wrapper<OtherStringType> {str});
+    }
+
+    template < typename OtherStringType,
+               detail::enable_if_t <
+                   !detail::is_detected<serializer_has_to_json_with_type_wrapper,
+                                        basic_json_t, JSONSerializer<OtherStringType>, OtherStringType,
+                                        detail::string_type_wrapper<OtherStringType>>::value, int > = 0 >
+    void other_string_to_json(const OtherStringType& str)
+    {
+        JSONSerializer<OtherStringType>::to_json(*this, str);
+    }
+
+    template <typename OtherObjectType,
+              detail::enable_if_t <
+                  detail::is_detected<serializer_has_to_json_with_type_wrapper,
+                                      basic_json_t, JSONSerializer<OtherObjectType>, OtherObjectType,
+                                      detail::object_type_wrapper<OtherObjectType>>::value, int > = 0 >
+    void other_object_to_json(const OtherObjectType& obj)
+    {
+        JSONSerializer<OtherObjectType>::to_json(*this, detail::object_type_wrapper<OtherObjectType> {obj});
+    }
+
+    template < typename OtherObjectType,
+               detail::enable_if_t <
+                   !detail::is_detected<serializer_has_to_json_with_type_wrapper,
+                                        basic_json_t, JSONSerializer<OtherObjectType>, OtherObjectType,
+                                        detail::object_type_wrapper<OtherObjectType>>::value, int > = 0 >
+    void other_object_to_json(const OtherObjectType& obj)
+    {
+        JSONSerializer<OtherObjectType>::to_json(*this, obj);
+    }
+
+    template <typename OtherArrayType,
+              detail::enable_if_t <
+                  detail::is_detected<serializer_has_to_json_with_type_wrapper,
+                                      basic_json_t, JSONSerializer<OtherArrayType>, OtherArrayType,
+                                      detail::array_type_wrapper<OtherArrayType>>::value, int > = 0 >
+    void other_array_to_json(const OtherArrayType& arr)
+    {
+        JSONSerializer<OtherArrayType>::to_json(*this, detail::array_type_wrapper<OtherArrayType> {arr});
+    }
+
+    template < typename OtherArrayType,
+               detail::enable_if_t <
+                   !detail::is_detected<serializer_has_to_json_with_type_wrapper,
+                                        basic_json_t, JSONSerializer<OtherArrayType>, OtherArrayType,
+                                        detail::array_type_wrapper<OtherArrayType>>::value, int > = 0 >
+    void other_array_to_json(const OtherArrayType& arr)
+    {
+        JSONSerializer<OtherArrayType>::to_json(*this, arr);
+    }
+
+  public:
     /// @brief create a JSON value from an existing one
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     template < typename BasicJsonType,
@@ -19170,13 +19329,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 JSONSerializer<other_number_unsigned_t>::to_json(*this, val.template get<other_number_unsigned_t>());
                 break;
             case value_t::string:
-                JSONSerializer<other_string_t>::to_json(*this, val.template get_ref<const other_string_t&>());
+                other_string_to_json(val.template get_ref<const other_string_t&>());
                 break;
             case value_t::object:
-                JSONSerializer<other_object_t>::to_json(*this, val.template get_ref<const other_object_t&>());
+                other_object_to_json(val.template get_ref<const other_object_t&>());
                 break;
             case value_t::array:
-                JSONSerializer<other_array_t>::to_json(*this, val.template get_ref<const other_array_t&>());
+                other_array_to_json(val.template get_ref<const other_array_t&>());
                 break;
             case value_t::binary:
                 JSONSerializer<other_binary_t>::to_json(*this, val.template get_ref<const other_binary_t&>());

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19303,7 +19303,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     template < typename BasicJsonType,
                detail::enable_if_t <
                    detail::is_basic_json<BasicJsonType>::value&& !std::is_same<basic_json, BasicJsonType>::value, int > = 0 >
-    basic_json(const BasicJsonType& val)
+    JSON_EXPLICIT basic_json(const BasicJsonType& val)
     {
         using other_boolean_t = typename BasicJsonType::boolean_t;
         using other_number_float_t = typename BasicJsonType::number_float_t;
@@ -20126,7 +20126,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    int > = 0 >
     BasicJsonType get_impl(detail::priority_tag<2> /*unused*/) const
     {
-        return *this;
+        return BasicJsonType(*this);
     }
 
     /*!

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -343,7 +343,11 @@ TEST_CASE("alternative string type")
             SECTION("json to alt_json")
             {
                 json j("foo");
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 alt_json aj = j;
+#else
+                alt_json aj = alt_json(j);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(j.is_string());
@@ -354,7 +358,11 @@ TEST_CASE("alternative string type")
             SECTION("alt_json to json")
             {
                 alt_json aj("foo");
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 json j = aj;
+#else
+                json j = json(aj);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(aj.is_string());
@@ -368,7 +376,11 @@ TEST_CASE("alternative string type")
             SECTION("json to alt_json")
             {
                 json j{"foo"};
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 alt_json aj = j;
+#else
+                alt_json aj = alt_json(j);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(j.is_array());
@@ -379,7 +391,11 @@ TEST_CASE("alternative string type")
             SECTION("alt_json to json")
             {
                 alt_json aj{"foo"};
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 json j = aj;
+#else
+                json j = json(aj);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(aj.is_array());
@@ -393,7 +409,11 @@ TEST_CASE("alternative string type")
             SECTION("json to alt_json")
             {
                 json j{{"foo", {"bar", "baz"}}};
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 alt_json aj = j;
+#else
+                alt_json aj = alt_json(j);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(j.is_object());
@@ -404,7 +424,11 @@ TEST_CASE("alternative string type")
             SECTION("alt_json to json")
             {
                 alt_json aj{{"foo", {"bar", "baz"}}};
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 json j = aj;
+#else
+                json j = json(aj);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(aj.is_object());
@@ -418,7 +442,11 @@ TEST_CASE("alternative string type")
             SECTION("json to alt_json")
             {
                 auto j = json::binary({1, 2, 3, 4}, 128);
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 alt_json aj = j;
+#else
+                alt_json aj = alt_json(j);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(j.is_binary());
@@ -429,7 +457,11 @@ TEST_CASE("alternative string type")
             SECTION("alt_json to json")
             {
                 auto aj = alt_json::binary({1, 2, 3, 4}, 128);
+#if JSON_USE_IMPLICIT_CONVERSIONS
                 json j = aj;
+#else
+                json j = json(aj);
+#endif
 
                 alt_string as = aj.dump();
                 CHECK(aj.is_binary());

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -30,7 +30,9 @@ SOFTWARE.
 #include "doctest_compatibility.h"
 
 #include <nlohmann/json.hpp>
+using nlohmann::json;
 
+#include <iostream>
 #include <string>
 #include <utility>
 
@@ -328,17 +330,112 @@ TEST_CASE("alternative string type")
 
     SECTION("JSON pointer")
     {
-        // conversion from json to alt_json fails to compile (see #3425);
-        // attempted fix(*) produces: [[['b','a','r'],['b','a','z']]] (with each char being an integer)
-        // (*) disable implicit conversion for json_refs of any basic_json type
-        // alt_json j = R"(
-        // {
-        //     "foo": ["bar", "baz"]
-        // }
-        // )"_json;
         auto j = alt_json::parse(R"({"foo": ["bar", "baz"]})");
 
         CHECK(j.at(alt_json::json_pointer("/foo/0")) == j["foo"][0]);
         CHECK(j.at(alt_json::json_pointer("/foo/1")) == j["foo"][1]);
+    }
+
+    SECTION("conversion (#3425)")
+    {
+        SECTION("string")
+        {
+            SECTION("json to alt_json")
+            {
+                json j("foo");
+                alt_json aj = j;
+
+                alt_string as = aj.dump();
+                CHECK(j.is_string());
+                CHECK(j.dump() == "\"foo\"");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+
+            SECTION("alt_json to json")
+            {
+                alt_json aj("foo");
+                json j = aj;
+
+                alt_string as = aj.dump();
+                CHECK(aj.is_string());
+                CHECK(j.dump() == "\"foo\"");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+        }
+
+        SECTION("array")
+        {
+            SECTION("json to alt_json")
+            {
+                json j{"foo"};
+                alt_json aj = j;
+
+                alt_string as = aj.dump();
+                CHECK(j.is_array());
+                CHECK(j.dump() == "[\"foo\"]");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+
+            SECTION("alt_json to json")
+            {
+                alt_json aj{"foo"};
+                json j = aj;
+
+                alt_string as = aj.dump();
+                CHECK(aj.is_array());
+                CHECK(j.dump() == "[\"foo\"]");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+        }
+
+        SECTION("object")
+        {
+            SECTION("json to alt_json")
+            {
+                json j{{"foo", {"bar", "baz"}}};
+                alt_json aj = j;
+
+                alt_string as = aj.dump();
+                CHECK(j.is_object());
+                CHECK(j.dump() == "{\"foo\":[\"bar\",\"baz\"]}");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+
+            SECTION("alt_json to json")
+            {
+                alt_json aj{{"foo", {"bar", "baz"}}};
+                json j = aj;
+
+                alt_string as = aj.dump();
+                CHECK(aj.is_object());
+                CHECK(j.dump() == "{\"foo\":[\"bar\",\"baz\"]}");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+        }
+
+        SECTION("binary")
+        {
+            SECTION("json to alt_json")
+            {
+                auto j = json::binary({1, 2, 3, 4}, 128);
+                alt_json aj = j;
+
+                alt_string as = aj.dump();
+                CHECK(j.is_binary());
+                CHECK(j.dump() == "{\"bytes\":[1,2,3,4],\"subtype\":128}");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+
+            SECTION("alt_json to json")
+            {
+                auto aj = alt_json::binary({1, 2, 3, 4}, 128);
+                json j = aj;
+
+                alt_string as = aj.dump();
+                CHECK(aj.is_binary());
+                CHECK(j.dump() == "{\"bytes\":[1,2,3,4],\"subtype\":128}");
+                CHECK(j.dump() == std::string(as.data(), as.size()));
+            }
+        }
     }
 }

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -1485,7 +1485,11 @@ TEST_CASE("regression tests 1")
 
     SECTION("issue #972 - Segmentation fault on G++ when trying to assign json string literal to custom json type")
     {
+#if JSON_USE_IMPLICIT_CONVERSIONS
         my_json foo = R"([1, 2, 3])"_json;
+#else
+        my_json foo = my_json(R"([1, 2, 3])"_json);
+#endif
     }
 
     SECTION("issue #977 - Assigning between different json types")
@@ -1496,7 +1500,11 @@ TEST_CASE("regression tests 1")
         CHECK(lj.size() == 1);
         CHECK(lj["x"] == 3);
         CHECK(ff.x == 3);
+#if JSON_USE_IMPLICIT_CONVERSIONS
         nlohmann::json nj = lj;                // This line works as expected
+#else
+        nlohmann::json nj = nlohmann::json(lj);                // This line works as expected
+#endif
     }
 }
 

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -774,12 +774,12 @@ TEST_CASE("regression tests 2")
         CHECK(test1.dump() == "{\"root\":{}}");
 
         ordered_json test2;
-        test2[ordered_json::json_pointer(p)] = json::object();
+        test2[ordered_json::json_pointer(p)] = ordered_json::object();
         CHECK(test2.dump() == "{\"root\":{}}");
 
         // json::json_pointer and ordered_json::json_pointer are the same type; behave as above
         ordered_json test3;
-        test3[json::json_pointer(p)] = json::object();
+        test3[json::json_pointer(p)] = ordered_json::object();
         CHECK(std::is_same<json::json_pointer::string_t, ordered_json::json_pointer::string_t>::value);
         CHECK(test3.dump() == "{\"root\":{}}");
     }
@@ -859,7 +859,8 @@ TEST_CASE("regression tests 2")
         CHECK(td.str == "value");
     }
 
-#ifdef JSON_HAS_CPP_20
+    // this is no longer supported when implicit conversions are disabled
+#if defined(JSON_HAS_CPP_20) && JSON_USE_IMPLICIT_CONVERSIONS
     SECTION("issue #3312 - Parse to custom class from unordered_json breaks on G++11.2.0 with C++20")
     {
         // see test for #3171

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -713,14 +713,22 @@ TEST_CASE("different basic_json types conversions")
     SECTION("null")
     {
         json j;
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj == nullptr);
     }
 
     SECTION("boolean")
     {
         json j = true;
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj == true);
     }
 
@@ -728,49 +736,77 @@ TEST_CASE("different basic_json types conversions")
     {
         json j(json::value_t::discarded);
         custom_json cj;
+#if JSON_USE_IMPLICIT_CONVERSIONS
         CHECK_NOTHROW(cj = j);
+#else
+        CHECK_NOTHROW(cj = custom_json(j));
+#endif
         CHECK(cj.type() == custom_json::value_t::discarded);
     }
 
     SECTION("array")
     {
         json j = {1, 2, 3};
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK((cj == std::vector<int> {1, 2, 3}));
     }
 
     SECTION("integer")
     {
         json j = 42;
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj == 42);
     }
 
     SECTION("float")
     {
         json j = 42.0;
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj == 42.0);
     }
 
     SECTION("unsigned")
     {
         json j = 42u;
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj == 42u);
     }
 
     SECTION("string")
     {
         json j = "forty-two";
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj == "forty-two");
     }
 
     SECTION("binary")
     {
         json j = json::binary({1, 2, 3}, 42);
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         CHECK(cj.get_binary().subtype() == 42);
         std::vector<std::uint8_t> cv = cj.get_binary();
         std::vector<std::uint8_t> v = j.get_binary();
@@ -780,7 +816,11 @@ TEST_CASE("different basic_json types conversions")
     SECTION("object")
     {
         json j = {{"forty", "two"}};
+#if JSON_USE_IMPLICIT_CONVERSIONS
         custom_json cj = j;
+#else
+        custom_json cj = custom_json(j);
+#endif
         auto m = j.get<std::map<std::string, std::string>>();
         CHECK(cj == m);
     }


### PR DESCRIPTION
This is an attempt to fix #3425.
The desired value type is communicated to the serializer by wrapping the source value in one of `string_type_wrapper`, `object_type_wrapper`, or `array_type_wrapper`.
It started fairly simple, but the ability to supply a custom serializer means this solution will only work with `nlohmann::adl_serializer` (and requires an indirection to compile with a custom serializer). The wrapper types could be made part of the public API to allow users of custom serializers to handle these conversions as well.
Additionally, the PR addresses aspects of #2649 (as discussed [here](https://github.com/nlohmann/json/discussions/2628#discussioncomment-350903)), by making the converting constructor explicit depending on `JSON_USE_IMPLICIT_CONVERSIONS`.

The converting `basic_json` constructor is kind of broken and with the current serializer API, I couldn't think of a better way to convey the destination type to the serializer. A well-designed solution should be an item for 4.0.

In the meantime, I'm rather uncertain as to how to proceed. At least this PR improves the situation for `adl_serializer` users, which is probably the vast majority of users anyway.

@nlohmann @gregmarr I'd appreciate some general feedback on the idea. The code isn't ready for a thorough review.

It also currently fails to build on MSVC due to the serializer's SFINAE template parameter, I'll look into that depending on feedback.