### PR TITLE
Bump macos-10.5 runner to macos-11 and update Xcode versions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   xcode_1:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
-        xcode: [12.4, 12.3, 12.2, 12.1.1, 12.1, 12, 11.7, 11.6, 11.5, 11.4.1, 11.3.1, 11.2.1, 10.3]
+        xcode: ['11.7', '12.4', '12.5.1', '13.0']
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: [13.3.1, 13.3, 13.2.1, 13.2, 13.1]
+        xcode: ['13.1', '13.2.1', '13.3.1', '13.4.1']
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 

--- a/README.md
+++ b/README.md
@@ -1137,24 +1137,14 @@ The following compilers are currently used in continuous integration at [AppVeyo
 
 | Compiler                                                                                               | Operating System   | CI Provider    |
 |--------------------------------------------------------------------------------------------------------|--------------------|----------------|
-| Apple Clang 10.0.1 (clang-1001.0.46.4); Xcode 10.3                                                     | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.0 (clang-1100.0.33.12); Xcode 11.2.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.0 (clang-1100.0.33.17); Xcode 11.3.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.59); Xcode 11.4.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.62); Xcode 11.5                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.62); Xcode 11.6                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.62); Xcode 11.7                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.2); Xcode 12                                                       | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.21); Xcode 12.1                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.21); Xcode 12.1.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.27); Xcode 12.2                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.28); Xcode 12.3                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.29); Xcode 12.4                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 13.0.0 (clang-1300.0.29.3); Xcode 13.1                                                     | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.0.0 (clang-1300.0.29.30); Xcode 13.2                                                    | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.0.0 (clang-1300.0.29.30); Xcode 13.2.1                                                  | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.1.6 (clang-1316.0.21.2); Xcode 13.3                                                     | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.1.6 (clang-1316.0.21.2.3); Xcode 13.3.1                                                 | macOS 12.3.1       | GitHub Actions |
+| Apple Clang 11.0.3 (clang-1103.0.32.62);  Xcode 11.7                                                   | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 12.0.0 (clang-1200.0.32.29);  Xcode 12.4                                                   | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 12.0.5 (clang-1205.0.22.11);  Xcode 12.5.1                                                 | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 13.0.0 (clang-1300.0.29.3);   Xcode 13.0                                                   | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 13.0.0 (clang-1300.0.29.3);   Xcode 13.1                                                   | macOS 12.4         | GitHub Actions |
+| Apple Clang 13.0.0 (clang-1300.0.29.30);  Xcode 13.2.1                                                 | macOS 12.4         | GitHub Actions |
+| Apple Clang 13.1.6 (clang-1316.0.21.2.3); Xcode 13.3.1                                                 | macOS 12.4         | GitHub Actions |
+| Apple Clang 13.1.6 (clang-1316.0.21.2.5); Xcode 13.4.1                                                 | macOS 12.4         | GitHub Actions |
 | Clang 3.5.2 (3.5.2-3ubuntu1)                                                                           | Ubuntu 20.04.3 LTS | GitHub Actions |
 | Clang 3.6.2 (3.6.2-3ubuntu2)                                                                           | Ubuntu 20.04.3 LTS | GitHub Actions |
 | Clang 3.7.1 (3.7.1-2ubuntu2)                                                                           | Ubuntu 20.04.3 LTS | GitHub Actions |


### PR DESCRIPTION
Updated CI based on:
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
https://gist.github.com/yamaya/2924292#file-xcode-clang-vers

If we merge this **after** 3.11.0 we have one more release tested with older Xcode versions.

Fixes #3612.