### PR TITLE
Enable overriding test properties and set Unicode test timeouts

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,11 +80,16 @@ endif()
 # disable exceptions for test-disabled_exceptions
 json_test_set_test_options(test-disabled_exceptions COMPILE_DEFINITIONS JSON_NOEXCEPTION)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-json_test_set_test_options(test-disabled_exceptions COMPILE_OPTIONS -fno-exceptions)
+    json_test_set_test_options(test-disabled_exceptions COMPILE_OPTIONS -fno-exceptions)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # disabled due to https://github.com/nlohmann/json/discussions/2824
     #json_test_set_test_options(test-disabled_exceptions COMPILE_DEFINITIONS _HAS_EXCEPTIONS=0 COMPILE_OPTIONS /EH)
 endif()
+
+# set timeouts for Unicode tests
+json_test_set_test_options("test-unicode2;test-unicode3;test-unicode4;test-unicode5"
+    TEST_PROPERTIES "TIMEOUT_AFTER_MATCH;1500$<SEMICOLON>UTF-8 strings checked"
+)
 
 #############################################################################
 # add unit tests


### PR DESCRIPTION
* Add `TEST_PROPERTIES` to `json_test_set_test_options()` to enable overriding test properties similarly to overriding build settings (`COMPILE_DEFINITIONS`, etc.).
* Set timeouts for Unicode tests 2 to 5 by matching the output (`100000 of 1641521 UTF-8 strings checked`).

This should prevent timeouts in CI (as witnessed in recent weeks) and fix #3579.