### PR TITLE
Make certain usage patterns more prominent in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
   - [Read JSON from a file](#read-json-from-a-file)
   - [Creating `json` objects from JSON literals](#creating-json-objects-from-json-literals)
   - [Reading and writing individual object keys](#reading-and-writing-individual-object-keys)
-  - [JSON as first-class data type](#json-as-first-class-data-type)
   - [Serialization / Deserialization](#serialization--deserialization)
   - [STL-like access](#stl-like-access)
   - [Conversion from STL containers](#conversion-from-stl-containers)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ json ex3 = {
 
 ### JSON as first-class data type
 
-Assume you want to create this JSON object by individually setting each key-value pair:
+Here are some examples to give you an idea how to use the class.
+
+Assume you want to create the JSON object
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
 - [Sponsors](#sponsors)
 - [Support](#support) ([documentation](https://json.nlohmann.me), [FAQ](https://json.nlohmann.me/home/faq/), [discussions](https://github.com/nlohmann/json/discussions), [API](https://json.nlohmann.me/api/basic_json/), [bug issues](https://github.com/nlohmann/json/issues))
 - [Examples](#examples)
+  - [Read JSON from a file](#read-json-from-a-file)
+  - [Creating `json` objects from JSON literals](#creating-json-objects-from-json-literals)
+  - [Reading and writing individual object keys](#reading-and-writing-individual-object-keys)
   - [JSON as first-class data type](#json-as-first-class-data-type)
   - [Serialization / Deserialization](#serialization--deserialization)
   - [STL-like access](#stl-like-access)
@@ -97,13 +100,70 @@ There is also a [**docset**](https://github.com/Kapeli/Dash-User-Contributions/t
 
 ## Examples
 
-Beside the examples below, you may want to check the [documentation](https://json.nlohmann.me/) where each function contains a separate code example (e.g., check out [`emplace()`](https://json.nlohmann.me/api/basic_json/emplace/)). All [example files](https://github.com/nlohmann/json/tree/develop/docs/examples) can be compiled and executed on their own (e.g., file [emplace.cpp](https://github.com/nlohmann/json/blob/develop/docs/examples/emplace.cpp)).
-
-### JSON as first-class data type
-
 Here are some examples to give you an idea how to use the class.
 
-Assume you want to create the JSON object
+Beside the examples below, you may want to:
+
+→ Check the [documentation](https://json.nlohmann.me/)\
+→ Browse the [standalone example files](https://github.com/nlohmann/json/tree/develop/docs/examples)
+
+Every API function (documented in the [API Documentation](https://json.nlohmann.me/api/basic_json/)) has a corresponding standalone example file. For example, the [`emplace()`](https://json.nlohmann.me/api/basic_json/emplace/) function has a matching [emplace.cpp](https://github.com/nlohmann/json/blob/develop/docs/examples/emplace.cpp) example file.
+
+### Read JSON from a file
+
+The `json` class provides an API for manipulating a JSON value. To create a `json` object by reading a JSON file:
+
+```cpp
+#include <fstream>
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+// ...
+
+std::ifstream f("example.json");
+json data = json::parse(f);
+```
+
+### Creating `json` objects from JSON literals
+
+Assume you want to create hard-code this literal JSON value in a file, as a `json` object:
+
+```json
+{
+  "pi": 3.141,
+  "happy": true
+}
+```
+
+There are various options:
+
+```cpp
+// Using (raw) string literals and json::parse
+json ex1 = json::parse(R"(
+  {
+    "pi": 3.141,
+    "happy": true
+  }
+)");
+
+// Using user-defined (raw) string literals
+json ex2 = R"(
+  {
+    "pi": 3.141,
+    "happy": true
+  }
+)"_json;
+
+// Using initializer lists
+json ex3 = {
+  {"happy", true},
+  {"pi", 3.141},
+};
+```
+
+### Reading and writing individual object keys
+
+Assume you want to create this JSON object by individually setting each key-value pair:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [Examples](#examples)
   - [Read JSON from a file](#read-json-from-a-file)
   - [Creating `json` objects from JSON literals](#creating-json-objects-from-json-literals)
-  - [Reading and writing individual object keys](#reading-and-writing-individual-object-keys)
+  - [JSON as first-class data type](#json-as-first-class-data-type)
   - [Serialization / Deserialization](#serialization--deserialization)
   - [STL-like access](#stl-like-access)
   - [Conversion from STL containers](#conversion-from-stl-containers)
@@ -160,7 +160,7 @@ json ex3 = {
 };
 ```
 
-### Reading and writing individual object keys
+### JSON as first-class data type
 
 Assume you want to create this JSON object by individually setting each key-value pair:
 


### PR DESCRIPTION
We use this library extensively where I work. After pairing with many
teammates, I've learned that one common stumbling point when using this
library is how to first get a JSON value in the first place (because
once they have a variable of type `json` in hand, the API is intuitive
and mostly does what you expect).

With that in mind, I've added two subsections to the top of the Examples
section: how to read JSON from a file, and how to hardcode a JSON
literal.

I understand that these are already documented elsewhere in the Examples
section, and so these new subsections are technically redundant. But to
defend this choice:

- Redundancy in docs is actually good, because not everyone consumes
  docs in the same way or in the same order.

- Having these things called out explicitly in isolation encourages
  people to get something working faster. In later sections, these
  examples are presented alongside many other options. Having to choose
  between alternatives gets in the way of quickly prototyping something.

If you have further suggestions for how to improve or modify these docs
I'm open to them. The changes included here would really make a huge
improvement in the productivity of newer members of my team using this
library.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.