### PR TITLE
Fix ndarray dimension signedness, fix ndarray length overflow, close #3519

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2079,7 +2079,7 @@ class binary_reader
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
                                             exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
                 }
-                if (number > std::numeric_limits<std::size_t>::max())
+                if (!value_in_range_of<std::size_t>(number))
                 {
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));
@@ -2129,7 +2129,7 @@ class binary_reader
                 {
                     return false;
                 }
-                if (number > std::numeric_limits<std::size_t>::max())
+                if (!value_in_range_of<std::size_t>(number))
                 {
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2079,6 +2079,11 @@ class binary_reader
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
                                             exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
                 }
+                if (number > std::numeric_limits<std::size_t>::max())
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                                            exception_message(input_format, "integer value overflow", "size"), nullptr));
+                }
                 result = static_cast<std::size_t>(number);
                 return true;
             }
@@ -2123,6 +2128,11 @@ class binary_reader
                 if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
                 {
                     return false;
+                }
+                if (number > std::numeric_limits<std::size_t>::max())
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                                            exception_message(input_format, "integer value overflow", "size"), nullptr));
                 }
                 result = detail::conditional_static_cast<std::size_t>(number);
                 return true;
@@ -2170,7 +2180,7 @@ class binary_reader
                         result *= i;
                         if (result == 0) // because dim elements shall not have zeros, result = 0 means overflow happened
                         {
-                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
                         }
                         if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
                         {

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2081,7 +2081,7 @@ class binary_reader
                 }
                 if (!value_in_range_of<std::size_t>(number))
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                    return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));
                 }
                 result = static_cast<std::size_t>(number);
@@ -2131,7 +2131,7 @@ class binary_reader
                 }
                 if (!value_in_range_of<std::size_t>(number))
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                    return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));
                 }
                 result = detail::conditional_static_cast<std::size_t>(number);
@@ -2180,7 +2180,7 @@ class binary_reader
                         result *= i;
                         if (result == 0) // because dim elements shall not have zeros, result = 0 means overflow happened
                         {
-                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                            return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
                         }
                         if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
                         {

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2168,7 +2168,11 @@ class binary_reader
                     for (auto i : dim)
                     {
                         result *= i;
-                        if (JSON_HEDLEY_UNLIKELY(!sax->number_integer(static_cast<number_integer_t>(i))))
+                        if (result == 0) // because dim elements shall not have zeros, result = 0 means overflow happened
+                        {
+                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                        }
+                        if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
                         {
                             return false;
                         }

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -577,5 +577,100 @@ T conditional_static_cast(U value)
     return value;
 }
 
+template<typename... Types>
+using all_integral = conjunction<std::is_integral<Types>...>;
+
+template<typename... Types>
+using all_signed = conjunction<std::is_signed<Types>...>;
+
+template<typename... Types>
+using all_unsigned = conjunction<std::is_unsigned<Types>...>;
+
+// there's a disjunction trait in another PR; replace when merged
+template<typename... Types>
+using same_sign = std::integral_constant < bool,
+      all_signed<Types...>::value || all_unsigned<Types...>::value >;
+
+template<typename OfType, typename T>
+using never_out_of_range = std::integral_constant < bool,
+      (std::is_signed<OfType>::value && (sizeof(T) < sizeof(OfType)))
+      || (same_sign<OfType, T>::value && sizeof(OfType) == sizeof(T)) >;
+
+template<typename OfType, typename T,
+         bool OfTypeSigned = std::is_signed<OfType>::value,
+         bool TSigned = std::is_signed<T>::value>
+struct value_in_range_of_impl2;
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, false, false>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, true, false>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, false, true>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return val >= 0 && static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, true, true>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) >= static_cast<CommonType>(std::numeric_limits<OfType>::min())
+               && static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+template<typename OfType, typename T,
+         bool NeverOutOfRange = never_out_of_range<OfType, T>::value,
+         typename = detail::enable_if_t<all_integral<OfType, T>::value>>
+struct value_in_range_of_impl1;
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl1<OfType, T, false>
+{
+    static constexpr bool test(T val)
+    {
+        return value_in_range_of_impl2<OfType, T>::test(val);
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl1<OfType, T, true>
+{
+    static constexpr bool test(T /*val*/)
+    {
+        return true;
+    }
+};
+
+template<typename OfType, typename T>
+inline constexpr bool value_in_range_of(T val)
+{
+    return value_in_range_of_impl1<OfType, T>::test(val);
+}
+
 }  // namespace detail
 }  // namespace nlohmann

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10766,7 +10766,7 @@ class binary_reader
                 }
                 if (!value_in_range_of<std::size_t>(number))
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                    return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));
                 }
                 result = static_cast<std::size_t>(number);
