### PR TITLE
Added simple nlohmann::json operator+

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5074,19 +5074,12 @@ std::string to_string(const NLOHMANN_BASIC_JSON_TPL& j)
     return j.dump();
 }
 
-inline nlohmann::json operator+(const nlohmann::json& lhs, const nlohmann::json& rhs)
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+inline NLOHMANN_BASIC_JSON_TPL operator+(const NLOHMANN_BASIC_JSON_TPL& lhs, const NLOHMANN_BASIC_JSON_TPL& rhs)
 {
-    nlohmann::json ret;
-    for (const auto& el : lhs.items())
-    {
-        ret[el.key()] = el.value();
-    }
-
-    for (const auto& el : rhs.items())
-    {
-        ret[el.key()] = el.value();
-    }
-
+    NLOHMANN_BASIC_JSON_TPL ret;
+    ret.update(lhs, true);
+    ret.update(rhs, true);
     return ret;
 }
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5074,6 +5074,22 @@ std::string to_string(const NLOHMANN_BASIC_JSON_TPL& j)
     return j.dump();
 }
 
+inline nlohmann::json operator+(const nlohmann::json& lhs, const nlohmann::json& rhs)
+{
+    nlohmann::json ret;
+    for (const auto& el : lhs.items())
+    {
+        ret[el.key()] = el.value();
+    }
+
+    for (const auto& el : rhs.items())
+    {
+        ret[el.key()] = el.value();
+    }
+
+    return ret;
+}
+
 inline namespace literals
 {
 inline namespace json_literals


### PR DESCRIPTION
Add a simple plus operator to easily combine json objects.
It is possible to combine various json objects into one json object.
If the same key value exists, the json object in the back order has a structure that overwrites that value.
I'm a beginner, so I'd appreciate it if you could understand even if there's a lack