### PR TITLE
Refine 'Publish documentation' workflow

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - docs/mkdocs/**
       - docs/examples/**
+  workflow_dispatch:
 
 # we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications
 concurrency:

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - docs/mkdocs/**
+      - docs/examples/**
 
 # we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications
 concurrency:

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   publish_documentation:
+    if: github.repository == 'nlohmann/json'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Refine the `Publish documentation` workflow:

* Only run the workflow when files in `/docs/mkdocs/` have changed.
* Allow triggering the workflow manually. (Can't hurt, can it?)
* Restrict the workflow to the `nlohmann/json` repository. I.e, don't try to publish the documentation on push to a fork.