### PR TITLE
Deprecate json_pointer/string_t comparisons

### DIFF
--- a/docs/mkdocs/docs/api/json_pointer/operator_eq.md
+++ b/docs/mkdocs/docs/api/json_pointer/operator_eq.md
@@ -71,6 +71,12 @@ whether the values `lhs`/`*this` and `rhs` are equal
 Constant if `lhs` and `rhs` differ in the number of reference tokens, otherwise linear in the number of reference
 tokens.
 
+## Notes
+
+!!! warning "Deprecation"
+
+    Overload 2 is deprecated and will be removed in a future major version release.
+
 ## Examples
 
 ??? example "Example: (1) Comparing JSON pointers"
@@ -104,4 +110,4 @@ tokens.
 ## Version history
 
 1. Added in version 2.1.0. Added C++20 member functions in version 3.11.2.
-2. Added in version 3.11.2.
+2. Added for backward compatibility and deprecated in version 3.11.2.

--- a/docs/mkdocs/docs/api/json_pointer/operator_ne.md
+++ b/docs/mkdocs/docs/api/json_pointer/operator_ne.md
@@ -69,6 +69,10 @@ tokens.
     Since C++20 overload resolution will consider the _rewritten candidate_ generated from
     [`operator==`](operator_eq.md).
 
+!!! warning "Deprecation"
+
+    Overload 2 is deprecated and will be removed in a future major version release.
+
 ## Examples
 
 ??? example "Example: (1) Comparing JSON pointers"
@@ -102,4 +106,4 @@ tokens.
 ## Version history
 
 1. Added in version 2.1.0.
-2. Added in version 3.11.2.
+2. Added for backward compatibility and deprecated in version 3.11.2.

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -858,6 +858,7 @@ class json_pointer
 
     /// @brief compares JSON pointer and string for equality
     /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer))
     bool operator==(const string_t& rhs) const
     {
         return *this == json_pointer(rhs);
@@ -922,6 +923,7 @@ inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeLhs,
          typename StringType = typename json_pointer<RefStringTypeLhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer, json_pointer))
 inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
                        const StringType& rhs)
 {
@@ -930,6 +932,7 @@ inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeRhs,
          typename StringType = typename json_pointer<RefStringTypeRhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer, json_pointer))
 inline bool operator==(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {
@@ -945,6 +948,7 @@ inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeLhs,
          typename StringType = typename json_pointer<RefStringTypeLhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator!=(json_pointer, json_pointer))
 inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
                        const StringType& rhs)
 {
@@ -953,6 +957,7 @@ inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeRhs,
          typename StringType = typename json_pointer<RefStringTypeRhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator!=(json_pointer, json_pointer))
 inline bool operator!=(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -14460,6 +14460,7 @@ class json_pointer
 
     /// @brief compares JSON pointer and string for equality
     /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer))
     bool operator==(const string_t& rhs) const
     {
         return *this == json_pointer(rhs);
@@ -14524,6 +14525,7 @@ inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeLhs,
          typename StringType = typename json_pointer<RefStringTypeLhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer, json_pointer))
 inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
                        const StringType& rhs)
 {
@@ -14532,6 +14534,7 @@ inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeRhs,
          typename StringType = typename json_pointer<RefStringTypeRhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer, json_pointer))
 inline bool operator==(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {
@@ -14547,6 +14550,7 @@ inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeLhs,
          typename StringType = typename json_pointer<RefStringTypeLhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator!=(json_pointer, json_pointer))
 inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
                        const StringType& rhs)
 {
@@ -14555,6 +14559,7 @@ inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
 
 template<typename RefStringTypeRhs,
          typename StringType = typename json_pointer<RefStringTypeRhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator!=(json_pointer, json_pointer))
 inline bool operator!=(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {


### PR DESCRIPTION
#3664 restored comparing `json_pointer` with strings but removed `noexcept`. This is due to no longer comparing by converting the `json_pointer` to string, but by converting the string to a `json_pointer`. Doing so is more accurate (\*) as we no longer allow comparing with strings that aren't valid JSON pointers. The creation of the `json_pointer` temporary is hidden from the user. For that reason I suggest deprecating the string overloads to make users aware of the implications (exceptions, allocation of a `json_pointer`).

\* The accuracy problem is of greater concern for the remaining relational operators, e.g., imagine comparing a `json_pointer` and the string `/foo~` for less-/greater-than.