@@ -10816,7 +10816,7 @@ class binary_reader
                 }
                 if (!value_in_range_of<std::size_t>(number))
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                    return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));
                 }
                 result = detail::conditional_static_cast<std::size_t>(number);
@@ -10865,7 +10865,7 @@ class binary_reader
                         result *= i;
                         if (result == 0) // because dim elements shall not have zeros, result = 0 means overflow happened
                         {
-                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                            return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
                         }
                         if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
                         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10758,7 +10758,11 @@ class binary_reader
                     for (auto i : dim)
                     {
                         result *= i;
-                        if (JSON_HEDLEY_UNLIKELY(!sax->number_integer(static_cast<number_integer_t>(i))))
+                        if (result == 0) // because dim elements shall not have zeros, result = 0 means overflow happened
+                        {
+                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                        }
+                        if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
                         {
                             return false;
                         }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3768,6 +3768,101 @@ T conditional_static_cast(U value)
     return value;
 }
 
+template<typename... Types>
+using all_integral = conjunction<std::is_integral<Types>...>;
+
+template<typename... Types>
+using all_signed = conjunction<std::is_signed<Types>...>;
+
+template<typename... Types>
+using all_unsigned = conjunction<std::is_unsigned<Types>...>;
+
+// there's a disjunction trait in another PR; replace when merged
+template<typename... Types>
+using same_sign = std::integral_constant < bool,
+      all_signed<Types...>::value || all_unsigned<Types...>::value >;
+
+template<typename OfType, typename T>
+using never_out_of_range = std::integral_constant < bool,
+      (std::is_signed<OfType>::value && (sizeof(T) < sizeof(OfType)))
+      || (same_sign<OfType, T>::value && sizeof(OfType) == sizeof(T)) >;
+
+template<typename OfType, typename T,
+         bool OfTypeSigned = std::is_signed<OfType>::value,
+         bool TSigned = std::is_signed<T>::value>
+struct value_in_range_of_impl2;
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, false, false>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, true, false>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, false, true>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return val >= 0 && static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, true, true>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) >= static_cast<CommonType>(std::numeric_limits<OfType>::min())
+               && static_cast<CommonType>(val) <= static_cast<CommonType>(std::numeric_limits<OfType>::max());
+    }
+};
+
+template<typename OfType, typename T,
+         bool NeverOutOfRange = never_out_of_range<OfType, T>::value,
+         typename = detail::enable_if_t<all_integral<OfType, T>::value>>
+struct value_in_range_of_impl1;
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl1<OfType, T, false>
+{
+    static constexpr bool test(T val)
+    {
+        return value_in_range_of_impl2<OfType, T>::test(val);
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl1<OfType, T, true>
+{
+    static constexpr bool test(T /*val*/)
+    {
+        return true;
+    }
+};
+
+template<typename OfType, typename T>
+inline constexpr bool value_in_range_of(T val)
+{
+    return value_in_range_of_impl1<OfType, T>::test(val);
+}
+
 }  // namespace detail
 }  // namespace nlohmann
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10764,7 +10764,7 @@ class binary_reader
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
                                             exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
                 }
