### PR TITLE
Add 'Check amalgamation' workflow

### DIFF
--- a/.github/workflows/check_amalgamation.yml
+++ b/.github/workflows/check_amalgamation.yml
@@ -1,0 +1,92 @@
+name: "Check amalgamation"
+
+on:
+  pull_request_target:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      MAIN_DIR: ${{ github.workspace }}/main
+      INCLUDE_DIR: ${{ github.workspace }}/main/single_include/nlohmann
+      TOOL_DIR: ${{ github.workspace }}/tools/tools/amalgamate
+      ASTYLE_FLAGS: >
+        --style=allman --indent=spaces=4 --indent-modifiers --indent-switches --indent-preproc-block
+        --indent-preproc-define --indent-col1-comments --pad-oper --pad-header --align-pointer=type
+        --align-reference=type --add-brackets --convert-tabs --close-templates --lineend=linux --preserve-date
+        --formatted
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v3
+        with:
+          path: main
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout tools
+        uses: actions/checkout@v3
+        with:
+          path: tools
+          ref: develop
+
+      - name: Install astyle
+        run: |
+          sudo apt-get update
+          sudo apt-get install astyle
+
+      - name: Check amalgamation
+        run: |
+          cd $MAIN_DIR
+
+          rm -fr $INCLUDE_DIR/json.hpp~ $INCLUDE_DIR/json_fwd.hpp~
+          cp $INCLUDE_DIR/json.hpp $INCLUDE_DIR/json.hpp~
+          cp $INCLUDE_DIR/json_fwd.hpp $INCLUDE_DIR/json_fwd.hpp~
+
+          python3 $TOOL_DIR/amalgamate.py -c $TOOL_DIR/config_json.json -s .
+          python3 $TOOL_DIR/amalgamate.py -c $TOOL_DIR/config_json_fwd.json -s .
+          echo "Format (1)"
+          astyle $ASTYLE_FLAGS --suffix=none --quiet $INCLUDE_DIR/json.hpp $INCLUDE_DIR/json_fwd.hpp
+
+          diff $INCLUDE_DIR/json.hpp~ $INCLUDE_DIR/json.hpp
+          diff $INCLUDE_DIR/json_fwd.hpp~ $INCLUDE_DIR/json_fwd.hpp
+
+          astyle $ASTYLE_FLAGS $(find docs/examples include tests -type f \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' \) -not -path 'tests/thirdparty/*' -not -path 'tests/abi/include/nlohmann/*' | sort)
+          echo Check
+          find $MAIN_DIR -name '*.orig' -exec false {} \+
+
+      - name: Comment on pull request
+        if: failure()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const author = context.payload.pull_request.user.login
+            const opts = github.rest.issues.listForRepo.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              creator: author,
+              state: 'all'
+            })
+
+            let first = true
+            const issues = await github.paginate(opts)
+            for (const issue of issues) {
+              if (issue.number === context.issue.number) {
+                continue
+              }
+
+              if (issue.pull_request) {
+                first = false
+                break
+              }
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '## 🔴 Amalgamation check failed! 🔴\nThe source code has not been amalgamated.'
+                    + (first ? ' @' + author + ' Please read and follow the [Contribution Guidelines]'
+                               + '(https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).'
+                             : '')
+              })


### PR DESCRIPTION
Add a workflow that checks if the sources have been amalgamated and leaves a comment directing to the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change) if they are not.

Because commenting on a PR requires *write* permission, there are two options for implementing this:

1. Use 'pull_request_target' and duplicate the code from the `ci_test_amalgamation` target.
2. Use two workflows.
     - One workflow using `pull_request` to run the `ci_test_amalgamation` target.
     - Another workflow using `workflow_run` to submit the comment.

The downside to option 2 is that the workflow submitting the comment will run after the main workflows have mostly been completed. This PR implements option 1.

Because of `pull_request_target`, for security reasons, this workflow won't take effect until merged into the main branch.

I've tested the workflow in my fork.
First-time contributors will see this message: https://github.com/falbrechtskirchinger/json/pull/3#issuecomment-1210221031
Everyone else: https://github.com/falbrechtskirchinger/json/pull/3#issuecomment-1210223882

The `check_amalgamation.yml` workflow should be excluded from the required checks for merging and enabled for first-time contributors.