### PR TITLE
Fix iterator_input_adapter consuming more than it should

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -158,14 +158,14 @@ class iterator_input_adapter
     }
 
   private:
-    IteratorType current;
-    IteratorType end;
-    bool current_has_been_consumed = false;
+    mutable IteratorType current;
+    const IteratorType end;
+    mutable bool current_has_been_consumed;
 
     template<typename BaseInputAdapter, size_t T>
     friend struct wide_string_input_helper;
 
-    bool empty()
+    bool empty() const
     {
         if (JSON_HEDLEY_LIKELY(current_has_been_consumed))
         {

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -123,7 +123,6 @@ class input_stream_adapter
 };
 #endif  // JSON_NO_IO
 
-
 // General-purpose iterator-based adapter. It might not be as fast as
 // theoretically possible for some containers, but it is extremely versatile.
 template<typename IteratorType>
@@ -133,12 +132,11 @@ class iterator_input_adapter
     using char_type = typename std::iterator_traits<IteratorType>::value_type;
 
     iterator_input_adapter(IteratorType first, IteratorType last)
-        : current(std::move(first)), end(std::move(last)), current_has_been_consumed(false)
+        : current(std::move(first)), end(std::move(last))
     {}
 
     typename std::char_traits<char_type>::int_type get_character()
     {
-
         if (JSON_HEDLEY_LIKELY(current_has_been_consumed))
         {
             std::advance(current, 1);
@@ -149,18 +147,15 @@ class iterator_input_adapter
             current_has_been_consumed = true;
             return std::char_traits<char_type>::to_int_type(*current);
         }
-        else
-        {
-            current_has_been_consumed = false;
-            return std::char_traits<char_type>::eof();
-        }
 
+        current_has_been_consumed = false;
+        return std::char_traits<char_type>::eof();
     }
 
   private:
     mutable IteratorType current;
     const IteratorType end;
-    mutable bool current_has_been_consumed;
+    mutable bool current_has_been_consumed = false;
 
     template<typename BaseInputAdapter, size_t T>
     friend struct wide_string_input_helper;
@@ -309,7 +304,7 @@ class wide_string_input_adapter
     using char_type = char;
 
     wide_string_input_adapter(BaseInputAdapter base)
-        : base_adapter(base) {}
+        : base_adapter(std::move(base)) {}
 
     typename std::char_traits<char>::int_type get_character() noexcept
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5869,14 +5869,14 @@ class iterator_input_adapter
     }
 
   private:
-    IteratorType current;
-    IteratorType end;
-    bool current_has_been_consumed = false;
+    mutable IteratorType current;
+    const IteratorType end;
+    mutable bool current_has_been_consumed;
 
     template<typename BaseInputAdapter, size_t T>
     friend struct wide_string_input_helper;
 
-    bool empty()
+    bool empty() const
     {
         if (JSON_HEDLEY_LIKELY(current_has_been_consumed))
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5834,6 +5834,7 @@ class input_stream_adapter
 };
 #endif  // JSON_NO_IO
 
+
 // General-purpose iterator-based adapter. It might not be as fast as
 // theoretically possible for some containers, but it is extremely versatile.
 template<typename IteratorType>
@@ -5843,30 +5844,46 @@ class iterator_input_adapter
     using char_type = typename std::iterator_traits<IteratorType>::value_type;
 
     iterator_input_adapter(IteratorType first, IteratorType last)
-        : current(std::move(first)), end(std::move(last))
+        : current(std::move(first)), end(std::move(last)), current_has_been_consumed(false)
     {}
 
     typename std::char_traits<char_type>::int_type get_character()
     {
-        if (JSON_HEDLEY_LIKELY(current != end))
+
+        if (JSON_HEDLEY_LIKELY(current_has_been_consumed))
         {
-            auto result = std::char_traits<char_type>::to_int_type(*current);
             std::advance(current, 1);
-            return result;
         }
 
-        return std::char_traits<char_type>::eof();
+        if (JSON_HEDLEY_LIKELY(current != end))
+        {
+            current_has_been_consumed = true;
+            return std::char_traits<char_type>::to_int_type(*current);
+        }
+        else
+        {
+            current_has_been_consumed = false;
+            return std::char_traits<char_type>::eof();
+        }
+
     }
 
   private:
     IteratorType current;
     IteratorType end;
+    bool current_has_been_consumed = false;
 
     template<typename BaseInputAdapter, size_t T>
     friend struct wide_string_input_helper;
 
-    bool empty() const
+    bool empty()
     {
+        if (JSON_HEDLEY_LIKELY(current_has_been_consumed))
+        {
+            std::advance(current, 1);
+            current_has_been_consumed = false;
+        }
+
         return current == end;
     }
 };

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5834,7 +5834,6 @@ class input_stream_adapter
 };
 #endif  // JSON_NO_IO
 
-
 // General-purpose iterator-based adapter. It might not be as fast as
 // theoretically possible for some containers, but it is extremely versatile.
 template<typename IteratorType>
@@ -5844,12 +5843,11 @@ class iterator_input_adapter
     using char_type = typename std::iterator_traits<IteratorType>::value_type;
 
     iterator_input_adapter(IteratorType first, IteratorType last)
-        : current(std::move(first)), end(std::move(last)), current_has_been_consumed(false)
+        : current(std::move(first)), end(std::move(last))
     {}
 
     typename std::char_traits<char_type>::int_type get_character()
     {
-
         if (JSON_HEDLEY_LIKELY(current_has_been_consumed))
         {
             std::advance(current, 1);
@@ -5860,18 +5858,15 @@ class iterator_input_adapter
             current_has_been_consumed = true;
             return std::char_traits<char_type>::to_int_type(*current);
         }
-        else
-        {
-            current_has_been_consumed = false;
-            return std::char_traits<char_type>::eof();
-        }
 
+        current_has_been_consumed = false;
+        return std::char_traits<char_type>::eof();
     }
 
   private:
     mutable IteratorType current;
     const IteratorType end;
-    mutable bool current_has_been_consumed;
+    mutable bool current_has_been_consumed = false;
 
     template<typename BaseInputAdapter, size_t T>
     friend struct wide_string_input_helper;
@@ -6020,7 +6015,7 @@ class wide_string_input_adapter
     using char_type = char;
 
     wide_string_input_adapter(BaseInputAdapter base)
-        : base_adapter(base) {}
+        : base_adapter(std::move(base)) {}
 
     typename std::char_traits<char>::int_type get_character() noexcept
     {


### PR DESCRIPTION
As identified by @imwhocodes, `iterator_input_adapter` consumes an additional character from the input during parsing. This PR based on #3442 by @imwhocodes fixes this. I'm finishing his work by incorporating requested changes and fixing CI issues.

At the moment, it's missing a unit test.

Replaces #3442.