-                if (number > std::numeric_limits<std::size_t>::max())
+                if (!value_in_range_of<std::size_t>(number))
                 {
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));
@@ -10814,7 +10814,7 @@ class binary_reader
                 {
                     return false;
                 }
-                if (number > std::numeric_limits<std::size_t>::max())
+                if (!value_in_range_of<std::size_t>(number))
                 {
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
                                             exception_message(input_format, "integer value overflow", "size"), nullptr));

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10669,6 +10669,11 @@ class binary_reader
                     return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
                                             exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
                 }
+                if (number > std::numeric_limits<std::size_t>::max())
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                                            exception_message(input_format, "integer value overflow", "size"), nullptr));
+                }
                 result = static_cast<std::size_t>(number);
                 return true;
             }
@@ -10713,6 +10718,11 @@ class binary_reader
                 if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
                 {
                     return false;
+                }
+                if (number > std::numeric_limits<std::size_t>::max())
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read,
+                                            exception_message(input_format, "integer value overflow", "size"), nullptr));
                 }
                 result = detail::conditional_static_cast<std::size_t>(number);
                 return true;
@@ -10760,7 +10770,7 @@ class binary_reader
                         result *= i;
                         if (result == 0) // because dim elements shall not have zeros, result = 0 means overflow happened
                         {
-                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                            return sax->parse_error(chars_read, get_token_string(), parse_error::create(408, chars_read, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
                         }
                         if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
                         {

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2511,6 +2511,7 @@ TEST_CASE("BJData")
                 std::vector<uint8_t> vI = {'[', '#', 'I', 0x00, 0xF1};
                 std::vector<uint8_t> vl = {'[', '#', 'l', 0x00, 0x00, 0x00, 0xF2};
                 std::vector<uint8_t> vL = {'[', '#', 'L', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF3};
+                std::vector<uint8_t> vM = {'[', '$', 'M', '#', '[', 'I', 0x00, 0x20, 'M', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, ']'};
 
                 json _;
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(v1), "[json.exception.parse_error.113] parse error at byte 4: syntax error while parsing BJData size: count in an optimized container must be positive", json::parse_error&);
@@ -2535,10 +2536,13 @@ TEST_CASE("BJData")
                 CHECK(json::from_bjdata(vI, true, false).is_discarded());
 
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vl), "[json.exception.parse_error.113] parse error at byte 7: syntax error while parsing BJData size: count in an optimized container must be positive", json::parse_error&);
-                CHECK(json::from_bjdata(vI, true, false).is_discarded());
+                CHECK(json::from_bjdata(vl, true, false).is_discarded());
 
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vL), "[json.exception.parse_error.113] parse error at byte 11: syntax error while parsing BJData size: count in an optimized container must be positive", json::parse_error&);
-                CHECK(json::from_bjdata(vI, true, false).is_discarded());
+                CHECK(json::from_bjdata(vL, true, false).is_discarded());
+
+                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.113] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
+                CHECK(json::from_bjdata(vM, true, false).is_discarded());
             }
 
             SECTION("do not accept NTFZ markers in ndarray optimized type (with count)")

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -29,6 +29,8 @@ SOFTWARE.
 
 #include "doctest_compatibility.h"
 
+#include <climits>
+#include <limits>
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
@@ -115,6 +117,113 @@ class SaxCountdown
     int events_left = 0;
 };
 } // namespace
