### PR TITLE
Attempt to fix labeler permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,10 +1,14 @@
 name: "Pull Request Labeler"
 
 on:
-  - pull_request
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
-  build:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Change trigger to `pull_request_target` for write permissions and limit permissions to minimum required.