### PR TITLE
Optimize output vector adapter write

### DIFF
--- a/include/nlohmann/detail/output/output_adapters.hpp
+++ b/include/nlohmann/detail/output/output_adapters.hpp
@@ -53,7 +53,7 @@ class output_vector_adapter : public output_adapter_protocol<CharType>
     JSON_HEDLEY_NON_NULL(2)
     void write_characters(const CharType* s, std::size_t length) override
     {
-        std::copy(s, s + length, std::back_inserter(v));
+        v.insert(v.end(), s, s + length);
     }
 
   private:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -14247,7 +14247,7 @@ class output_vector_adapter : public output_adapter_protocol<CharType>
     JSON_HEDLEY_NON_NULL(2)
     void write_characters(const CharType* s, std::size_t length) override
     {
-        std::copy(s, s + length, std::back_inserter(v));
+        v.insert(v.end(), s, s + length);
     }
 
   private:


### PR DESCRIPTION
The first commit of this pull request adds a benchmark for the CBOR serialization in order to compare the change introduced by the second commit of the pull request.

In the `output_vector_adapter` class, replace the usage of `std::copy` + `std::back_inserter` by the method `std::vector::insert`.
The `std::back_inserter` generates a lot of calls to `std::vector::push_back` which allocate the memory on the fly.
For big datasets, usually binary data, the overhead is important.
Resizing the vector in a first step and then copying the data helps a lot.
But from [my benchmarks](https://quick-bench.com/#eyJ0ZXh0IjoiI2luY2x1ZGUgPGJlbmNobWFyay9iZW5jaG1hcmsuaD5cbiNpbmNsdWRlIDx2ZWN0b3I+XG4jaW5jbHVkZSA8YWxnb3JpdGhtPlxuI2luY2x1ZGUgPG51bWVyaWM+XG4jaW5jbHVkZSA8Y3N0cmluZz5cblxuY29uc3Qgc2l6ZV90IElOX1NJWkU9MTAwMDAwMDtcblxuc3RhdGljIHN0ZDo6dmVjdG9yPHVpbnQ4X3Q+IGNyZWF0ZVZlY3RvcihzaXplX3Qgc2l6ZSlcbntcbiAgc3RkOjp2ZWN0b3I8dWludDhfdD4gaW5wdXQoc2l6ZSk7XG4gIHN0ZDo6aW90YShpbnB1dC5iZWdpbigpLCBpbnB1dC5lbmQoKSwgMCk7XG4gIHJldHVybiBpbnB1dDtcbn1cblxuc3RhdGljIHZvaWQgQ29weUJhY2tJbnNlcnRlcihiZW5jaG1hcms6OlN0YXRlJiBzdGF0ZSkge1xuICBjb25zdCBhdXRvIGlucHV0ID0gY3JlYXRlVmVjdG9yKElOX1NJWkUpO1xuXG4gIGNvbnN0IGF1dG8gaW5wdXQyID0gY3JlYXRlVmVjdG9yKDIqSU5fU0laRSk7XG5cbiAgZm9yIChhdXRvIF8gOiBzdGF0ZSkge1xuICAgIHN0ZDo6dmVjdG9yPHVpbnQ4X3Q+IG91dCA9IGlucHV0MjtcbiAgICBzdGQ6OmNvcHkoaW5wdXQuZGF0YSgpLCBpbnB1dC5kYXRhKCkgKyBpbnB1dC5zaXplKCksIHN0ZDo6YmFja19pbnNlcnRlcihvdXQpKTtcbiAgICBiZW5jaG1hcms6OkRvTm90T3B0aW1pemUob3V0KTtcbiAgfVxufVxuQkVOQ0hNQVJLKENvcHlCYWNrSW5zZXJ0ZXIpO1xuXG5zdGF0aWMgdm9pZCBDb3B5QmFja0luc2VydGVyUmVzZXJ2ZShiZW5jaG1hcms6OlN0YXRlJiBzdGF0ZSkge1xuICBjb25zdCBhdXRvIGlucHV0ID0gY3JlYXRlVmVjdG9yKElOX1NJWkUpO1xuXG4gIGNvbnN0IGF1dG8gaW5wdXQyID0gY3JlYXRlVmVjdG9yKDIqSU5fU0laRSk7XG5cbiAgZm9yIChhdXRvIF8gOiBzdGF0ZSkge1xuICAgIHN0ZDo6dmVjdG9yPHVpbnQ4X3Q+IG91dCA9IGlucHV0MjtcbiAgICBvdXQucmVzZXJ2ZShpbnB1dC5zaXplKCkpO1xuICAgIHN0ZDo6Y29weShpbnB1dC5kYXRhKCksIGlucHV0LmRhdGEoKSArIGlucHV0LnNpemUoKSwgc3RkOjpiYWNrX2luc2VydGVyKG91dCkpO1xuICAgIGJlbmNobWFyazo6RG9Ob3RPcHRpbWl6ZShvdXQpO1xuICB9XG59XG5CRU5DSE1BUksoQ29weUJhY2tJbnNlcnRlclJlc2VydmUpO1xuXG5zdGF0aWMgdm9pZCBJbnNlcnQoYmVuY2htYXJrOjpTdGF0ZSYgc3RhdGUpIHtcbiAgY29uc3QgYXV0byBpbnB1dCA9IGNyZWF0ZVZlY3RvcihJTl9TSVpFKTtcblxuICBjb25zdCBhdXRvIGlucHV0MiA9IGNyZWF0ZVZlY3RvcigyKklOX1NJWkUpO1xuXG4gIGZvciAoYXV0byBfIDogc3RhdGUpIHtcbiAgICBzdGQ6OnZlY3Rvcjx1aW50OF90PiBvdXQgPSBpbnB1dDI7XG4gICAgb3V0Lmluc2VydChvdXQuZW5kKCksIGlucHV0LmRhdGEoKSwgaW5wdXQuZGF0YSgpICsgaW5wdXQuc2l6ZSgpKTtcbiAgICBiZW5jaG1hcms6OkRvTm90T3B0aW1pemUob3V0KTtcbiAgfVxufVxuQkVOQ0hNQVJLKEluc2VydCk7XG5cbnN0YXRpYyB2b2lkIFJlc2l6ZUNvcHkoYmVuY2htYXJrOjpTdGF0ZSYgc3RhdGUpIHtcbiAgY29uc3QgYXV0byBpbnB1dCA9IGNyZWF0ZVZlY3RvcihJTl9TSVpFKTtcblxuICBjb25zdCBhdXRvIGlucHV0MiA9IGNyZWF0ZVZlY3RvcigyKklOX1NJWkUpO1xuXG4gIGZvciAoYXV0byBfIDogc3RhdGUpIHtcbiAgICBzdGQ6OnZlY3Rvcjx1aW50OF90PiBvdXQgPSBpbnB1dDI7XG4gICAgY29uc3QgYXV0byBpbml0U2l6ZSA9IG91dC5zaXplKCk7XG4gICAgb3V0LnJlc2l6ZShpbml0U2l6ZSArIGlucHV0LnNpemUoKSk7XG4gICAgc3RkOjpjb3B5KGlucHV0LmRhdGEoKSwgaW5wdXQuZGF0YSgpICsgaW5wdXQuc2l6ZSgpLCBvdXQuZGF0YSgpICsgaW5pdFNpemUpO1xuICAgIGJlbmNobWFyazo6RG9Ob3RPcHRpbWl6ZShvdXQpO1xuICB9XG59XG5CRU5DSE1BUksoUmVzaXplQ29weSk7XG5cbnN0YXRpYyB2b2lkIFJlc2l6ZU1lbWNweShiZW5jaG1hcms6OlN0YXRlJiBzdGF0ZSkge1xuICBjb25zdCBhdXRvIGlucHV0ID0gY3JlYXRlVmVjdG9yKElOX1NJWkUpO1xuXG4gIGNvbnN0IGF1dG8gaW5wdXQyID0gY3JlYXRlVmVjdG9yKDIqSU5fU0laRSk7XG5cbiAgZm9yIChhdXRvIF8gOiBzdGF0ZSkge1xuICAgIHN0ZDo6dmVjdG9yPHVpbnQ4X3Q+IG91dCA9IGlucHV0MjtcbiAgICBjb25zdCBhdXRvIGluaXRTaXplID0gb3V0LnNpemUoKTtcbiAgICBvdXQucmVzaXplKGluaXRTaXplICsgaW5wdXQuc2l6ZSgpKTtcbiAgICBzdGQ6Om1lbWNweShvdXQuZGF0YSgpICsgaW5pdFNpemUsIGlucHV0LmRhdGEoKSwgaW5wdXQuc2l6ZSgpKTtcbiAgICBiZW5jaG1hcms6OkRvTm90T3B0aW1pemUob3V0KTtcbiAgfVxufVxuQkVOQ0hNQVJLKFJlc2l6ZU1lbWNweSk7XG5CRU5DSE1BUktfTUFJTigpOyIsImNvbXBpbGVyIjoiY2xhbmctMTMuMCIsIm9wdGltIjoiMyIsImNwcFZlcnNpb24iOiIyMCJ9), it appears that using the method `.insert()` on a vector is almost as performant and shorter to write.

I have added a benchmark similar to the `.dump()` for JSON but using `json::to_cbor()` but the performance change is not significant.
But because the application in which I have noticed a bottleneck in the use of `std::vector::push_back()` was serializaing a lot of binary data to cbor, I have added a benchmark serializing vectors of bytes. For this case, the change proposed is significant.

Original:
```
2022-07-04T14:43:24+02:00
Running ./json_benchmarks
Run on (8 X 3603.48 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 0.43, 0.72, 0.85
-----------------------------------------------------------------------------
Benchmark                   Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------
BinaryToCbor/8            239 ns          239 ns      2949279 bytes_per_second=107.695M/s
BinaryToCbor/16           264 ns          264 ns      2701934 bytes_per_second=126.646M/s
BinaryToCbor/32           289 ns          289 ns      2419848 bytes_per_second=171.441M/s
BinaryToCbor/64           368 ns          368 ns      1915804 bytes_per_second=217.621M/s
BinaryToCbor/128          502 ns          502 ns      1000000 bytes_per_second=281.356M/s
BinaryToCbor/256          773 ns          773 ns       901424 bytes_per_second=341.569M/s
BinaryToCbor/512         1285 ns         1285 ns       546804 bytes_per_second=395.719M/s
BinaryToCbor/1024        2358 ns         2358 ns       302891 bytes_per_second=422.628M/s
BinaryToCbor/2048        4328 ns         4328 ns       162237 bytes_per_second=455.93M/s
BinaryToCbor/4096        8252 ns         8252 ns        84487 bytes_per_second=475.822M/s
BinaryToCbor/8192       15994 ns        15993 ns        43813 bytes_per_second=489.738M/s
BinaryToCbor/16384      31647 ns        31645 ns        22234 bytes_per_second=494.39M/s
BinaryToCbor/32768      63097 ns        63095 ns        11096 bytes_per_second=495.604M/s
```

New version with `std::vector::insert()`:
```
2022-07-04T14:42:37+02:00
Running ./json_benchmarks
Run on (8 X 3786.38 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 0.34, 0.76, 0.86
-----------------------------------------------------------------------------
Benchmark                   Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------
BinaryToCbor/8            232 ns          232 ns      3067496 bytes_per_second=111.04M/s
BinaryToCbor/16           229 ns          229 ns      3011982 bytes_per_second=145.559M/s
BinaryToCbor/32           230 ns          230 ns      3022206 bytes_per_second=215.89M/s
BinaryToCbor/64           231 ns          231 ns      3037105 bytes_per_second=346.82M/s
BinaryToCbor/128          235 ns          235 ns      2979490 bytes_per_second=601.678M/s
BinaryToCbor/256          236 ns          236 ns      2935424 bytes_per_second=1118.63M/s
BinaryToCbor/512          259 ns          259 ns      2712207 bytes_per_second=1.91596G/s
BinaryToCbor/1024         285 ns          285 ns      2489110 bytes_per_second=3.41833G/s
BinaryToCbor/2048         295 ns          295 ns      2364411 bytes_per_second=6.53373G/s
BinaryToCbor/4096         366 ns          366 ns      1925247 bytes_per_second=10.4859G/s
BinaryToCbor/8192         531 ns          531 ns      1319473 bytes_per_second=14.3938G/s
BinaryToCbor/16384       1042 ns         1042 ns       672042 bytes_per_second=14.6641G/s
BinaryToCbor/32768       1853 ns         1853 ns       380673 bytes_per_second=16.4827G/s
```

If you prefer an implementation with `std::vector::resize()` + `std::memcpy()` or `std::copy()`, the performance is equivalent.
