### PR TITLE
Add a unit test including windows.h

### DIFF
--- a/tests/src/unit-windows_h.cpp
+++ b/tests/src/unit-windows_h.cpp
@@ -1,0 +1,21 @@
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++ (supporting code)
+// |  |  |__   |  |  | | | |  version 3.10.5
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+#include "doctest_compatibility.h"
+
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
+#include <nlohmann/json.hpp>
+using nlohmann::json;
+
+TEST_CASE("include windows.h")
+{
+    CHECK(true);
+}


### PR DESCRIPTION
Add a unit test to catch issues when `<windows.h>` is included.

This is not handled by AppVeyor despite some code in `appveyor.yml` suggesting otherwise.