### PR TITLE
Add overloads for more key types to ordered_map and fix ordered_map::erase(first, last) with first == last

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -2022,7 +2022,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element with bounds checking
     /// @sa https://json.nlohmann.me/api/basic_json/at/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     reference at(KeyType && key)
     {
         // at only works for objects
@@ -2060,7 +2060,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element with bounds checking
     /// @sa https://json.nlohmann.me/api/basic_json/at/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     const_reference at(KeyType && key) const
     {
         // at only works for objects
@@ -2190,7 +2190,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element
     /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int > = 0 >
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
     reference operator[](KeyType && key)
     {
         // implicitly convert null value to an empty object
@@ -2214,7 +2214,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element
     /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int > = 0 >
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
     const_reference operator[](KeyType && key) const
     {
         // const operator[] only works for objects
@@ -2283,7 +2283,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     template < class KeyType, class ValueType, detail::enable_if_t <
                    detail::is_getable<basic_json_t, ValueType>::value
                    && !std::is_same<value_t, ValueType>::value
-                   && detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int > = 0 >
+                   && detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
     typename std::decay<ValueType>::type value(KeyType && key, ValueType && default_value) const
     {
         // value only works for objects
@@ -2582,7 +2582,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief remove element from a JSON object given a key
     /// @sa https://json.nlohmann.me/api/basic_json/erase/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     size_type erase(KeyType && key)
     {
         return erase_internal(std::forward<KeyType>(key));
@@ -2649,7 +2649,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief find an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/find/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     iterator find(KeyType && key)
     {
         auto result = end();
@@ -2665,7 +2665,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief find an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/find/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     const_iterator find(KeyType && key) const
     {
         auto result = cend();
@@ -2689,7 +2689,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief returns the number of occurrences of a key in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/count/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     size_type count(KeyType && key) const
     {
         // return 0 for all nonobject types
@@ -2706,7 +2706,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief check the existence of an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/contains/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     bool contains(KeyType && key) const
     {
         return is_object() && m_value.object->find(std::forward<KeyType>(key)) != m_value.object->end();

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -10,6 +10,7 @@
 #include <vector> // vector
 
 #include <nlohmann/detail/macro_scope.hpp>
+#include <nlohmann/detail/meta/type_traits.hpp>
 
 namespace nlohmann
 {
@@ -52,21 +53,50 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
                 return {it, false};
             }
         }
-        Container::emplace_back(key, t);
-        return {--this->end(), true};
+        Container::emplace_back(key, std::forward<T>(t));
+        return {std::prev(this->end()), true};
     }
 
-    T& operator[](const Key& key)
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return {it, false};
+            }
+        }
+        Container::emplace_back(std::forward<KeyType>(key), std::forward<T>(t));
+        return {std::prev(this->end()), true};
+    }
+
+    T& operator[](const key_type& key)
     {
         return emplace(key, T{}).first->second;
     }
 
-    const T& operator[](const Key& key) const
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    T & operator[](KeyType && key)
+    {
+        return emplace(std::forward<KeyType>(key), T{}).first->second;
+    }
+
+    const T& operator[](const key_type& key) const
     {
         return at(key);
     }
 
-    T& at(const Key& key)
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const T & operator[](KeyType && key) const
+    {
+        return at(std::forward<KeyType>(key));
+    }
+
+    T& at(const key_type& key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -79,7 +109,9 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         JSON_THROW(std::out_of_range("key not found"));
     }
 
-    const T& at(const Key& key) const
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    T & at(KeyType && key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -92,7 +124,56 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         JSON_THROW(std::out_of_range("key not found"));
     }
 
-    size_type erase(const Key& key)
+    const T& at(const key_type& key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const T & at(KeyType && key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    size_type erase(const key_type& key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                // Since we cannot move const Keys, re-construct them in place
+                for (auto next = it; ++next != this->end(); ++it)
+                {
+                    it->~value_type(); // Destroy but keep allocation
+                    new (&*it) value_type{std::move(*next)};
+                }
+                Container::pop_back();
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type erase(KeyType && key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -164,7 +245,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::begin() + offset;
     }
 
-    size_type count(const Key& key) const
+    size_type count(const key_type& key) const
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -176,7 +257,21 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return 0;
     }
 
-    iterator find(const Key& key)
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type count(KeyType && key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    iterator find(const key_type& key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -188,7 +283,21 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::end();
     }
 
-    const_iterator find(const Key& key) const
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator find(KeyType && key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+
+    const_iterator find(const key_type& key) const
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -199,6 +199,11 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     iterator erase(iterator first, iterator last)
     {
+        if (first == last)
+        {
+            return first;
+        }
+
         const auto elements_affected = std::distance(first, last);
         const auto offset = std::distance(Container::begin(), first);
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18458,6 +18458,11 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     iterator erase(iterator first, iterator last)
     {
+        if (first == last)
+        {
+            return first;
+        }
+
         const auto elements_affected = std::distance(first, last);
         const auto offset = std::distance(Container::begin(), first);
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3699,15 +3699,22 @@ decltype(std::declval<Compare>()(std::declval<A>(), std::declval<B>())),
 decltype(std::declval<Compare>()(std::declval<B>(), std::declval<A>()))
 >> : std::true_type {};
 
-// checks if BasicJsonType::object_t::key_type and KeyType are comparable using Compare functor
-template<typename BasicJsonType, typename KeyType>
-using is_key_type_comparable = typename is_comparable <
-                               typename BasicJsonType::object_comparator_t,
-                               const key_type_t<typename BasicJsonType::object_t>&,
-                               KeyType >::type;
-
 template<typename T>
 using detect_is_transparent = typename T::is_transparent;
+
+// type trait to check if KeyType can be used as object key (without a BasicJsonType)
+// see is_usable_as_basic_json_key_type below
+template<typename Comparator, typename ObjectKeyType, typename KeyTypeCVRef, bool RequireTransparentComparator = true,
+         bool ExcludeObjectKeyType = RequireTransparentComparator, typename KeyType = uncvref_t<KeyTypeCVRef>>
+using is_usable_as_key_type = typename std::conditional <
+                              is_comparable<Comparator, ObjectKeyType, KeyTypeCVRef>::value
+                              && !(ExcludeObjectKeyType && std::is_same<KeyType,
+                                   ObjectKeyType>::value)
+                              && (!RequireTransparentComparator
+                                  || is_detected <detect_is_transparent, Comparator>::value)
+                              && !is_json_pointer<KeyType>::value,
+                              std::true_type,
+                              std::false_type >::type;
 
 // type trait to check if KeyType can be used as object key
 // true if:
@@ -3717,17 +3724,13 @@ using detect_is_transparent = typename T::is_transparent;
 //   - KeyType is not a JSON iterator or json_pointer
 template<typename BasicJsonType, typename KeyTypeCVRef, bool RequireTransparentComparator = true,
          bool ExcludeObjectKeyType = RequireTransparentComparator, typename KeyType = uncvref_t<KeyTypeCVRef>>
-using is_usable_as_key_type = typename std::conditional <
-                              is_key_type_comparable<BasicJsonType, KeyTypeCVRef>::value
-                              && !(ExcludeObjectKeyType && std::is_same<KeyType,
-                                   typename BasicJsonType::object_t::key_type>::value)
-                              && (!RequireTransparentComparator || is_detected <
-                                  detect_is_transparent,
-                                  typename BasicJsonType::object_comparator_t >::value)
-                              && !is_json_iterator_of<BasicJsonType, KeyType>::value
-                              && !is_json_pointer<KeyType>::value,
-                              std::true_type,
-                              std::false_type >::type;
+using is_usable_as_basic_json_key_type = typename std::conditional <
+        is_usable_as_key_type<typename BasicJsonType::object_comparator_t,
+        typename BasicJsonType::object_t::key_type, KeyTypeCVRef,
+        RequireTransparentComparator, ExcludeObjectKeyType>::value
+        && !is_json_iterator_of<BasicJsonType, KeyType>::value,
+        std::true_type,
+        std::false_type >::type;
 
 template<typename ObjectType, typename KeyType>
 using detect_erase_with_key_type = decltype(std::declval<ObjectType&>().erase(std::declval<KeyType>()));
@@ -18265,6 +18268,8 @@ class serializer
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
 
 namespace nlohmann
 {
@@ -18307,21 +18312,50 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
                 return {it, false};
             }
         }
-        Container::emplace_back(key, t);
-        return {--this->end(), true};
+        Container::emplace_back(key, std::forward<T>(t));
+        return {std::prev(this->end()), true};
     }
 
-    T& operator[](const Key& key)
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return {it, false};
+            }
+        }
+        Container::emplace_back(std::forward<KeyType>(key), std::forward<T>(t));
+        return {std::prev(this->end()), true};
+    }
+
+    T& operator[](const key_type& key)
     {
         return emplace(key, T{}).first->second;
     }
 
-    const T& operator[](const Key& key) const
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    T & operator[](KeyType && key)
+    {
+        return emplace(std::forward<KeyType>(key), T{}).first->second;
+    }
+
+    const T& operator[](const key_type& key) const
     {
         return at(key);
     }
 
-    T& at(const Key& key)
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const T & operator[](KeyType && key) const
+    {
+        return at(std::forward<KeyType>(key));
+    }
+
+    T& at(const key_type& key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -18334,7 +18368,9 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         JSON_THROW(std::out_of_range("key not found"));
     }
 
-    const T& at(const Key& key) const
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    T & at(KeyType && key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -18347,7 +18383,56 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         JSON_THROW(std::out_of_range("key not found"));
     }
 
-    size_type erase(const Key& key)
+    const T& at(const key_type& key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const T & at(KeyType && key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    size_type erase(const key_type& key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                // Since we cannot move const Keys, re-construct them in place
+                for (auto next = it; ++next != this->end(); ++it)
+                {
+                    it->~value_type(); // Destroy but keep allocation
+                    new (&*it) value_type{std::move(*next)};
+                }
+                Container::pop_back();
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type erase(KeyType && key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -18419,7 +18504,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::begin() + offset;
     }
 
-    size_type count(const Key& key) const
+    size_type count(const key_type& key) const
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -18431,7 +18516,21 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return 0;
     }
 
-    iterator find(const Key& key)
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type count(KeyType && key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    iterator find(const key_type& key)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -18443,7 +18542,21 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::end();
     }
 
-    const_iterator find(const Key& key) const
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator find(KeyType && key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+
+    const_iterator find(const key_type& key) const
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -20421,7 +20534,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element with bounds checking
     /// @sa https://json.nlohmann.me/api/basic_json/at/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     reference at(KeyType && key)
     {
         // at only works for objects
@@ -20459,7 +20572,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element with bounds checking
     /// @sa https://json.nlohmann.me/api/basic_json/at/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     const_reference at(KeyType && key) const
     {
         // at only works for objects
@@ -20589,7 +20702,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element
     /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int > = 0 >
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
     reference operator[](KeyType && key)
     {
         // implicitly convert null value to an empty object
@@ -20613,7 +20726,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief access specified object element
     /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int > = 0 >
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
     const_reference operator[](KeyType && key) const
     {
         // const operator[] only works for objects
@@ -20682,7 +20795,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     template < class KeyType, class ValueType, detail::enable_if_t <
                    detail::is_getable<basic_json_t, ValueType>::value
                    && !std::is_same<value_t, ValueType>::value
-                   && detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int > = 0 >
+                   && detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
     typename std::decay<ValueType>::type value(KeyType && key, ValueType && default_value) const
     {
         // value only works for objects
@@ -20981,7 +21094,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief remove element from a JSON object given a key
     /// @sa https://json.nlohmann.me/api/basic_json/erase/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     size_type erase(KeyType && key)
     {
         return erase_internal(std::forward<KeyType>(key));
@@ -21048,7 +21161,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief find an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/find/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     iterator find(KeyType && key)
     {
         auto result = end();
@@ -21064,7 +21177,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief find an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/find/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     const_iterator find(KeyType && key) const
     {
         auto result = cend();
@@ -21088,7 +21201,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief returns the number of occurrences of a key in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/count/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     size_type count(KeyType && key) const
     {
         // return 0 for all nonobject types
@@ -21105,7 +21218,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief check the existence of an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/contains/
     template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<basic_json_t, KeyType>::value, int> = 0>
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     bool contains(KeyType && key) const
     {
         return is_object() && m_value.object->find(std::forward<KeyType>(key)) != m_value.object->end();

--- a/tests/src/unit-element_access2.cpp
+++ b/tests/src/unit-element_access2.cpp
@@ -30,67 +30,66 @@ SOFTWARE.
 #include "doctest_compatibility.h"
 
 #include <nlohmann/json.hpp>
-using nlohmann::json;
 
-TEST_CASE("element access 2")
+TEST_CASE_TEMPLATE("element access 2", Json, nlohmann::json, nlohmann::ordered_json)
 {
     SECTION("object")
     {
-        json j = {{"integer", 1}, {"unsigned", 1u}, {"floating", 42.23}, {"null", nullptr}, {"string", "hello world"}, {"boolean", true}, {"object", json::object()}, {"array", {1, 2, 3}}};
-        const json j_const = j;
+        Json j = {{"integer", 1}, {"unsigned", 1u}, {"floating", 42.23}, {"null", nullptr}, {"string", "hello world"}, {"boolean", true}, {"object", Json::object()}, {"array", {1, 2, 3}}};
+        const Json j_const = j;
 
         SECTION("access specified element with bounds checking")
         {
             SECTION("access within bounds")
             {
-                CHECK(j.at("integer") == json(1));
-                CHECK(j.at("unsigned") == json(1u));
-                CHECK(j.at("boolean") == json(true));
-                CHECK(j.at("null") == json(nullptr));
-                CHECK(j.at("string") == json("hello world"));
-                CHECK(j.at("floating") == json(42.23));
-                CHECK(j.at("object") == json::object());
-                CHECK(j.at("array") == json({1, 2, 3}));
+                CHECK(j.at("integer") == Json(1));
+                CHECK(j.at("unsigned") == Json(1u));
+                CHECK(j.at("boolean") == Json(true));
+                CHECK(j.at("null") == Json(nullptr));
+                CHECK(j.at("string") == Json("hello world"));
+                CHECK(j.at("floating") == Json(42.23));
+                CHECK(j.at("object") == Json::object());
+                CHECK(j.at("array") == Json({1, 2, 3}));
 
-                CHECK(j_const.at("integer") == json(1));
-                CHECK(j_const.at("unsigned") == json(1u));
-                CHECK(j_const.at("boolean") == json(true));
-                CHECK(j_const.at("null") == json(nullptr));
-                CHECK(j_const.at("string") == json("hello world"));
-                CHECK(j_const.at("floating") == json(42.23));
-                CHECK(j_const.at("object") == json::object());
-                CHECK(j_const.at("array") == json({1, 2, 3}));
+                CHECK(j_const.at("integer") == Json(1));
+                CHECK(j_const.at("unsigned") == Json(1u));
+                CHECK(j_const.at("boolean") == Json(true));
+                CHECK(j_const.at("null") == Json(nullptr));
+                CHECK(j_const.at("string") == Json("hello world"));
+                CHECK(j_const.at("floating") == Json(42.23));
+                CHECK(j_const.at("object") == Json::object());
+                CHECK(j_const.at("array") == Json({1, 2, 3}));
 
 #ifdef JSON_HAS_CPP_17
-                CHECK(j.at(std::string_view("integer")) == json(1));
-                CHECK(j.at(std::string_view("unsigned")) == json(1u));
-                CHECK(j.at(std::string_view("boolean")) == json(true));
-                CHECK(j.at(std::string_view("null")) == json(nullptr));
-                CHECK(j.at(std::string_view("string")) == json("hello world"));
-                CHECK(j.at(std::string_view("floating")) == json(42.23));
-                CHECK(j.at(std::string_view("object")) == json::object());
-                CHECK(j.at(std::string_view("array")) == json({1, 2, 3}));
+                CHECK(j.at(std::string_view("integer")) == Json(1));
+                CHECK(j.at(std::string_view("unsigned")) == Json(1u));
+                CHECK(j.at(std::string_view("boolean")) == Json(true));
+                CHECK(j.at(std::string_view("null")) == Json(nullptr));
+                CHECK(j.at(std::string_view("string")) == Json("hello world"));
+                CHECK(j.at(std::string_view("floating")) == Json(42.23));
+                CHECK(j.at(std::string_view("object")) == Json::object());
+                CHECK(j.at(std::string_view("array")) == Json({1, 2, 3}));
 
-                CHECK(j_const.at(std::string_view("integer")) == json(1));
-                CHECK(j_const.at(std::string_view("unsigned")) == json(1u));
-                CHECK(j_const.at(std::string_view("boolean")) == json(true));
-                CHECK(j_const.at(std::string_view("null")) == json(nullptr));
-                CHECK(j_const.at(std::string_view("string")) == json("hello world"));
-                CHECK(j_const.at(std::string_view("floating")) == json(42.23));
-                CHECK(j_const.at(std::string_view("object")) == json::object());
-                CHECK(j_const.at(std::string_view("array")) == json({1, 2, 3}));
+                CHECK(j_const.at(std::string_view("integer")) == Json(1));
+                CHECK(j_const.at(std::string_view("unsigned")) == Json(1u));
+                CHECK(j_const.at(std::string_view("boolean")) == Json(true));
+                CHECK(j_const.at(std::string_view("null")) == Json(nullptr));
+                CHECK(j_const.at(std::string_view("string")) == Json("hello world"));
+                CHECK(j_const.at(std::string_view("floating")) == Json(42.23));
+                CHECK(j_const.at(std::string_view("object")) == Json::object());
+                CHECK(j_const.at(std::string_view("array")) == Json({1, 2, 3}));
 #endif
             }
 
             SECTION("access outside bounds")
             {
-                CHECK_THROWS_WITH_AS(j.at("foo"), "[json.exception.out_of_range.403] key 'foo' not found", json::out_of_range&);
-                CHECK_THROWS_WITH_AS(j_const.at("foo"), "[json.exception.out_of_range.403] key 'foo' not found", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j.at("foo"), "[json.exception.out_of_range.403] key 'foo' not found", typename Json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const.at("foo"), "[json.exception.out_of_range.403] key 'foo' not found", typename Json::out_of_range&);
 
 
 #ifdef JSON_HAS_CPP_17
-                CHECK_THROWS_WITH_AS(j.at(std::string_view("foo")), "[json.exception.out_of_range.403] key 'foo' not found", json::out_of_range&);
-                CHECK_THROWS_WITH_AS(j_const.at(std::string_view("foo")), "[json.exception.out_of_range.403] key 'foo' not found", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j.at(std::string_view("foo")), "[json.exception.out_of_range.403] key 'foo' not found", typename Json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const.at(std::string_view("foo")), "[json.exception.out_of_range.403] key 'foo' not found", typename Json::out_of_range&);
 #endif
             }
 
@@ -98,92 +97,92 @@ TEST_CASE("element access 2")
             {
                 SECTION("null")
                 {
-                    json j_nonobject(json::value_t::null);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
+                    Json j_nonobject(Json::value_t::null);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with null", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with null", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view(std::string_view("foo"))), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view(std::string_view("foo"))), "[json.exception.type_error.304] cannot use at() with null", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view(std::string_view("foo"))), "[json.exception.type_error.304] cannot use at() with null", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view(std::string_view("foo"))), "[json.exception.type_error.304] cannot use at() with null", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("boolean")
                 {
-                    json j_nonobject(json::value_t::boolean);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
+                    Json j_nonobject(Json::value_t::boolean);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with boolean", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with boolean", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with boolean", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("string")
                 {
-                    json j_nonobject(json::value_t::string);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
+                    Json j_nonobject(Json::value_t::string);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with string", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with string", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with string", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with string", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("array")
                 {
-                    json j_nonobject(json::value_t::array);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with array", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with array", json::type_error&);
+                    Json j_nonobject(Json::value_t::array);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with array", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with array", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with array", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with array", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with array", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (integer)")
                 {
-                    json j_nonobject(json::value_t::number_integer);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    Json j_nonobject(Json::value_t::number_integer);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (unsigned)")
                 {
-                    json j_nonobject(json::value_t::number_unsigned);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    Json j_nonobject(Json::value_t::number_unsigned);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (floating-point)")
                 {
-                    json j_nonobject(json::value_t::number_float);
-                    const json j_nonobject_const(j_nonobject);
-                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    Json j_nonobject(Json::value_t::number_float);
+                    const Json j_nonobject_const(j_nonobject);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at("foo"), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at("foo"), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject_const.at(std::string_view("foo")), "[json.exception.type_error.304] cannot use at() with number", typename Json::type_error&);
 #endif
                 }
             }
@@ -199,14 +198,14 @@ TEST_CASE("element access 2")
                     CHECK(j.value("integer", 1.0) == Approx(1));
                     CHECK(j.value("unsigned", 2) == 1u);
                     CHECK(j.value("unsigned", 1.0) == Approx(1u));
-                    CHECK(j.value("null", json(1)) == json());
+                    CHECK(j.value("null", Json(1)) == Json());
                     CHECK(j.value("boolean", false) == true);
                     CHECK(j.value("string", "bar") == "hello world");
                     CHECK(j.value("string", std::string("bar")) == "hello world");
                     CHECK(j.value("floating", 12.34) == Approx(42.23));
                     CHECK(j.value("floating", 12) == 42);
-                    CHECK(j.value("object", json({{"foo", "bar"}})) == json::object());
-                    CHECK(j.value("array", json({10, 100})) == json({1, 2, 3}));
+                    CHECK(j.value("object", Json({{"foo", "bar"}})) == Json::object());
+                    CHECK(j.value("array", Json({10, 100})) == Json({1, 2, 3}));
 
                     CHECK(j_const.value("integer", 2) == 1);
                     CHECK(j_const.value("integer", 1.0) == Approx(1));
@@ -217,22 +216,22 @@ TEST_CASE("element access 2")
                     CHECK(j_const.value("string", std::string("bar")) == "hello world");
                     CHECK(j_const.value("floating", 12.34) == Approx(42.23));
                     CHECK(j_const.value("floating", 12) == 42);
-                    CHECK(j_const.value("object", json({{"foo", "bar"}})) == json::object());
-                    CHECK(j_const.value("array", json({10, 100})) == json({1, 2, 3}));
+                    CHECK(j_const.value("object", Json({{"foo", "bar"}})) == Json::object());
+                    CHECK(j_const.value("array", Json({10, 100})) == Json({1, 2, 3}));
 
 #ifdef JSON_HAS_CPP_17
                     CHECK(j.value(std::string_view("integer"), 2) == 1);
                     CHECK(j.value(std::string_view("integer"), 1.0) == Approx(1));
                     CHECK(j.value(std::string_view("unsigned"), 2) == 1u);
                     CHECK(j.value(std::string_view("unsigned"), 1.0) == Approx(1u));
-                    CHECK(j.value(std::string_view("null"), json(1)) == json());
+                    CHECK(j.value(std::string_view("null"), Json(1)) == Json());
                     CHECK(j.value(std::string_view("boolean"), false) == true);
                     CHECK(j.value(std::string_view("string"), "bar") == "hello world");
                     CHECK(j.value(std::string_view("string"), std::string("bar")) == "hello world");
                     CHECK(j.value(std::string_view("floating"), 12.34) == Approx(42.23));
                     CHECK(j.value(std::string_view("floating"), 12) == 42);
-                    CHECK(j.value(std::string_view("object"), json({{"foo", "bar"}})) == json::object());
-                    CHECK(j.value(std::string_view("array"), json({10, 100})) == json({1, 2, 3}));
+                    CHECK(j.value(std::string_view("object"), Json({{"foo", "bar"}})) == Json::object());
+                    CHECK(j.value(std::string_view("array"), Json({10, 100})) == Json({1, 2, 3}));
 
                     CHECK(j_const.value(std::string_view("integer"), 2) == 1);
                     CHECK(j_const.value(std::string_view("integer"), 1.0) == Approx(1));
@@ -243,8 +242,8 @@ TEST_CASE("element access 2")
                     CHECK(j_const.value(std::string_view("string"), std::string("bar")) == "hello world");
                     CHECK(j_const.value(std::string_view("floating"), 12.34) == Approx(42.23));
                     CHECK(j_const.value(std::string_view("floating"), 12) == 42);
-                    CHECK(j_const.value(std::string_view("object"), json({{"foo", "bar"}})) == json::object());
-                    CHECK(j_const.value(std::string_view("array"), json({10, 100})) == json({1, 2, 3}));
+                    CHECK(j_const.value(std::string_view("object"), Json({{"foo", "bar"}})) == Json::object());
+                    CHECK(j_const.value(std::string_view("array"), Json({10, 100})) == Json({1, 2, 3}));
 #endif
                 }
 
@@ -255,16 +254,16 @@ TEST_CASE("element access 2")
                     CHECK(j.value("_", false) == false);
                     CHECK(j.value("_", "bar") == "bar");
                     CHECK(j.value("_", 12.34) == Approx(12.34));
-                    CHECK(j.value("_", json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
-                    CHECK(j.value("_", json({10, 100})) == json({10, 100}));
+                    CHECK(j.value("_", Json({{"foo", "bar"}})) == Json({{"foo", "bar"}}));
+                    CHECK(j.value("_", Json({10, 100})) == Json({10, 100}));
 
                     CHECK(j_const.value("_", 2) == 2);
                     CHECK(j_const.value("_", 2u) == 2u);
                     CHECK(j_const.value("_", false) == false);
                     CHECK(j_const.value("_", "bar") == "bar");
                     CHECK(j_const.value("_", 12.34) == Approx(12.34));
-                    CHECK(j_const.value("_", json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
-                    CHECK(j_const.value("_", json({10, 100})) == json({10, 100}));
+                    CHECK(j_const.value("_", Json({{"foo", "bar"}})) == Json({{"foo", "bar"}}));
+                    CHECK(j_const.value("_", Json({10, 100})) == Json({10, 100}));
 
 #ifdef JSON_HAS_CPP_17
                     CHECK(j.value(std::string_view("_"), 2) == 2);
@@ -272,16 +271,16 @@ TEST_CASE("element access 2")
                     CHECK(j.value(std::string_view("_"), false) == false);
                     CHECK(j.value(std::string_view("_"), "bar") == "bar");
                     CHECK(j.value(std::string_view("_"), 12.34) == Approx(12.34));
-                    CHECK(j.value(std::string_view("_"), json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
-                    CHECK(j.value(std::string_view("_"), json({10, 100})) == json({10, 100}));
+                    CHECK(j.value(std::string_view("_"), Json({{"foo", "bar"}})) == Json({{"foo", "bar"}}));
+                    CHECK(j.value(std::string_view("_"), Json({10, 100})) == Json({10, 100}));
 
                     CHECK(j_const.value(std::string_view("_"), 2) == 2);
                     CHECK(j_const.value(std::string_view("_"), 2u) == 2u);
                     CHECK(j_const.value(std::string_view("_"), false) == false);
                     CHECK(j_const.value(std::string_view("_"), "bar") == "bar");
                     CHECK(j_const.value(std::string_view("_"), 12.34) == Approx(12.34));
-                    CHECK(j_const.value(std::string_view("_"), json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
-                    CHECK(j_const.value(std::string_view("_"), json({10, 100})) == json({10, 100}));
+                    CHECK(j_const.value(std::string_view("_"), Json({{"foo", "bar"}})) == Json({{"foo", "bar"}}));
+                    CHECK(j_const.value(std::string_view("_"), Json({10, 100})) == Json({10, 100}));
 #endif
                 }
 
@@ -289,92 +288,92 @@ TEST_CASE("element access 2")
                 {
                     SECTION("null")
                     {
-                        json j_nonobject(json::value_t::null);
-                        const json j_nonobject_const(json::value_t::null);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
+                        Json j_nonobject(Json::value_t::null);
+                        const Json j_nonobject_const(Json::value_t::null);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with null", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with null", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with null", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with null", typename Json::type_error&);
 #endif
                     }
 
                     SECTION("boolean")
                     {
-                        json j_nonobject(json::value_t::boolean);
-                        const json j_nonobject_const(json::value_t::boolean);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
+                        Json j_nonobject(Json::value_t::boolean);
+                        const Json j_nonobject_const(Json::value_t::boolean);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with boolean", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with boolean", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with boolean", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with boolean", typename Json::type_error&);
 #endif
                     }
 
                     SECTION("string")
                     {
-                        json j_nonobject(json::value_t::string);
-                        const json j_nonobject_const(json::value_t::string);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
+                        Json j_nonobject(Json::value_t::string);
+                        const Json j_nonobject_const(Json::value_t::string);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with string", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with string", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with string", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with string", typename Json::type_error&);
 #endif
                     }
 
                     SECTION("array")
                     {
-                        json j_nonobject(json::value_t::array);
-                        const json j_nonobject_const(json::value_t::array);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
+                        Json j_nonobject(Json::value_t::array);
+                        const Json j_nonobject_const(Json::value_t::array);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with array", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with array", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with array", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with array", typename Json::type_error&);
 #endif
                     }
 
                     SECTION("number (integer)")
                     {
-                        json j_nonobject(json::value_t::number_integer);
-                        const json j_nonobject_const(json::value_t::number_integer);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        Json j_nonobject(Json::value_t::number_integer);
+                        const Json j_nonobject_const(Json::value_t::number_integer);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
 #endif
                     }
 
                     SECTION("number (unsigned)")
                     {
-                        json j_nonobject(json::value_t::number_unsigned);
-                        const json j_nonobject_const(json::value_t::number_unsigned);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        Json j_nonobject(Json::value_t::number_unsigned);
+                        const Json j_nonobject_const(Json::value_t::number_unsigned);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
 #endif
                     }
 
                     SECTION("number (floating-point)")
                     {
-                        json j_nonobject(json::value_t::number_float);
-                        const json j_nonobject_const(json::value_t::number_float);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        Json j_nonobject(Json::value_t::number_float);
+                        const Json j_nonobject_const(Json::value_t::number_float);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("foo", 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value(std::string_view("foo"), 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
 #endif
                     }
                 }
@@ -388,14 +387,14 @@ TEST_CASE("element access 2")
                     CHECK(j.value("/integer"_json_pointer, 1.0) == Approx(1));
                     CHECK(j.value("/unsigned"_json_pointer, 2) == 1u);
                     CHECK(j.value("/unsigned"_json_pointer, 1.0) == Approx(1u));
-                    CHECK(j.value("/null"_json_pointer, json(1)) == json());
+                    CHECK(j.value("/null"_json_pointer, Json(1)) == Json());
                     CHECK(j.value("/boolean"_json_pointer, false) == true);
                     CHECK(j.value("/string"_json_pointer, "bar") == "hello world");
                     CHECK(j.value("/string"_json_pointer, std::string("bar")) == "hello world");
                     CHECK(j.value("/floating"_json_pointer, 12.34) == Approx(42.23));
                     CHECK(j.value("/floating"_json_pointer, 12) == 42);
-                    CHECK(j.value("/object"_json_pointer, json({{"foo", "bar"}})) == json::object());
-                    CHECK(j.value("/array"_json_pointer, json({10, 100})) == json({1, 2, 3}));
+                    CHECK(j.value("/object"_json_pointer, Json({{"foo", "bar"}})) == Json::object());
+                    CHECK(j.value("/array"_json_pointer, Json({10, 100})) == Json({1, 2, 3}));
 
                     CHECK(j_const.value("/integer"_json_pointer, 2) == 1);
                     CHECK(j_const.value("/integer"_json_pointer, 1.0) == Approx(1));
@@ -406,66 +405,66 @@ TEST_CASE("element access 2")
                     CHECK(j_const.value("/string"_json_pointer, std::string("bar")) == "hello world");
                     CHECK(j_const.value("/floating"_json_pointer, 12.34) == Approx(42.23));
                     CHECK(j_const.value("/floating"_json_pointer, 12) == 42);
-                    CHECK(j_const.value("/object"_json_pointer, json({{"foo", "bar"}})) == json::object());
-                    CHECK(j_const.value("/array"_json_pointer, json({10, 100})) == json({1, 2, 3}));
+                    CHECK(j_const.value("/object"_json_pointer, Json({{"foo", "bar"}})) == Json::object());
+                    CHECK(j_const.value("/array"_json_pointer, Json({10, 100})) == Json({1, 2, 3}));
                 }
 
                 SECTION("access on non-object type")
                 {
                     SECTION("null")
                     {
-                        json j_nonobject(json::value_t::null);
-                        const json j_nonobject_const(json::value_t::null);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with null", json::type_error&);
+                        Json j_nonobject(Json::value_t::null);
+                        const Json j_nonobject_const(Json::value_t::null);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with null", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with null", typename Json::type_error&);
                     }
 
                     SECTION("boolean")
                     {
-                        json j_nonobject(json::value_t::boolean);
-                        const json j_nonobject_const(json::value_t::boolean);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with boolean", json::type_error&);
+                        Json j_nonobject(Json::value_t::boolean);
+                        const Json j_nonobject_const(Json::value_t::boolean);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with boolean", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with boolean", typename Json::type_error&);
                     }
 
                     SECTION("string")
                     {
-                        json j_nonobject(json::value_t::string);
-                        const json j_nonobject_const(json::value_t::string);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with string", json::type_error&);
+                        Json j_nonobject(Json::value_t::string);
+                        const Json j_nonobject_const(Json::value_t::string);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with string", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with string", typename Json::type_error&);
                     }
 
                     SECTION("array")
                     {
-                        json j_nonobject(json::value_t::array);
-                        const json j_nonobject_const(json::value_t::array);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with array", json::type_error&);
+                        Json j_nonobject(Json::value_t::array);
+                        const Json j_nonobject_const(Json::value_t::array);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with array", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with array", typename Json::type_error&);
                     }
 
                     SECTION("number (integer)")
                     {
-                        json j_nonobject(json::value_t::number_integer);
-                        const json j_nonobject_const(json::value_t::number_integer);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        Json j_nonobject(Json::value_t::number_integer);
+                        const Json j_nonobject_const(Json::value_t::number_integer);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
                     }
 
                     SECTION("number (unsigned)")
                     {
-                        json j_nonobject(json::value_t::number_unsigned);
-                        const json j_nonobject_const(json::value_t::number_unsigned);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        Json j_nonobject(Json::value_t::number_unsigned);
+                        const Json j_nonobject_const(Json::value_t::number_unsigned);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
                     }
 
                     SECTION("number (floating-point)")
                     {
-                        json j_nonobject(json::value_t::number_float);
-                        const json j_nonobject_const(json::value_t::number_float);
-                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
-                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", json::type_error&);
+                        Json j_nonobject(Json::value_t::number_float);
+                        const Json j_nonobject_const(Json::value_t::number_float);
+                        CHECK_THROWS_WITH_AS(j_nonobject.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
+                        CHECK_THROWS_WITH_AS(j_nonobject_const.value("/foo"_json_pointer, 1), "[json.exception.type_error.306] cannot use value() with number", typename Json::type_error&);
                     }
                 }
             }
@@ -474,7 +473,7 @@ TEST_CASE("element access 2")
         SECTION("non-const operator[]")
         {
             {
-                json j_null;
+                Json j_null;
                 CHECK(j_null.is_null());
                 j_null["key"] = 1;
                 CHECK(j_null.is_object());
@@ -485,7 +484,7 @@ TEST_CASE("element access 2")
 #ifdef JSON_HAS_CPP_17
             {
                 std::string_view key = "key";
-                json j_null;
+                Json j_null;
                 CHECK(j_null.is_null());
                 j_null[key] = 1;
                 CHECK(j_null.is_object());
@@ -498,110 +497,122 @@ TEST_CASE("element access 2")
 
         SECTION("front and back")
         {
-            // "array" is the smallest key
-            CHECK(j.front() == json({1, 2, 3}));
-            CHECK(j_const.front() == json({1, 2, 3}));
-            // "unsigned" is the largest key
-            CHECK(j.back() == json(1u));
-            CHECK(j_const.back() == json(1u));
+            if (std::is_same<Json, nlohmann::ordered_json>::value)
+            {
+                // "integer" is the first key
+                CHECK(j.front() == Json(1));
+                CHECK(j_const.front() == Json(1));
+                // "array" is last key
+                CHECK(j.back() == Json({1, 2, 3}));
+                CHECK(j_const.back() == Json({1, 2, 3}));
+            }
+            else
+            {
+                // "array" is the smallest key
+                CHECK(j.front() == Json({1, 2, 3}));
+                CHECK(j_const.front() == Json({1, 2, 3}));
+                // "unsigned" is the largest key
+                CHECK(j.back() == Json(1u));
+                CHECK(j_const.back() == Json(1u));
+            }
         }
 
         SECTION("access specified element")
         {
             SECTION("access within bounds")
             {
-                CHECK(j["integer"] == json(1));
-                CHECK(j[json::object_t::key_type("integer")] == j["integer"]);
+                CHECK(j["integer"] == Json(1));
+                CHECK(j[typename Json::object_t::key_type("integer")] == j["integer"]);
 
-                CHECK(j["unsigned"] == json(1u));
-                CHECK(j[json::object_t::key_type("unsigned")] == j["unsigned"]);
+                CHECK(j["unsigned"] == Json(1u));
+                CHECK(j[typename Json::object_t::key_type("unsigned")] == j["unsigned"]);
 
-                CHECK(j["boolean"] == json(true));
-                CHECK(j[json::object_t::key_type("boolean")] == j["boolean"]);
+                CHECK(j["boolean"] == Json(true));
+                CHECK(j[typename Json::object_t::key_type("boolean")] == j["boolean"]);
 
-                CHECK(j["null"] == json(nullptr));
-                CHECK(j[json::object_t::key_type("null")] == j["null"]);
+                CHECK(j["null"] == Json(nullptr));
+                CHECK(j[typename Json::object_t::key_type("null")] == j["null"]);
 
-                CHECK(j["string"] == json("hello world"));
-                CHECK(j[json::object_t::key_type("string")] == j["string"]);
+                CHECK(j["string"] == Json("hello world"));
+                CHECK(j[typename Json::object_t::key_type("string")] == j["string"]);
 
-                CHECK(j["floating"] == json(42.23));
-                CHECK(j[json::object_t::key_type("floating")] == j["floating"]);
+                CHECK(j["floating"] == Json(42.23));
+                CHECK(j[typename Json::object_t::key_type("floating")] == j["floating"]);
 
-                CHECK(j["object"] == json::object());
-                CHECK(j[json::object_t::key_type("object")] == j["object"]);
+                CHECK(j["object"] == Json::object());
+                CHECK(j[typename Json::object_t::key_type("object")] == j["object"]);
 
-                CHECK(j["array"] == json({1, 2, 3}));
-                CHECK(j[json::object_t::key_type("array")] == j["array"]);
+                CHECK(j["array"] == Json({1, 2, 3}));
+                CHECK(j[typename Json::object_t::key_type("array")] == j["array"]);
 
-                CHECK(j_const["integer"] == json(1));
-                CHECK(j_const[json::object_t::key_type("integer")] == j["integer"]);
+                CHECK(j_const["integer"] == Json(1));
+                CHECK(j_const[typename Json::object_t::key_type("integer")] == j["integer"]);
 
-                CHECK(j_const["boolean"] == json(true));
-                CHECK(j_const[json::object_t::key_type("boolean")] == j["boolean"]);
+                CHECK(j_const["boolean"] == Json(true));
+                CHECK(j_const[typename Json::object_t::key_type("boolean")] == j["boolean"]);
 
-                CHECK(j_const["null"] == json(nullptr));
-                CHECK(j_const[json::object_t::key_type("null")] == j["null"]);
+                CHECK(j_const["null"] == Json(nullptr));
+                CHECK(j_const[typename Json::object_t::key_type("null")] == j["null"]);
 
-                CHECK(j_const["string"] == json("hello world"));
-                CHECK(j_const[json::object_t::key_type("string")] == j["string"]);
+                CHECK(j_const["string"] == Json("hello world"));
+                CHECK(j_const[typename Json::object_t::key_type("string")] == j["string"]);
 
-                CHECK(j_const["floating"] == json(42.23));
-                CHECK(j_const[json::object_t::key_type("floating")] == j["floating"]);
+                CHECK(j_const["floating"] == Json(42.23));
+                CHECK(j_const[typename Json::object_t::key_type("floating")] == j["floating"]);
 
-                CHECK(j_const["object"] == json::object());
-                CHECK(j_const[json::object_t::key_type("object")] == j["object"]);
+                CHECK(j_const["object"] == Json::object());
+                CHECK(j_const[typename Json::object_t::key_type("object")] == j["object"]);
 
-                CHECK(j_const["array"] == json({1, 2, 3}));
-                CHECK(j_const[json::object_t::key_type("array")] == j["array"]);
+                CHECK(j_const["array"] == Json({1, 2, 3}));
+                CHECK(j_const[typename Json::object_t::key_type("array")] == j["array"]);
             }
 
 #ifdef JSON_HAS_CPP_17
             SECTION("access within bounds (string_view)")
             {
-                CHECK(j["integer"] == json(1));
+                CHECK(j["integer"] == Json(1));
                 CHECK(j[std::string_view("integer")] == j["integer"]);
 
-                CHECK(j["unsigned"] == json(1u));
+                CHECK(j["unsigned"] == Json(1u));
                 CHECK(j[std::string_view("unsigned")] == j["unsigned"]);
 
-                CHECK(j["boolean"] == json(true));
+                CHECK(j["boolean"] == Json(true));
                 CHECK(j[std::string_view("boolean")] == j["boolean"]);
 
-                CHECK(j["null"] == json(nullptr));
+                CHECK(j["null"] == Json(nullptr));
                 CHECK(j[std::string_view("null")] == j["null"]);
 
-                CHECK(j["string"] == json("hello world"));
+                CHECK(j["string"] == Json("hello world"));
                 CHECK(j[std::string_view("string")] == j["string"]);
 
-                CHECK(j["floating"] == json(42.23));
+                CHECK(j["floating"] == Json(42.23));
                 CHECK(j[std::string_view("floating")] == j["floating"]);
 
-                CHECK(j["object"] == json::object());
+                CHECK(j["object"] == Json::object());
                 CHECK(j[std::string_view("object")] == j["object"]);
 
-                CHECK(j["array"] == json({1, 2, 3}));
+                CHECK(j["array"] == Json({1, 2, 3}));
                 CHECK(j[std::string_view("array")] == j["array"]);
 
-                CHECK(j_const["integer"] == json(1));
+                CHECK(j_const["integer"] == Json(1));
                 CHECK(j_const[std::string_view("integer")] == j["integer"]);
 
-                CHECK(j_const["boolean"] == json(true));
+                CHECK(j_const["boolean"] == Json(true));
                 CHECK(j_const[std::string_view("boolean")] == j["boolean"]);
 
-                CHECK(j_const["null"] == json(nullptr));
+                CHECK(j_const["null"] == Json(nullptr));
                 CHECK(j_const[std::string_view("null")] == j["null"]);
 
-                CHECK(j_const["string"] == json("hello world"));
+                CHECK(j_const["string"] == Json("hello world"));
                 CHECK(j_const[std::string_view("string")] == j["string"]);
 
-                CHECK(j_const["floating"] == json(42.23));
+                CHECK(j_const["floating"] == Json(42.23));
                 CHECK(j_const[std::string_view("floating")] == j["floating"]);
 
-                CHECK(j_const["object"] == json::object());
+                CHECK(j_const["object"] == Json::object());
                 CHECK(j_const[std::string_view("object")] == j["object"]);
 
-                CHECK(j_const["array"] == json({1, 2, 3}));
+                CHECK(j_const["array"] == Json({1, 2, 3}));
                 CHECK(j_const[std::string_view("array")] == j["array"]);
             }
 #endif
@@ -610,131 +621,131 @@ TEST_CASE("element access 2")
             {
                 SECTION("null")
                 {
-                    json j_nonobject(json::value_t::null);
-                    json j_nonobject2(json::value_t::null);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::null);
+                    Json j_nonobject2(Json::value_t::null);
+                    const Json j_const_nonobject(j_nonobject);
 
                     CHECK_NOTHROW(j_nonobject["foo"]);
-                    CHECK_NOTHROW(j_nonobject2[json::object_t::key_type("foo")]);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", json::type_error&);
+                    CHECK_NOTHROW(j_nonobject2[typename Json::object_t::key_type("foo")]);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject["foo"], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
                     CHECK_NOTHROW(j_nonobject2[std::string_view("foo")]);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with null", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("boolean")
                 {
-                    json j_nonobject(json::value_t::boolean);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::boolean);
+                    const Json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", typename Json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with boolean", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("string")
                 {
-                    json j_nonobject(json::value_t::string);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::string);
+                    const Json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", typename Json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with string", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with string", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with string", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("array")
                 {
-                    json j_nonobject(json::value_t::array);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::array);
+                    const Json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[typename Json::object_t::key_type("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", typename Json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with array", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with array", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (integer)")
                 {
-                    json j_nonobject(json::value_t::number_integer);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::number_integer);
+                    const Json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (unsigned)")
                 {
-                    json j_nonobject(json::value_t::number_unsigned);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::number_unsigned);
+                    const Json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (floating-point)")
                 {
-                    json j_nonobject(json::value_t::number_float);
-                    const json j_const_nonobject(j_nonobject);
+                    Json j_nonobject(Json::value_t::number_float);
+                    const Json j_const_nonobject(j_nonobject);
                     CHECK_THROWS_WITH_AS(j_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
                     CHECK_THROWS_WITH_AS(j_const_nonobject["foo"],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[json::object_t::key_type("foo")],
-                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[typename Json::object_t::key_type("foo")],
+                                         "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
-                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_const_nonobject[std::string_view("foo")], "[json.exception.type_error.305] cannot use operator[] with a string argument with number", typename Json::type_error&);
 #endif
                 }
             }
@@ -835,31 +846,31 @@ TEST_CASE("element access 2")
                 SECTION("erase(begin())")
                 {
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::iterator it2 = jobject.erase(jobject.begin());
-                        CHECK(jobject == json({{"b", 1}, {"c", 17u}}));
-                        CHECK(*it2 == json(1));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::iterator it2 = jobject.erase(jobject.begin());
+                        CHECK(jobject == Json({{"b", 1}, {"c", 17u}}));
+                        CHECK(*it2 == Json(1));
                     }
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::const_iterator it2 = jobject.erase(jobject.cbegin());
-                        CHECK(jobject == json({{"b", 1}, {"c", 17u}}));
-                        CHECK(*it2 == json(1));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::const_iterator it2 = jobject.erase(jobject.cbegin());
+                        CHECK(jobject == Json({{"b", 1}, {"c", 17u}}));
+                        CHECK(*it2 == Json(1));
                     }
                 }
 
                 SECTION("erase(begin(), end())")
                 {
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::iterator it2 = jobject.erase(jobject.begin(), jobject.end());
-                        CHECK(jobject == json::object());
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::iterator it2 = jobject.erase(jobject.begin(), jobject.end());
+                        CHECK(jobject == Json::object());
                         CHECK(it2 == jobject.end());
                     }
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::const_iterator it2 = jobject.erase(jobject.cbegin(), jobject.cend());
-                        CHECK(jobject == json::object());
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::const_iterator it2 = jobject.erase(jobject.cbegin(), jobject.cend());
+                        CHECK(jobject == Json::object());
                         CHECK(it2 == jobject.cend());
                     }
                 }
@@ -867,78 +878,78 @@ TEST_CASE("element access 2")
                 SECTION("erase(begin(), begin())")
                 {
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::iterator it2 = jobject.erase(jobject.begin(), jobject.begin());
-                        CHECK(jobject == json({{"a", "a"}, {"b", 1}, {"c", 17u}}));
-                        CHECK(*it2 == json("a"));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::iterator it2 = jobject.erase(jobject.begin(), jobject.begin());
+                        CHECK(jobject == Json({{"a", "a"}, {"b", 1}, {"c", 17u}}));
+                        CHECK(*it2 == Json("a"));
                     }
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::const_iterator it2 = jobject.erase(jobject.cbegin(), jobject.cbegin());
-                        CHECK(jobject == json({{"a", "a"}, {"b", 1}, {"c", 17u}}));
-                        CHECK(*it2 == json("a"));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::const_iterator it2 = jobject.erase(jobject.cbegin(), jobject.cbegin());
+                        CHECK(jobject == Json({{"a", "a"}, {"b", 1}, {"c", 17u}}));
+                        CHECK(*it2 == Json("a"));
                     }
                 }
 
                 SECTION("erase at offset")
                 {
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::iterator it = jobject.find("b");
-                        json::iterator it2 = jobject.erase(it);
-                        CHECK(jobject == json({{"a", "a"}, {"c", 17u}}));
-                        CHECK(*it2 == json(17));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::iterator it = jobject.find("b");
+                        typename Json::iterator it2 = jobject.erase(it);
+                        CHECK(jobject == Json({{"a", "a"}, {"c", 17u}}));
+                        CHECK(*it2 == Json(17));
                     }
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        json::const_iterator it = jobject.find("b");
-                        json::const_iterator it2 = jobject.erase(it);
-                        CHECK(jobject == json({{"a", "a"}, {"c", 17u}}));
-                        CHECK(*it2 == json(17));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        typename Json::const_iterator it = jobject.find("b");
+                        typename Json::const_iterator it2 = jobject.erase(it);
+                        CHECK(jobject == Json({{"a", "a"}, {"c", 17u}}));
+                        CHECK(*it2 == Json(17));
                     }
                 }
 
                 SECTION("erase subrange")
                 {
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
-                        json::iterator it2 = jobject.erase(jobject.find("b"), jobject.find("e"));
-                        CHECK(jobject == json({{"a", "a"}, {"e", true}}));
-                        CHECK(*it2 == json(true));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
+                        typename Json::iterator it2 = jobject.erase(jobject.find("b"), jobject.find("e"));
+                        CHECK(jobject == Json({{"a", "a"}, {"e", true}}));
+                        CHECK(*it2 == Json(true));
                     }
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
-                        json::const_iterator it2 = jobject.erase(jobject.find("b"), jobject.find("e"));
-                        CHECK(jobject == json({{"a", "a"}, {"e", true}}));
-                        CHECK(*it2 == json(true));
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
+                        typename Json::const_iterator it2 = jobject.erase(jobject.find("b"), jobject.find("e"));
+                        CHECK(jobject == Json({{"a", "a"}, {"e", true}}));
+                        CHECK(*it2 == Json(true));
                     }
                 }
 
                 SECTION("different objects")
                 {
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
-                        json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
+                        Json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin()),
-                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", typename Json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject.begin(), jobject2.end()),
-                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", typename Json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin(), jobject.end()),
-                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", typename Json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.begin(), jobject2.end()),
-                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", typename Json::invalid_iterator&);
                     }
                     {
-                        json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
-                        json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
+                        Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
+                        Json jobject2 = {{"a", "a"}, {"b", 1}, {"c", 17u}};
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin()),
-                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.202] iterator does not fit current value", typename Json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject.cbegin(), jobject2.cend()),
-                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", typename Json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin(), jobject.cend()),
-                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", typename Json::invalid_iterator&);
                         CHECK_THROWS_WITH_AS(jobject.erase(jobject2.cbegin(), jobject2.cend()),
-                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", json::invalid_iterator&);
+                                             "[json.exception.invalid_iterator.203] iterators do not fit current value", typename Json::invalid_iterator&);
                     }
                 }
             }
@@ -947,61 +958,61 @@ TEST_CASE("element access 2")
             {
                 SECTION("null")
                 {
-                    json j_nonobject(json::value_t::null);
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
+                    Json j_nonobject(Json::value_t::null);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with null", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with null", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with null", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("boolean")
                 {
-                    json j_nonobject(json::value_t::boolean);
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with boolean", json::type_error&);
+                    Json j_nonobject(Json::value_t::boolean);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with boolean", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with boolean", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with boolean", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("string")
                 {
-                    json j_nonobject(json::value_t::string);
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with string", json::type_error&);
+                    Json j_nonobject(Json::value_t::string);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with string", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with string", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with string", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("array")
                 {
-                    json j_nonobject(json::value_t::array);
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with array", json::type_error&);
+                    Json j_nonobject(Json::value_t::array);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with array", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with array", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with array", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (integer)")
                 {
-                    json j_nonobject(json::value_t::number_integer);
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
+                    Json j_nonobject(Json::value_t::number_integer);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with number", typename Json::type_error&);
 #endif
                 }
 
                 SECTION("number (floating-point)")
                 {
-                    json j_nonobject(json::value_t::number_float);
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
+                    Json j_nonobject(Json::value_t::number_float);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase("foo"), "[json.exception.type_error.307] cannot use erase() with number", typename Json::type_error&);
 
 #ifdef JSON_HAS_CPP_17
-                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with number", json::type_error&);
+                    CHECK_THROWS_WITH_AS(j_nonobject.erase(std::string_view("foo")), "[json.exception.type_error.307] cannot use erase() with number", typename Json::type_error&);
 #endif
                 }
             }
@@ -1048,8 +1059,8 @@ TEST_CASE("element access 2")
             {
                 SECTION("null")
                 {
-                    json j_nonarray(json::value_t::null);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::null);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1062,8 +1073,8 @@ TEST_CASE("element access 2")
 
                 SECTION("string")
                 {
-                    json j_nonarray(json::value_t::string);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::string);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1076,8 +1087,8 @@ TEST_CASE("element access 2")
 
                 SECTION("object")
                 {
-                    json j_nonarray(json::value_t::object);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::object);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1090,8 +1101,8 @@ TEST_CASE("element access 2")
 
                 SECTION("array")
                 {
-                    json j_nonarray(json::value_t::array);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::array);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1104,8 +1115,8 @@ TEST_CASE("element access 2")
 
                 SECTION("boolean")
                 {
-                    json j_nonarray(json::value_t::boolean);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::boolean);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1118,8 +1129,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (integer)")
                 {
-                    json j_nonarray(json::value_t::number_integer);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::number_integer);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1132,8 +1143,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (unsigned)")
                 {
-                    json j_nonarray(json::value_t::number_unsigned);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::number_unsigned);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1146,8 +1157,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (floating-point)")
                 {
-                    json j_nonarray(json::value_t::number_float);
-                    const json j_nonarray_const(j_nonarray);
+                    Json j_nonarray(Json::value_t::number_float);
+                    const Json j_nonarray_const(j_nonarray);
 
                     CHECK(j_nonarray.find("foo") == j_nonarray.end());
                     CHECK(j_nonarray_const.find("foo") == j_nonarray_const.end());
@@ -1197,8 +1208,8 @@ TEST_CASE("element access 2")
             {
                 SECTION("null")
                 {
-                    json j_nonobject(json::value_t::null);
-                    const json j_nonobject_const(json::value_t::null);
+                    Json j_nonobject(Json::value_t::null);
+                    const Json j_nonobject_const(Json::value_t::null);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1211,8 +1222,8 @@ TEST_CASE("element access 2")
 
                 SECTION("string")
                 {
-                    json j_nonobject(json::value_t::string);
-                    const json j_nonobject_const(json::value_t::string);
+                    Json j_nonobject(Json::value_t::string);
+                    const Json j_nonobject_const(Json::value_t::string);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1225,8 +1236,8 @@ TEST_CASE("element access 2")
 
                 SECTION("object")
                 {
-                    json j_nonobject(json::value_t::object);
-                    const json j_nonobject_const(json::value_t::object);
+                    Json j_nonobject(Json::value_t::object);
+                    const Json j_nonobject_const(Json::value_t::object);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1239,8 +1250,8 @@ TEST_CASE("element access 2")
 
                 SECTION("array")
                 {
-                    json j_nonobject(json::value_t::array);
-                    const json j_nonobject_const(json::value_t::array);
+                    Json j_nonobject(Json::value_t::array);
+                    const Json j_nonobject_const(Json::value_t::array);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1253,8 +1264,8 @@ TEST_CASE("element access 2")
 
                 SECTION("boolean")
                 {
-                    json j_nonobject(json::value_t::boolean);
-                    const json j_nonobject_const(json::value_t::boolean);
+                    Json j_nonobject(Json::value_t::boolean);
+                    const Json j_nonobject_const(Json::value_t::boolean);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1267,8 +1278,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (integer)")
                 {
-                    json j_nonobject(json::value_t::number_integer);
-                    const json j_nonobject_const(json::value_t::number_integer);
+                    Json j_nonobject(Json::value_t::number_integer);
+                    const Json j_nonobject_const(Json::value_t::number_integer);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1281,8 +1292,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (unsigned)")
                 {
-                    json j_nonobject(json::value_t::number_unsigned);
-                    const json j_nonobject_const(json::value_t::number_unsigned);
+                    Json j_nonobject(Json::value_t::number_unsigned);
+                    const Json j_nonobject_const(Json::value_t::number_unsigned);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1295,8 +1306,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (floating-point)")
                 {
-                    json j_nonobject(json::value_t::number_float);
-                    const json j_nonobject_const(json::value_t::number_float);
+                    Json j_nonobject(Json::value_t::number_float);
+                    const Json j_nonobject_const(Json::value_t::number_float);
 
                     CHECK(j_nonobject.count("foo") == 0);
                     CHECK(j_nonobject_const.count("foo") == 0);
@@ -1347,8 +1358,8 @@ TEST_CASE("element access 2")
             {
                 SECTION("null")
                 {
-                    json j_nonobject(json::value_t::null);
-                    const json j_nonobject_const(json::value_t::null);
+                    Json j_nonobject(Json::value_t::null);
+                    const Json j_nonobject_const(Json::value_t::null);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1361,8 +1372,8 @@ TEST_CASE("element access 2")
 
                 SECTION("string")
                 {
-                    json j_nonobject(json::value_t::string);
-                    const json j_nonobject_const(json::value_t::string);
+                    Json j_nonobject(Json::value_t::string);
+                    const Json j_nonobject_const(Json::value_t::string);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1375,8 +1386,8 @@ TEST_CASE("element access 2")
 
                 SECTION("object")
                 {
-                    json j_nonobject(json::value_t::object);
-                    const json j_nonobject_const(json::value_t::object);
+                    Json j_nonobject(Json::value_t::object);
+                    const Json j_nonobject_const(Json::value_t::object);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1389,8 +1400,8 @@ TEST_CASE("element access 2")
 
                 SECTION("array")
                 {
-                    json j_nonobject(json::value_t::array);
-                    const json j_nonobject_const(json::value_t::array);
+                    Json j_nonobject(Json::value_t::array);
+                    const Json j_nonobject_const(Json::value_t::array);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1403,8 +1414,8 @@ TEST_CASE("element access 2")
 
                 SECTION("boolean")
                 {
-                    json j_nonobject(json::value_t::boolean);
-                    const json j_nonobject_const(json::value_t::boolean);
+                    Json j_nonobject(Json::value_t::boolean);
+                    const Json j_nonobject_const(Json::value_t::boolean);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1417,8 +1428,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (integer)")
                 {
-                    json j_nonobject(json::value_t::number_integer);
-                    const json j_nonobject_const(json::value_t::number_integer);
+                    Json j_nonobject(Json::value_t::number_integer);
+                    const Json j_nonobject_const(Json::value_t::number_integer);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1431,8 +1442,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (unsigned)")
                 {
-                    json j_nonobject(json::value_t::number_unsigned);
-                    const json j_nonobject_const(json::value_t::number_unsigned);
+                    Json j_nonobject(Json::value_t::number_unsigned);
+                    const Json j_nonobject_const(Json::value_t::number_unsigned);
 
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
@@ -1445,8 +1456,8 @@ TEST_CASE("element access 2")
 
                 SECTION("number (floating-point)")
                 {
-                    json j_nonobject(json::value_t::number_float);
-                    const json j_nonobject_const(json::value_t::number_float);
+                    Json j_nonobject(Json::value_t::number_float);
+                    const Json j_nonobject_const(Json::value_t::number_float);
                     CHECK(j_nonobject.contains("foo") == false);
                     CHECK(j_nonobject_const.contains("foo") == false);
 #ifdef JSON_HAS_CPP_17
@@ -1460,12 +1471,12 @@ TEST_CASE("element access 2")
 }
 
 #if !defined(JSON_NOEXCEPTION)
-TEST_CASE("element access 2 (throwing tests)")
+TEST_CASE_TEMPLATE("element access 2 (throwing tests)", Json, nlohmann::json, nlohmann::ordered_json)
 {
     SECTION("object")
     {
-        json j = {{"integer", 1}, {"unsigned", 1u}, {"floating", 42.23}, {"null", nullptr}, {"string", "hello world"}, {"boolean", true}, {"object", json::object()}, {"array", {1, 2, 3}}};
-        const json j_const = {{"integer", 1}, {"unsigned", 1u}, {"floating", 42.23}, {"null", nullptr}, {"string", "hello world"}, {"boolean", true}, {"object", json::object()}, {"array", {1, 2, 3}}};
+        Json j = {{"integer", 1}, {"unsigned", 1u}, {"floating", 42.23}, {"null", nullptr}, {"string", "hello world"}, {"boolean", true}, {"object", Json::object()}, {"array", {1, 2, 3}}};
+        const Json j_const = {{"integer", 1}, {"unsigned", 1u}, {"floating", 42.23}, {"null", nullptr}, {"string", "hello world"}, {"boolean", true}, {"object", Json::object()}, {"array", {1, 2, 3}}};
 
         SECTION("access specified element with default value")
         {
@@ -1478,16 +1489,16 @@ TEST_CASE("element access 2 (throwing tests)")
                     CHECK(j.value("/not/existing"_json_pointer, false) == false);
                     CHECK(j.value("/not/existing"_json_pointer, "bar") == "bar");
                     CHECK(j.value("/not/existing"_json_pointer, 12.34) == Approx(12.34));
-                    CHECK(j.value("/not/existing"_json_pointer, json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
-                    CHECK(j.value("/not/existing"_json_pointer, json({10, 100})) == json({10, 100}));
+                    CHECK(j.value("/not/existing"_json_pointer, Json({{"foo", "bar"}})) == Json({{"foo", "bar"}}));
+                    CHECK(j.value("/not/existing"_json_pointer, Json({10, 100})) == Json({10, 100}));
 
                     CHECK(j_const.value("/not/existing"_json_pointer, 2) == 2);
                     CHECK(j_const.value("/not/existing"_json_pointer, 2u) == 2u);
                     CHECK(j_const.value("/not/existing"_json_pointer, false) == false);
                     CHECK(j_const.value("/not/existing"_json_pointer, "bar") == "bar");
                     CHECK(j_const.value("/not/existing"_json_pointer, 12.34) == Approx(12.34));
-                    CHECK(j_const.value("/not/existing"_json_pointer, json({{"foo", "bar"}})) == json({{"foo", "bar"}}));
-                    CHECK(j_const.value("/not/existing"_json_pointer, json({10, 100})) == json({10, 100}));
+                    CHECK(j_const.value("/not/existing"_json_pointer, Json({{"foo", "bar"}})) == Json({{"foo", "bar"}}));
+                    CHECK(j_const.value("/not/existing"_json_pointer, Json({10, 100})) == Json({10, 100}));
                 }
             }
         }


### PR DESCRIPTION
Add the overloads we missed in the `string_view` PR to `ordered_map`.

The type trait `is_usable_as_key_type` (introduced in the `string_view` PR) was refactored into `is_usable_as_basic_json_key_type` (equivalent to `is_usable_as_key_type` before the PR), and `is_usable_as_key_type`, which now accepts a comparator and key type directly. No functional change is intended.

Extending the element_access2 unit test to also cover `ordered_json` revealed a bug in `ordered_map` that is also fixed by this patch.

Fixes #3558.