### PR TITLE
Add dark mode toggle to documentation

### DIFF
--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -16,8 +16,21 @@ theme:
   name: material
   language: en
   palette:
-    primary: indigo
-    accent: indigo
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7 
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
   font:
     text: Roboto
     code: JetBrains Mono


### PR DESCRIPTION
In 2022 every website should have a dark mode toggle. :-)

(Automatic switching is only available in the Insiders edition of `mkdocs-material` at the moment.)