+
+// at some point in the future, a unit test dedicated to type traits might be a good idea
+template <typename OfType, typename T, bool MinInRange, bool MaxInRange>
+struct trait_test_arg
+{
+    using of_type = OfType;
+    using type = T;
+    static constexpr bool min_in_range = MinInRange;
+    static constexpr bool max_in_range = MaxInRange;
+};
+
+TEST_CASE_TEMPLATE_DEFINE("value_in_range_of trait", T, value_in_range_of_test)
+{
+    //using namespace nlohmann::detail; // NOLINT(google-build-using-namespace)
+    using nlohmann::detail::value_in_range_of;
+
+    using of_type = typename T::of_type;
+    using type = typename T::type;
+    constexpr bool min_in_range = T::min_in_range;
+    constexpr bool max_in_range = T::max_in_range;
+
+    type val_min = std::numeric_limits<type>::min();
+    type val_min2 = val_min + 1;
+    type val_max = std::numeric_limits<type>::max();
+    type val_max2 = val_max - 1;
+
+    REQUIRE(CHAR_BIT == 8);
+
+    std::string of_type_str;
+    if (std::is_unsigned<of_type>::value)
+    {
+        of_type_str += "u";
+    }
+    of_type_str += "int";
+    of_type_str += std::to_string(sizeof(of_type) * 8);
+
+    INFO("of_type := ", of_type_str);
+
+    std::string type_str;
+    if (std::is_unsigned<type>::value)
+    {
+        type_str += "u";
+    }
+    type_str += "int";
+    type_str += std::to_string(sizeof(type) * 8);
+
+    INFO("type := ", type_str);
+
+    CAPTURE(val_min);
+    CAPTURE(min_in_range);
+    CAPTURE(val_max);
+    CAPTURE(max_in_range);
+
+    if (min_in_range)
+    {
+        CHECK(value_in_range_of<of_type>(val_min));
+        CHECK(value_in_range_of<of_type>(val_min2));
+    }
+    else
+    {
+        CHECK_FALSE(value_in_range_of<of_type>(val_min));
+        CHECK_FALSE(value_in_range_of<of_type>(val_min2));
+    }
+
+    if (max_in_range)
+    {
+        CHECK(value_in_range_of<of_type>(val_max));
+        CHECK(value_in_range_of<of_type>(val_max2));
+    }
+    else
+    {
+        CHECK_FALSE(value_in_range_of<of_type>(val_max));
+        CHECK_FALSE(value_in_range_of<of_type>(val_max2));
+    }
+}
+
+TEST_CASE_TEMPLATE_INVOKE(value_in_range_of_test, \
+                          trait_test_arg<std::int32_t, std::int32_t, true, true>, \
+                          trait_test_arg<std::int32_t, std::uint32_t, true, false>, \
+                          trait_test_arg<std::uint32_t, std::int32_t, false, true>, \
+                          trait_test_arg<std::uint32_t, std::uint32_t, true, true>, \
+                          trait_test_arg<std::int32_t, std::int64_t, false, false>, \
+                          trait_test_arg<std::int32_t, std::uint64_t, true, false>, \
+                          trait_test_arg<std::uint32_t, std::int64_t, false, false>, \
+                          trait_test_arg<std::uint32_t, std::uint64_t, true, false>, \
+                          trait_test_arg<std::int64_t, std::int32_t, true, true>, \
+                          trait_test_arg<std::int64_t, std::uint32_t, true, true>, \
+                          trait_test_arg<std::uint64_t, std::int32_t, false, true>, \
+                          trait_test_arg<std::uint64_t, std::uint32_t, true, true>, \
+                          trait_test_arg<std::int64_t, std::int64_t, true, true>, \
+                          trait_test_arg<std::int64_t, std::uint64_t, true, false>, \
+                          trait_test_arg<std::uint64_t, std::int64_t, false, true>, \
+                          trait_test_arg<std::uint64_t, std::uint64_t, true, true>);
+
+#if SIZE_MAX == 0xffffffff
+TEST_CASE_TEMPLATE_INVOKE(value_in_range_of_test, \
+                          trait_test_arg<std::size_t, std::int32_t, false, true>, \
+                          trait_test_arg<std::size_t, std::uint32_t, true, true>, \
+                          trait_test_arg<std::size_t, std::int64_t, false, false>, \
+                          trait_test_arg<std::size_t, std::uint64_t, true, false>);
+#else
+TEST_CASE_TEMPLATE_INVOKE(value_in_range_of_test, \
+                          trait_test_arg<std::size_t, std::int32_t, false, true>, \
+                          trait_test_arg<std::size_t, std::uint32_t, true, true>, \
+                          trait_test_arg<std::size_t, std::int64_t, false, true>, \
+                          trait_test_arg<std::size_t, std::uint64_t, true, true>);
+#endif
 
 TEST_CASE("BJData")
 {

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2651,9 +2651,9 @@ TEST_CASE("BJData")
                 CHECK(json::from_bjdata(vL, true, false).is_discarded());
 
 #if SIZE_MAX == 0xffffffff
-                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 17: syntax error while parsing BJData size: integer value overflow", json::parse_error&);
+                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.out_of_range.408] syntax error while parsing BJData size: integer value overflow", json::out_of_range&);
 #else
