### PR TITLE
Adjust naming of GitHub action jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,11 +24,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On -DJSON_FastTests=ON
-      - name: build
+      - name: Build
         run: cmake --build build --parallel 10
-      - name: test
+      - name: Test
         run: cd build ; ctest -j 10 --output-on-failure
 
   xcode_2:
@@ -41,11 +41,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On -DJSON_FastTests=ON
-      - name: build
+      - name: Build
         run: cmake --build build --parallel 10
-      - name: test
+      - name: Test
         run: cd build ; ctest -j 10 --output-on-failure
 
   xcode_standards:
@@ -58,9 +58,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On -DJSON_TestStandards=${{ matrix.standard }}
-      - name: build
+      - name: Build
         run: cmake --build build --parallel 10
-      - name: test
+      - name: Test
         run: cd build ; ctest -j 10 --output-on-failure

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,9 +19,9 @@ jobs:
     container: ghcr.io/nlohmann/json-ci:v2.4.0
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_clang
 
   ci_test_gcc:
@@ -29,9 +29,9 @@ jobs:
     container: ghcr.io/nlohmann/json-ci:v2.4.0
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_gcc
 
   ci_static_analysis:
@@ -42,9 +42,9 @@ jobs:
         target: [ci_clang_tidy, ci_cppcheck, ci_test_valgrind, ci_test_clang_sanitizer, ci_test_amalgamation, ci_clang_analyze, ci_cpplint, ci_cmake_flags, ci_single_binaries, ci_reproducible_tests, ci_non_git_tests, ci_offline_testdata, ci_infer]
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ${{ matrix.target }}
 
   ci_test_single_header:
@@ -52,9 +52,9 @@ jobs:
     container: ghcr.io/nlohmann/json-ci:v2.4.0
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_single_header
 
   ci_cmake_options:
@@ -65,9 +65,9 @@ jobs:
         target: [ci_test_diagnostics, ci_test_noexceptions, ci_test_noimplicitconversions, ci_test_legacycomparison, ci_test_noglobaludls]
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ${{ matrix.target }}
 
   ci_test_coverage:
@@ -75,16 +75,16 @@ jobs:
     container: ghcr.io/nlohmann/json-ci:v2.4.0
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_coverage
-      - name: archive coverage report
+      - name: Archive coverage report
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
           path: ${{ github.workspace }}/build/html
-      - name: Coveralls
+      - name: Publish report to Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,9 +98,9 @@ jobs:
         compiler: [g++-4.8, g++-4.9, g++-5, g++-6, g++-7, g++-8, g++-9, g++-10, g++-11, clang++-3.5, clang++-3.6, clang++-3.7, clang++-3.8, clang++-3.9, clang++-4.0, clang++-5.0, clang++-6.0, clang++-7, clang++-8, clang++-9, clang++-10, clang++-11, clang++-12, clang++-13, clang++-14]
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_compiler_${{ matrix.compiler }}
 
   ci_test_standards:
@@ -112,9 +112,9 @@ jobs:
         compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_${{ matrix.compiler }}_cxx${{ matrix.standard }}
 
   ci_cuda_example:
@@ -122,9 +122,9 @@ jobs:
     container: ghcr.io/nlohmann/json-ci:v2.4.0
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_cuda_example
 
   ci_icpc:
@@ -132,9 +132,9 @@ jobs:
     container: ghcr.io/nlohmann/json-ci:v2.2.0
     steps:
       - uses: actions/checkout@v2
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: |
           . /opt/intel/oneapi/setvars.sh
           cmake --build build --target ci_icpc
@@ -143,16 +143,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
-      - name: install REUSE tool
+      - name: Install REUSE tool
         run:  python -m pip install reuse
-      - name: REUSE lint
+      - name: Run REUSE lint
         run: reuse lint
 
   ci_test_documentation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: build
+      - name: Build
         run: cmake --build build --target ci_test_documentation

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,11 +47,11 @@ jobs:
       #  uses: egor-tensin/setup-mingw@v2
       #  with:
       #    platform: ${{ matrix.architecture }}
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On
-      - name: build
+      - name: Build
         run: cmake --build build --parallel 10
-      - name: test
+      - name: Test
         run: cd build ; ctest -j 10 -C Debug --output-on-failure
 
   msvc2019:
@@ -63,15 +63,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: cmake
+    - name: Run CMake
       run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Release'
-    - name: cmake
+    - name: Run CMake
       run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Debug'
-    - name: build
+    - name: Build
       run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
-    - name: test
+    - name: Test
       run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
 
   msvc2019_latest:
@@ -79,11 +79,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: cmake
+    - name: Run CMake
       run: cmake -S . -B build -G "Visual Studio 16 2019" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
-    - name: build
+    - name: Build
       run: cmake --build build --config Release --parallel 10
-    - name: test
+    - name: Test
       run: cd build ; ctest -j 10 -C Release --output-on-failure
 
   msvc2022:
@@ -95,15 +95,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: cmake
+    - name: Run CMake
       run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Release'
-    - name: cmake
+    - name: Run CMake
       run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
       if: matrix.build_type == 'Debug'
-    - name: build
+    - name: Build
       run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
-    - name: test
+    - name: Test
       run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
 
   msvc2022_latest:
@@ -111,11 +111,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: cmake
+    - name: Run CMake
       run: cmake -S . -B build -G "Visual Studio 17 2022" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
-    - name: build
+    - name: Build
       run: cmake --build build --config Release --parallel 10
-    - name: test
+    - name: Test
       run: cd build ; ctest -j 10 -C Release --output-on-failure
 
   clang:
@@ -126,13 +126,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: install Clang
+      - name: Install Clang
         run: curl -fsSL -o LLVM${{ matrix.version }}.exe https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ matrix.version }}.0.0/LLVM-${{ matrix.version }}.0.0-win64.exe ; 7z x LLVM${{ matrix.version }}.exe -y -o"C:/Program Files/LLVM"
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe" -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DJSON_BuildTests=On
-      - name: build
+      - name: Build
         run: cmake --build build --parallel 10
-      - name: test
+      - name: Test
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure
 
   clang-cl-11:
@@ -143,9 +143,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: cmake
+      - name: Run CMake
         run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL -DJSON_BuildTests=On
-      - name: build
+      - name: Build
         run: cmake --build build --config Debug --parallel 10
-      - name: test
+      - name: Test
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure


### PR DESCRIPTION
Job names in GitHub Actions should begin with a capital letter to harmonize the appearance when using default recipes like checkout.