### PR TITLE
Make json_pointer usable as map key (again)

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -847,7 +847,7 @@ class json_pointer
     }
 
   public:
-#ifdef JSON_HAS_CPP_20
+#if JSON_HAS_THREE_WAY_COMPARISON
     /// @brief compares two JSON pointers for equality
     /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
     template<typename RefStringTypeRhs>
@@ -861,6 +861,13 @@ class json_pointer
     bool operator==(const string_t& rhs) const
     {
         return *this == json_pointer(rhs);
+    }
+
+    /// @brief 3-way compares two JSON pointers
+    template<typename RefStringTypeRhs>
+    std::strong_ordering operator<=>(const json_pointer<RefStringTypeRhs>& rhs) const noexcept // *NOPAD*
+    {
+        return  reference_tokens <=> rhs.reference_tokens; // *NOPAD*
     }
 #else
     /// @brief compares two JSON pointers for equality
@@ -904,6 +911,12 @@ class json_pointer
     // NOLINTNEXTLINE(readability-redundant-declaration)
     friend bool operator!=(const StringType& lhs,
                            const json_pointer<RefStringTypeRhs>& rhs);
+
+    /// @brief compares two JSON pointer for less-than
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                          const json_pointer<RefStringTypeRhs>& rhs) noexcept;
 #endif
 
   private:
@@ -911,7 +924,7 @@ class json_pointer
     std::vector<string_t> reference_tokens;
 };
 
-#ifndef JSON_HAS_CPP_20
+#if !JSON_HAS_THREE_WAY_COMPARISON
 // functions cannot be defined inside class due to ODR violations
 template<typename RefStringTypeLhs, typename RefStringTypeRhs>
 inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
@@ -957,6 +970,13 @@ inline bool operator!=(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {
     return !(lhs == rhs);
+}
+
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                      const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return lhs.reference_tokens < rhs.reference_tokens;
 }
 #endif
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -14449,7 +14449,7 @@ class json_pointer
     }
 
   public:
-#ifdef JSON_HAS_CPP_20
+#if JSON_HAS_THREE_WAY_COMPARISON
     /// @brief compares two JSON pointers for equality
     /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
     template<typename RefStringTypeRhs>
@@ -14463,6 +14463,13 @@ class json_pointer
     bool operator==(const string_t& rhs) const
     {
         return *this == json_pointer(rhs);
+    }
+
+    /// @brief 3-way compares two JSON pointers
+    template<typename RefStringTypeRhs>
+    std::strong_ordering operator<=>(const json_pointer<RefStringTypeRhs>& rhs) const noexcept // *NOPAD*
+    {
+        return  reference_tokens <=> rhs.reference_tokens; // *NOPAD*
     }
 #else
     /// @brief compares two JSON pointers for equality
@@ -14506,6 +14513,12 @@ class json_pointer
     // NOLINTNEXTLINE(readability-redundant-declaration)
     friend bool operator!=(const StringType& lhs,
                            const json_pointer<RefStringTypeRhs>& rhs);
+
+    /// @brief compares two JSON pointer for less-than
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                          const json_pointer<RefStringTypeRhs>& rhs) noexcept;
 #endif
 
   private:
@@ -14513,7 +14526,7 @@ class json_pointer
     std::vector<string_t> reference_tokens;
 };
 
-#ifndef JSON_HAS_CPP_20
+#if !JSON_HAS_THREE_WAY_COMPARISON
 // functions cannot be defined inside class due to ODR violations
 template<typename RefStringTypeLhs, typename RefStringTypeRhs>
 inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
@@ -14559,6 +14572,13 @@ inline bool operator!=(const StringType& lhs,
                        const json_pointer<RefStringTypeRhs>& rhs)
 {
     return !(lhs == rhs);
+}
+
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                      const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return lhs.reference_tokens < rhs.reference_tokens;
 }
 #endif
 

--- a/tests/src/unit-json_pointer.cpp
+++ b/tests/src/unit-json_pointer.cpp
@@ -15,6 +15,7 @@ using nlohmann::json;
     using namespace nlohmann::literals; // NOLINT(google-build-using-namespace)
 #endif
 
+#include <map>
 #include <sstream>
 
 TEST_CASE("JSON pointers")
@@ -695,6 +696,32 @@ TEST_CASE("JSON pointers")
             CHECK_THROWS_WITH_AS("/~~" == ptr1,
                                  "[json.exception.parse_error.108] parse error: escape character '~' must be followed with '0' or '1'", json::parse_error&);
         }
+    }
+
+    SECTION("less-than comparison")
+    {
+        auto ptr1 = json::json_pointer("/foo/a");
+        auto ptr2 = json::json_pointer("/foo/b");
+
+        CHECK(ptr1 < ptr2);
+        CHECK_FALSE(ptr2 < ptr1);
+
+        // build with C++20
+        // JSON_HAS_CPP_20
+#if JSON_HAS_THREE_WAY_COMPARISON
+        CHECK((ptr1 <=> ptr2) == std::strong_ordering::less); // *NOPAD*
+        CHECK(ptr2 > ptr1);
+#endif
+    }
+
+    SECTION("usable as map key")
+    {
+        auto ptr = json::json_pointer("/foo");
+        std::map<json::json_pointer, int> m;
+
+        m[ptr] = 42;
+
+        CHECK(m.find(ptr) != m.end());
     }
 
     SECTION("backwards compatibility and mixing")


### PR DESCRIPTION
Add `operator<(json_pointer, json_pointer)` and `operator<=>(json_pointer)` (C++20) to make `json_pointer` usable as a map key.

Documentation deferred to when the remaining operators are added.

Closes #3680.

#### To Do:
- [x] Add at least *some* unit tests.