### PR TITLE
Allow custom number types to be used

### DIFF
--- a/docs/mkdocs/docs/features/types/number_handling.md
+++ b/docs/mkdocs/docs/features/types/number_handling.md
@@ -311,6 +311,9 @@ The number types can be changed with template parameters.
       in case of overflow.
     - The type for unsigned integers must be convertible from `#!c unsigned long long`.  The type for floating-point
       numbers is used in case of overflow.
+    - Custom `struct`s and `class`es are supported for signed and unsigned integers, providing they are trivially
+      default-constructible, move-constructible, and destructible. This enables extended- but not dynamic-length
+      integers.
     - The types for signed and unsigned integers must be distinct, see
       [#2573](https://github.com/nlohmann/json/issues/2573).
     - Only `#!c double`, `#!c float`, and `#!c long double` are supported for floating-point numbers.

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -50,7 +50,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,
-           enable_if_t < std::is_arithmetic<ArithmeticType>::value&&
+           enable_if_t < std::numeric_limits<ArithmeticType>::is_specialized&&
                          !std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
                          int > = 0 >
 void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1250,7 +1250,7 @@ scan_number_done:
             if (errno == 0)
             {
                 value_unsigned = static_cast<number_unsigned_t>(x);
-                if (value_unsigned == x)
+                if (static_cast<typeof(x)>(value_unsigned) == x)
                 {
                     return token_type::value_unsigned;
                 }
@@ -1266,7 +1266,7 @@ scan_number_done:
             if (errno == 0)
             {
                 value_integer = static_cast<number_integer_t>(x);
-                if (value_integer == x)
+                if (static_cast<typeof(x)>(value_integer) == x)
                 {
                     return token_type::value_integer;
                 }

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1250,7 +1250,7 @@ scan_number_done:
             if (errno == 0)
             {
                 value_unsigned = static_cast<number_unsigned_t>(x);
-                if (static_cast<typeof(x)>(value_unsigned) == x)
+                if (static_cast<decltype(x)>(value_unsigned) == x)
                 {
                     return token_type::value_unsigned;
                 }
@@ -1266,7 +1266,7 @@ scan_number_done:
             if (errno == 0)
             {
                 value_integer = static_cast<number_integer_t>(x);
-                if (static_cast<typeof(x)>(value_integer) == x)
+                if (static_cast<decltype(x)>(value_integer) == x)
                 {
                     return token_type::value_integer;
                 }

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -432,8 +432,8 @@ struct is_compatible_integer_type_impl : std::false_type {};
 template<typename RealIntegerType, typename CompatibleNumberIntegerType>
 struct is_compatible_integer_type_impl <
     RealIntegerType, CompatibleNumberIntegerType,
-    enable_if_t < std::is_integral<RealIntegerType>::value&&
-    std::is_integral<CompatibleNumberIntegerType>::value&&
+    enable_if_t < std::numeric_limits<RealIntegerType>::is_integer&&
+    std::numeric_limits<CompatibleNumberIntegerType>::is_integer&&
     !std::is_same<bool, CompatibleNumberIntegerType>::value >>
 {
     // is there an assert somewhere on overflows?

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -678,7 +678,7 @@ class serializer
     template <typename NumberType, enable_if_t<std::numeric_limits<NumberType>::is_signed, int> = 0>
     bool is_negative_number(NumberType x)
     {
-        return x < NumberType(0);
+        return x < 0;
     }
 
     template < typename NumberType, enable_if_t < !std::numeric_limits<NumberType>::is_signed, int > = 0 >
@@ -721,7 +721,7 @@ class serializer
         };
 
         // special case for "0"
-        if (x == NumberType(0))
+        if (x == 0)
         {
             o->write_character('0');
             return;
@@ -757,16 +757,15 @@ class serializer
 
         // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
         // See: https://www.youtube.com/watch?v=o4-CwDo2zpg
-        const NumberType hundred = 100;
-        while (abs_value >= hundred)
+        while (abs_value >= 100)
         {
-            const auto digits_index = static_cast<unsigned>((abs_value % hundred));
-            abs_value /= hundred;
+            const auto digits_index = static_cast<unsigned>((abs_value % 100));
+            abs_value /= 100;
             *(--buffer_ptr) = digits_to_99[digits_index][1];
             *(--buffer_ptr) = digits_to_99[digits_index][0];
         }
 
-        if (abs_value >= NumberType(10))
+        if (abs_value >= 10)
         {
             const auto digits_index = static_cast<unsigned>(abs_value);
             *(--buffer_ptr) = digits_to_99[digits_index][1];

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3627,8 +3627,8 @@ struct is_compatible_integer_type_impl : std::false_type {};
 template<typename RealIntegerType, typename CompatibleNumberIntegerType>
 struct is_compatible_integer_type_impl <
     RealIntegerType, CompatibleNumberIntegerType,
-    enable_if_t < std::is_integral<RealIntegerType>::value&&
-    std::is_integral<CompatibleNumberIntegerType>::value&&
+    enable_if_t < std::numeric_limits<RealIntegerType>::is_integer&&
+    std::numeric_limits<CompatibleNumberIntegerType>::is_integer&&
     !std::is_same<bool, CompatibleNumberIntegerType>::value >>
 {
     // is there an assert somewhere on overflows?
@@ -4302,7 +4302,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,
-           enable_if_t < std::is_arithmetic<ArithmeticType>::value&&
+           enable_if_t < std::numeric_limits<ArithmeticType>::is_specialized&&
                          !std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
                          int > = 0 >
 void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
@@ -8193,7 +8193,7 @@ scan_number_done:
             if (errno == 0)
             {
                 value_unsigned = static_cast<number_unsigned_t>(x);
-                if (value_unsigned == x)
+                if (static_cast<typeof(x)>(value_unsigned) == x)
                 {
                     return token_type::value_unsigned;
                 }
@@ -8209,7 +8209,7 @@ scan_number_done:
             if (errno == 0)
             {
                 value_integer = static_cast<number_integer_t>(x);
-                if (value_integer == x)
+                if (static_cast<typeof(x)>(value_integer) == x)
                 {
                     return token_type::value_integer;
                 }
@@ -17948,13 +17948,13 @@ class serializer
     }
 
     // templates to avoid warnings about useless casts
-    template <typename NumberType, enable_if_t<std::is_signed<NumberType>::value, int> = 0>
+    template <typename NumberType, enable_if_t<std::numeric_limits<NumberType>::is_signed, int> = 0>
     bool is_negative_number(NumberType x)
     {
-        return x < 0;
+        return x < NumberType(0);
     }
 
-    template < typename NumberType, enable_if_t <std::is_unsigned<NumberType>::value, int > = 0 >
+    template < typename NumberType, enable_if_t < !std::numeric_limits<NumberType>::is_signed, int > = 0 >
     bool is_negative_number(NumberType /*unused*/)
     {
         return false;
@@ -17970,7 +17970,7 @@ class serializer
     @tparam NumberType either @a number_integer_t or @a number_unsigned_t
     */
     template < typename NumberType, detail::enable_if_t <
-                   std::is_integral<NumberType>::value ||
+                   std::numeric_limits<NumberType>::is_integer ||
                    std::is_same<NumberType, number_unsigned_t>::value ||
                    std::is_same<NumberType, number_integer_t>::value ||
                    std::is_same<NumberType, binary_char_t>::value,
@@ -17994,7 +17994,7 @@ class serializer
         };
 
         // special case for "0"
-        if (x == 0)
+        if (x == NumberType(0))
         {
             o->write_character('0');
             return;
@@ -18030,15 +18030,16 @@ class serializer
 
         // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
         // See: https://www.youtube.com/watch?v=o4-CwDo2zpg
-        while (abs_value >= 100)
+        const NumberType hundred = 100;
+        while (abs_value >= hundred)
         {
-            const auto digits_index = static_cast<unsigned>((abs_value % 100));
-            abs_value /= 100;
+            const auto digits_index = static_cast<unsigned>((abs_value % hundred));
+            abs_value /= hundred;
             *(--buffer_ptr) = digits_to_99[digits_index][1];
             *(--buffer_ptr) = digits_to_99[digits_index][0];
         }
 
-        if (abs_value >= 10)
+        if (abs_value >= NumberType(10))
         {
             const auto digits_index = static_cast<unsigned>(abs_value);
             *(--buffer_ptr) = digits_to_99[digits_index][1];

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -48,7 +48,7 @@ class wrapped_int
     // allow implicit conversions from any builtin types that `T` allows conversions from
     template<typename T2,
              typename = typename std::enable_if<std::is_convertible<T2, T>::value && std::is_arithmetic<T2>::value>::type>
-    wrapped_int(T2 val) : m_val(val) {}
+    wrapped_int(T2 val) : m_val(static_cast<T>(val)) {}
 
     bool operator==(const wrapped_int& other) const
     {

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -43,7 +43,7 @@ class wrapped_int
         return val;
     }
     wrapped_int() = default;
-    wrapped_int(T val) : val(val) {}
+    /* implicit */ wrapped_int(T val) : val(val) {}
 
     bool operator==(const wrapped_int& other) const
     {
@@ -59,37 +59,29 @@ class wrapped_int
     }
     bool operator%(const wrapped_int& other) const
     {
-        return static_cast<T>(*this) % static_cast<T>(other.val);
+        return static_cast<T>(*this) % static_cast<T>(other);
     }
     wrapped_int& operator/=(const wrapped_int& other)
     {
-        if (val != nullptr)
-        {
-            *val /= static_cast<T>(other.val);
-        }
+        val /= static_cast<T>(other);
         return *this;
     }
     bool operator<(const wrapped_int& other) const
     {
-        return static_cast<T>(*this) <  static_cast<T>(other.val);
+        return static_cast<T>(*this) < static_cast<T>(other);
     }
     bool operator<=(const wrapped_int& other) const
     {
-        return static_cast<T>(*this) <=  static_cast<T>(other.val);
-    }
-
-    friend void swap(wrapped_int& self, wrapped_int& other)
-    {
-        swap(self.val, other.val);
+        return static_cast<T>(*this) <= static_cast<T>(other);
     }
 };
 
 template<typename T> class std::numeric_limits<wrapped_int<T>>
 {
   public:
+    static constexpr bool is_specialized = std::numeric_limits<T>::is_specialized;
     static constexpr bool is_signed = std::numeric_limits<T>::is_signed;
     static constexpr bool is_integer = std::numeric_limits<T>::is_integer;
-    static constexpr bool is_specialized = std::numeric_limits<T>::is_specialized;
 };
 
 TEST_CASE("custom integer types")

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -47,7 +47,7 @@ class wrapped_int
 
     // allow implicit conversions from anything that `T` allows conversions from
     template<typename T2, typename = typename std::enable_if<std::is_convertible<T2, T>::value>::type>
-    wrapped_int(T2 val) : val(val) {}
+    wrapped_int(T2 val) : m_val(val) {}
 
     bool operator==(const wrapped_int& other) const
     {

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -97,6 +97,6 @@ TEST_CASE("custom integer types")
     my_json as_json = my_json::parse(data.begin(), data.end());
     wrapped_int<std::uint64_t> i1 = as_json[1];
     wrapped_int<std::int64_t> i2 = as_json[2];
-    CHECK(i1 == wrapped_int<std::uint64_t>(2));
+    CHECK(i1 == wrapped_int<std::uint64_t>(2u));
     CHECK(i2 == wrapped_int<std::int64_t>(-3));
 }

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -45,8 +45,9 @@ class wrapped_int
     wrapped_int() = default;
     explicit wrapped_int(T val) : m_val(val) {}
 
-    // allow implicit conversions from anything that `T` allows conversions from
-    template<typename T2, typename = typename std::enable_if<std::is_convertible<T2, T>::value>::type>
+    // allow implicit conversions from any builtin types that `T` allows conversions from
+    template<typename T2,
+             typename = typename std::enable_if<std::is_convertible<T2, T>::value && std::is_arithmetic<T2>::value>::type>
     wrapped_int(T2 val) : m_val(val) {}
 
     bool operator==(const wrapped_int& other) const
@@ -67,7 +68,7 @@ class wrapped_int
     }
     wrapped_int& operator/=(const wrapped_int& other)
     {
-        val /= static_cast<T>(other);
+        m_val /= static_cast<T>(other);
         return *this;
     }
     bool operator<(const wrapped_int& other) const

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -1,0 +1,106 @@
+/*
+    __ _____ _____ _____
+ __|  |   __|     |   | |  JSON for Modern C++ (test suite)
+|  |  |__   |  |  | | | |  version 3.10.5
+|_____|_____|_____|_|___|  https://github.com/nlohmann/json
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+SPDX-License-Identifier: MIT
+Copyright (c) 2013-2022 Niels Lohmann <http://nlohmann.me>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "doctest_compatibility.h"
+
+#include <nlohmann/json.hpp>
+using nlohmann::json;
+
+/// A wrapped integer
+template<typename T>
+class wrapped_int
+{
+  public:
+    T val;
+    operator T() const
+    {
+        return val;
+    }
+    wrapped_int() = default;
+    wrapped_int(T val) : val(val) {}
+
+    bool operator==(const wrapped_int& other) const
+    {
+        return static_cast<T>(*this) == static_cast<T>(other);
+    }
+    bool operator<(const int& other) const
+    {
+        return static_cast<T>(*this) < other;
+    }
+    wrapped_int operator+(const wrapped_int& other) const
+    {
+        return static_cast<T>(*this) + static_cast<T>(other);
+    }
+    bool operator%(const wrapped_int& other) const
+    {
+        return static_cast<T>(*this) % static_cast<T>(other.val);
+    }
+    wrapped_int& operator/=(const wrapped_int& other)
+    {
+        if (val != nullptr)
+        {
+            *val /= static_cast<T>(other.val);
+        }
+        return *this;
+    }
+    bool operator<(const wrapped_int& other) const
+    {
+        return static_cast<T>(*this) <  static_cast<T>(other.val);
+    }
+    bool operator<=(const wrapped_int& other) const
+    {
+        return static_cast<T>(*this) <=  static_cast<T>(other.val);
+    }
+
+    friend void swap(wrapped_int& self, wrapped_int& other)
+    {
+        swap(self.val, other.val);
+    }
+};
+
+template<typename T> class std::numeric_limits<wrapped_int<T>>
+{
+  public:
+    static constexpr bool is_signed = std::numeric_limits<T>::is_signed;
+    static constexpr bool is_integer = std::numeric_limits<T>::is_integer;
+    static constexpr bool is_specialized = std::numeric_limits<T>::is_specialized;
+};
+
+TEST_CASE("custom integer types")
+{
+    using json = nlohmann::basic_json <
+                 std::map, std::vector, std::string, bool,
+                 wrapped_int<std::int64_t>, wrapped_int<std::uint64_t>, double, std::allocator >;
+    std::string data = "[1,2,-3,-4]";
+    json as_json = json::parse(data.begin(), data.end());
+    wrapped_int<std::uint64_t> i1 = as_json[1];
+    wrapped_int<std::int64_t> i2 = as_json[2];
+    CHECK(i1 == wrapped_int<std::uint64_t>(2));
+    CHECK(i2 == wrapped_int<std::int64_t>(-3));
+}

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -36,14 +36,14 @@ using nlohmann::json;
 template<typename T>
 class wrapped_int
 {
+    T m_val;
   public:
-    T val;
     operator T() const
     {
-        return val;
+        return m_val;
     }
     wrapped_int() = default;
-    explicit wrapped_int(T val) : val(val) {}
+    explicit wrapped_int(T val) : m_val(val) {}
 
     // allow implicit conversions from anything that `T` allows conversions from
     template<typename T2, typename = typename std::enable_if<std::is_convertible<T2, T>::value>::type>

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -43,7 +43,11 @@ class wrapped_int
         return val;
     }
     wrapped_int() = default;
-    /* implicit */ wrapped_int(T val) : val(val) {}
+    explicit wrapped_int(T val) : val(val) {}
+
+    // allow implicit conversions from anything that `T` allows conversions from
+    template<typename T2, typename = typename std::enable_if<std::is_convertible<T2, T>::value>::type>
+    wrapped_int(T2 val) : val(val) {}
 
     bool operator==(const wrapped_int& other) const
     {

--- a/tests/src/unit-custom-integer.cpp
+++ b/tests/src/unit-custom-integer.cpp
@@ -94,11 +94,11 @@ template<typename T> class std::numeric_limits<wrapped_int<T>>
 
 TEST_CASE("custom integer types")
 {
-    using json = nlohmann::basic_json <
-                 std::map, std::vector, std::string, bool,
-                 wrapped_int<std::int64_t>, wrapped_int<std::uint64_t>, double, std::allocator >;
+    using my_json = nlohmann::basic_json <
+                    std::map, std::vector, std::string, bool,
+                    wrapped_int<std::int64_t>, wrapped_int<std::uint64_t>, double, std::allocator >;
     std::string data = "[1,2,-3,-4]";
-    json as_json = json::parse(data.begin(), data.end());
+    my_json as_json = my_json::parse(data.begin(), data.end());
     wrapped_int<std::uint64_t> i1 = as_json[1];
     wrapped_int<std::int64_t> i2 = as_json[2];
     CHECK(i1 == wrapped_int<std::uint64_t>(2));


### PR DESCRIPTION
The `std::is_signed<T>`, `std::is_integral<T>` type traits do not permit custom types, and extending these is specified as undefined behavior.
Using `std::numeric_limits<T>::is_signed` and `std::numeric_limits<T>::is_integral` means that supporting custom types is doable.

This includes a test constructing a very simple integer wrapper type.

In a few places, we have to be a little more precise about what the casts mean.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
