### PR TITLE
Publish documentation on push to develop branch

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -17,7 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: install PlantUML
+        run: sudo apt-get install -y plantuml
+      - name: install virtual environment
+        run: make install_venv -C docs/mkdocs
       - name: build documentation
-        run: make install_venv build -C docs/mkdocs
+        run: make build -C docs/mkdocs
       - name: publish documentation
         run: make publish -C docs/mkdocs

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -4,8 +4,7 @@ name: Publish documentation
 on:
   push:
     branches:
-      #- develop
-      - documentation_update
+      - develop
 
 # we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications
 concurrency:

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -40,4 +40,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: docset
-          path: docs/docset/JSON_for_Modern_C++.tgz
+          path: docs/docset/JSON_for_Modern_C++.docset

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install PlantUML
-        run: sudo apt-get update ; sudo apt-get install -y plantuml
+        run: sudo apt-get install -y plantuml ; which plantuml ; plantuml -version
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
       - name: Build documentation

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - documentation_update # TODO: remove before merging
 
 # we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications
 concurrency:
@@ -40,4 +39,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: docset
-          path: docs/docset/JSON_for_Modern_C++.docset
+          path: docs/docset/JSON_for_Modern_C++.tgz

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -1,0 +1,23 @@
+name: Publish documentation
+
+# publish the documentation on every merge to develop
+on:
+  push:
+    branches:
+      - develop
+      - documentation_update # TODO: remove before merging
+
+# we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications
+concurrency:
+  group: documentation
+  cancel-in-progress: false
+
+jobs:
+  publish_documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build documentation
+        run: make install_venv build -C docs/mkdocs
+      - name: publish documentation
+        run: make publish -C docs/mkdocs

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install PlantUML
-        run: sudo apt-get install -y plantuml
+        run: sudo apt-get update ; sudo apt-get install -y plantuml
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
       - name: Build documentation

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: install PlantUML
+      - name: Install PlantUML
         run: sudo apt-get install -y plantuml
-      - name: install virtual environment
+      - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
-      - name: build documentation
+      - name: Build documentation
         run: make build -C docs/mkdocs
-      - name: publish documentation
+      - name: Publish documentation
         run: make publish -C docs/mkdocs

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install PlantUML
-        run: sudo apt-get install -y plantuml ; which plantuml ; plantuml -version
+        run: sudo apt-get install -y plantuml ; which plantuml ; plantuml -version ; cat $(which plantuml)
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
       - name: Build documentation

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install PlantUML
         run: sudo apt-get install -y plantuml
       - name: Patch PlantUML
-        run: wget https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar ; mv plantuml-1.2022.6.jar /usr/share/plantuml/plantuml.jar ; plantuml -version
+        run: wget https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar ; sudo mv plantuml-1.2022.6.jar /usr/share/plantuml/plantuml.jar ; plantuml -version
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
       - name: Build documentation

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -1,6 +1,6 @@
 name: Publish documentation
 
-# publish the documentation on every merge to develop
+# publish the documentation on every merge to develop branch
 on:
   push:
     branches:
@@ -17,13 +17,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install PlantUML
-        run: sudo apt-get install -y plantuml
-      - name: Patch PlantUML
-        run: wget https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar ; sudo mv plantuml-1.2022.6.jar /usr/share/plantuml/plantuml.jar ; plantuml -version
+
+      # We need a recent PlantUML version to generate UML diagrams. The version from Ubuntu is outdated, so we
+      # need to replace the JAR file with a release from PlantUML's GitHub page.
+      - name: Install and update PlantUML
+        run: |
+          sudo apt-get install -y plantuml
+          wget https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar
+          sudo mv plantuml-1.2022.6.jar /usr/share/plantuml/plantuml.jar
+          plantuml -version
+
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
-      - name: Build documentation
-        run: make build -C docs/mkdocs
+
       - name: Publish documentation
         run: make publish -C docs/mkdocs
+
+      - name: Create docset
+        run: make -C docs/docset
+
+      - name: Archive docset
+        uses: actions/upload-artifact@v3
+        with:
+          name: docset
+          path: docs/docset/JSON_for_Modern_C++.tgz

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install PlantUML
-        run: sudo apt-get install -y plantuml ; which plantuml ; plantuml -version ; cat $(which plantuml)
+        run: sudo apt-get install -y plantuml
+      - name: Patch PlantUML
+        run: wget https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar ; mv plantuml-1.2022.6.jar /usr/share/plantuml/plantuml.jar ; plantuml -version
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs
       - name: Build documentation

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -31,12 +31,3 @@ jobs:
 
       - name: Publish documentation
         run: make publish -C docs/mkdocs
-
-      - name: Create docset
-        run: make -C docs/docset
-
-      - name: Archive docset
-        uses: actions/upload-artifact@v3
-        with:
-          name: docset
-          path: docs/docset/JSON_for_Modern_C++.tgz

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -4,7 +4,8 @@ name: Publish documentation
 on:
   push:
     branches:
-      - develop
+      #- develop
+      - documentation_update
 
 # we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications
 concurrency:
@@ -13,18 +14,12 @@ concurrency:
 
 jobs:
   publish_documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
-      # We need a recent PlantUML version to generate UML diagrams. The version from Ubuntu is outdated, so we
-      # need to replace the JAR file with a release from PlantUML's GitHub page.
       - name: Install and update PlantUML
-        run: |
-          sudo apt-get install -y plantuml
-          wget https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar
-          sudo mv plantuml-1.2022.6.jar /usr/share/plantuml/plantuml.jar
-          plantuml -version
+        run: sudo apt-get install -y plantuml
 
       - name: Install virtual environment
         run: make install_venv -C docs/mkdocs

--- a/docs/docset/Makefile
+++ b/docs/docset/Makefile
@@ -1,3 +1,4 @@
+SHELL=/usr/bin/env bash
 SED ?= $(shell which gsed 2>/dev/null || which sed)
 
 MKDOCS_PAGES=$(shell cd ../mkdocs/docs/ && find * -type f -name '*.md' | sort)

--- a/docs/mkdocs/requirements.txt
+++ b/docs/mkdocs/requirements.txt
@@ -30,7 +30,7 @@ mkdocs-simple-hooks==0.1.5
 nltk==3.7
 packaging==21.3
 plantuml==0.3.0
-plantuml-markdown==3.5.2
+plantuml-markdown==3.6.3
 Pygments==2.11.0
 pymdown-extensions==9.3
 pyparsing==3.0.8


### PR DESCRIPTION
## Changes

- add workflow to publish documentation on push to develop branch
- minor changes:
  - make sure bash is used in docset Makefile (not needed here, but calling the Makefile in GitHub actions yielded errors, because `/bin/sh` was used as default shell)
  - bump version of `plantuml-markdown` package

## Notes

The concurrency setting make sure that no two jobs of the workflow run concurrently. Jobs are waiting until previous jobs complete:

<img width="803" alt="Screen Shot 2022-08-03 at 10 11 27" src="https://user-images.githubusercontent.com/159488/182621335-c58dc266-33d2-4ac9-bbb3-eead2e08598c.png">
