### PR TITLE
Add `operator<` to , to allow use as a map key

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -862,6 +862,15 @@ class json_pointer
     {
         return *this == json_pointer(rhs);
     }
+
+    /// @brief compares JSON pointer and string for less-than
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    friend bool operator<(json_pointer<RefStringTypeLhs> const& lhs,
+                          json_pointer<RefStringTypeRhs> const& rhs) noexcept
+    {
+        return lhs.reference_tokens < rhs.reference_tokens;
+    }
+
 #else
     /// @brief compares two JSON pointers for equality
     /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
@@ -904,6 +913,12 @@ class json_pointer
     // NOLINTNEXTLINE(readability-redundant-declaration)
     friend bool operator!=(const StringType& lhs,
                            const json_pointer<RefStringTypeRhs>& rhs);
+
+    /// @brief compares string and JSON pointer for less-than
+    template<typename RefStringTypeRhs, typename StringType>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator<(const StringType& lhs,
+                          const json_pointer<RefStringTypeRhs>& rhs);
 #endif
 
   private:
@@ -957,6 +972,13 @@ inline bool operator!=(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {
     return !(lhs == rhs);
+}
+
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                      const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return lhs.reference_tokens < rhs.reference_tokens;
 }
 #endif
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -14464,6 +14464,15 @@ class json_pointer
     {
         return *this == json_pointer(rhs);
     }
+
+    /// @brief compares JSON pointer and string for less-than
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    friend bool operator<(json_pointer<RefStringTypeLhs> const& lhs,
+                          json_pointer<RefStringTypeRhs> const& rhs) noexcept
+    {
+        return lhs.reference_tokens < rhs.reference_tokens;
+    }
+
 #else
     /// @brief compares two JSON pointers for equality
     /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
@@ -14506,6 +14515,12 @@ class json_pointer
     // NOLINTNEXTLINE(readability-redundant-declaration)
     friend bool operator!=(const StringType& lhs,
                            const json_pointer<RefStringTypeRhs>& rhs);
+
+    /// @brief compares string and JSON pointer for less-than
+    template<typename RefStringTypeRhs, typename StringType>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator<(const StringType& lhs,
+                          const json_pointer<RefStringTypeRhs>& rhs);
 #endif
 
   private:
@@ -14559,6 +14574,13 @@ inline bool operator!=(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {
     return !(lhs == rhs);
+}
+
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                      const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return lhs.reference_tokens < rhs.reference_tokens;
 }
 #endif
 


### PR DESCRIPTION
This is a replacement for https://github.com/nlohmann/json/pull/3667

After looking at how extensive [the commit for the other equality operators is](https://github.com/nlohmann/json/commit/9e1a7c85e342a5edec6cc3e96087d4070f55bea7), I see how much this PR needs that's not here (tests/docs/etc). I'm more than happy to cargo code/copy-paste and edit based on that commit to make this one look just like that. Lmk if that would be of value and actually helpful and not just a burden to you vs doing it yourself.