### PR TITLE
add patch_inplace function

### DIFF
--- a/docs/examples/patch_inplace.cpp
+++ b/docs/examples/patch_inplace.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+int main()
+{
+    // the original document
+    json doc = R"(
+        {
+          "baz": "qux",
+          "foo": "bar"
+        }
+    )"_json;
+
+    // the patch
+    json patch = R"(
+        [
+          { "op": "replace", "path": "/baz", "value": "boo" },
+          { "op": "add", "path": "/hello", "value": ["world"] },
+          { "op": "remove", "path": "/foo"}
+        ]
+    )"_json;
+
+    // output original document
+    std::cout << "Before\n" << std::setw(4) << doc << std::endl;
+
+    // apply the patch
+    doc.patch_inplace(patch);
+
+    // output patched document
+    std::cout << "After\n" << std::setw(4) << doc << std::endl;
+}

--- a/docs/examples/patch_inplace.output
+++ b/docs/examples/patch_inplace.output
@@ -1,0 +1,13 @@
+Before
+{
+    "baz": "qux",
+    "foo": "bar"
+}
+
+After
+{
+    "baz": "boo",
+    "hello": [
+        "world"
+    ]
+}

--- a/docs/mkdocs/docs/api/basic_json/patch.md
+++ b/docs/mkdocs/docs/api/basic_json/patch.md
@@ -65,6 +65,7 @@ is thrown. In any case, the original value is not changed: the patch is applied 
 
 - [RFC 6902 (JSON Patch)](https://tools.ietf.org/html/rfc6902)
 - [RFC 6901 (JSON Pointer)](https://tools.ietf.org/html/rfc6901)
+- [patch_inplace](patch_inplace.md) applies a JSON Patch without creating a copy of the document
 - [merge_patch](merge_patch.md) applies a JSON Merge Patch
 
 ## Version history

--- a/docs/mkdocs/docs/api/basic_json/patch.md
+++ b/docs/mkdocs/docs/api/basic_json/patch.md
@@ -1,12 +1,19 @@
 # <small>nlohmann::basic_json::</small>patch
 
 ```cpp
+// (1)
 basic_json patch(const basic_json& json_patch) const;
+
+// (2)
+void patch_inplace(const basic_json& json_patch) const;
 ```
 
 [JSON Patch](http://jsonpatch.com) defines a JSON document structure for expressing a sequence of operations to apply to
 a JSON document. With this function, a JSON Patch is applied to the current JSON value by executing all operations from
 the patch.
+
+1. applies a JSON patch to a copy of the current object and returns the copy
+2. applies a JSON patch in place and returns void
 
 ## Parameters
 
@@ -15,11 +22,13 @@ the patch.
 
 ## Return value
 
-patched document
+1. patched document
+2. void
 
 ## Exception safety
 
-Strong guarantee: if an exception is thrown, there are no changes in the JSON value.
+1. Strong guarantee: if an exception is thrown, there are no changes in the JSON value.
+2. No guarantees, value may be corruted.
 
 ## Exceptions
 

--- a/docs/mkdocs/docs/api/basic_json/patch_inplace.md
+++ b/docs/mkdocs/docs/api/basic_json/patch_inplace.md
@@ -1,4 +1,4 @@
-# <small>nlohmann::basic_json::</small>patch
+# <small>nlohmann::basic_json::</small>patch_inplace
 
 ```cpp
 void patch_inplace(const basic_json& json_patch) const;
@@ -11,10 +11,6 @@ a JSON document. With this function, a JSON Patch is applied to the current JSON
 
 `json_patch` (in)
 :   JSON patch document
-
-## Return value
-
-void
 
 ## Exception safety
 
@@ -41,7 +37,7 @@ affected by the patch, the complexity can usually be neglected.
 
 ## Notes
 
-Unlike `patch`, `patch_inplace` applies the operation "in place" and no copy of the json document is created. That makes it faster for large documents by avoiding the copy. However, the value of the json document might be corrupted if the function throws an exception.
+Unlike [`patch`](patch.md), `patch_inplace` applies the operation "in place" and no copy of the JSON value is created. That makes it faster for large documents by avoiding the copy. However, the JSON value might be corrupted if the function throws an exception.
 
 ## Examples
 
@@ -63,4 +59,5 @@ Unlike `patch`, `patch_inplace` applies the operation "in place" and no copy of 
 
 - [RFC 6902 (JSON Patch)](https://tools.ietf.org/html/rfc6902)
 - [RFC 6901 (JSON Pointer)](https://tools.ietf.org/html/rfc6901)
+- [patch](patch.md) applies a JSON Merge Patch
 - [merge_patch](merge_patch.md) applies a JSON Merge Patch

--- a/docs/mkdocs/docs/api/basic_json/patch_inplace.md
+++ b/docs/mkdocs/docs/api/basic_json/patch_inplace.md
@@ -1,12 +1,11 @@
 # <small>nlohmann::basic_json::</small>patch
 
 ```cpp
-basic_json patch(const basic_json& json_patch) const;
+void patch_inplace(const basic_json& json_patch) const;
 ```
 
 [JSON Patch](http://jsonpatch.com) defines a JSON document structure for expressing a sequence of operations to apply to
-a JSON document. With this function, a JSON Patch is applied to the current JSON value by executing all operations from
-the patch.
+a JSON document. With this function, a JSON Patch is applied to the current JSON value by executing all operations from the patch. This function applies a JSON patch in place and returns void.
 
 ## Parameters
 
@@ -15,11 +14,11 @@ the patch.
 
 ## Return value
 
-patched document
+void
 
 ## Exception safety
 
-Strong guarantee: if an exception is thrown, there are no changes in the JSON value.
+No guarantees, value may be corrupted by an unsuccessful patch operation.
 
 ## Exceptions
 
@@ -42,8 +41,7 @@ affected by the patch, the complexity can usually be neglected.
 
 ## Notes
 
-The application of a patch is atomic: Either all operations succeed and the patched document is returned or an exception
-is thrown. In any case, the original value is not changed: the patch is applied to a copy of the value.
+Unlike `patch`, `patch_inplace` applies the operation "in place" and no copy of the json document is created. That makes it faster for large documents by avoiding the copy. However, the value of the json document might be corrupted if the function throws an exception.
 
 ## Examples
 
@@ -52,13 +50,13 @@ is thrown. In any case, the original value is not changed: the patch is applied 
     The following code shows how a JSON patch is applied to a value.
      
     ```cpp
-    --8<-- "examples/patch.cpp"
+    --8<-- "examples/patch_inplace.cpp"
     ```
     
     Output:
     
     ```json
-    --8<-- "examples/patch.output"
+    --8<-- "examples/patch_inplace.output"
     ```
 
 ## See also
@@ -66,7 +64,3 @@ is thrown. In any case, the original value is not changed: the patch is applied 
 - [RFC 6902 (JSON Patch)](https://tools.ietf.org/html/rfc6902)
 - [RFC 6901 (JSON Pointer)](https://tools.ietf.org/html/rfc6901)
 - [merge_patch](merge_patch.md) applies a JSON Merge Patch
-
-## Version history
-
-- Added in version 2.0.0.

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -4641,13 +4641,11 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @name JSON Patch functions
     /// @{
 
-    /// @brief applies a JSON patch
+    /// @brief applies a JSON patch in-place without copying the object
     /// @sa https://json.nlohmann.me/api/basic_json/patch/
-    basic_json patch(const basic_json& json_patch) const
+    void patch_inplace(const basic_json& json_patch)
     {
-        // make a working copy to apply the patch to
-        basic_json result = *this;
-
+        basic_json& result = *this;
         // the valid JSON Patch operations
         enum class patch_operations {add, remove, replace, move, copy, test, invalid};
 
@@ -4911,7 +4909,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 }
             }
         }
+    }
 
+    /// @brief applies a JSON patch to a copy of the current object
+    /// @sa https://json.nlohmann.me/api/basic_json/patch/
+    basic_json patch(const basic_json& json_patch) const
+    {
+        basic_json result = *this;
+        result.patch_inplace(json_patch);
         return result;
     }
 
@@ -5049,7 +5054,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         return result;
     }
-
     /// @}
 
     ////////////////////////////////

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -23158,13 +23158,11 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @name JSON Patch functions
     /// @{
 
-    /// @brief applies a JSON patch
+    /// @brief applies a JSON patch in-place without copying the object
     /// @sa https://json.nlohmann.me/api/basic_json/patch/
-    basic_json patch(const basic_json& json_patch) const
+    void patch_inplace(const basic_json& json_patch)
     {
-        // make a working copy to apply the patch to
-        basic_json result = *this;
-
+        basic_json& result = *this;
         // the valid JSON Patch operations
         enum class patch_operations {add, remove, replace, move, copy, test, invalid};
 
@@ -23428,7 +23426,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 }
             }
         }
+    }
 
+    /// @brief applies a JSON patch to a copy of the current object
+    /// @sa https://json.nlohmann.me/api/basic_json/patch/
+    basic_json patch(const basic_json& json_patch) const
+    {
+        basic_json result = *this;
+        result.patch_inplace(json_patch);
         return result;
     }
 
@@ -23566,7 +23571,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         return result;
     }
-
     /// @}
 
     ////////////////////////////////


### PR DESCRIPTION
I am trying to `patch` a >100Mb JSON file and it turns out that the copying / destruction of JSON objects takes quite long.

Not allocating a new JSON for each patch helps a lot in terms of speed (>100x improvement).

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
