### PR TITLE
Use DOCTEST_* compiler macros and suppress pragmas warning

### DIFF
--- a/tests/src/unit-items.cpp
+++ b/tests/src/unit-items.cpp
@@ -34,7 +34,9 @@ using nlohmann::json;
 
 // This test suite uses range for loops where values are copied. This is inefficient in usual code, but required to achieve 100% coverage.
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wrange-loop-construct")
+#if DOCTEST_GCC >= DOCTEST_COMPILER(11, 0, 0)
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wrange-loop-construct")
+#endif
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wrange-loop-construct")
 

--- a/tests/src/unit-iterators2.cpp
+++ b/tests/src/unit-iterators2.cpp
@@ -916,7 +916,7 @@ TEST_CASE("iterators 2")
         }
 
         // libstdc++ algorithms don't work with Clang 15 (04/2022)
-#if !defined(__clang__) || (defined(__clang__) && defined(__GLIBCXX__))
+#if !DOCTEST_CLANG || (DOCTEST_CLANG && defined(__GLIBCXX__))
         SECTION("algorithms")
         {
             SECTION("copy")
@@ -955,7 +955,7 @@ TEST_CASE("iterators 2")
 
         // libstdc++ views don't work with Clang 15 (04/2022)
         // libc++ hides limited ranges implementation behind guard macro
-#if !(defined(__clang__) && (defined(__GLIBCXX__) || defined(_LIBCPP_HAS_NO_INCOMPLETE_RANGES)))
+#if !(DOCTEST_CLANG && (defined(__GLIBCXX__) || defined(_LIBCPP_HAS_NO_INCOMPLETE_RANGES)))
         SECTION("views")
         {
             SECTION("reverse")

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -1520,7 +1520,7 @@ TEST_CASE("regression tests, exceptions dependent")
 /////////////////////////////////////////////////////////////////////
 
 // the code below fails with Clang on Windows, so we need to exclude it there
-#if defined(__clang__) && (defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__))
+#if DOCTEST_CLANG && (defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__))
 #else
 template <typename T> class array {};
 template <typename T> class object {};

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -803,7 +803,7 @@ TEST_CASE("regression tests 2")
         const auto j_path = j.get<nlohmann::detail::std_fs::path>();
         CHECK(j_path == text_path);
 
-#if defined(__clang__) || ((defined(__GNUC__) && !defined(__INTEL_COMPILER)) && (__GNUC__ > 8 || (__GNUC__ == 8 && __GNUC_MINOR__ >= 4)))
+#if DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(8, 4, 0)
         // only known to work on Clang and GCC >=8.4
         CHECK_THROWS_WITH_AS(nlohmann::detail::std_fs::path(json(1)), "[json.exception.type_error.302] type must be string, but is number", json::type_error);
 #endif


### PR DESCRIPTION
Use `DOCTEST_*` macros in place of predefined compiler macros for compiler detection and version checks.

The suppression of warning `-Wrange-loop-construct` in `unit-items.cpp` causes GCC<11 to warn about pragmas.