-                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
+                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.out_of_range.408] syntax error while parsing BJData size: excessive ndarray size caused overflow", json::out_of_range&);
 #endif
                 CHECK(json::from_bjdata(vM, true, false).is_discarded());
             }

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2541,7 +2541,14 @@ TEST_CASE("BJData")
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vL), "[json.exception.parse_error.113] parse error at byte 11: syntax error while parsing BJData size: count in an optimized container must be positive", json::parse_error&);
                 CHECK(json::from_bjdata(vL, true, false).is_discarded());
 
-                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.113] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
+                if(sizeof(size_t)==4)
+                {
+                     CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 17: syntax error while parsing BJData size: integer value overflow", json::parse_error&);
+                }
+                else
+                {
+                     CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
+                }
                 CHECK(json::from_bjdata(vM, true, false).is_discarded());
             }
 

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2541,14 +2541,11 @@ TEST_CASE("BJData")
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vL), "[json.exception.parse_error.113] parse error at byte 11: syntax error while parsing BJData size: count in an optimized container must be positive", json::parse_error&);
                 CHECK(json::from_bjdata(vL, true, false).is_discarded());
 
-                if (sizeof(std::size_t) == 4)
-                {
-                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 17: syntax error while parsing BJData size: integer value overflow", json::parse_error&);
-                }
-                else
-                {
-                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
-                }
+#if SIZE_MAX == 0xffffffff
+                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 17: syntax error while parsing BJData size: integer value overflow", json::parse_error&);
+#else
+                CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
+#endif
                 CHECK(json::from_bjdata(vM, true, false).is_discarded());
             }
 

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2541,13 +2541,13 @@ TEST_CASE("BJData")
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vL), "[json.exception.parse_error.113] parse error at byte 11: syntax error while parsing BJData size: count in an optimized container must be positive", json::parse_error&);
                 CHECK(json::from_bjdata(vL, true, false).is_discarded());
 
-                if(sizeof(size_t)==4)
+                if (sizeof(std::size_t) == 4)
                 {
-                     CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 17: syntax error while parsing BJData size: integer value overflow", json::parse_error&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 17: syntax error while parsing BJData size: integer value overflow", json::parse_error&);
                 }
                 else
                 {
-                     CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
+                    CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vM), "[json.exception.parse_error.408] parse error at byte 18: syntax error while parsing BJData size: excessive ndarray size caused overflow", json::parse_error&);
                 }
                 CHECK(json::from_bjdata(vM, true, false).is_discarded());
             }


### PR DESCRIPTION
hi @nlohmann, sorry for the new bug from my code.

I debugged this, and found there were two issues:

1. the dimension vector elements were not written in the correct signedness
2. when the total length overflew, the length resets to 0 and did not raise an error.

with this patch, I was able to fix both, an additional test was added to verify both, the fuzzer data now raise an "excessive ndarray size caused overflow" error.

One thing I want to verify with you is the error code, now I am using 113, let me know if there is a better code. if the length is non-zero and passed to sax functions, it raise a 408 error "excessive array size". but I am capturing this overflow before that.