### PR TITLE
Update CI

### DIFF
--- a/.github/external_ci/appveyor.yml
+++ b/.github/external_ci/appveyor.yml
@@ -1,5 +1,19 @@
 version: '{build}'
 
+# only build PRs and commits to develop branch
+# (see https://help.appveyor.com/discussions/questions/55079-two-builds-per-commit-to-pull-request)
+branches:
+  only:
+    - develop
+
+only_commits:
+  files:
+    - .github/external_ci/appveyor.yml
+    - cmake/
+    - include/
+    - tests/
+    - CMakeLists.txt
+
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -75,9 +89,3 @@ test_script:
   # occasional timeouts on AppVeyor.
   # More info: https://github.com/nlohmann/json/pull/1570
   - if "%configuration%"=="Debug" ctest --exclude-regex "test-unicode" -C "%configuration%" --parallel 2 --output-on-failure
-
-# only build PRs and commits to develop branch
-# (see https://help.appveyor.com/discussions/questions/55079-two-builds-per-commit-to-pull-request)
-branches:
-  only:
-    - develop

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,38 +23,15 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can check out the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,10 +15,10 @@ concurrency:
 
 jobs:
   xcode_1:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
-        xcode: [12.4, 12.3, 12.2, 12.1.1, 12.1, 12, 11.7, 11.6, 11.5, 11.4.1, 11.3.1, 11.2.1, 10.3]
+        xcode: ['11.7', '12.4', '12.5.1', '13.0']
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: [13.3.1, 13.3, 13.2.1, 13.2, 13.1]
+        xcode: ['13.1', '13.2.1', '13.3.1', '13.4.1']
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -83,12 +83,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
-          path: /__w/json/json/build/html
+          path: ${{ github.workspace }}/build/html
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: /__w/json/json/build/json.info.filtered.noexcept
+          path-to-lcov: ${{ github.workspace }}/build/json.info.filtered.noexcept
 
   ci_test_compilers:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1143,24 +1143,14 @@ The following compilers are currently used in continuous integration at [AppVeyo
 
 | Compiler                                                                                               | Operating System   | CI Provider    |
 |--------------------------------------------------------------------------------------------------------|--------------------|----------------|
-| Apple Clang 10.0.1 (clang-1001.0.46.4); Xcode 10.3                                                     | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.0 (clang-1100.0.33.12); Xcode 11.2.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.0 (clang-1100.0.33.17); Xcode 11.3.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.59); Xcode 11.4.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.62); Xcode 11.5                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.62); Xcode 11.6                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 11.0.3 (clang-1103.0.32.62); Xcode 11.7                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.2); Xcode 12                                                       | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.21); Xcode 12.1                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.21); Xcode 12.1.1                                                  | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.27); Xcode 12.2                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.28); Xcode 12.3                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 12.0.0 (clang-1200.0.32.29); Xcode 12.4                                                    | macOS 10.15.7      | GitHub Actions |
-| Apple Clang 13.0.0 (clang-1300.0.29.3); Xcode 13.1                                                     | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.0.0 (clang-1300.0.29.30); Xcode 13.2                                                    | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.0.0 (clang-1300.0.29.30); Xcode 13.2.1                                                  | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.1.6 (clang-1316.0.21.2); Xcode 13.3                                                     | macOS 12.3.1       | GitHub Actions |
-| Apple Clang 13.1.6 (clang-1316.0.21.2.3); Xcode 13.3.1                                                 | macOS 12.3.1       | GitHub Actions |
+| Apple Clang 11.0.3 (clang-1103.0.32.62);  Xcode 11.7                                                   | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 12.0.0 (clang-1200.0.32.29);  Xcode 12.4                                                   | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 12.0.5 (clang-1205.0.22.11);  Xcode 12.5.1                                                 | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 13.0.0 (clang-1300.0.29.3);   Xcode 13.0                                                   | macOS 11.6.8       | GitHub Actions |
+| Apple Clang 13.0.0 (clang-1300.0.29.3);   Xcode 13.1                                                   | macOS 12.4         | GitHub Actions |
+| Apple Clang 13.0.0 (clang-1300.0.29.30);  Xcode 13.2.1                                                 | macOS 12.4         | GitHub Actions |
+| Apple Clang 13.1.6 (clang-1316.0.21.2.3); Xcode 13.3.1                                                 | macOS 12.4         | GitHub Actions |
+| Apple Clang 13.1.6 (clang-1316.0.21.2.5); Xcode 13.4.1                                                 | macOS 12.4         | GitHub Actions |
 | Clang 3.5.2 (3.5.2-3ubuntu1)                                                                           | Ubuntu 20.04.3 LTS | GitHub Actions |
 | Clang 3.6.2 (3.6.2-3ubuntu2)                                                                           | Ubuntu 20.04.3 LTS | GitHub Actions |
 | Clang 3.7.1 (3.7.1-2ubuntu2)                                                                           | Ubuntu 20.04.3 LTS | GitHub Actions |


### PR DESCRIPTION
* Bump macos-10.5 runner to macos-11 and update Xcode versions
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
https://gist.github.com/yamaya/2924292#file-xcode-clang-vers

* Fix CodeQL workflow warning:
  > 2 issues were detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results. Please make sure that every branch in on.pull_request is also in on.push so that Code Scanning can compare pull requests against the state of the base branch.

* Only start AppVeyor builds if a commit touches these paths:
  ```
  cmake/
  include/
  tests/
  CMakeLists.txt
  ```

Fixes #3612.