### PR TITLE
Replace limit macros with std::numeric_limits

### DIFF
--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -12,6 +12,7 @@
 using nlohmann::json;
 
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include "make_test_data_available.hpp"
 #include "test_utils.hpp"
@@ -865,7 +866,7 @@ TEST_CASE("BSON numerical data")
             {
                 std::vector<int64_t> const numbers
                 {
-                    INT64_MIN,
+                    (std::numeric_limits<int64_t>::min)(),
                     -1000000000000000000LL,
                     -100000000000000000LL,
                     -10000000000000000LL,
@@ -875,7 +876,7 @@ TEST_CASE("BSON numerical data")
                     -1000000000000LL,
                     -100000000000LL,
                     -10000000000LL,
-                    static_cast<std::int64_t>(INT32_MIN) - 1,
+                    static_cast<std::int64_t>((std::numeric_limits<std::int32_t>::min)()) - 1,
                 };
 
                 for (const auto i : numbers)
@@ -923,7 +924,7 @@ TEST_CASE("BSON numerical data")
             {
                 std::vector<int32_t> const numbers
                 {
-                    INT32_MIN,
+                    (std::numeric_limits<int32_t>::min)(),
                     -2147483647L,
                     -1000000000L,
                     -100000000L,
@@ -947,7 +948,7 @@ TEST_CASE("BSON numerical data")
                     100000000L,
                     1000000000L,
                     2147483646L,
-                    INT32_MAX
+                    (std::numeric_limits<int32_t>::max)()
                 };
 
                 for (const auto i : numbers)
@@ -990,7 +991,7 @@ TEST_CASE("BSON numerical data")
             {
                 std::vector<int64_t> const numbers
                 {
-                    INT64_MAX,
+                    (std::numeric_limits<int64_t>::max)(),
                     1000000000000000000LL,
                     100000000000000000LL,
                     10000000000000000LL,
@@ -1000,7 +1001,7 @@ TEST_CASE("BSON numerical data")
                     1000000000000LL,
                     100000000000LL,
                     10000000000LL,
-                    static_cast<std::int64_t>(INT32_MAX) + 1,
+                    static_cast<std::int64_t>((std::numeric_limits<int32_t>::max)()) + 1,
                 };
 
                 for (const auto i : numbers)
@@ -1062,7 +1063,7 @@ TEST_CASE("BSON numerical data")
                     100000000ULL,
                     1000000000ULL,
                     2147483646ULL,
-                    static_cast<std::uint64_t>(INT32_MAX)
+                    static_cast<std::uint64_t>((std::numeric_limits<int32_t>::max)())
                 };
 
                 for (const auto i : numbers)
@@ -1105,9 +1106,9 @@ TEST_CASE("BSON numerical data")
             {
                 std::vector<std::uint64_t> const numbers
                 {
-                    static_cast<std::uint64_t>(INT32_MAX) + 1,
+                    static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()) + 1,
                     4000000000ULL,
-                    static_cast<std::uint64_t>(UINT32_MAX),
+                    static_cast<std::uint64_t>((std::numeric_limits<std::uint32_t>::max)()),
                     10000000000ULL,
                     100000000000ULL,
                     1000000000000ULL,
@@ -1117,7 +1118,7 @@ TEST_CASE("BSON numerical data")
                     10000000000000000ULL,
                     100000000000000000ULL,
                     1000000000000000000ULL,
-                    static_cast<std::uint64_t>(INT64_MAX),
+                    static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()),
                 };
 
                 for (const auto i : numbers)
@@ -1163,11 +1164,11 @@ TEST_CASE("BSON numerical data")
             {
                 std::vector<std::uint64_t> const numbers
                 {
-                    static_cast<std::uint64_t>(INT64_MAX) + 1ULL,
+                    static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()) + 1ULL,
                     10000000000000000000ULL,
                     18000000000000000000ULL,
-                    UINT64_MAX - 1ULL,
-                    UINT64_MAX,
+                    (std::numeric_limits<std::uint64_t>::max)() - 1ULL,
+                    (std::numeric_limits<std::uint64_t>::max)(),
                 };
 
                 for (const auto i : numbers)

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -15,6 +15,7 @@ using nlohmann::json;
 #include <sstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <set>
 #include "make_test_data_available.hpp"
 #include "test_utils.hpp"
@@ -174,7 +175,7 @@ TEST_CASE("CBOR")
                 {
                     const std::vector<int64_t> numbers
                     {
-                        INT64_MIN,
+                        (std::numeric_limits<int64_t>::min)(),
                         -1000000000000000000,
                         -100000000000000000,
                         -10000000000000000,

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -17,6 +17,7 @@ using nlohmann::json;
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <limits>
 #include <set>
 #include "make_test_data_available.hpp"
 #include "test_utils.hpp"
@@ -526,7 +527,7 @@ TEST_CASE("MessagePack")
                 {
                     std::vector<int64_t> const numbers
                     {
-                        INT64_MIN,
+                        (std::numeric_limits<int64_t>::min)(),
                         -2147483649LL,
                     };
                     for (auto i : numbers)

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -21,6 +21,7 @@ using nlohmann::json;
 #include <fstream>
 #include <sstream>
 #include <list>
+#include <limits>
 #include <cstdio>
 #include "make_test_data_available.hpp"
 
@@ -877,12 +878,12 @@ TEST_CASE("regression tests 1")
         // original test case
         json const j1 = json::parse("-9223372036854775808");
         CHECK(j1.is_number_integer());
-        CHECK(j1.get<json::number_integer_t>() == INT64_MIN);
+        CHECK(j1.get<json::number_integer_t>() == (std::numeric_limits<std::int64_t>::min)());
 
         // edge case (+1; still an integer)
         json const j2 = json::parse("-9223372036854775807");
         CHECK(j2.is_number_integer());
-        CHECK(j2.get<json::number_integer_t>() == INT64_MIN + 1);
+        CHECK(j2.get<json::number_integer_t>() == (std::numeric_limits<std::int64_t>::min)() + 1);
 
         // edge case (-1; overflow -> floats)
         json const j3 = json::parse("-9223372036854775809");

--- a/tests/src/unit-windows_h.cpp
+++ b/tests/src/unit-windows_h.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "doctest_compatibility.h"
+#undef WIN32_LEAN_AND_MEAN
+#undef NOMINMAX
 
 #ifdef _WIN32
     #include <windows.h>


### PR DESCRIPTION
Replace uses of `INT_MIN`/`INT_MAX`, etc. with `std::numeric_limits` and consistently use `std` namespaced integer types.

Fixes #3722.