### PR TITLE
Fix whitespace in workflow files

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -138,6 +138,7 @@ jobs:
         run: |
           . /opt/intel/oneapi/setvars.sh
           cmake --build build --target ci_icpc
+
   ci_reuse_compliance:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR fixes a whitespace in the workflow files, but also tries to check whether #3674 fixed the labeler.