### PR TITLE
Fix Unicode test timeout (for real this time!)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,10 +86,8 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     #json_test_set_test_options(test-disabled_exceptions COMPILE_DEFINITIONS _HAS_EXCEPTIONS=0 COMPILE_OPTIONS /EH)
 endif()
 
-# set timeouts for Unicode tests
-json_test_set_test_options("test-unicode2;test-unicode3;test-unicode4;test-unicode5"
-    TEST_PROPERTIES "TIMEOUT_AFTER_MATCH;1500$<SEMICOLON>UTF-8 strings checked"
-)
+# raise timeout of expensive Unicode test
+json_test_set_test_options(test-unicode4 TEST_PROPERTIES TIMEOUT 3000)
 
 #############################################################################
 # add unit tests


### PR DESCRIPTION
The previous attempt didn't quite do the job because `TIMEOUT_AFTER_MATCH` doesn't work as expected. This sets the timeout of `test-unicode4` to twice the default (i.e., 3000s).

Fixes #3579.