### PR TITLE
Fix MinGW CI failures

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,10 +18,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: ${{ matrix.architecture }}
+      - name: Download MinGW 8.1.0
+        run: |
+          $headers = @{Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}'}
+          $uri = 'https://nuget.pkg.github.com/falbrechtskirchinger/download/mingw/8.1.0/mingw.8.1.0.nupkg'
+          Invoke-WebRequest -Uri $uri -Headers $headers -OutFile mingw.8.1.0.nupkg
+      - name: Uninstall MinGW
+        continue-on-error: true
+        run: choco uninstall mingw
+      # Based on egor-tensin/setup-mingw
+      - name: Install MinGW 8.1.0
+        run: |
+          choco install mingw.8.1.0.nupkg ${{ matrix.architecture == 'x86' && '--x86' || '' }}
+          $prefix = "${{ matrix.architecture == 'x64' && 'x86_64-w64-mingw32' || 'i686-w64-mingw32' }}"
+          $mingw = "${{ matrix.architecture == 'x64' && 'mingw64' || 'mingw32' }}"
+          $mingw_install = Join-Path C: ProgramData chocolatey lib mingw tools install
+          $mingw_root = Join-Path $mingw_install $mingw
+          $mingw_bin = Join-Path $mingw_root bin
+          $mingw_lib = Join-Path $mingw_root $prefix lib
+          echo $mingw_bin >> $env:GITHUB_PATH
+          Remove-Item (Join-Path $mingw_lib 'libpthread.dll.a')
+          Remove-Item (Join-Path $mingw_lib 'libwinpthread.dll.a')
+      #- name: Set up MinGW
+      #  uses: egor-tensin/setup-mingw@v2
+      #  with:
+      #    platform: ${{ matrix.architecture }}
       - name: cmake
         run: cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On
       - name: build


### PR DESCRIPTION
Attempt to workaround recent, frequent failures of the MinGW jobs by installing an internalized Chocolatey package hosted on GitHub.

NuGet package hosted here: https://github.com/falbrechtskirchinger/json/packages/1564692

<hr />

I've since figured out how to create and upload a package without using Chocolatey and NuGet.

1) Download the Chocolatey  NuGet package from here:
https://community.chocolatey.org/packages/mingw/8.1.0
(Gray download button at the bottom of the left sidebar.)
2) Unzip `mingw.8.1.0.nupkg`.
3) Open `tools/chocolateyinstall.ps1` in an editor.
4) Download the 2 URLs listed near the top and save the files to the `tools/` folder.
5) Replace the URLs with the local file names:
```ps1
$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

$packageName = 'mingw'
$url = "$toolsDir\i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z"
$checksum = 'adb84b70094c0225dd30187ff995e311d19424b1eb8f60934c60e4903297f946'
$url64 = "$toolsDir\x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z"
$checksum64 = '853970527b5de4a55ec8ca4d3fd732c00ae1c69974cc930c82604396d43e79f8'
```
(Don't forget the line defining `$toolsDir`.)
6) Zip the directory and rename it to `*.nupkg`. (Note that not all programs produce a ZIP file that Microsoft's implementation can read. I successfully used my command line `zip` tool from http://www.info-zip.org/.)
7) Upload to [nuget.org](https://www.nuget.org/).
8) The package can now be downloaded from here: https://www.nuget.org/api/v2/package/mingw/8.1.0

Optionally, it might be a good idea to change the package ID.
1) Open `mingw.nuspec`.
2) Change the `<id>` element value as desired, e.g. `nlohmann-json.mingw`.
3) I don't know if the `*.nuspec` file name has to match. Maybe rename it to the ID, to be safe.
