### PR TITLE
Use 'concurrency' in GitHub workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ on:
     - cron: '0 19 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   xcode_1:
     runs-on: macos-10.15

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci_test_clang:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mingw:
     runs-on: windows-latest


### PR DESCRIPTION
Use concurrency in GitHub workflows to cancel in-progress or pending runs for the same ref.

This automatically cancels builds if a newer commit is pushed to a branch or pull request.

Documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency

<hr>

Similar settings exist for AppVeyor and Drone CI but cannot be enabled from the configuration file.

#### AppVeyor

AppVeyor calls this feature *Rolling builds*. It can be enabled in the general project settings:
![appveyor_rolling_builds](https://user-images.githubusercontent.com/320854/181048838-e10137a7-8e8b-40b9-9700-ae672a25c500.png)

#### Drone CI

Drone CI has 3 CLI settings that control this functionality:
```
drone repo update nlohmann/json --auto-cancel-pull-requests=true --auto-cancel-pushes=true --auto-cancel-running=true
```

https://docs.drone.io/cli/repo/drone-repo-update/