### PR TITLE
CI: fix "JSON_MultipleHeaders" option spelling

### DIFF
--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -595,7 +595,7 @@ add_custom_target(ci_test_amalgamation
 add_custom_target(ci_test_single_header
     COMMAND CXX=${GCC_TOOL} CXXFLAGS="${GCC_CXXFLAGS}" ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
-        -DJSON_BuildTests=ON -DJSON_MultipleHeader=OFF -DJSON_FastTests=ON
+        -DJSON_BuildTests=ON -DJSON_MultipleHeaders=OFF -DJSON_FastTests=ON
         -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_single_header
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_single_header
     COMMAND cd ${PROJECT_BINARY_DIR}/build_single_header && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure


### PR DESCRIPTION
Due to a typo, the test `ci_test_single_header` uses actually multiple headers.