### PR TITLE
Add non-expandable internal documentation section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /docs/mkdocs/docs/__pycache__/
 /docs/mkdocs/docs/examples/
 /docs/mkdocs/docs/images/json.gif
+/docs/mkdocs/scripts/__pycache__/
 /docs/mkdocs/site/
 /docs/mkdocs/venv/
 

--- a/docs/mkdocs/docs/api/internal/index.md
+++ b/docs/mkdocs/docs/api/internal/index.md
@@ -1,0 +1,9 @@
+---
+x-nlohmann-json-is-internal: true
+---
+
+# Developer Documentation
+
+!!! missing
+
+    This section is under construction.

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -277,6 +277,8 @@ nav:
         - 'NLOHMANN_JSON_VERSION_MAJOR': api/macros/nlohmann_json_version_major.md
         - 'NLOHMANN_JSON_VERSION_MINOR': api/macros/nlohmann_json_version_major.md
         - 'NLOHMANN_JSON_VERSION_PATCH': api/macros/nlohmann_json_version_major.md
+      - Internal:
+        - api/internal/index.md
 
 # Extras
 extra:
@@ -341,6 +343,9 @@ plugins:
             'api/basic_json/operator_literal_json.md': api/operator_literal_json.md
             'api/basic_json/operator_literal_json_pointer.md': api/operator_literal_json_pointer.md
             'api/json_pointer/operator_string.md': api/json_pointer/operator_string_t.md
+    - mkdocs-simple-hooks:
+        hooks:
+          on_page_context: scripts.internal_section:on_page_context
 
 extra_css:
     - css/custom.css

--- a/docs/mkdocs/scripts/internal_section.py
+++ b/docs/mkdocs/scripts/internal_section.py
@@ -1,0 +1,30 @@
+import sys
+
+from copy import deepcopy
+from mkdocs.structure.nav import Navigation, Section, Page
+
+def _get_internal_sections(items, current_page):
+    res = []
+    sections = [item for item in items if isinstance(item, Section)]
+    while sections:
+        for section in sections[:]:
+            for item in section.children:
+                if isinstance(item, Section):
+                    sections.append(item)
+                elif isinstance(item, Page):
+                    if item.meta.get("x-nlohmann-json-is-internal", False):
+                        res.append(section)
+            sections.remove(section)
+    return res
+
+def on_page_context(context, page, config, nav):
+    sys.setrecursionlimit(1200)
+    nav = deepcopy(nav)
+    context["nav"] = nav
+
+    sections = _get_internal_sections(nav.items, page)
+    for section in sections:
+        if not section.active:
+            section.children = [child for child in section.children if child.is_index]
+
+    return context


### PR DESCRIPTION
Add a section for developer documentation that is non-expandable in the navigation. This is to avoid users bypassing the warnings about the nature of the internal documentation on the index page (text not included in this PR).

The internal documentation section is currently empty. Every once in a while, I find myself wanting to write a sentence or two about internal aspects of the library. Individually, this never warranted adding a page, but in total, I would have added several pages by now. The internal section is excluded from the style check, as I expect it to be more freeform and not necessarily follow the style of the public API documentation.

I plan on cleaning up/refactoring the type traits in small chunks soon and documenting some details where I deem it to be helpful.