### PR TITLE
:rotating_light: fix Clang-Tidy warnings

### DIFF
--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -396,7 +396,7 @@
 
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 /*!
 @brief macro
@@ -409,7 +409,7 @@
 
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 
 // inspired from https://stackoverflow.com/a/26745591

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2748,7 +2748,7 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 /*!
 @brief macro
@@ -2761,7 +2761,7 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 
 // inspired from https://stackoverflow.com/a/26745591

--- a/tests/src/unit-32bit.cpp
+++ b/tests/src/unit-32bit.cpp
@@ -33,9 +33,9 @@ TEST_CASE_TEMPLATE_DEFINE("value_in_range_of trait", T, value_in_range_of_test)
     constexpr bool min_in_range = T::min_in_range;
     constexpr bool max_in_range = T::max_in_range;
 
-    type val_min = std::numeric_limits<type>::min();
+    type const val_min = std::numeric_limits<type>::min();
     type const val_min2 = val_min + 1;
-    type val_max = std::numeric_limits<type>::max();
+    type const val_max = std::numeric_limits<type>::max();
     type const val_max2 = val_max - 1;
 
     REQUIRE(CHAR_BIT == 8);

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -118,9 +118,9 @@ TEST_CASE_TEMPLATE_DEFINE("value_in_range_of trait", T, value_in_range_of_test)
     constexpr bool min_in_range = T::min_in_range;
     constexpr bool max_in_range = T::max_in_range;
 
-    type val_min = std::numeric_limits<type>::min();
+    type const val_min = std::numeric_limits<type>::min();
     type const val_min2 = val_min + 1;
-    type val_max = std::numeric_limits<type>::max();
+    type const val_max = std::numeric_limits<type>::max();
     type const val_max2 = val_max - 1;
 
     REQUIRE(CHAR_BIT == 8);
@@ -230,8 +230,8 @@ TEST_CASE("BJData")
 
         SECTION("null")
         {
-            json j = nullptr;
-            std::vector<uint8_t> expected = {'Z'};
+            json const j = nullptr;
+            std::vector<uint8_t> const expected = {'Z'};
             const auto result = json::to_bjdata(j);
             CHECK(result == expected);
 
@@ -244,8 +244,8 @@ TEST_CASE("BJData")
         {
             SECTION("true")
             {
-                json j = true;
-                std::vector<uint8_t> expected = {'T'};
+                json const j = true;
+                std::vector<uint8_t> const expected = {'T'};
                 const auto result = json::to_bjdata(j);
                 CHECK(result == expected);
 
@@ -256,8 +256,8 @@ TEST_CASE("BJData")
 
             SECTION("false")
             {
-                json j = false;
-                std::vector<uint8_t> expected = {'F'};
+                json const j = false;
+                std::vector<uint8_t> const expected = {'F'};
                 const auto result = json::to_bjdata(j);
                 CHECK(result == expected);
 
@@ -273,39 +273,43 @@ TEST_CASE("BJData")
             {
                 SECTION("-9223372036854775808..-2147483649 (int64)")
                 {
-                    std::vector<int64_t> numbers;
-                    numbers.push_back((std::numeric_limits<int64_t>::min)());
-                    numbers.push_back(-1000000000000000000LL);
-                    numbers.push_back(-100000000000000000LL);
-                    numbers.push_back(-10000000000000000LL);
-                    numbers.push_back(-1000000000000000LL);
-                    numbers.push_back(-100000000000000LL);
-                    numbers.push_back(-10000000000000LL);
-                    numbers.push_back(-1000000000000LL);
-                    numbers.push_back(-100000000000LL);
-                    numbers.push_back(-10000000000LL);
-                    numbers.push_back(-2147483649LL);
-                    for (auto i : numbers)
+                    std::vector<int64_t> const numbers
+                    {
+                        (std::numeric_limits<int64_t>::min)(),
+                        -1000000000000000000LL,
+                        -100000000000000000LL,
+                        -10000000000000000LL,
+                        -1000000000000000LL,
+                        -100000000000000LL,
+                        -10000000000000LL,
+                        -1000000000000LL,
+                        -100000000000LL,
+                        -10000000000LL,
+                        -2147483649LL,
+                    };
+                    for (const auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('L'));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 32) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 40) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 48) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 56) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('L'),
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 32) & 0xff),
+                            static_cast<uint8_t>((i >> 40) & 0xff),
+                            static_cast<uint8_t>((i >> 48) & 0xff),
+                            static_cast<uint8_t>((i >> 56) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -314,14 +318,14 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'L');
-                        int64_t restored = (static_cast<int64_t>(result[8]) << 070) +
-                                           (static_cast<int64_t>(result[7]) << 060) +
-                                           (static_cast<int64_t>(result[6]) << 050) +
-                                           (static_cast<int64_t>(result[5]) << 040) +
-                                           (static_cast<int64_t>(result[4]) << 030) +
-                                           (static_cast<int64_t>(result[3]) << 020) +
-                                           (static_cast<int64_t>(result[2]) << 010) +
-                                           static_cast<int64_t>(result[1]);
+                        int64_t const restored = (static_cast<int64_t>(result[8]) << 070) +
+                                                 (static_cast<int64_t>(result[7]) << 060) +
+                                                 (static_cast<int64_t>(result[6]) << 050) +
+                                                 (static_cast<int64_t>(result[5]) << 040) +
+                                                 (static_cast<int64_t>(result[4]) << 030) +
+                                                 (static_cast<int64_t>(result[3]) << 020) +
+                                                 (static_cast<int64_t>(result[2]) << 010) +
+                                                 static_cast<int64_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -332,31 +336,35 @@ TEST_CASE("BJData")
 
                 SECTION("-2147483648..-32769 (int32)")
                 {
-                    std::vector<int32_t> numbers;
-                    numbers.push_back(-32769);
-                    numbers.push_back(-100000);
-                    numbers.push_back(-1000000);
-                    numbers.push_back(-10000000);
-                    numbers.push_back(-100000000);
-                    numbers.push_back(-1000000000);
-                    numbers.push_back(-2147483647 - 1); // https://stackoverflow.com/a/29356002/266378
-                    for (auto i : numbers)
+                    std::vector<int32_t> numbers
+                    {
+                        -32769,
+                            -100000,
+                            -1000000,
+                            -10000000,
+                            -100000000,
+                            -1000000000,
+                            -2147483647 - 1, // https://stackoverflow.com/a/29356002/266378
+                        };
+                    for (const auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('l'));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('l'),
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -365,10 +373,10 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'l');
-                        int32_t restored = (static_cast<int32_t>(result[4]) << 030) +
-                                           (static_cast<int32_t>(result[3]) << 020) +
-                                           (static_cast<int32_t>(result[2]) << 010) +
-                                           static_cast<int32_t>(result[1]);
+                        int32_t const restored = (static_cast<int32_t>(result[4]) << 030) +
+                                                 (static_cast<int32_t>(result[3]) << 020) +
+                                                 (static_cast<int32_t>(result[2]) << 010) +
+                                                 static_cast<int32_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -384,16 +392,18 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('I'));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('I'),
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -402,7 +412,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'I');
-                        auto restored = static_cast<int16_t>(((result[2] << 8) + result[1]));
+                        auto const restored = static_cast<int16_t>(((result[2] << 8) + result[1]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -413,7 +423,7 @@ TEST_CASE("BJData")
 
                 SECTION("-9263 (int16)")
                 {
-                    json j = -9263;
+                    json const j = -9263;
                     std::vector<uint8_t> expected = {'I', 0xd1, 0xdb};
 
                     // compare result + size
@@ -423,7 +433,7 @@ TEST_CASE("BJData")
 
                     // check individual bytes
                     CHECK(result[0] == 'I');
-                    auto restored = static_cast<int16_t>(((result[2] << 8) + result[1]));
+                    auto const restored = static_cast<int16_t>(((result[2] << 8) + result[1]));
                     CHECK(restored == -9263);
 
                     // roundtrip
@@ -438,15 +448,17 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('i');
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            'i',
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -477,9 +489,11 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('i'));
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('i'),
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -510,9 +524,11 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('U'));
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('U'),
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -543,10 +559,12 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('I'));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('I'),
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -555,7 +573,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'I');
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -566,7 +584,7 @@ TEST_CASE("BJData")
 
                 SECTION("32768..65535 (uint16)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 32768u, 55555u, 65535u
                             })
@@ -581,10 +599,12 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('u'));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('u'),
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -593,7 +613,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'u');
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -604,7 +624,7 @@ TEST_CASE("BJData")
 
                 SECTION("65536..2147483647 (int32)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 65536u, 77777u, 2147483647u
                             })
@@ -619,12 +639,14 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('l');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'l',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -633,10 +655,10 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'l');
-                        uint32_t restored = (static_cast<uint32_t>(result[4]) << 030) +
-                                            (static_cast<uint32_t>(result[3]) << 020) +
-                                            (static_cast<uint32_t>(result[2]) << 010) +
-                                            static_cast<uint32_t>(result[1]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[4]) << 030) +
+                                                  (static_cast<uint32_t>(result[3]) << 020) +
+                                                  (static_cast<uint32_t>(result[2]) << 010) +
+                                                  static_cast<uint32_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -647,7 +669,7 @@ TEST_CASE("BJData")
 
                 SECTION("2147483648..4294967295 (uint32)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 2147483648u, 3333333333u, 4294967295u
                             })
@@ -662,12 +684,14 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('m');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'm',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -676,10 +700,10 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'm');
-                        uint32_t restored = (static_cast<uint32_t>(result[4]) << 030) +
-                                            (static_cast<uint32_t>(result[3]) << 020) +
-                                            (static_cast<uint32_t>(result[2]) << 010) +
-                                            static_cast<uint32_t>(result[1]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[4]) << 030) +
+                                                  (static_cast<uint32_t>(result[3]) << 020) +
+                                                  (static_cast<uint32_t>(result[2]) << 010) +
+                                                  static_cast<uint32_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -691,7 +715,7 @@ TEST_CASE("BJData")
                 SECTION("4294967296..9223372036854775807 (int64)")
                 {
                     std::vector<uint64_t> const v = {4294967296LU, 9223372036854775807LU};
-                    for (uint64_t i : v)
+                    for (const uint64_t i : v)
                     {
                         CAPTURE(i)
 
@@ -703,16 +727,18 @@ TEST_CASE("BJData")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('L');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'L',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -721,14 +747,14 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'L');
-                        uint64_t restored = (static_cast<uint64_t>(result[8]) << 070) +
-                                            (static_cast<uint64_t>(result[7]) << 060) +
-                                            (static_cast<uint64_t>(result[6]) << 050) +
-                                            (static_cast<uint64_t>(result[5]) << 040) +
-                                            (static_cast<uint64_t>(result[4]) << 030) +
-                                            (static_cast<uint64_t>(result[3]) << 020) +
-                                            (static_cast<uint64_t>(result[2]) << 010) +
-                                            static_cast<uint64_t>(result[1]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[8]) << 070) +
+                                                  (static_cast<uint64_t>(result[7]) << 060) +
+                                                  (static_cast<uint64_t>(result[6]) << 050) +
+                                                  (static_cast<uint64_t>(result[5]) << 040) +
+                                                  (static_cast<uint64_t>(result[4]) << 030) +
+                                                  (static_cast<uint64_t>(result[3]) << 020) +
+                                                  (static_cast<uint64_t>(result[2]) << 010) +
+                                                  static_cast<uint64_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -740,27 +766,29 @@ TEST_CASE("BJData")
                 SECTION("9223372036854775808..18446744073709551615 (uint64)")
                 {
                     std::vector<uint64_t> const v = {9223372036854775808ull, 18446744073709551615ull};
-                    for (uint64_t i : v)
+                    for (const uint64_t i : v)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('M');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'M',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -769,14 +797,14 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'M');
-                        uint64_t restored = (static_cast<uint64_t>(result[8]) << 070) +
-                                            (static_cast<uint64_t>(result[7]) << 060) +
-                                            (static_cast<uint64_t>(result[6]) << 050) +
-                                            (static_cast<uint64_t>(result[5]) << 040) +
-                                            (static_cast<uint64_t>(result[4]) << 030) +
-                                            (static_cast<uint64_t>(result[3]) << 020) +
-                                            (static_cast<uint64_t>(result[2]) << 010) +
-                                            static_cast<uint64_t>(result[1]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[8]) << 070) +
+                                                  (static_cast<uint64_t>(result[7]) << 060) +
+                                                  (static_cast<uint64_t>(result[6]) << 050) +
+                                                  (static_cast<uint64_t>(result[5]) << 040) +
+                                                  (static_cast<uint64_t>(result[4]) << 030) +
+                                                  (static_cast<uint64_t>(result[3]) << 020) +
+                                                  (static_cast<uint64_t>(result[2]) << 010) +
+                                                  static_cast<uint64_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -795,15 +823,13 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('i');
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected{'i', static_cast<uint8_t>(i)};
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -812,7 +838,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'i');
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        auto const restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -828,15 +854,13 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('U');
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected{'U', static_cast<uint8_t>(i)};
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -845,7 +869,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'U');
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        auto const restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -861,16 +885,18 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('I');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'I',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -879,7 +905,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'I');
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -890,7 +916,7 @@ TEST_CASE("BJData")
 
                 SECTION("32768..65535 (uint16)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 32768u, 55555u, 65535u
                             })
@@ -898,16 +924,18 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('u');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'u',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -916,7 +944,7 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'u');
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[2]) * 256 + static_cast<uint8_t>(result[1]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -926,7 +954,7 @@ TEST_CASE("BJData")
                 }
                 SECTION("65536..2147483647 (int32)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 65536u, 77777u, 2147483647u
                             })
@@ -934,18 +962,20 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('l');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'l',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -954,10 +984,10 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'l');
-                        uint32_t restored = (static_cast<uint32_t>(result[4]) << 030) +
-                                            (static_cast<uint32_t>(result[3]) << 020) +
-                                            (static_cast<uint32_t>(result[2]) << 010) +
-                                            static_cast<uint32_t>(result[1]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[4]) << 030) +
+                                                  (static_cast<uint32_t>(result[3]) << 020) +
+                                                  (static_cast<uint32_t>(result[2]) << 010) +
+                                                  static_cast<uint32_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -968,7 +998,7 @@ TEST_CASE("BJData")
 
                 SECTION("2147483648..4294967295 (uint32)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 2147483648u, 3333333333u, 4294967295u
                             })
@@ -976,18 +1006,20 @@ TEST_CASE("BJData")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('m');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'm',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -996,10 +1028,10 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'm');
-                        uint32_t restored = (static_cast<uint32_t>(result[4]) << 030) +
-                                            (static_cast<uint32_t>(result[3]) << 020) +
-                                            (static_cast<uint32_t>(result[2]) << 010) +
-                                            static_cast<uint32_t>(result[1]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[4]) << 030) +
+                                                  (static_cast<uint32_t>(result[3]) << 020) +
+                                                  (static_cast<uint32_t>(result[2]) << 010) +
+                                                  static_cast<uint32_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -1011,27 +1043,29 @@ TEST_CASE("BJData")
                 SECTION("4294967296..9223372036854775807 (int64)")
                 {
                     std::vector<uint64_t> const v = {4294967296ul, 9223372036854775807ul};
-                    for (uint64_t i : v)
+                    for (const uint64_t i : v)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('L');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'L',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -1040,14 +1074,14 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'L');
-                        uint64_t restored = (static_cast<uint64_t>(result[8]) << 070) +
-                                            (static_cast<uint64_t>(result[7]) << 060) +
-                                            (static_cast<uint64_t>(result[6]) << 050) +
-                                            (static_cast<uint64_t>(result[5]) << 040) +
-                                            (static_cast<uint64_t>(result[4]) << 030) +
-                                            (static_cast<uint64_t>(result[3]) << 020) +
-                                            (static_cast<uint64_t>(result[2]) << 010) +
-                                            static_cast<uint64_t>(result[1]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[8]) << 070) +
+                                                  (static_cast<uint64_t>(result[7]) << 060) +
+                                                  (static_cast<uint64_t>(result[6]) << 050) +
+                                                  (static_cast<uint64_t>(result[5]) << 040) +
+                                                  (static_cast<uint64_t>(result[4]) << 030) +
+                                                  (static_cast<uint64_t>(result[3]) << 020) +
+                                                  (static_cast<uint64_t>(result[2]) << 010) +
+                                                  static_cast<uint64_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -1059,27 +1093,29 @@ TEST_CASE("BJData")
                 SECTION("9223372036854775808..18446744073709551615 (uint64)")
                 {
                     std::vector<uint64_t> const v = {9223372036854775808ull, 18446744073709551615ull};
-                    for (uint64_t i : v)
+                    for (const uint64_t i : v)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('M');
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'M',
+                            static_cast<uint8_t>(i & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_bjdata(j);
@@ -1088,14 +1124,14 @@ TEST_CASE("BJData")
 
                         // check individual bytes
                         CHECK(result[0] == 'M');
-                        uint64_t restored = (static_cast<uint64_t>(result[8]) << 070) +
-                                            (static_cast<uint64_t>(result[7]) << 060) +
-                                            (static_cast<uint64_t>(result[6]) << 050) +
-                                            (static_cast<uint64_t>(result[5]) << 040) +
-                                            (static_cast<uint64_t>(result[4]) << 030) +
-                                            (static_cast<uint64_t>(result[3]) << 020) +
-                                            (static_cast<uint64_t>(result[2]) << 010) +
-                                            static_cast<uint64_t>(result[1]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[8]) << 070) +
+                                                  (static_cast<uint64_t>(result[7]) << 060) +
+                                                  (static_cast<uint64_t>(result[6]) << 050) +
+                                                  (static_cast<uint64_t>(result[5]) << 040) +
+                                                  (static_cast<uint64_t>(result[4]) << 030) +
+                                                  (static_cast<uint64_t>(result[3]) << 020) +
+                                                  (static_cast<uint64_t>(result[2]) << 010) +
+                                                  static_cast<uint64_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -1109,7 +1145,7 @@ TEST_CASE("BJData")
                 SECTION("3.1415925")
                 {
                     double v = 3.1415925;
-                    json j = v;
+                    json const j = v;
                     std::vector<uint8_t> expected =
                     {
                         'D', 0xfc, 0xde, 0xa6, 0x3f, 0xfb, 0x21, 0x09, 0x40
@@ -1297,7 +1333,7 @@ TEST_CASE("BJData")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -1333,7 +1369,7 @@ TEST_CASE("BJData")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -1360,7 +1396,7 @@ TEST_CASE("BJData")
 
             SECTION("N = 256..32767")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             256u, 999u, 1025u, 3333u, 2048u, 32767u
                         })
@@ -1369,7 +1405,7 @@ TEST_CASE("BJData")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1394,7 +1430,7 @@ TEST_CASE("BJData")
 
             SECTION("N = 32768..65535")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             32768u, 55555u, 65535u
                         })
@@ -1403,7 +1439,7 @@ TEST_CASE("BJData")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1428,7 +1464,7 @@ TEST_CASE("BJData")
 
             SECTION("N = 65536..2147483647")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             65536u, 77777u, 1048576u
                         })
@@ -1437,7 +1473,7 @@ TEST_CASE("BJData")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1556,7 +1592,7 @@ TEST_CASE("BJData")
 
             SECTION("N = 256..32767")
             {
-                for (std::size_t N :
+                for (const std::size_t N :
                         {
                             256u, 999u, 1025u, 3333u, 2048u, 32767u
                         })
@@ -1593,7 +1629,7 @@ TEST_CASE("BJData")
 
             SECTION("N = 32768..65535")
             {
-                for (std::size_t N :
+                for (const std::size_t N :
                         {
                             32768u, 55555u, 65535u
                         })
@@ -1630,7 +1666,7 @@ TEST_CASE("BJData")
 
             SECTION("N = 65536..2147483647")
             {
-                for (std::size_t N :
+                for (const std::size_t N :
                         {
                             65536u, 77777u, 1048576u
                         })
@@ -1731,7 +1767,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::array();
+                    json const j = json::array();
                     std::vector<uint8_t> expected = {'[', ']'};
                     const auto result = json::to_bjdata(j);
                     CHECK(result == expected);
@@ -1743,7 +1779,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::array();
+                    json const j = json::array();
                     std::vector<uint8_t> expected = {'[', '#', 'i', 0};
                     const auto result = json::to_bjdata(j, true);
                     CHECK(result == expected);
@@ -1755,7 +1791,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::array();
+                    json const j = json::array();
                     std::vector<uint8_t> expected = {'[', '#', 'i', 0};
                     const auto result = json::to_bjdata(j, true, true);
                     CHECK(result == expected);
@@ -1770,7 +1806,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = {nullptr};
+                    json const j = {nullptr};
                     std::vector<uint8_t> expected = {'[', 'Z', ']'};
                     const auto result = json::to_bjdata(j);
                     CHECK(result == expected);
@@ -1782,7 +1818,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = {nullptr};
+                    json const j = {nullptr};
                     std::vector<uint8_t> expected = {'[', '#', 'i', 1, 'Z'};
                     const auto result = json::to_bjdata(j, true);
                     CHECK(result == expected);
@@ -1794,7 +1830,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=true")
                 {
-                    json j = {nullptr};
+                    json const j = {nullptr};
                     std::vector<uint8_t> expected = {'[', '#', 'i', 1, 'Z'};
                     const auto result = json::to_bjdata(j, true, true);
                     CHECK(result == expected);
@@ -1809,7 +1845,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::parse("[1,2,3,4,5]");
+                    json const j = json::parse("[1,2,3,4,5]");
                     std::vector<uint8_t> expected = {'[', 'i', 1, 'i', 2, 'i', 3, 'i', 4, 'i', 5, ']'};
                     const auto result = json::to_bjdata(j);
                     CHECK(result == expected);
@@ -1821,7 +1857,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::parse("[1,2,3,4,5]");
+                    json const j = json::parse("[1,2,3,4,5]");
                     std::vector<uint8_t> expected = {'[', '#', 'i', 5, 'i', 1, 'i', 2, 'i', 3, 'i', 4, 'i', 5};
                     const auto result = json::to_bjdata(j, true);
                     CHECK(result == expected);
@@ -1833,7 +1869,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::parse("[1,2,3,4,5]");
+                    json const j = json::parse("[1,2,3,4,5]");
                     std::vector<uint8_t> expected = {'[', '$', 'i', '#', 'i', 5, 1, 2, 3, 4, 5};
                     const auto result = json::to_bjdata(j, true, true);
                     CHECK(result == expected);
@@ -1848,7 +1884,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::parse("[[[[]]]]");
+                    json const j = json::parse("[[[[]]]]");
                     std::vector<uint8_t> expected = {'[', '[', '[', '[', ']', ']', ']', ']'};
                     const auto result = json::to_bjdata(j);
                     CHECK(result == expected);
@@ -1860,7 +1896,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::parse("[[[[]]]]");
+                    json const j = json::parse("[[[[]]]]");
                     std::vector<uint8_t> expected = {'[', '#', 'i', 1, '[', '#', 'i', 1, '[', '#', 'i', 1, '[', '#', 'i', 0};
                     const auto result = json::to_bjdata(j, true);
                     CHECK(result == expected);
@@ -1872,7 +1908,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::parse("[[[[]]]]");
+                    json const j = json::parse("[[[[]]]]");
                     std::vector<uint8_t> expected = {'[', '#', 'i', 1, '[', '#', 'i', 1, '[', '#', 'i', 1, '[', '#', 'i', 0};
                     const auto result = json::to_bjdata(j, true, true);
                     CHECK(result == expected);
@@ -1994,7 +2030,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::object();
+                    json const j = json::object();
                     std::vector<uint8_t> expected = {'{', '}'};
                     const auto result = json::to_bjdata(j);
                     CHECK(result == expected);
@@ -2006,7 +2042,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::object();
+                    json const j = json::object();
                     std::vector<uint8_t> expected = {'{', '#', 'i', 0};
                     const auto result = json::to_bjdata(j, true);
                     CHECK(result == expected);
@@ -2018,7 +2054,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::object();
+                    json const j = json::object();
                     std::vector<uint8_t> expected = {'{', '#', 'i', 0};
                     const auto result = json::to_bjdata(j, true, true);
                     CHECK(result == expected);
@@ -2033,7 +2069,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = {{"", nullptr}};
+                    json const j = {{"", nullptr}};
                     std::vector<uint8_t> expected = {'{', 'i', 0, 'Z', '}'};
                     const auto result = json::to_bjdata(j);
                     CHECK(result == expected);
@@ -2045,7 +2081,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = {{"", nullptr}};
+                    json const j = {{"", nullptr}};
                     std::vector<uint8_t> expected = {'{', '#', 'i', 1, 'i', 0, 'Z'};
                     const auto result = json::to_bjdata(j, true);
                     CHECK(result == expected);
@@ -2060,7 +2096,7 @@ TEST_CASE("BJData")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                    json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
                     std::vector<uint8_t> expected =
                     {
                         '{', 'i', 1, 'a', '{', 'i', 1, 'b', '{', 'i', 1, 'c', '{', '}', '}', '}', '}'
@@ -2075,7 +2111,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                    json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
                     std::vector<uint8_t> expected =
                     {
                         '{', '#', 'i', 1, 'i', 1, 'a', '{', '#', 'i', 1, 'i', 1, 'b', '{', '#', 'i', 1, 'i', 1, 'c', '{', '#', 'i', 0
@@ -2090,7 +2126,7 @@ TEST_CASE("BJData")
 
                 SECTION("size=true type=true ignore object type marker")
                 {
-                    json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                    json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
                     std::vector<uint8_t> expected =
                     {
                         '{', '#', 'i', 1, 'i', 1, 'a', '{', '#', 'i', 1, 'i', 1, 'b', '{', '#', 'i', 1, 'i', 1, 'c', '{', '#', 'i', 0
@@ -2662,7 +2698,7 @@ TEST_CASE("BJData")
                 std::vector<uint8_t> const vL = {'[', '#', 'L', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7F};
                 std::vector<uint8_t> const vM = {'[', '$', 'M', '#', '[', 'I', 0x00, 0x20, 'M', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, ']'};
 
-                json const _;
+                json _;
 #if SIZE_MAX == 0xffffffff
                 CHECK_THROWS_WITH_AS(_ = json::from_bjdata(vL), "[json.exception.out_of_range.408] syntax error while parsing BJData size: integer value overflow", json::out_of_range&);
                 CHECK(json::from_bjdata(vL, true, false).is_discarded());
@@ -3095,7 +3131,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 {
     SECTION("Null Value")
     {
-        json j = {{"passcode", nullptr}};
+        json const j = {{"passcode", nullptr}};
         std::vector<uint8_t> v = {'{', 'i', 8, 'p', 'a', 's', 's', 'c', 'o', 'd', 'e', 'Z', '}'};
         CHECK(json::to_bjdata(j) == v);
         CHECK(json::from_bjdata(v) == j);
@@ -3103,7 +3139,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 
     SECTION("No-Op Value")
     {
-        json j = {"foo", "bar", "baz"};
+        json const j = {"foo", "bar", "baz"};
         std::vector<uint8_t> v = {'[', 'S', 'i', 3, 'f', 'o', 'o',
                                   'S', 'i', 3, 'b', 'a', 'r',
                                   'S', 'i', 3, 'b', 'a', 'z', ']'
@@ -3119,7 +3155,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 
     SECTION("Boolean Types")
     {
-        json j = {{"authorized", true}, {"verified", false}};
+        json const j = {{"authorized", true}, {"verified", false}};
         std::vector<uint8_t> v = {'{', 'i', 10, 'a', 'u', 't', 'h', 'o', 'r', 'i', 'z', 'e', 'd', 'T',
                                   'i', 8, 'v', 'e', 'r', 'i', 'f', 'i', 'e', 'd', 'F', '}'
                                  };
@@ -3159,7 +3195,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 
     SECTION("Char Type")
     {
-        json j = {{"rolecode", "a"}, {"delim", ";"}};
+        json const j = {{"rolecode", "a"}, {"delim", ";"}};
         std::vector<uint8_t> const v = {'{', 'i', 5, 'd', 'e', 'l', 'i', 'm', 'C', ';', 'i', 8, 'r', 'o', 'l', 'e', 'c', 'o', 'd', 'e', 'C', 'a', '}'};
         //CHECK(json::to_bjdata(j) == v);
         CHECK(json::from_bjdata(v) == j);
@@ -3169,7 +3205,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
     {
         SECTION("English")
         {
-            json j = "hello";
+            json const j = "hello";
             std::vector<uint8_t> v = {'S', 'i', 5, 'h', 'e', 'l', 'l', 'o'};
             CHECK(json::to_bjdata(j) == v);
             CHECK(json::from_bjdata(v) == j);
@@ -3177,7 +3213,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 
         SECTION("Russian")
         {
-            json j = "привет";
+            json const j = "привет";
             std::vector<uint8_t> v = {'S', 'i', 12, 0xD0, 0xBF, 0xD1, 0x80, 0xD0, 0xB8, 0xD0, 0xB2, 0xD0, 0xB5, 0xD1, 0x82};
             CHECK(json::to_bjdata(j) == v);
             CHECK(json::from_bjdata(v) == j);
@@ -3185,7 +3221,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 
         SECTION("Russian")
         {
-            json j = "مرحبا";
+            json const j = "مرحبا";
             std::vector<uint8_t> v = {'S', 'i', 10, 0xD9, 0x85, 0xD8, 0xB1, 0xD8, 0xAD, 0xD8, 0xA8, 0xD8, 0xA7};
             CHECK(json::to_bjdata(j) == v);
             CHECK(json::from_bjdata(v) == j);
@@ -3197,7 +3233,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
         SECTION("size=false type=false")
         {
             // note the float has been replaced by a double
-            json j = {nullptr, true, false, 4782345193, 153.132, "ham"};
+            json const j = {nullptr, true, false, 4782345193, 153.132, "ham"};
             std::vector<uint8_t> v = {'[', 'Z', 'T', 'F', 'L', 0xE9, 0xCB, 0x0C, 0x1D, 0x01, 0x00, 0x00, 0x00, 'D', 0x4e, 0x62, 0x10, 0x58, 0x39, 0x24, 0x63, 0x40, 'S', 'i', 3, 'h', 'a', 'm', ']'};
             CHECK(json::to_bjdata(j) == v);
             CHECK(json::from_bjdata(v) == j);
@@ -3206,7 +3242,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
         SECTION("size=true type=false")
         {
             // note the float has been replaced by a double
-            json j = {nullptr, true, false, 4782345193, 153.132, "ham"};
+            json const j = {nullptr, true, false, 4782345193, 153.132, "ham"};
             std::vector<uint8_t> v = {'[', '#', 'i', 6, 'Z', 'T', 'F', 'L', 0xE9, 0xCB, 0x0C, 0x1D, 0x01, 0x00, 0x00, 0x00, 'D', 0x4e, 0x62, 0x10, 0x58, 0x39, 0x24, 0x63, 0x40, 'S', 'i', 3, 'h', 'a', 'm'};
             CHECK(json::to_bjdata(j, true) == v);
             CHECK(json::from_bjdata(v) == j);
@@ -3215,7 +3251,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
         SECTION("size=true type=true")
         {
             // note the float has been replaced by a double
-            json j = {nullptr, true, false, 4782345193, 153.132, "ham"};
+            json const j = {nullptr, true, false, 4782345193, 153.132, "ham"};
             std::vector<uint8_t> v = {'[', '#', 'i', 6, 'Z', 'T', 'F', 'L', 0xE9, 0xCB, 0x0C, 0x1D, 0x01, 0x00, 0x00, 0x00, 'D', 0x4e, 0x62, 0x10, 0x58, 0x39, 0x24, 0x63, 0x40, 'S', 'i', 3, 'h', 'a', 'm'};
             CHECK(json::to_bjdata(j, true, true) == v);
             CHECK(json::from_bjdata(v) == j);
@@ -3302,7 +3338,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("No Optimization")
             {
                 // note the floats have been replaced by doubles
-                json j = {29.97, 31.13, 67.0, 2.113, 23.888};
+                json const j = {29.97, 31.13, 67.0, 2.113, 23.888};
                 std::vector<uint8_t> v = {'[',
                                           'D', 0xb8, 0x1e, 0x85, 0xeb, 0x51, 0xf8, 0x3d, 0x40,
                                           'D', 0xe1, 0x7a, 0x14, 0xae, 0x47, 0x21, 0x3f, 0x40,
@@ -3318,7 +3354,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with count")
             {
                 // note the floats have been replaced by doubles
-                json j = {29.97, 31.13, 67.0, 2.113, 23.888};
+                json const j = {29.97, 31.13, 67.0, 2.113, 23.888};
                 std::vector<uint8_t> v = {'[', '#', 'i', 5,
                                           'D', 0xb8, 0x1e, 0x85, 0xeb, 0x51, 0xf8, 0x3d, 0x40,
                                           'D', 0xe1, 0x7a, 0x14, 0xae, 0x47, 0x21, 0x3f, 0x40,
@@ -3333,7 +3369,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with type & count")
             {
                 // note the floats have been replaced by doubles
-                json j = {29.97, 31.13, 67.0, 2.113, 23.888};
+                json const j = {29.97, 31.13, 67.0, 2.113, 23.888};
                 std::vector<uint8_t> v = {'[', '$', 'D', '#', 'i', 5,
                                           0xb8, 0x1e, 0x85, 0xeb, 0x51, 0xf8, 0x3d, 0x40,
                                           0xe1, 0x7a, 0x14, 0xae, 0x47, 0x21, 0x3f, 0x40,
@@ -3351,7 +3387,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("No Optimization")
             {
                 // note the floats have been replaced by doubles
-                json j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
+                json const j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
                 std::vector<uint8_t> v = {'{',
                                           'i', 3, 'a', 'l', 't', 'D',      0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x50, 0x40,
                                           'i', 3, 'l', 'a', 't', 'D',      0x60, 0xe5, 0xd0, 0x22, 0xdb, 0xf9, 0x3d, 0x40,
@@ -3365,7 +3401,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with count")
             {
                 // note the floats have been replaced by doubles
-                json j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
+                json const j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
                 std::vector<uint8_t> v = {'{', '#', 'i', 3,
                                           'i', 3, 'a', 'l', 't', 'D',      0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x50, 0x40,
                                           'i', 3, 'l', 'a', 't', 'D',      0x60, 0xe5, 0xd0, 0x22, 0xdb, 0xf9, 0x3d, 0x40,
@@ -3378,7 +3414,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with type & count")
             {
                 // note the floats have been replaced by doubles
-                json j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
+                json const j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
                 std::vector<uint8_t> v = {'{', '$', 'D', '#', 'i', 3,
                                           'i', 3, 'a', 'l', 't',      0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x50, 0x40,
                                           'i', 3, 'l', 'a', 't',      0x60, 0xe5, 0xd0, 0x22, 0xdb, 0xf9, 0x3d, 0x40,
@@ -3450,7 +3486,7 @@ TEST_CASE("BJData roundtrips" * doctest::skip())
 {
     SECTION("input from self-generated BJData files")
     {
-        for (std::string filename :
+        for (const std::string filename :
                 {
                     TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json",
                     TEST_DATA_DIRECTORY "/json.org/1.json",

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -97,8 +97,8 @@ TEST_CASE("BSON")
     {
         SECTION("empty object")
         {
-            json j = json::object();
-            std::vector<std::uint8_t> expected =
+            json const j = json::object();
+            std::vector<std::uint8_t> const expected =
             {
                 0x05, 0x00, 0x00, 0x00, // size (little endian)
                 // no entries
@@ -115,12 +115,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with bool")
         {
-            json j =
+            json const j =
             {
                 { "entry", true }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x0D, 0x00, 0x00, 0x00, // size (little endian)
                 0x08,               // entry: boolean
@@ -139,12 +139,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with bool")
         {
-            json j =
+            json const j =
             {
                 { "entry", false }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x0D, 0x00, 0x00, 0x00, // size (little endian)
                 0x08,               // entry: boolean
@@ -163,12 +163,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with double")
         {
-            json j =
+            json const j =
             {
                 { "entry", 4.2 }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x14, 0x00, 0x00, 0x00, // size (little endian)
                 0x01, /// entry: double
@@ -187,12 +187,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with string")
         {
-            json j =
+            json const j =
             {
                 { "entry", "bsonstr" }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x18, 0x00, 0x00, 0x00, // size (little endian)
                 0x02, /// entry: string (UTF-8)
@@ -211,12 +211,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with null member")
         {
-            json j =
+            json const j =
             {
                 { "entry", nullptr }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x0C, 0x00, 0x00, 0x00, // size (little endian)
                 0x0A, /// entry: null
@@ -234,12 +234,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with integer (32-bit) member")
         {
-            json j =
+            json const j =
             {
                 { "entry", std::int32_t{0x12345678} }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x10, 0x00, 0x00, 0x00, // size (little endian)
                 0x10, /// entry: int32
@@ -258,12 +258,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with integer (64-bit) member")
         {
-            json j =
+            json const j =
             {
                 { "entry", std::int64_t{0x1234567804030201} }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x14, 0x00, 0x00, 0x00, // size (little endian)
                 0x12, /// entry: int64
@@ -282,12 +282,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with negative integer (32-bit) member")
         {
-            json j =
+            json const j =
             {
                 { "entry", std::int32_t{-1} }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x10, 0x00, 0x00, 0x00, // size (little endian)
                 0x10, /// entry: int32
@@ -306,12 +306,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with negative integer (64-bit) member")
         {
-            json j =
+            json const j =
             {
                 { "entry", std::int64_t{-1} }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x10, 0x00, 0x00, 0x00, // size (little endian)
                 0x10, /// entry: int32
@@ -331,12 +331,12 @@ TEST_CASE("BSON")
         SECTION("non-empty object with unsigned integer (64-bit) member")
         {
             // directly encoding uint64 is not supported in bson (only for timestamp values)
-            json j =
+            json const j =
             {
                 { "entry", std::uint64_t{0x1234567804030201} }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x14, 0x00, 0x00, 0x00, // size (little endian)
                 0x12, /// entry: int64
@@ -355,12 +355,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with small unsigned integer member")
         {
-            json j =
+            json const j =
             {
                 { "entry", std::uint64_t{0x42} }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x10, 0x00, 0x00, 0x00, // size (little endian)
                 0x10, /// entry: int32
@@ -379,12 +379,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with object member")
         {
-            json j =
+            json const j =
             {
                 { "entry", json::object() }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x11, 0x00, 0x00, 0x00, // size (little endian)
                 0x03, /// entry: embedded document
@@ -407,12 +407,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with array member")
         {
-            json j =
+            json const j =
             {
                 { "entry", json::array() }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x11, 0x00, 0x00, 0x00, // size (little endian)
                 0x04, /// entry: embedded document
@@ -435,12 +435,12 @@ TEST_CASE("BSON")
 
         SECTION("non-empty object with non-empty array member")
         {
-            json j =
+            json const j =
             {
                 { "entry", json::array({1, 2, 3, 4, 5, 6, 7, 8}) }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x49, 0x00, 0x00, 0x00, // size (little endian)
                 0x04, /// entry: embedded document
@@ -472,12 +472,12 @@ TEST_CASE("BSON")
         {
             const size_t N = 10;
             const auto s = std::vector<std::uint8_t>(N, 'x');
-            json j =
+            json const j =
             {
                 { "entry", json::binary(s, 0) }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x1B, 0x00, 0x00, 0x00, // size (little endian)
                 0x05, // entry: binary
@@ -502,12 +502,12 @@ TEST_CASE("BSON")
         {
             // an MD5 hash
             const std::vector<std::uint8_t> md5hash = {0xd7, 0x7e, 0x27, 0x54, 0xbe, 0x12, 0x37, 0xfe, 0xd6, 0x0c, 0x33, 0x98, 0x30, 0x3b, 0x8d, 0xc4};
-            json j =
+            json const j =
             {
                 { "entry", json::binary(md5hash, 5) }
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 0x21, 0x00, 0x00, 0x00, // size (little endian)
                 0x05, // entry: binary
@@ -531,7 +531,7 @@ TEST_CASE("BSON")
         SECTION("Some more complex document")
         {
             // directly encoding uint64 is not supported in bson (only for timestamp values)
-            json j =
+            json const j =
             {
                 {"double", 42.5},
                 {"entry", 4.2},
@@ -539,7 +539,7 @@ TEST_CASE("BSON")
                 {"object", {{ "string", "value" }}}
             };
 
-            std::vector<std::uint8_t> expected =
+            std::vector<std::uint8_t> const expected =
             {
                 /*size */ 0x4f, 0x00, 0x00, 0x00,
                 /*entry*/ 0x01, 'd',  'o',  'u',  'b',  'l',  'e',  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x45, 0x40,
@@ -878,19 +878,19 @@ TEST_CASE("BSON numerical data")
                     static_cast<std::int64_t>(INT32_MIN) - 1,
                 };
 
-                for (auto i : numbers)
+                for (const auto i : numbers)
                 {
 
                     CAPTURE(i)
 
-                    json j =
+                    json const j =
                     {
                         { "entry", i }
                     };
                     CHECK(j.at("entry").is_number_integer());
 
-                    std::uint64_t const iu = *reinterpret_cast<std::uint64_t*>(&i);
-                    std::vector<std::uint8_t> expected_bson =
+                    std::uint64_t const iu = *reinterpret_cast<const std::uint64_t*>(&i);
+                    std::vector<std::uint8_t> const expected_bson =
                     {
                         0x14u, 0x00u, 0x00u, 0x00u, // size (little endian)
                         0x12u, /// entry: int64
@@ -950,19 +950,19 @@ TEST_CASE("BSON numerical data")
                     INT32_MAX
                 };
 
-                for (auto i : numbers)
+                for (const auto i : numbers)
                 {
 
                     CAPTURE(i)
 
-                    json j =
+                    json const j =
                     {
                         { "entry", i }
                     };
                     CHECK(j.at("entry").is_number_integer());
 
-                    std::uint32_t const iu = *reinterpret_cast<std::uint32_t*>(&i);
-                    std::vector<std::uint8_t> expected_bson =
+                    std::uint32_t const iu = *reinterpret_cast<const std::uint32_t*>(&i);
+                    std::vector<std::uint8_t> const expected_bson =
                     {
                         0x10u, 0x00u, 0x00u, 0x00u, // size (little endian)
                         0x10u, /// entry: int32
@@ -1003,19 +1003,19 @@ TEST_CASE("BSON numerical data")
                     static_cast<std::int64_t>(INT32_MAX) + 1,
                 };
 
-                for (auto i : numbers)
+                for (const auto i : numbers)
                 {
 
                     CAPTURE(i)
 
-                    json j =
+                    json const j =
                     {
                         { "entry", i }
                     };
                     CHECK(j.at("entry").is_number_integer());
 
-                    std::uint64_t const iu = *reinterpret_cast<std::uint64_t*>(&i);
-                    std::vector<std::uint8_t> expected_bson =
+                    std::uint64_t const iu = *reinterpret_cast<const std::uint64_t*>(&i);
+                    std::vector<std::uint8_t> const expected_bson =
                     {
                         0x14u, 0x00u, 0x00u, 0x00u, // size (little endian)
                         0x12u, /// entry: int64
@@ -1065,18 +1065,18 @@ TEST_CASE("BSON numerical data")
                     static_cast<std::uint64_t>(INT32_MAX)
                 };
 
-                for (auto i : numbers)
+                for (const auto i : numbers)
                 {
 
                     CAPTURE(i)
 
-                    json j =
+                    json const j =
                     {
                         { "entry", i }
                     };
 
                     auto iu = i;
-                    std::vector<std::uint8_t> expected_bson =
+                    std::vector<std::uint8_t> const expected_bson =
                     {
                         0x10u, 0x00u, 0x00u, 0x00u, // size (little endian)
                         0x10u, /// entry: int32
@@ -1120,18 +1120,18 @@ TEST_CASE("BSON numerical data")
                     static_cast<std::uint64_t>(INT64_MAX),
                 };
 
-                for (auto i : numbers)
+                for (const auto i : numbers)
                 {
 
                     CAPTURE(i)
 
-                    json j =
+                    json const j =
                     {
                         { "entry", i }
                     };
 
                     auto iu = i;
-                    std::vector<std::uint8_t> expected_bson =
+                    std::vector<std::uint8_t> const expected_bson =
                     {
                         0x14u, 0x00u, 0x00u, 0x00u, // size (little endian)
                         0x12u, /// entry: int64
@@ -1170,7 +1170,7 @@ TEST_CASE("BSON numerical data")
                     UINT64_MAX,
                 };
 
-                for (auto i : numbers)
+                for (const auto i : numbers)
                 {
 
                     CAPTURE(i)
@@ -1214,7 +1214,7 @@ TEST_CASE("BSON roundtrips" * doctest::skip())
 {
     SECTION("reference files")
     {
-        for (std::string filename :
+        for (const std::string filename :
                 {
                     TEST_DATA_DIRECTORY "/json.org/1.json",
                     TEST_DATA_DIRECTORY "/json.org/2.json",

--- a/tests/src/unit-capacity.cpp
+++ b/tests/src/unit-capacity.cpp
@@ -416,8 +416,8 @@ TEST_CASE("capacity")
     {
         SECTION("boolean")
         {
-            json const j = true;
-            const json j_const = true;
+            json j = true;
+            const json j_const(j);
 
             SECTION("result of max_size")
             {
@@ -428,8 +428,8 @@ TEST_CASE("capacity")
 
         SECTION("string")
         {
-            json const j = "hello world";
-            const json j_const = "hello world";
+            json j = "hello world";
+            const json j_const(j);
 
             SECTION("result of max_size")
             {
@@ -442,8 +442,8 @@ TEST_CASE("capacity")
         {
             SECTION("empty array")
             {
-                json const j = json::array();
-                const json j_const = json::array();
+                json j = json::array();
+                const json j_const(j);
 
                 SECTION("result of max_size")
                 {
@@ -454,8 +454,8 @@ TEST_CASE("capacity")
 
             SECTION("filled array")
             {
-                json const j = {1, 2, 3};
-                const json j_const = {1, 2, 3};
+                json j = {1, 2, 3};
+                const json j_const(j);
 
                 SECTION("result of max_size")
                 {
@@ -469,8 +469,8 @@ TEST_CASE("capacity")
         {
             SECTION("empty object")
             {
-                json const j = json::object();
-                const json j_const = json::object();
+                json j = json::object();
+                const json j_const(j);
 
                 SECTION("result of max_size")
                 {
@@ -481,8 +481,8 @@ TEST_CASE("capacity")
 
             SECTION("filled object")
             {
-                json const j = {{"one", 1}, {"two", 2}, {"three", 3}};
-                const json j_const = {{"one", 1}, {"two", 2}, {"three", 3}};
+                json j = {{"one", 1}, {"two", 2}, {"three", 3}};
+                const json j_const(j);
 
                 SECTION("result of max_size")
                 {
@@ -494,8 +494,8 @@ TEST_CASE("capacity")
 
         SECTION("number (integer)")
         {
-            json const j = -23;
-            const json j_const = -23;
+            json j = -23;
+            const json j_const(j);
 
             SECTION("result of max_size")
             {
@@ -506,8 +506,8 @@ TEST_CASE("capacity")
 
         SECTION("number (unsigned)")
         {
-            json const j = 23u;
-            const json j_const = 23u;
+            json j = 23u;
+            const json j_const(j);
 
             SECTION("result of max_size")
             {
@@ -518,8 +518,8 @@ TEST_CASE("capacity")
 
         SECTION("number (float)")
         {
-            json const j = 23.42;
-            const json j_const = 23.42;
+            json j = 23.42;
+            const json j_const(j);
 
             SECTION("result of max_size")
             {
@@ -530,8 +530,8 @@ TEST_CASE("capacity")
 
         SECTION("null")
         {
-            json const j = nullptr;
-            const json j_const = nullptr;
+            json j = nullptr;
+            const json j_const(j);
 
             SECTION("result of max_size")
             {

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -113,7 +113,7 @@ TEST_CASE("CBOR")
         {
             // NaN value
             json const j = std::numeric_limits<json::number_float_t>::quiet_NaN();
-            std::vector<uint8_t> expected = {0xf9, 0x7e, 0x00};
+            const std::vector<uint8_t> expected = {0xf9, 0x7e, 0x00};
             const auto result = json::to_cbor(j);
             CHECK(result == expected);
         }
@@ -122,15 +122,15 @@ TEST_CASE("CBOR")
         {
             // Infinity value
             json const j = std::numeric_limits<json::number_float_t>::infinity();
-            std::vector<uint8_t> expected = {0xf9, 0x7c, 0x00};
+            const std::vector<uint8_t> expected = {0xf9, 0x7c, 0x00};
             const auto result = json::to_cbor(j);
             CHECK(result == expected);
         }
 
         SECTION("null")
         {
-            json j = nullptr;
-            std::vector<uint8_t> expected = {0xf6};
+            const json j = nullptr;
+            const std::vector<uint8_t> expected = {0xf6};
             const auto result = json::to_cbor(j);
             CHECK(result == expected);
 
@@ -143,8 +143,8 @@ TEST_CASE("CBOR")
         {
             SECTION("true")
             {
-                json j = true;
-                std::vector<uint8_t> expected = {0xf5};
+                const json j = true;
+                const std::vector<uint8_t> expected = {0xf5};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -155,8 +155,8 @@ TEST_CASE("CBOR")
 
             SECTION("false")
             {
-                json j = false;
-                std::vector<uint8_t> expected = {0xf4};
+                const json j = false;
+                const std::vector<uint8_t> expected = {0xf4};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -172,40 +172,44 @@ TEST_CASE("CBOR")
             {
                 SECTION("-9223372036854775808..-4294967297")
                 {
-                    std::vector<int64_t> numbers;
-                    numbers.push_back(INT64_MIN);
-                    numbers.push_back(-1000000000000000000);
-                    numbers.push_back(-100000000000000000);
-                    numbers.push_back(-10000000000000000);
-                    numbers.push_back(-1000000000000000);
-                    numbers.push_back(-100000000000000);
-                    numbers.push_back(-10000000000000);
-                    numbers.push_back(-1000000000000);
-                    numbers.push_back(-100000000000);
-                    numbers.push_back(-10000000000);
-                    numbers.push_back(-4294967297);
-                    for (auto i : numbers)
+                    const std::vector<int64_t> numbers
+                    {
+                        INT64_MIN,
+                        -1000000000000000000,
+                        -100000000000000000,
+                        -10000000000000000,
+                        -1000000000000000,
+                        -100000000000000,
+                        -10000000000000,
+                        -1000000000000,
+                        -100000000000,
+                        -10000000000,
+                        -4294967297,
+                    };
+                    for (const auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(0x3b));
-                        auto positive = static_cast<uint64_t>(-1 - i);
-                        expected.push_back(static_cast<uint8_t>((positive >> 56) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 48) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 40) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 32) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(positive & 0xff));
+                        const auto positive = static_cast<uint64_t>(-1 - i);
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(0x3b),
+                            static_cast<uint8_t>((positive >> 56) & 0xff),
+                            static_cast<uint8_t>((positive >> 48) & 0xff),
+                            static_cast<uint8_t>((positive >> 40) & 0xff),
+                            static_cast<uint8_t>((positive >> 32) & 0xff),
+                            static_cast<uint8_t>((positive >> 24) & 0xff),
+                            static_cast<uint8_t>((positive >> 16) & 0xff),
+                            static_cast<uint8_t>((positive >> 8) & 0xff),
+                            static_cast<uint8_t>(positive & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -214,14 +218,14 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x3b);
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        const uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == positive);
                         CHECK(-1 - static_cast<int64_t>(restored) == i);
 
@@ -233,32 +237,36 @@ TEST_CASE("CBOR")
 
                 SECTION("-4294967296..-65537")
                 {
-                    std::vector<int64_t> numbers;
-                    numbers.push_back(-65537);
-                    numbers.push_back(-100000);
-                    numbers.push_back(-1000000);
-                    numbers.push_back(-10000000);
-                    numbers.push_back(-100000000);
-                    numbers.push_back(-1000000000);
-                    numbers.push_back(-4294967296);
-                    for (auto i : numbers)
+                    const std::vector<int64_t> numbers
+                    {
+                        -65537,
+                            -100000,
+                            -1000000,
+                            -10000000,
+                            -100000000,
+                            -1000000000,
+                            -4294967296,
+                        };
+                    for (const auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(0x3a));
                         auto positive = static_cast<uint32_t>(static_cast<uint64_t>(-1 - i) & 0x00000000ffffffff);
-                        expected.push_back(static_cast<uint8_t>((positive >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((positive >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(positive & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(0x3a),
+                            static_cast<uint8_t>((positive >> 24) & 0xff),
+                            static_cast<uint8_t>((positive >> 16) & 0xff),
+                            static_cast<uint8_t>((positive >> 8) & 0xff),
+                            static_cast<uint8_t>(positive & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -267,10 +275,10 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x3a);
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        const uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == positive);
                         CHECK(-1LL - restored == i);
 
@@ -287,17 +295,19 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(0x39));
-                        auto positive = static_cast<uint16_t>(-1 - i);
-                        expected.push_back(static_cast<uint8_t>((positive >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(positive & 0xff));
+                        const auto positive = static_cast<uint16_t>(-1 - i);
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(0x39),
+                            static_cast<uint8_t>((positive >> 8) & 0xff),
+                            static_cast<uint8_t>(positive & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -306,7 +316,7 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x39);
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        const auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == positive);
                         CHECK(-1 - restored == i);
 
@@ -318,13 +328,13 @@ TEST_CASE("CBOR")
 
                 SECTION("-9263 (int 16)")
                 {
-                    json j = -9263;
+                    const json j = -9263;
                     std::vector<uint8_t> expected = {0x39, 0x24, 0x2e};
 
                     const auto result = json::to_cbor(j);
                     CHECK(result == expected);
 
-                    auto restored = static_cast<int16_t>(-1 - ((result[1] << 8) + result[2]));
+                    const auto restored = static_cast<int16_t>(-1 - ((result[1] << 8) + result[2]));
                     CHECK(restored == -9263);
 
                     // roundtrip
@@ -339,15 +349,17 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x38);
-                        expected.push_back(static_cast<uint8_t>(-1 - i));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x38,
+                            static_cast<uint8_t>(-1 - i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -371,14 +383,16 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(0x20 - 1 - static_cast<uint8_t>(i)));
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(0x20 - 1 - static_cast<uint8_t>(i)),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -408,8 +422,10 @@ TEST_CASE("CBOR")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(i));
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -439,9 +455,11 @@ TEST_CASE("CBOR")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(0x18));
-                        expected.push_back(static_cast<uint8_t>(i));
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(0x18),
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -472,10 +490,12 @@ TEST_CASE("CBOR")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(0x19));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(0x19),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -484,7 +504,7 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x19);
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        const auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -495,7 +515,7 @@ TEST_CASE("CBOR")
 
                 SECTION("65536..4294967295")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 65536u, 77777u, 1048576u
                             })
@@ -510,12 +530,14 @@ TEST_CASE("CBOR")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x1a);
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x1a,
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -524,10 +546,10 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x1a);
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        const uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -538,7 +560,7 @@ TEST_CASE("CBOR")
 
                 SECTION("4294967296..4611686018427387903")
                 {
-                    for (uint64_t i :
+                    for (const uint64_t i :
                             {
                                 4294967296ul, 4611686018427387903ul
                             })
@@ -553,16 +575,18 @@ TEST_CASE("CBOR")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x1b);
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x1b,
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -571,14 +595,14 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x1b);
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        const uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -594,16 +618,18 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xd1);
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            0xd1,
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -612,7 +638,7 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0xd1);
-                        auto restored = static_cast<int16_t>((result[1] << 8) + result[2]);
+                        const auto restored = static_cast<int16_t>((result[1] << 8) + result[2]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -630,14 +656,16 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(i));
+                        const std::vector<uint8_t> expected
+                        {
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -660,15 +688,17 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x18);
-                        expected.push_back(static_cast<uint8_t>(i));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x18,
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -677,7 +707,7 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x18);
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        const auto restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -693,16 +723,18 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x19);
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x19,
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -711,7 +743,7 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x19);
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        const auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -722,7 +754,7 @@ TEST_CASE("CBOR")
 
                 SECTION("65536..4294967295 (four-byte uint32_t)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 65536u, 77777u, 1048576u
                             })
@@ -730,18 +762,20 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x1a);
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x1a,
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -750,10 +784,10 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x1a);
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        const uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -764,7 +798,7 @@ TEST_CASE("CBOR")
 
                 SECTION("4294967296..4611686018427387903 (eight-byte uint64_t)")
                 {
-                    for (uint64_t i :
+                    for (const uint64_t i :
                             {
                                 4294967296ul, 4611686018427387903ul
                             })
@@ -772,22 +806,24 @@ TEST_CASE("CBOR")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        const json j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0x1b);
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        const std::vector<uint8_t> expected
+                        {
+                            0x1b,
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_cbor(j);
@@ -796,14 +832,14 @@ TEST_CASE("CBOR")
 
                         // check individual bytes
                         CHECK(result[0] == 0x1b);
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        const uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -818,7 +854,7 @@ TEST_CASE("CBOR")
                 SECTION("3.1415925")
                 {
                     double v = 3.1415925;
-                    json j = v;
+                    const json j = v;
                     std::vector<uint8_t> expected =
                     {
                         0xfb, 0x40, 0x09, 0x21, 0xfb, 0x3f, 0xa6, 0xde, 0xfc
@@ -839,11 +875,11 @@ TEST_CASE("CBOR")
                 SECTION("0.5")
                 {
                     double v = 0.5;
-                    json j = v;
+                    const json j = v;
                     // its double-precision float binary value is
                     // {0xfb, 0x3f, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
                     // but to save memory, we can store it as single-precision float.
-                    std::vector<uint8_t> expected = {0xfa, 0x3f, 0x00, 0x00, 0x00};
+                    const std::vector<uint8_t> expected = {0xfa, 0x3f, 0x00, 0x00, 0x00};
                     const auto result = json::to_cbor(j);
                     CHECK(result == expected);
                     // roundtrip
@@ -853,10 +889,10 @@ TEST_CASE("CBOR")
                 SECTION("0.0")
                 {
                     double v = 0.0;
-                    json j = v;
+                    const json j = v;
                     // its double-precision binary value is:
                     // {0xfb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-                    std::vector<uint8_t> expected = {0xfa, 0x00, 0x00, 0x00, 0x00};
+                    const std::vector<uint8_t> expected = {0xfa, 0x00, 0x00, 0x00, 0x00};
                     const auto result = json::to_cbor(j);
                     CHECK(result == expected);
                     // roundtrip
@@ -866,10 +902,10 @@ TEST_CASE("CBOR")
                 SECTION("-0.0")
                 {
                     double v = -0.0;
-                    json j = v;
+                    const json j = v;
                     // its double-precision binary value is:
                     // {0xfb, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-                    std::vector<uint8_t> expected = {0xfa, 0x80, 0x00, 0x00, 0x00};
+                    const std::vector<uint8_t> expected = {0xfa, 0x80, 0x00, 0x00, 0x00};
                     const auto result = json::to_cbor(j);
                     CHECK(result == expected);
                     // roundtrip
@@ -879,10 +915,10 @@ TEST_CASE("CBOR")
                 SECTION("100.0")
                 {
                     double v = 100.0;
-                    json j = v;
+                    const json j = v;
                     // its double-precision binary value is:
                     // {0xfb, 0x40, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-                    std::vector<uint8_t> expected = {0xfa, 0x42, 0xc8, 0x00, 0x00};
+                    const std::vector<uint8_t> expected = {0xfa, 0x42, 0xc8, 0x00, 0x00};
                     const auto result = json::to_cbor(j);
                     CHECK(result == expected);
                     // roundtrip
@@ -892,10 +928,10 @@ TEST_CASE("CBOR")
                 SECTION("200.0")
                 {
                     double v = 200.0;
-                    json j = v;
+                    const json j = v;
                     // its double-precision binary value is:
                     // {0xfb, 0x40, 0x69, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-                    std::vector<uint8_t> expected = {0xfa, 0x43, 0x48, 0x00, 0x00};
+                    const std::vector<uint8_t> expected = {0xfa, 0x43, 0x48, 0x00, 0x00};
                     const auto result = json::to_cbor(j);
                     CHECK(result == expected);
                     // roundtrip
@@ -905,8 +941,8 @@ TEST_CASE("CBOR")
                 SECTION("3.40282e+38(max float)")
                 {
                     float v = (std::numeric_limits<float>::max)();
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    const json j = v;
+                    const std::vector<uint8_t> expected =
                     {
                         0xfa, 0x7f, 0x7f, 0xff, 0xff
                     };
@@ -919,8 +955,8 @@ TEST_CASE("CBOR")
                 SECTION("-3.40282e+38(lowest float)")
                 {
                     auto v = static_cast<double>(std::numeric_limits<float>::lowest());
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    const json j = v;
+                    const std::vector<uint8_t> expected =
                     {
                         0xfa, 0xff, 0x7f, 0xff, 0xff
                     };
@@ -933,8 +969,8 @@ TEST_CASE("CBOR")
                 SECTION("1 + 3.40282e+38(more than max float)")
                 {
                     double v = static_cast<double>((std::numeric_limits<float>::max)()) + 0.1e+34;
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    const json j = v;
+                    const std::vector<uint8_t> expected =
                     {
                         0xfb, 0x47, 0xf0, 0x00, 0x03, 0x04, 0xdc, 0x64, 0x49
                     };
@@ -948,8 +984,8 @@ TEST_CASE("CBOR")
                 SECTION("-1 - 3.40282e+38(less than lowest float)")
                 {
                     double v = static_cast<double>(std::numeric_limits<float>::lowest()) - 1.0;
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    const json j = v;
+                    const std::vector<uint8_t> expected =
                     {
                         0xfa, 0xff, 0x7f, 0xff, 0xff
                     };
@@ -1076,7 +1112,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    const json j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -1110,10 +1146,11 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    const json j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
+
                     expected.push_back(0x78);
                     expected.push_back(static_cast<uint8_t>(N));
                     for (size_t i = 0; i < N; ++i)
@@ -1136,7 +1173,7 @@ TEST_CASE("CBOR")
 
             SECTION("N = 256..65535")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             256u, 999u, 1025u, 3333u, 2048u, 65535u
                         })
@@ -1145,7 +1182,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    const json j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1169,7 +1206,7 @@ TEST_CASE("CBOR")
 
             SECTION("N = 65536..4294967295")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             65536u, 77777u, 1048576u
                         })
@@ -1178,7 +1215,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    const json j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1207,7 +1244,7 @@ TEST_CASE("CBOR")
         {
             SECTION("empty")
             {
-                json j = json::array();
+                const json j = json::array();
                 std::vector<uint8_t> expected = {0x80};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
@@ -1219,8 +1256,8 @@ TEST_CASE("CBOR")
 
             SECTION("[null]")
             {
-                json j = {nullptr};
-                std::vector<uint8_t> expected = {0x81, 0xf6};
+                const json j = {nullptr};
+                const std::vector<uint8_t> expected = {0x81, 0xf6};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -1231,8 +1268,8 @@ TEST_CASE("CBOR")
 
             SECTION("[1,2,3,4,5]")
             {
-                json j = json::parse("[1,2,3,4,5]");
-                std::vector<uint8_t> expected = {0x85, 0x01, 0x02, 0x03, 0x04, 0x05};
+                const json j = json::parse("[1,2,3,4,5]");
+                const std::vector<uint8_t> expected = {0x85, 0x01, 0x02, 0x03, 0x04, 0x05};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -1243,8 +1280,8 @@ TEST_CASE("CBOR")
 
             SECTION("[[[[]]]]")
             {
-                json j = json::parse("[[[[]]]]");
-                std::vector<uint8_t> expected = {0x81, 0x81, 0x81, 0x80};
+                const json j = json::parse("[[[[]]]]");
+                const std::vector<uint8_t> expected = {0x81, 0x81, 0x81, 0x80};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -1255,7 +1292,7 @@ TEST_CASE("CBOR")
 
             SECTION("array with uint16_t elements")
             {
-                json j(257, nullptr);
+                const json j(257, nullptr);
                 std::vector<uint8_t> expected(j.size() + 3, 0xf6); // all null
                 expected[0] = 0x99; // array 16 bit
                 expected[1] = 0x01; // size (0x0101), byte 0
@@ -1270,7 +1307,7 @@ TEST_CASE("CBOR")
 
             SECTION("array with uint32_t elements")
             {
-                json j(65793, nullptr);
+                const json j(65793, nullptr);
                 std::vector<uint8_t> expected(j.size() + 5, 0xf6); // all null
                 expected[0] = 0x9a; // array 32 bit
                 expected[1] = 0x00; // size (0x00010101), byte 0
@@ -1290,8 +1327,8 @@ TEST_CASE("CBOR")
         {
             SECTION("empty")
             {
-                json j = json::object();
-                std::vector<uint8_t> expected = {0xa0};
+                const json j = json::object();
+                const std::vector<uint8_t> expected = {0xa0};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -1302,8 +1339,8 @@ TEST_CASE("CBOR")
 
             SECTION("{\"\":null}")
             {
-                json j = {{"", nullptr}};
-                std::vector<uint8_t> expected = {0xa1, 0x60, 0xf6};
+                const json j = {{"", nullptr}};
+                const std::vector<uint8_t> expected = {0xa1, 0x60, 0xf6};
                 const auto result = json::to_cbor(j);
                 CHECK(result == expected);
 
@@ -1314,8 +1351,8 @@ TEST_CASE("CBOR")
 
             SECTION("{\"a\": {\"b\": {\"c\": {}}}}")
             {
-                json j = json::parse(R"({"a": {"b": {"c": {}}}})");
-                std::vector<uint8_t> expected =
+                const json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                const std::vector<uint8_t> expected =
                 {
                     0xa1, 0x61, 0x61, 0xa1, 0x61, 0x62, 0xa1, 0x61, 0x63, 0xa0
                 };
@@ -1425,7 +1462,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with byte array containing of N * 'x'
                     const auto s = std::vector<uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    const json j = json::binary(s);
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -1459,7 +1496,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::vector<uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    const json j = json::binary(s);
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -1485,7 +1522,7 @@ TEST_CASE("CBOR")
 
             SECTION("N = 256..65535")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             256u, 999u, 1025u, 3333u, 2048u, 65535u
                         })
@@ -1494,7 +1531,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::vector<uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    const json j = json::binary(s);
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1518,7 +1555,7 @@ TEST_CASE("CBOR")
 
             SECTION("N = 65536..4294967295")
             {
-                for (size_t N :
+                for (const size_t N :
                         {
                             65536u, 77777u, 1048576u
                         })
@@ -1527,7 +1564,7 @@ TEST_CASE("CBOR")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::vector<uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    const json j = json::binary(s);
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1609,7 +1646,7 @@ TEST_CASE("CBOR")
             std::vector<uint8_t> const given = {0x5b, 0x00, 0x00, 0x00, 0x00,
                                                 0x00, 0x00, 0x00, 0x01, 0x61
                                                };
-            json j = json::from_cbor(given);
+            const json j = json::from_cbor(given);
             CHECK(j == json::binary(std::vector<uint8_t> {'a'}));
         }
 
@@ -1618,7 +1655,7 @@ TEST_CASE("CBOR")
             std::vector<uint8_t> const given = {0x7b, 0x00, 0x00, 0x00, 0x00,
                                                 0x00, 0x00, 0x00, 0x01, 0x61
                                                };
-            json j = json::from_cbor(given);
+            const json j = json::from_cbor(given);
             CHECK(j == "a");
         }
 
@@ -1627,7 +1664,7 @@ TEST_CASE("CBOR")
             std::vector<uint8_t> const given = {0x9b, 0x00, 0x00, 0x00, 0x00,
                                                 0x00, 0x00, 0x00, 0x01, 0xf4
                                                };
-            json j = json::from_cbor(given);
+            const json j = json::from_cbor(given);
             CHECK(j == json::parse("[false]"));
         }
 
@@ -1636,7 +1673,7 @@ TEST_CASE("CBOR")
             std::vector<uint8_t> const given = {0xbb, 0x00, 0x00, 0x00, 0x00,
                                                 0x00, 0x00, 0x00, 0x01, 0x60, 0xf4
                                                };
-            json j = json::from_cbor(given);
+            const json j = json::from_cbor(given);
             CHECK(j == json::parse("{\"\": false}"));
         }
     }
@@ -1724,7 +1761,7 @@ TEST_CASE("CBOR")
 
             SECTION("all unsupported bytes")
             {
-                for (auto byte :
+                for (const auto byte :
                         {
                             // ?
                             0x1c, 0x1d, 0x1e, 0x1f,
@@ -1829,7 +1866,7 @@ TEST_CASE("single CBOR roundtrip")
 
         // parse JSON file
         std::ifstream f_json(filename);
-        json j1 = json::parse(f_json);
+        const json j1 = json::parse(f_json);
 
         // parse CBOR file
         auto packed = utils::read_binary_file(filename + ".cbor");
@@ -1874,7 +1911,7 @@ TEST_CASE("CBOR regressions")
         AFL-Fuzz. As a result, empty byte vectors and excessive lengths are
         detected.
         */
-        for (std::string filename :
+        for (const std::string filename :
                 {
                     TEST_DATA_DIRECTORY "/cbor_regression/test01",
                     TEST_DATA_DIRECTORY "/cbor_regression/test02",
@@ -1951,7 +1988,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
         exclude_packed.insert(TEST_DATA_DIRECTORY "/nst_json_testsuite/test_parsing/y_object_duplicated_key.json");
         exclude_packed.insert(TEST_DATA_DIRECTORY "/nst_json_testsuite/test_parsing/y_object_long_strings.json");
 
-        for (std::string filename :
+        for (const std::string filename :
                 {
                     TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json",
                     TEST_DATA_DIRECTORY "/json.org/1.json",
@@ -2109,7 +2146,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
                 json j1 = json::parse(f_json);
 
                 // parse CBOR file
-                auto packed = utils::read_binary_file(filename + ".cbor");
+                const auto packed = utils::read_binary_file(filename + ".cbor");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_cbor(packed));
 
@@ -2139,7 +2176,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
                 json j1 = json::parse(f_json);
 
                 // parse CBOR file
-                auto packed = utils::read_binary_file(filename + ".cbor");
+                const auto packed = utils::read_binary_file(filename + ".cbor");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_cbor({packed.data(), packed.size()}));
 
@@ -2154,7 +2191,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
                 json const j1 = json::parse(f_json);
 
                 // parse CBOR file
-                auto packed = utils::read_binary_file(filename + ".cbor");
+                const auto packed = utils::read_binary_file(filename + ".cbor");
 
                 if (exclude_packed.count(filename) == 0u)
                 {
@@ -2389,11 +2426,11 @@ TEST_CASE("examples from RFC 7049 Appendix A")
 
     SECTION("byte arrays")
     {
-        auto packed = utils::read_binary_file(TEST_DATA_DIRECTORY "/binary_data/cbor_binary.cbor");
+        const auto packed = utils::read_binary_file(TEST_DATA_DIRECTORY "/binary_data/cbor_binary.cbor");
         json j;
         CHECK_NOTHROW(j = json::from_cbor(packed));
 
-        auto expected = utils::read_binary_file(TEST_DATA_DIRECTORY "/binary_data/cbor_binary.out");
+        const auto expected = utils::read_binary_file(TEST_DATA_DIRECTORY "/binary_data/cbor_binary.out");
         CHECK(j == json::binary(expected));
 
         // 0xd8
@@ -2460,12 +2497,12 @@ TEST_CASE("examples from RFC 7049 Appendix A")
 
 TEST_CASE("Tagged values")
 {
-    json j = "s";
+    const json j = "s";
     auto v = json::to_cbor(j);
 
     SECTION("0xC6..0xD4")
     {
-        for (auto b : std::vector<std::uint8_t>
+        for (const auto b : std::vector<std::uint8_t>
     {
         0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4
     })

--- a/tests/src/unit-constructor1.cpp
+++ b/tests/src/unit-constructor1.cpp
@@ -27,76 +27,76 @@ TEST_CASE("constructors")
     {
         SECTION("null")
         {
-            auto t = json::value_t::null;
+            auto const t = json::value_t::null;
             json const j(t);
             CHECK(j.type() == t);
         }
 
         SECTION("discarded")
         {
-            auto t = json::value_t::discarded;
+            auto const t = json::value_t::discarded;
             json const j(t);
             CHECK(j.type() == t);
         }
 
         SECTION("object")
         {
-            auto t = json::value_t::object;
+            auto const t = json::value_t::object;
             json const j(t);
             CHECK(j.type() == t);
         }
 
         SECTION("array")
         {
-            auto t = json::value_t::array;
+            auto const t = json::value_t::array;
             json const j(t);
             CHECK(j.type() == t);
         }
 
         SECTION("boolean")
         {
-            auto t = json::value_t::boolean;
-            json j(t);
+            auto const t = json::value_t::boolean;
+            json const j(t);
             CHECK(j.type() == t);
             CHECK(j == false);
         }
 
         SECTION("string")
         {
-            auto t = json::value_t::string;
-            json j(t);
+            auto const t = json::value_t::string;
+            json const j(t);
             CHECK(j.type() == t);
             CHECK(j == "");
         }
 
         SECTION("number_integer")
         {
-            auto t = json::value_t::number_integer;
-            json j(t);
+            auto const t = json::value_t::number_integer;
+            json const j(t);
             CHECK(j.type() == t);
             CHECK(j == 0);
         }
 
         SECTION("number_unsigned")
         {
-            auto t = json::value_t::number_unsigned;
-            json j(t);
+            auto const t = json::value_t::number_unsigned;
+            json const j(t);
             CHECK(j.type() == t);
             CHECK(j == 0);
         }
 
         SECTION("number_float")
         {
-            auto t = json::value_t::number_float;
-            json j(t);
+            auto const t = json::value_t::number_float;
+            json const j(t);
             CHECK(j.type() == t);
             CHECK(j == 0.0);
         }
 
         SECTION("binary")
         {
-            auto t = json::value_t::binary;
-            json j(t);
+            auto const t = json::value_t::binary;
+            json const j(t);
             CHECK(j.type() == t);
             CHECK(j == json::binary({}));
         }
@@ -141,22 +141,24 @@ TEST_CASE("constructors")
     {
         // reference object
         json::object_t const o_reference {{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}};
-        json j_reference(o_reference);
+        json const j_reference(o_reference);
 
         SECTION("std::map<json::string_t, json>")
         {
             std::map<json::string_t, json> const o {{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}};
-            json j(o);
+            json const j(o);
             CHECK(j.type() == json::value_t::object);
             CHECK(j == j_reference);
         }
 
         SECTION("std::map<std::string, std::string> #600")
         {
-            std::map<std::string, std::string> m;
-            m["a"] = "b";
-            m["c"] = "d";
-            m["e"] = "f";
+            std::map<std::string, std::string> m
+            {
+                {"a", "b"},
+                {"c", "d"},
+                {"e", "f"},
+            };
 
             json const j(m);
             CHECK((j.get<decltype(m)>() == m));
@@ -165,7 +167,7 @@ TEST_CASE("constructors")
         SECTION("std::map<const char*, json>")
         {
             std::map<const char*, json> const o {{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}};
-            json j(o);
+            json const j(o);
             CHECK(j.type() == json::value_t::object);
             CHECK(j == j_reference);
         }
@@ -174,7 +176,7 @@ TEST_CASE("constructors")
         SECTION("std::multimap<json::string_t, json>")
         {
             std::multimap<json::string_t, json> const o {{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}};
-            json j(o);
+            json const j(o);
             CHECK(j.type() == json::value_t::object);
             CHECK(j == j_reference);
         }
@@ -182,7 +184,7 @@ TEST_CASE("constructors")
         SECTION("std::unordered_map<json::string_t, json>")
         {
             std::unordered_map<json::string_t, json> const o {{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}};
-            json j(o);
+            json const j(o);
             CHECK(j.type() == json::value_t::object);
             CHECK(j == j_reference);
         }
@@ -190,14 +192,14 @@ TEST_CASE("constructors")
         SECTION("std::unordered_multimap<json::string_t, json>")
         {
             std::unordered_multimap<json::string_t, json> const o {{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}};
-            json j(o);
+            json const j(o);
             CHECK(j.type() == json::value_t::object);
             CHECK(j == j_reference);
         }
 
         SECTION("associative container literal")
         {
-            json j({{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}});
+            json const j({{"a", json(1)}, {"b", json(1u)}, {"c", json(2.2)}, {"d", json(false)}, {"e", json("string")}, {"f", json()}});
             CHECK(j.type() == json::value_t::object);
             CHECK(j == j_reference);
         }
@@ -224,20 +226,20 @@ TEST_CASE("constructors")
     {
         // reference array
         json::array_t const a_reference {json(1), json(1u), json(2.2), json(false), json("string"), json()};
-        json j_reference(a_reference);
+        json const j_reference(a_reference);
 
         SECTION("std::list<json>")
         {
             std::list<json> const a {json(1), json(1u), json(2.2), json(false), json("string"), json()};
-            json j(a);
+            json const j(a);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == j_reference);
         }
 
         SECTION("std::pair")
         {
-            std::pair<float, std::string> p{1.0f, "string"};
-            json j(p);
+            std::pair<float, std::string> const p{1.0f, "string"};
+            json const j(p);
 
             CHECK(j.type() == json::value_t::array);
             CHECK(j.get<decltype(p)>() == p);
@@ -248,7 +250,7 @@ TEST_CASE("constructors")
 
         SECTION("std::pair with discarded values")
         {
-            json j{1, 2.0, "string"};
+            json const j{1, 2.0, "string"};
 
             const auto p = j.get<std::pair<int, float>>();
             CHECK(p.first == j[0]);
@@ -258,7 +260,7 @@ TEST_CASE("constructors")
         SECTION("std::tuple")
         {
             const auto t = std::make_tuple(1.0, std::string{"string"}, 42, std::vector<int> {0, 1});
-            json j(t);
+            json const j(t);
 
             CHECK(j.type() == json::value_t::array);
             REQUIRE(j.size() == 4);
@@ -272,7 +274,7 @@ TEST_CASE("constructors")
 
         SECTION("std::tuple with discarded values")
         {
-            json j{1, 2.0, "string", 42};
+            json const j{1, 2.0, "string", 42};
 
             const auto t = j.get<std::tuple<int, float, std::string>>();
             CHECK(std::get<0>(t) == j[0]);
@@ -292,15 +294,15 @@ TEST_CASE("constructors")
         SECTION("std::forward_list<json>")
         {
             std::forward_list<json> const a {json(1), json(1u), json(2.2), json(false), json("string"), json()};
-            json j(a);
+            json const j(a);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == j_reference);
         }
 
         SECTION("std::array<json, 6>")
         {
-            std::array<json, 6> a {{json(1), json(1u), json(2.2), json(false), json("string"), json()}};
-            json j(a);
+            std::array<json, 6> const a {{json(1), json(1u), json(2.2), json(false), json("string"), json()}};
+            json const j(a);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == j_reference);
 
@@ -310,8 +312,8 @@ TEST_CASE("constructors")
 
         SECTION("std::valarray<int>")
         {
-            std::valarray<int> va = {1, 2, 3, 4, 5};
-            json j(va);
+            std::valarray<int> const va = {1, 2, 3, 4, 5};
+            json const j(va);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == json({1, 2, 3, 4, 5}));
 
@@ -325,8 +327,8 @@ TEST_CASE("constructors")
 
         SECTION("std::valarray<double>")
         {
-            std::valarray<double> va = {1.2, 2.3, 3.4, 4.5, 5.6};
-            json j(va);
+            std::valarray<double> const va = {1.2, 2.3, 3.4, 4.5, 5.6};
+            json const j(va);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == json({1.2, 2.3, 3.4, 4.5, 5.6}));
 
@@ -341,7 +343,7 @@ TEST_CASE("constructors")
         SECTION("std::vector<json>")
         {
             std::vector<json> const a {json(1), json(1u), json(2.2), json(false), json("string"), json()};
-            json j(a);
+            json const j(a);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == j_reference);
         }
@@ -349,7 +351,7 @@ TEST_CASE("constructors")
         SECTION("std::deque<json>")
         {
             std::deque<json> const a {json(1), json(1u), json(2.2), json(false), json("string"), json()};
-            json j(a);
+            json const j(a);
             CHECK(j.type() == json::value_t::array);
             CHECK(j == j_reference);
         }
@@ -372,7 +374,7 @@ TEST_CASE("constructors")
 
         SECTION("sequence container literal")
         {
-            json j({json(1), json(1u), json(2.2), json(false), json("string"), json()});
+            json const j({json(1), json(1u), json(2.2), json(false), json("string"), json()});
             CHECK(j.type() == json::value_t::array);
             CHECK(j == j_reference);
         }
@@ -399,12 +401,12 @@ TEST_CASE("constructors")
     {
         // reference string
         json::string_t const s_reference {"Hello world"};
-        json j_reference(s_reference);
+        json const j_reference(s_reference);
 
         SECTION("std::string")
         {
             std::string const s {"Hello world"};
-            json j(s);
+            json const j(s);
             CHECK(j.type() == json::value_t::string);
             CHECK(j == j_reference);
         }
@@ -412,7 +414,7 @@ TEST_CASE("constructors")
         SECTION("char[]")
         {
             char const s[] {"Hello world"}; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
-            json j(s);
+            json const j(s);
             CHECK(j.type() == json::value_t::string);
             CHECK(j == j_reference);
         }
@@ -420,14 +422,14 @@ TEST_CASE("constructors")
         SECTION("const char*")
         {
             const char* s {"Hello world"};
-            json j(s);
+            json const j(s);
             CHECK(j.type() == json::value_t::string);
             CHECK(j == j_reference);
         }
 
         SECTION("string literal")
         {
-            json j("Hello world");
+            json const j("Hello world");
             CHECK(j.type() == json::value_t::string);
             CHECK(j == j_reference);
         }
@@ -509,14 +511,14 @@ TEST_CASE("constructors")
     {
         // reference objects
         json::number_integer_t const n_reference = 42;
-        json j_reference(n_reference);
+        json const j_reference(n_reference);
         json::number_unsigned_t const n_unsigned_reference = 42;
-        json j_unsigned_reference(n_unsigned_reference);
+        json const j_unsigned_reference(n_unsigned_reference);
 
         SECTION("short")
         {
             short const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -524,7 +526,7 @@ TEST_CASE("constructors")
         SECTION("unsigned short")
         {
             unsigned short const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -532,7 +534,7 @@ TEST_CASE("constructors")
         SECTION("int")
         {
             int const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -540,7 +542,7 @@ TEST_CASE("constructors")
         SECTION("unsigned int")
         {
             unsigned int const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -548,7 +550,7 @@ TEST_CASE("constructors")
         SECTION("long")
         {
             long const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -556,7 +558,7 @@ TEST_CASE("constructors")
         SECTION("unsigned long")
         {
             unsigned long const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -564,7 +566,7 @@ TEST_CASE("constructors")
         SECTION("long long")
         {
             long long const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -572,7 +574,7 @@ TEST_CASE("constructors")
         SECTION("unsigned long long")
         {
             unsigned long long const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -580,7 +582,7 @@ TEST_CASE("constructors")
         SECTION("int8_t")
         {
             int8_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -588,7 +590,7 @@ TEST_CASE("constructors")
         SECTION("int16_t")
         {
             int16_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -596,7 +598,7 @@ TEST_CASE("constructors")
         SECTION("int32_t")
         {
             int32_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -604,7 +606,7 @@ TEST_CASE("constructors")
         SECTION("int64_t")
         {
             int64_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -612,7 +614,7 @@ TEST_CASE("constructors")
         SECTION("int_fast8_t")
         {
             int_fast8_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -620,7 +622,7 @@ TEST_CASE("constructors")
         SECTION("int_fast16_t")
         {
             int_fast16_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -628,7 +630,7 @@ TEST_CASE("constructors")
         SECTION("int_fast32_t")
         {
             int_fast32_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -636,7 +638,7 @@ TEST_CASE("constructors")
         SECTION("int_fast64_t")
         {
             int_fast64_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -644,7 +646,7 @@ TEST_CASE("constructors")
         SECTION("int_least8_t")
         {
             int_least8_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -652,7 +654,7 @@ TEST_CASE("constructors")
         SECTION("int_least16_t")
         {
             int_least16_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -660,7 +662,7 @@ TEST_CASE("constructors")
         SECTION("int_least32_t")
         {
             int_least32_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -668,7 +670,7 @@ TEST_CASE("constructors")
         SECTION("int_least64_t")
         {
             int_least64_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -676,7 +678,7 @@ TEST_CASE("constructors")
         SECTION("uint8_t")
         {
             uint8_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -684,7 +686,7 @@ TEST_CASE("constructors")
         SECTION("uint16_t")
         {
             uint16_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -692,7 +694,7 @@ TEST_CASE("constructors")
         SECTION("uint32_t")
         {
             uint32_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -700,7 +702,7 @@ TEST_CASE("constructors")
         SECTION("uint64_t")
         {
             uint64_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -708,7 +710,7 @@ TEST_CASE("constructors")
         SECTION("uint_fast8_t")
         {
             uint_fast8_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -716,7 +718,7 @@ TEST_CASE("constructors")
         SECTION("uint_fast16_t")
         {
             uint_fast16_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -724,7 +726,7 @@ TEST_CASE("constructors")
         SECTION("uint_fast32_t")
         {
             uint_fast32_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -732,7 +734,7 @@ TEST_CASE("constructors")
         SECTION("uint_fast64_t")
         {
             uint_fast64_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -740,7 +742,7 @@ TEST_CASE("constructors")
         SECTION("uint_least8_t")
         {
             uint_least8_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -748,7 +750,7 @@ TEST_CASE("constructors")
         SECTION("uint_least16_t")
         {
             uint_least16_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -756,7 +758,7 @@ TEST_CASE("constructors")
         SECTION("uint_least32_t")
         {
             uint_least32_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -764,14 +766,14 @@ TEST_CASE("constructors")
         SECTION("uint_least64_t")
         {
             uint_least64_t const n = 42;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
 
         SECTION("integer literal without suffix")
         {
-            json j(42);
+            json const j(42);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -785,7 +787,7 @@ TEST_CASE("constructors")
 
         SECTION("integer literal with l suffix")
         {
-            json j(42L);
+            json const j(42L);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -799,7 +801,7 @@ TEST_CASE("constructors")
 
         SECTION("integer literal with ll suffix")
         {
-            json j(42LL);
+            json const j(42LL);
             CHECK(j.type() == json::value_t::number_integer);
             CHECK(j == j_reference);
         }
@@ -846,12 +848,12 @@ TEST_CASE("constructors")
         SECTION("infinity")
         {
             // infinity is stored properly, but serialized to null
-            json::number_float_t n(std::numeric_limits<json::number_float_t>::infinity());
+            json::number_float_t const n(std::numeric_limits<json::number_float_t>::infinity());
             json const j(n);
             CHECK(j.type() == json::value_t::number_float);
 
             // check round trip of infinity
-            json::number_float_t d{j};
+            json::number_float_t const d{j};
             CHECK(d == n);
 
             // check that inf is serialized to null
@@ -868,7 +870,7 @@ TEST_CASE("constructors")
         SECTION("float")
         {
             float const n = 42.23f;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_float);
             CHECK(j.m_value.number_float == Approx(j_reference.m_value.number_float));
         }
@@ -876,7 +878,7 @@ TEST_CASE("constructors")
         SECTION("double")
         {
             double const n = 42.23;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_float);
             CHECK(j.m_value.number_float == Approx(j_reference.m_value.number_float));
         }
@@ -884,28 +886,28 @@ TEST_CASE("constructors")
         SECTION("long double")
         {
             long double const n = 42.23L;
-            json j(n);
+            json const j(n);
             CHECK(j.type() == json::value_t::number_float);
             CHECK(j.m_value.number_float == Approx(j_reference.m_value.number_float));
         }
 
         SECTION("floating-point literal without suffix")
         {
-            json j(42.23);
+            json const j(42.23);
             CHECK(j.type() == json::value_t::number_float);
             CHECK(j.m_value.number_float == Approx(j_reference.m_value.number_float));
         }
 
         SECTION("integer literal with f suffix")
         {
-            json j(42.23f);
+            json const j(42.23f);
             CHECK(j.type() == json::value_t::number_float);
             CHECK(j.m_value.number_float == Approx(j_reference.m_value.number_float));
         }
 
         SECTION("integer literal with l suffix")
         {
-            json j(42.23L);
+            json const j(42.23L);
             CHECK(j.type() == json::value_t::number_float);
             CHECK(j.m_value.number_float == Approx(j_reference.m_value.number_float));
         }
@@ -1106,9 +1108,9 @@ TEST_CASE("constructors")
                 SECTION("constructor with implicit types (array)")
                 {
                     // This should break through any short string optimization in std::string
-                    std::string source(1024, '!');
+                    std::string const source(1024, '!');
                     const auto* source_addr = source.data();
-                    json j = {std::move(source)};
+                    json const j = {std::move(source)};
                     const auto* target_addr = j[0].get_ref<std::string const&>().data();
                     const bool success = (target_addr == source_addr);
                     CHECK(success);
@@ -1117,9 +1119,9 @@ TEST_CASE("constructors")
                 SECTION("constructor with implicit types (object)")
                 {
                     // This should break through any short string optimization in std::string
-                    std::string source(1024, '!');
+                    std::string const source(1024, '!');
                     const auto* source_addr = source.data();
-                    json j = {{"key", std::move(source)}};
+                    json const j = {{"key", std::move(source)}};
                     const auto* target_addr = j["key"].get_ref<std::string const&>().data();
                     const bool success = (target_addr == source_addr);
                     CHECK(success);
@@ -1128,7 +1130,7 @@ TEST_CASE("constructors")
                 SECTION("constructor with implicit types (object key)")
                 {
                     // This should break through any short string optimization in std::string
-                    std::string source(1024, '!');
+                    std::string const source(1024, '!');
                     const auto* source_addr = source.data();
                     json j = {{std::move(source), 42}};
                     const auto* target_addr = j.get_ref<json::object_t&>().begin()->first.data();
@@ -1141,9 +1143,9 @@ TEST_CASE("constructors")
             {
                 SECTION("constructor with implicit types (array)")
                 {
-                    json::array_t source = {1, 2, 3};
+                    json::array_t const source = {1, 2, 3};
                     const auto* source_addr = source.data();
-                    json j {std::move(source)};
+                    json const j {std::move(source)};
                     const auto* target_addr = j[0].get_ref<json::array_t const&>().data();
                     const bool success = (target_addr == source_addr);
                     CHECK(success);
@@ -1151,9 +1153,9 @@ TEST_CASE("constructors")
 
                 SECTION("constructor with implicit types (object)")
                 {
-                    json::array_t source = {1, 2, 3};
+                    json::array_t const source = {1, 2, 3};
                     const auto* source_addr = source.data();
-                    json j {{"key", std::move(source)}};
+                    json const j {{"key", std::move(source)}};
                     const auto* target_addr = j["key"].get_ref<json::array_t const&>().data();
                     const bool success = (target_addr == source_addr);
                     CHECK(success);
@@ -1161,9 +1163,9 @@ TEST_CASE("constructors")
 
                 SECTION("assignment with implicit types (array)")
                 {
-                    json::array_t source = {1, 2, 3};
+                    json::array_t const source = {1, 2, 3};
                     const auto* source_addr = source.data();
-                    json j = {std::move(source)};
+                    json const j = {std::move(source)};
                     const auto* target_addr = j[0].get_ref<json::array_t const&>().data();
                     const bool success = (target_addr == source_addr);
                     CHECK(success);
@@ -1171,9 +1173,9 @@ TEST_CASE("constructors")
 
                 SECTION("assignment with implicit types (object)")
                 {
-                    json::array_t source = {1, 2, 3};
+                    json::array_t const source = {1, 2, 3};
                     const auto* source_addr = source.data();
-                    json j = {{"key", std::move(source)}};
+                    json const j = {{"key", std::move(source)}};
                     const auto* target_addr = j["key"].get_ref<json::array_t const&>().data();
                     const bool success = (target_addr == source_addr);
                     CHECK(success);
@@ -1184,17 +1186,17 @@ TEST_CASE("constructors")
             {
                 SECTION("constructor with implicit types (array)")
                 {
-                    json::object_t source = {{"hello", "world"}};
+                    json::object_t const source = {{"hello", "world"}};
                     const json* source_addr = &source.at("hello");
-                    json j {std::move(source)};
+                    json const j {std::move(source)};
                     CHECK(&(j[0].get_ref<json::object_t const&>().at("hello")) == source_addr);
                 }
 
                 SECTION("constructor with implicit types (object)")
                 {
-                    json::object_t source = {{"hello", "world"}};
+                    json::object_t const source = {{"hello", "world"}};
                     const json* source_addr = &source.at("hello");
-                    json j {{"key", std::move(source)}};
+                    json const j {{"key", std::move(source)}};
                     CHECK(&(j["key"].get_ref<json::object_t const&>().at("hello")) == source_addr);
                 }
 
@@ -1208,9 +1210,9 @@ TEST_CASE("constructors")
 
                 SECTION("assignment with implicit types (object)")
                 {
-                    json::object_t source = {{"hello", "world"}};
+                    json::object_t const source = {{"hello", "world"}};
                     const json* source_addr = &source.at("hello");
-                    json j = {{"key", std::move(source)}};
+                    json const j = {{"key", std::move(source)}};
                     CHECK(&(j["key"].get_ref<json::object_t const&>().at("hello")) == source_addr);
                 }
             }
@@ -1219,33 +1221,33 @@ TEST_CASE("constructors")
             {
                 SECTION("constructor with implicit types (array)")
                 {
-                    json source {1, 2, 3};
+                    json const source {1, 2, 3};
                     const json* source_addr = &source[0];
-                    json j {std::move(source), {}};
+                    json const j {std::move(source), {}};
                     CHECK(&j[0][0] == source_addr);
                 }
 
                 SECTION("constructor with implicit types (object)")
                 {
-                    json source {1, 2, 3};
+                    json const source {1, 2, 3};
                     const json* source_addr = &source[0];
-                    json j {{"key", std::move(source)}};
+                    json const j {{"key", std::move(source)}};
                     CHECK(&j["key"][0] == source_addr);
                 }
 
                 SECTION("assignment with implicit types (array)")
                 {
-                    json source {1, 2, 3};
+                    json const source {1, 2, 3};
                     const json* source_addr = &source[0];
-                    json j = {std::move(source), {}};
+                    json const j = {std::move(source), {}};
                     CHECK(&j[0][0] == source_addr);
                 }
 
                 SECTION("assignment with implicit types (object)")
                 {
-                    json source {1, 2, 3};
+                    json const source {1, 2, 3};
                     const json* source_addr = &source[0];
-                    json j = {{"key", std::move(source)}};
+                    json const j = {{"key", std::move(source)}};
                     CHECK(&j["key"][0] == source_addr);
                 }
             }
@@ -1264,8 +1266,8 @@ TEST_CASE("constructors")
 
         SECTION("cnt = 1")
         {
-            json v = {1, "foo", 34.23, {1, 2, 3}, {{"A", 1}, {"B", 2u}}};
-            json arr(1, v);
+            json const v = {1, "foo", 34.23, {1, 2, 3}, {{"A", 1}, {"B", 2u}}};
+            json const arr(1, v);
             CHECK(arr.size() == 1);
             for (auto& x : arr)
             {
@@ -1275,8 +1277,8 @@ TEST_CASE("constructors")
 
         SECTION("cnt = 3")
         {
-            json v = {1, "foo", 34.23, {1, 2, 3}, {{"A", 1}, {"B", 2u}}};
-            json arr(3, v);
+            json const v = {1, "foo", 34.23, {1, 2, 3}, {{"A", 1}, {"B", 2u}}};
+            json const arr(3, v);
             CHECK(arr.size() == 3);
             for (auto& x : arr)
             {
@@ -1293,12 +1295,12 @@ TEST_CASE("constructors")
             {
                 {
                     json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                    json j_new(jobject.begin(), jobject.end());
+                    json const j_new(jobject.begin(), jobject.end());
                     CHECK(j_new == jobject);
                 }
                 {
                     json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                    json j_new(jobject.cbegin(), jobject.cend());
+                    json const j_new(jobject.cbegin(), jobject.cend());
                     CHECK(j_new == jobject);
                 }
             }
@@ -1307,20 +1309,20 @@ TEST_CASE("constructors")
             {
                 {
                     json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                    json j_new(jobject.begin(), jobject.begin());
+                    json const j_new(jobject.begin(), jobject.begin());
                     CHECK(j_new == json::object());
                 }
                 {
                     json const jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                    json j_new(jobject.cbegin(), jobject.cbegin());
+                    json const j_new(jobject.cbegin(), jobject.cbegin());
                     CHECK(j_new == json::object());
                 }
             }
 
             SECTION("construct from subrange")
             {
-                json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
-                json j_new(jobject.find("b"), jobject.find("e"));
+                json const jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}, {"d", false}, {"e", true}};
+                json const j_new(jobject.find("b"), jobject.find("e"));
                 CHECK(j_new == json({{"b", 1}, {"c", 17u}, {"d", false}}));
             }
 
@@ -1347,12 +1349,12 @@ TEST_CASE("constructors")
             {
                 {
                     json jarray = {1, 2, 3, 4, 5};
-                    json j_new(jarray.begin(), jarray.end());
+                    json const j_new(jarray.begin(), jarray.end());
                     CHECK(j_new == jarray);
                 }
                 {
-                    json jarray = {1, 2, 3, 4, 5};
-                    json j_new(jarray.cbegin(), jarray.cend());
+                    json const jarray = {1, 2, 3, 4, 5};
+                    json const j_new(jarray.cbegin(), jarray.cend());
                     CHECK(j_new == jarray);
                 }
             }
@@ -1366,7 +1368,7 @@ TEST_CASE("constructors")
                 }
                 {
                     json const jarray = {1, 2, 3, 4, 5};
-                    json j_new(jarray.cbegin(), jarray.cbegin());
+                    json const j_new(jarray.cbegin(), jarray.cbegin());
                     CHECK(j_new == json::array());
                 }
             }
@@ -1375,12 +1377,12 @@ TEST_CASE("constructors")
             {
                 {
                     json jarray = {1, 2, 3, 4, 5};
-                    json j_new(jarray.begin() + 1, jarray.begin() + 3);
+                    json const j_new(jarray.begin() + 1, jarray.begin() + 3);
                     CHECK(j_new == json({2, 3}));
                 }
                 {
                     json const jarray = {1, 2, 3, 4, 5};
-                    json j_new(jarray.cbegin() + 1, jarray.cbegin() + 3);
+                    json const j_new(jarray.cbegin() + 1, jarray.cbegin() + 3);
                     CHECK(j_new == json({2, 3}));
                 }
             }
@@ -1422,12 +1424,12 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = "foo";
-                        json j_new(j.begin(), j.end());
+                        json const j_new(j.begin(), j.end());
                         CHECK(j == j_new);
                     }
                     {
-                        json j = "bar";
-                        json j_new(j.cbegin(), j.cend());
+                        json const j = "bar";
+                        json const j_new(j.cbegin(), j.cend());
                         CHECK(j == j_new);
                     }
                 }
@@ -1436,12 +1438,12 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = false;
-                        json j_new(j.begin(), j.end());
+                        json const j_new(j.begin(), j.end());
                         CHECK(j == j_new);
                     }
                     {
-                        json j = true;
-                        json j_new(j.cbegin(), j.cend());
+                        json const j = true;
+                        json const j_new(j.cbegin(), j.cend());
                         CHECK(j == j_new);
                     }
                 }
@@ -1450,12 +1452,12 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = 17;
-                        json j_new(j.begin(), j.end());
+                        json const j_new(j.begin(), j.end());
                         CHECK(j == j_new);
                     }
                     {
-                        json j = 17;
-                        json j_new(j.cbegin(), j.cend());
+                        json const j = 17;
+                        json const j_new(j.cbegin(), j.cend());
                         CHECK(j == j_new);
                     }
                 }
@@ -1464,12 +1466,12 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = 17u;
-                        json j_new(j.begin(), j.end());
+                        json const j_new(j.begin(), j.end());
                         CHECK(j == j_new);
                     }
                     {
-                        json j = 17u;
-                        json j_new(j.cbegin(), j.cend());
+                        json const j = 17u;
+                        json const j_new(j.cbegin(), j.cend());
                         CHECK(j == j_new);
                     }
                 }
@@ -1478,12 +1480,12 @@ TEST_CASE("constructors")
                 {
                     {
                         json j = 23.42;
-                        json j_new(j.begin(), j.end());
+                        json const j_new(j.begin(), j.end());
                         CHECK(j == j_new);
                     }
                     {
-                        json j = 23.42;
-                        json j_new(j.cbegin(), j.cend());
+                        json const j = 23.42;
+                        json const j_new(j.cbegin(), j.cend());
                         CHECK(j == j_new);
                     }
                 }

--- a/tests/src/unit-json_pointer.cpp
+++ b/tests/src/unit-json_pointer.cpp
@@ -40,7 +40,7 @@ TEST_CASE("JSON pointers")
         SECTION("array index error")
         {
             json v = {1, 2, 3, 4};
-            json::json_pointer const const ptr("/10e");
+            json::json_pointer const ptr("/10e");
             CHECK_THROWS_WITH_AS(v[ptr],
                                  "[json.exception.out_of_range.404] unresolved reference token '10e'", json::out_of_range&);
         }
@@ -311,7 +311,7 @@ TEST_CASE("JSON pointers")
 
             {
                 auto too_large_index = std::to_string((std::numeric_limits<unsigned long long>::max)()) + "1";
-                json::json_pointer const const jp(std::string("/") + too_large_index);
+                json::json_pointer const jp(std::string("/") + too_large_index);
                 std::string const throw_msg = std::string("[json.exception.out_of_range.404] unresolved reference token '") + too_large_index + "'";
 
                 CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
@@ -326,7 +326,7 @@ TEST_CASE("JSON pointers")
             {
                 auto size_type_max_uul = static_cast<unsigned long long>((std::numeric_limits<json::size_type>::max)());
                 auto too_large_index = std::to_string(size_type_max_uul);
-                json::json_pointer const const jp(std::string("/") + too_large_index);
+                json::json_pointer const jp(std::string("/") + too_large_index);
                 std::string const throw_msg = std::string("[json.exception.out_of_range.410] array index ") + too_large_index + " exceeds size_type";
 
                 CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
@@ -485,7 +485,7 @@ TEST_CASE("JSON pointers")
                 {"", "/foo", "/foo/0", "/", "/a~1b", "/c%d", "/e^f", "/g|h", "/i\\j", "/k\"l", "/ ", "/m~0n"
                 })
         {
-            json::json_pointer const const ptr(ptr_str);
+            json::json_pointer const ptr(ptr_str);
             std::stringstream ss;
             ss << ptr;
             CHECK(ptr.to_string() == ptr_str);

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -113,8 +113,8 @@ TEST_CASE("MessagePack")
 
         SECTION("null")
         {
-            json j = nullptr;
-            std::vector<uint8_t> expected = {0xc0};
+            json const j = nullptr;
+            std::vector<uint8_t> const expected = {0xc0};
             const auto result = json::to_msgpack(j);
             CHECK(result == expected);
 
@@ -127,8 +127,8 @@ TEST_CASE("MessagePack")
         {
             SECTION("true")
             {
-                json j = true;
-                std::vector<uint8_t> expected = {0xc3};
+                json const j = true;
+                std::vector<uint8_t> const expected = {0xc3};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -139,8 +139,8 @@ TEST_CASE("MessagePack")
 
             SECTION("false")
             {
-                json j = false;
-                std::vector<uint8_t> expected = {0xc2};
+                json const j = false;
+                std::vector<uint8_t> const expected = {0xc2};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -161,14 +161,16 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>(i)
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -198,8 +200,7 @@ TEST_CASE("MessagePack")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected{static_cast<uint8_t>(i)};
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -229,9 +230,11 @@ TEST_CASE("MessagePack")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xcc);
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xcc,
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -240,7 +243,7 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xcc);
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        auto const restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -263,10 +266,12 @@ TEST_CASE("MessagePack")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xcd);
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xcd,
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -275,7 +280,7 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xcd);
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -301,12 +306,14 @@ TEST_CASE("MessagePack")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xce);
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xce,
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -315,10 +322,10 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xce);
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -344,16 +351,18 @@ TEST_CASE("MessagePack")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xcf);
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xcf,
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -362,14 +371,14 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xcf);
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -385,15 +394,17 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xd0);
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xd0,
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -412,13 +423,13 @@ TEST_CASE("MessagePack")
 
                 SECTION("-9263 (int 16)")
                 {
-                    json j = -9263;
-                    std::vector<uint8_t> expected = {0xd1, 0xdb, 0xd1};
+                    json const j = -9263;
+                    std::vector<uint8_t> const expected = {0xd1, 0xdb, 0xd1};
 
                     const auto result = json::to_msgpack(j);
                     CHECK(result == expected);
 
-                    auto restored = static_cast<int16_t>((result[1] << 8) + result[2]);
+                    auto const restored = static_cast<int16_t>((result[1] << 8) + result[2]);
                     CHECK(restored == -9263);
 
                     // roundtrip
@@ -433,16 +444,18 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xd1);
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xd1,
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -451,7 +464,7 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xd1);
-                        auto restored = static_cast<int16_t>((result[1] << 8) + result[2]);
+                        auto const restored = static_cast<int16_t>((result[1] << 8) + result[2]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -462,29 +475,33 @@ TEST_CASE("MessagePack")
 
                 SECTION("-32769..-2147483648")
                 {
-                    std::vector<int32_t> numbers;
-                    numbers.push_back(-32769);
-                    numbers.push_back(-65536);
-                    numbers.push_back(-77777);
-                    numbers.push_back(-1048576);
-                    numbers.push_back(-2147483648LL);
+                    std::vector<int32_t> const numbers
+                    {
+                        -32769,
+                            -65536,
+                            -77777,
+                            -1048576,
+                            -2147483648LL,
+                        };
                     for (auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xd2);
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xd2,
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -493,10 +510,10 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xd2);
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(static_cast<std::int32_t>(restored) == i);
 
                         // roundtrip
@@ -507,30 +524,34 @@ TEST_CASE("MessagePack")
 
                 SECTION("-9223372036854775808..-2147483649 (int 64)")
                 {
-                    std::vector<int64_t> numbers;
-                    numbers.push_back(INT64_MIN);
-                    numbers.push_back(-2147483649LL);
+                    std::vector<int64_t> numbers
+                    {
+                        INT64_MIN,
+                        -2147483649LL,
+                    };
                     for (auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xd3);
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xd3,
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -539,14 +560,14 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xd3);
-                        int64_t restored = (static_cast<int64_t>(result[1]) << 070) +
-                                           (static_cast<int64_t>(result[2]) << 060) +
-                                           (static_cast<int64_t>(result[3]) << 050) +
-                                           (static_cast<int64_t>(result[4]) << 040) +
-                                           (static_cast<int64_t>(result[5]) << 030) +
-                                           (static_cast<int64_t>(result[6]) << 020) +
-                                           (static_cast<int64_t>(result[7]) << 010) +
-                                           static_cast<int64_t>(result[8]);
+                        int64_t const restored = (static_cast<int64_t>(result[1]) << 070) +
+                                                 (static_cast<int64_t>(result[2]) << 060) +
+                                                 (static_cast<int64_t>(result[3]) << 050) +
+                                                 (static_cast<int64_t>(result[4]) << 040) +
+                                                 (static_cast<int64_t>(result[5]) << 030) +
+                                                 (static_cast<int64_t>(result[6]) << 020) +
+                                                 (static_cast<int64_t>(result[7]) << 010) +
+                                                 static_cast<int64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -565,14 +586,13 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected{static_cast<uint8_t>(i)};
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -595,15 +615,17 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xcc);
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xcc,
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -612,7 +634,7 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xcc);
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        auto const restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -628,16 +650,18 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xcd);
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xcd,
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -646,7 +670,7 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xcd);
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -657,7 +681,7 @@ TEST_CASE("MessagePack")
 
                 SECTION("65536..4294967295 (uint 32)")
                 {
-                    for (uint32_t i :
+                    for (const uint32_t i :
                             {
                                 65536u, 77777u, 1048576u, 4294967295u
                             })
@@ -665,18 +689,20 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xce);
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xce,
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -685,10 +711,10 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xce);
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -699,7 +725,7 @@ TEST_CASE("MessagePack")
 
                 SECTION("4294967296..18446744073709551615 (uint 64)")
                 {
-                    for (uint64_t i :
+                    for (const uint64_t i :
                             {
                                 4294967296LU, 18446744073709551615LU
                             })
@@ -707,22 +733,24 @@ TEST_CASE("MessagePack")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(0xcf);
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            0xcf,
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_msgpack(j);
@@ -731,14 +759,14 @@ TEST_CASE("MessagePack")
 
                         // check individual bytes
                         CHECK(result[0] == 0xcf);
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -752,9 +780,9 @@ TEST_CASE("MessagePack")
             {
                 SECTION("3.1415925")
                 {
-                    double v = 3.1415925;
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    double const v = 3.1415925;
+                    json const j = v;
+                    std::vector<uint8_t> const expected =
                     {
                         0xcb, 0x40, 0x09, 0x21, 0xfb, 0x3f, 0xa6, 0xde, 0xfc
                     };
@@ -769,9 +797,9 @@ TEST_CASE("MessagePack")
 
                 SECTION("1.0")
                 {
-                    double v = 1.0;
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    double const v = 1.0;
+                    json const j = v;
+                    std::vector<uint8_t> const expected =
                     {
                         0xca, 0x3f, 0x80, 0x00, 0x00
                     };
@@ -786,9 +814,9 @@ TEST_CASE("MessagePack")
 
                 SECTION("128.128")
                 {
-                    double v = 128.1280059814453125;
-                    json j = v;
-                    std::vector<uint8_t> expected =
+                    double const v = 128.1280059814453125;
+                    json const j = v;
+                    std::vector<uint8_t> const expected =
                     {
                         0xca, 0x43, 0x00, 0x20, 0xc5
                     };
@@ -822,7 +850,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -859,7 +887,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -894,7 +922,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -927,7 +955,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -956,8 +984,8 @@ TEST_CASE("MessagePack")
         {
             SECTION("empty")
             {
-                json j = json::array();
-                std::vector<uint8_t> expected = {0x90};
+                json const j = json::array();
+                std::vector<uint8_t> const expected = {0x90};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -968,8 +996,8 @@ TEST_CASE("MessagePack")
 
             SECTION("[null]")
             {
-                json j = {nullptr};
-                std::vector<uint8_t> expected = {0x91, 0xc0};
+                json const j = {nullptr};
+                std::vector<uint8_t> const expected = {0x91, 0xc0};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -980,8 +1008,8 @@ TEST_CASE("MessagePack")
 
             SECTION("[1,2,3,4,5]")
             {
-                json j = json::parse("[1,2,3,4,5]");
-                std::vector<uint8_t> expected = {0x95, 0x01, 0x02, 0x03, 0x04, 0x05};
+                json const j = json::parse("[1,2,3,4,5]");
+                std::vector<uint8_t> const expected = {0x95, 0x01, 0x02, 0x03, 0x04, 0x05};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -992,8 +1020,8 @@ TEST_CASE("MessagePack")
 
             SECTION("[[[[]]]]")
             {
-                json j = json::parse("[[[[]]]]");
-                std::vector<uint8_t> expected = {0x91, 0x91, 0x91, 0x90};
+                json const j = json::parse("[[[[]]]]");
+                std::vector<uint8_t> const expected = {0x91, 0x91, 0x91, 0x90};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -1046,8 +1074,8 @@ TEST_CASE("MessagePack")
         {
             SECTION("empty")
             {
-                json j = json::object();
-                std::vector<uint8_t> expected = {0x80};
+                json const j = json::object();
+                std::vector<uint8_t> const expected = {0x80};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -1058,8 +1086,8 @@ TEST_CASE("MessagePack")
 
             SECTION("{\"\":null}")
             {
-                json j = {{"", nullptr}};
-                std::vector<uint8_t> expected = {0x81, 0xa0, 0xc0};
+                json const j = {{"", nullptr}};
+                std::vector<uint8_t> const expected = {0x81, 0xa0, 0xc0};
                 const auto result = json::to_msgpack(j);
                 CHECK(result == expected);
 
@@ -1070,8 +1098,8 @@ TEST_CASE("MessagePack")
 
             SECTION("{\"a\": {\"b\": {\"c\": {}}}}")
             {
-                json j = json::parse(R"({"a": {"b": {"c": {}}}})");
-                std::vector<uint8_t> expected =
+                json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                std::vector<uint8_t> const expected =
                 {
                     0x81, 0xa1, 0x61, 0x81, 0xa1, 0x62, 0x81, 0xa1, 0x63, 0x80
                 };
@@ -1085,7 +1113,7 @@ TEST_CASE("MessagePack")
 
             SECTION("map 16")
             {
-                json j = R"({"00": null, "01": null, "02": null, "03": null,
+                json const j = R"({"00": null, "01": null, "02": null, "03": null,
                              "04": null, "05": null, "06": null, "07": null,
                              "08": null, "09": null, "10": null, "11": null,
                              "12": null, "13": null, "14": null, "15": null})"_json;
@@ -1298,7 +1326,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with byte array containing of N * 'x'
                     const auto s = std::vector<uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    json const j = json::binary(s);
 
                     // create expected byte vector
                     std::vector<std::uint8_t> expected;
@@ -1336,7 +1364,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::vector<std::uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    json const j = json::binary(s);
 
                     // create expected byte vector (hack: create string first)
                     std::vector<std::uint8_t> expected(N, 'x');
@@ -1369,7 +1397,7 @@ TEST_CASE("MessagePack")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::vector<std::uint8_t>(N, 'x');
-                    json j = json::binary(s);
+                    json const j = json::binary(s);
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');

--- a/tests/src/unit-ubjson.cpp
+++ b/tests/src/unit-ubjson.cpp
@@ -109,7 +109,7 @@ TEST_CASE("UBJSON")
 
         SECTION("null")
         {
-            json j = nullptr;
+            json const j = nullptr;
             std::vector<uint8_t> expected = {'Z'};
             const auto result = json::to_ubjson(j);
             CHECK(result == expected);
@@ -123,8 +123,8 @@ TEST_CASE("UBJSON")
         {
             SECTION("true")
             {
-                json j = true;
-                std::vector<uint8_t> expected = {'T'};
+                json const j = true;
+                std::vector<uint8_t> const expected = {'T'};
                 const auto result = json::to_ubjson(j);
                 CHECK(result == expected);
 
@@ -135,8 +135,8 @@ TEST_CASE("UBJSON")
 
             SECTION("false")
             {
-                json j = false;
-                std::vector<uint8_t> expected = {'F'};
+                json const j = false;
+                std::vector<uint8_t> const expected = {'F'};
                 const auto result = json::to_ubjson(j);
                 CHECK(result == expected);
 
@@ -152,39 +152,43 @@ TEST_CASE("UBJSON")
             {
                 SECTION("-9223372036854775808..-2147483649 (int64)")
                 {
-                    std::vector<int64_t> numbers;
-                    numbers.push_back((std::numeric_limits<int64_t>::min)());
-                    numbers.push_back(-1000000000000000000LL);
-                    numbers.push_back(-100000000000000000LL);
-                    numbers.push_back(-10000000000000000LL);
-                    numbers.push_back(-1000000000000000LL);
-                    numbers.push_back(-100000000000000LL);
-                    numbers.push_back(-10000000000000LL);
-                    numbers.push_back(-1000000000000LL);
-                    numbers.push_back(-100000000000LL);
-                    numbers.push_back(-10000000000LL);
-                    numbers.push_back(-2147483649LL);
+                    std::vector<int64_t> const numbers
+                    {
+                        (std::numeric_limits<int64_t>::min)(),
+                        -1000000000000000000LL,
+                        -100000000000000000LL,
+                        -10000000000000000LL,
+                        -1000000000000000LL,
+                        -100000000000000LL,
+                        -10000000000000LL,
+                        -1000000000000LL,
+                        -100000000000LL,
+                        -10000000000LL,
+                        -2147483649LL,
+                    };
                     for (auto i : numbers)
                     {
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('L'));
-                        expected.push_back(static_cast<uint8_t>((i >> 56) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 48) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 40) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 32) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('L'),
+                            static_cast<uint8_t>((i >> 56) & 0xff),
+                            static_cast<uint8_t>((i >> 48) & 0xff),
+                            static_cast<uint8_t>((i >> 40) & 0xff),
+                            static_cast<uint8_t>((i >> 32) & 0xff),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -193,14 +197,14 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'L');
-                        int64_t restored = (static_cast<int64_t>(result[1]) << 070) +
-                                           (static_cast<int64_t>(result[2]) << 060) +
-                                           (static_cast<int64_t>(result[3]) << 050) +
-                                           (static_cast<int64_t>(result[4]) << 040) +
-                                           (static_cast<int64_t>(result[5]) << 030) +
-                                           (static_cast<int64_t>(result[6]) << 020) +
-                                           (static_cast<int64_t>(result[7]) << 010) +
-                                           static_cast<int64_t>(result[8]);
+                        int64_t const restored = (static_cast<int64_t>(result[1]) << 070) +
+                                                 (static_cast<int64_t>(result[2]) << 060) +
+                                                 (static_cast<int64_t>(result[3]) << 050) +
+                                                 (static_cast<int64_t>(result[4]) << 040) +
+                                                 (static_cast<int64_t>(result[5]) << 030) +
+                                                 (static_cast<int64_t>(result[6]) << 020) +
+                                                 (static_cast<int64_t>(result[7]) << 010) +
+                                                 static_cast<int64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -224,18 +228,20 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('l'));
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('l'),
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -244,10 +250,10 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'l');
-                        int32_t restored = (static_cast<int32_t>(result[1]) << 030) +
-                                           (static_cast<int32_t>(result[2]) << 020) +
-                                           (static_cast<int32_t>(result[3]) << 010) +
-                                           static_cast<int32_t>(result[4]);
+                        int32_t const restored = (static_cast<int32_t>(result[1]) << 030) +
+                                                 (static_cast<int32_t>(result[2]) << 020) +
+                                                 (static_cast<int32_t>(result[3]) << 010) +
+                                                 static_cast<int32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -263,16 +269,18 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('I'));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('I'),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -281,7 +289,7 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'I');
-                        auto restored = static_cast<int16_t>(((result[1] << 8) + result[2]));
+                        auto const restored = static_cast<int16_t>(((result[1] << 8) + result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -292,7 +300,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("-9263 (int16)")
                 {
-                    json j = -9263;
+                    json const j = -9263;
                     std::vector<uint8_t> expected = {'I', 0xdb, 0xd1};
 
                     // compare result + size
@@ -302,7 +310,7 @@ TEST_CASE("UBJSON")
 
                     // check individual bytes
                     CHECK(result[0] == 'I');
-                    auto restored = static_cast<int16_t>(((result[1] << 8) + result[2]));
+                    auto const restored = static_cast<int16_t>(((result[1] << 8) + result[2]));
                     CHECK(restored == -9263);
 
                     // roundtrip
@@ -317,15 +325,17 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('i');
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            'i',
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -356,9 +366,11 @@ TEST_CASE("UBJSON")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('i'));
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('i'),
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -389,9 +401,11 @@ TEST_CASE("UBJSON")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('U'));
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('U'),
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -422,10 +436,12 @@ TEST_CASE("UBJSON")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back(static_cast<uint8_t>('I'));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            static_cast<uint8_t>('I'),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -434,7 +450,7 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'I');
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -460,12 +476,14 @@ TEST_CASE("UBJSON")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('l');
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'l',
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -474,10 +492,10 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'l');
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -501,16 +519,18 @@ TEST_CASE("UBJSON")
                         CHECK(j.is_number_integer());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('L');
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'L',
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -519,14 +539,14 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'L');
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -545,15 +565,17 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('i');
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            'i',
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -562,7 +584,7 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'i');
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        auto const restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -578,15 +600,17 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('U');
-                        expected.push_back(static_cast<uint8_t>(i));
+                        std::vector<uint8_t> const expected
+                        {
+                            'U',
+                            static_cast<uint8_t>(i),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -595,7 +619,7 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'U');
-                        auto restored = static_cast<uint8_t>(result[1]);
+                        auto const restored = static_cast<uint8_t>(result[1]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -611,16 +635,18 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('I');
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'I',
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -629,7 +655,7 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'I');
-                        auto restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
+                        auto const restored = static_cast<uint16_t>(static_cast<uint8_t>(result[1]) * 256 + static_cast<uint8_t>(result[2]));
                         CHECK(restored == i);
 
                         // roundtrip
@@ -648,18 +674,20 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with unsigned integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('l');
-                        expected.push_back(static_cast<uint8_t>((i >> 24) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 16) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 8) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'l',
+                            static_cast<uint8_t>((i >> 24) & 0xff),
+                            static_cast<uint8_t>((i >> 16) & 0xff),
+                            static_cast<uint8_t>((i >> 8) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -668,10 +696,10 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'l');
-                        uint32_t restored = (static_cast<uint32_t>(result[1]) << 030) +
-                                            (static_cast<uint32_t>(result[2]) << 020) +
-                                            (static_cast<uint32_t>(result[3]) << 010) +
-                                            static_cast<uint32_t>(result[4]);
+                        uint32_t const restored = (static_cast<uint32_t>(result[1]) << 030) +
+                                                  (static_cast<uint32_t>(result[2]) << 020) +
+                                                  (static_cast<uint32_t>(result[3]) << 010) +
+                                                  static_cast<uint32_t>(result[4]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -688,22 +716,24 @@ TEST_CASE("UBJSON")
                         CAPTURE(i)
 
                         // create JSON value with integer number
-                        json j = i;
+                        json const j = i;
 
                         // check type
                         CHECK(j.is_number_unsigned());
 
                         // create expected byte vector
-                        std::vector<uint8_t> expected;
-                        expected.push_back('L');
-                        expected.push_back(static_cast<uint8_t>((i >> 070) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 060) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 050) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 040) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 030) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 020) & 0xff));
-                        expected.push_back(static_cast<uint8_t>((i >> 010) & 0xff));
-                        expected.push_back(static_cast<uint8_t>(i & 0xff));
+                        std::vector<uint8_t> const expected
+                        {
+                            'L',
+                            static_cast<uint8_t>((i >> 070) & 0xff),
+                            static_cast<uint8_t>((i >> 060) & 0xff),
+                            static_cast<uint8_t>((i >> 050) & 0xff),
+                            static_cast<uint8_t>((i >> 040) & 0xff),
+                            static_cast<uint8_t>((i >> 030) & 0xff),
+                            static_cast<uint8_t>((i >> 020) & 0xff),
+                            static_cast<uint8_t>((i >> 010) & 0xff),
+                            static_cast<uint8_t>(i & 0xff),
+                        };
 
                         // compare result + size
                         const auto result = json::to_ubjson(j);
@@ -712,14 +742,14 @@ TEST_CASE("UBJSON")
 
                         // check individual bytes
                         CHECK(result[0] == 'L');
-                        uint64_t restored = (static_cast<uint64_t>(result[1]) << 070) +
-                                            (static_cast<uint64_t>(result[2]) << 060) +
-                                            (static_cast<uint64_t>(result[3]) << 050) +
-                                            (static_cast<uint64_t>(result[4]) << 040) +
-                                            (static_cast<uint64_t>(result[5]) << 030) +
-                                            (static_cast<uint64_t>(result[6]) << 020) +
-                                            (static_cast<uint64_t>(result[7]) << 010) +
-                                            static_cast<uint64_t>(result[8]);
+                        uint64_t const restored = (static_cast<uint64_t>(result[1]) << 070) +
+                                                  (static_cast<uint64_t>(result[2]) << 060) +
+                                                  (static_cast<uint64_t>(result[3]) << 050) +
+                                                  (static_cast<uint64_t>(result[4]) << 040) +
+                                                  (static_cast<uint64_t>(result[5]) << 030) +
+                                                  (static_cast<uint64_t>(result[6]) << 020) +
+                                                  (static_cast<uint64_t>(result[7]) << 010) +
+                                                  static_cast<uint64_t>(result[8]);
                         CHECK(restored == i);
 
                         // roundtrip
@@ -734,7 +764,7 @@ TEST_CASE("UBJSON")
                 SECTION("3.1415925")
                 {
                     double v = 3.1415925;
-                    json j = v;
+                    json const j = v;
                     std::vector<uint8_t> expected =
                     {
                         'D', 0x40, 0x09, 0x21, 0xfb, 0x3f, 0xa6, 0xde, 0xfc
@@ -796,7 +826,7 @@ TEST_CASE("UBJSON")
                 SECTION("serialization")
                 {
                     // number that does not fit int64
-                    json j = 11111111111111111111ULL;
+                    json const j = 11111111111111111111ULL;
                     CHECK(j.is_number_unsigned());
 
                     // number will be serialized to high-precision number
@@ -820,7 +850,7 @@ TEST_CASE("UBJSON")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -856,7 +886,7 @@ TEST_CASE("UBJSON")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector
                     std::vector<uint8_t> expected;
@@ -892,7 +922,7 @@ TEST_CASE("UBJSON")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -926,7 +956,7 @@ TEST_CASE("UBJSON")
 
                     // create JSON value with string containing of N * 'x'
                     const auto s = std::string(N, 'x');
-                    json j = s;
+                    json const j = s;
 
                     // create expected byte vector (hack: create string first)
                     std::vector<uint8_t> expected(N, 'x');
@@ -1183,7 +1213,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::array();
+                    json const j = json::array();
                     std::vector<uint8_t> expected = {'[', ']'};
                     const auto result = json::to_ubjson(j);
                     CHECK(result == expected);
@@ -1195,7 +1225,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::array();
+                    json const j = json::array();
                     std::vector<uint8_t> expected = {'[', '#', 'i', 0};
                     const auto result = json::to_ubjson(j, true);
                     CHECK(result == expected);
@@ -1207,7 +1237,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::array();
+                    json const j = json::array();
                     std::vector<uint8_t> expected = {'[', '#', 'i', 0};
                     const auto result = json::to_ubjson(j, true, true);
                     CHECK(result == expected);
@@ -1222,7 +1252,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = {nullptr};
+                    json const j = {nullptr};
                     std::vector<uint8_t> expected = {'[', 'Z', ']'};
                     const auto result = json::to_ubjson(j);
                     CHECK(result == expected);
@@ -1234,7 +1264,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = {nullptr};
+                    json const j = {nullptr};
                     std::vector<uint8_t> expected = {'[', '#', 'i', 1, 'Z'};
                     const auto result = json::to_ubjson(j, true);
                     CHECK(result == expected);
@@ -1246,7 +1276,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = {nullptr};
+                    json const j = {nullptr};
                     std::vector<uint8_t> expected = {'[', '$', 'Z', '#', 'i', 1};
                     const auto result = json::to_ubjson(j, true, true);
                     CHECK(result == expected);
@@ -1261,7 +1291,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::parse("[1,2,3,4,5]");
+                    json const j = json::parse("[1,2,3,4,5]");
                     std::vector<uint8_t> expected = {'[', 'i', 1, 'i', 2, 'i', 3, 'i', 4, 'i', 5, ']'};
                     const auto result = json::to_ubjson(j);
                     CHECK(result == expected);
@@ -1273,7 +1303,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::parse("[1,2,3,4,5]");
+                    json const j = json::parse("[1,2,3,4,5]");
                     std::vector<uint8_t> expected = {'[', '#', 'i', 5, 'i', 1, 'i', 2, 'i', 3, 'i', 4, 'i', 5};
                     const auto result = json::to_ubjson(j, true);
                     CHECK(result == expected);
@@ -1285,7 +1315,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::parse("[1,2,3,4,5]");
+                    json const j = json::parse("[1,2,3,4,5]");
                     std::vector<uint8_t> expected = {'[', '$', 'i', '#', 'i', 5, 1, 2, 3, 4, 5};
                     const auto result = json::to_ubjson(j, true, true);
                     CHECK(result == expected);
@@ -1300,7 +1330,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::parse("[[[[]]]]");
+                    json const j = json::parse("[[[[]]]]");
                     std::vector<uint8_t> expected = {'[', '[', '[', '[', ']', ']', ']', ']'};
                     const auto result = json::to_ubjson(j);
                     CHECK(result == expected);
@@ -1312,7 +1342,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::parse("[[[[]]]]");
+                    json const j = json::parse("[[[[]]]]");
                     std::vector<uint8_t> expected = {'[', '#', 'i', 1, '[', '#', 'i', 1, '[', '#', 'i', 1, '[', '#', 'i', 0};
                     const auto result = json::to_ubjson(j, true);
                     CHECK(result == expected);
@@ -1324,7 +1354,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::parse("[[[[]]]]");
+                    json const j = json::parse("[[[[]]]]");
                     std::vector<uint8_t> expected = {'[', '$', '[', '#', 'i', 1, '$', '[', '#', 'i', 1, '$', '[', '#', 'i', 1, '#', 'i', 0};
                     const auto result = json::to_ubjson(j, true, true);
                     CHECK(result == expected);
@@ -1436,7 +1466,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::object();
+                    json const j = json::object();
                     std::vector<uint8_t> expected = {'{', '}'};
                     const auto result = json::to_ubjson(j);
                     CHECK(result == expected);
@@ -1448,7 +1478,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::object();
+                    json const j = json::object();
                     std::vector<uint8_t> expected = {'{', '#', 'i', 0};
                     const auto result = json::to_ubjson(j, true);
                     CHECK(result == expected);
@@ -1460,7 +1490,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::object();
+                    json const j = json::object();
                     std::vector<uint8_t> expected = {'{', '#', 'i', 0};
                     const auto result = json::to_ubjson(j, true, true);
                     CHECK(result == expected);
@@ -1475,7 +1505,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = {{"", nullptr}};
+                    json const j = {{"", nullptr}};
                     std::vector<uint8_t> expected = {'{', 'i', 0, 'Z', '}'};
                     const auto result = json::to_ubjson(j);
                     CHECK(result == expected);
@@ -1487,7 +1517,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = {{"", nullptr}};
+                    json const j = {{"", nullptr}};
                     std::vector<uint8_t> expected = {'{', '#', 'i', 1, 'i', 0, 'Z'};
                     const auto result = json::to_ubjson(j, true);
                     CHECK(result == expected);
@@ -1499,7 +1529,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = {{"", nullptr}};
+                    json const j = {{"", nullptr}};
                     std::vector<uint8_t> expected = {'{', '$', 'Z', '#', 'i', 1, 'i', 0};
                     const auto result = json::to_ubjson(j, true, true);
                     CHECK(result == expected);
@@ -1514,7 +1544,7 @@ TEST_CASE("UBJSON")
             {
                 SECTION("size=false type=false")
                 {
-                    json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                    json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
                     std::vector<uint8_t> expected =
                     {
                         '{', 'i', 1, 'a', '{', 'i', 1, 'b', '{', 'i', 1, 'c', '{', '}', '}', '}', '}'
@@ -1529,7 +1559,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=false")
                 {
-                    json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                    json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
                     std::vector<uint8_t> expected =
                     {
                         '{', '#', 'i', 1, 'i', 1, 'a', '{', '#', 'i', 1, 'i', 1, 'b', '{', '#', 'i', 1, 'i', 1, 'c', '{', '#', 'i', 0
@@ -1544,7 +1574,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("size=true type=true")
                 {
-                    json j = json::parse(R"({"a": {"b": {"c": {}}}})");
+                    json const j = json::parse(R"({"a": {"b": {"c": {}}}})");
                     std::vector<uint8_t> expected =
                     {
                         '{', '$', '{', '#', 'i', 1, 'i', 1, 'a', '$', '{', '#', 'i', 1, 'i', 1, 'b', '$', '{', '#', 'i', 1, 'i', 1, 'c', '#', 'i', 0
@@ -1704,16 +1734,16 @@ TEST_CASE("UBJSON")
             {
                 // create vector with two elements of the same type
                 std::vector<uint8_t> const v_TU = {'[', '#', 'U', 2, 'T', 'T'};
-                std::vector<uint8_t> v_T = {'[', '#', 'i', 2, 'T', 'T'};
-                std::vector<uint8_t> v_F = {'[', '#', 'i', 2, 'F', 'F'};
-                std::vector<uint8_t> v_Z = {'[', '#', 'i', 2, 'Z', 'Z'};
-                std::vector<uint8_t> v_i = {'[', '#', 'i', 2, 'i', 0x7F, 'i', 0x7F};
-                std::vector<uint8_t> v_U = {'[', '#', 'i', 2, 'U', 0xFF, 'U', 0xFF};
-                std::vector<uint8_t> v_I = {'[', '#', 'i', 2, 'I', 0x7F, 0xFF, 'I', 0x7F, 0xFF};
-                std::vector<uint8_t> v_l = {'[', '#', 'i', 2, 'l', 0x7F, 0xFF, 0xFF, 0xFF, 'l', 0x7F, 0xFF, 0xFF, 0xFF};
-                std::vector<uint8_t> v_L = {'[', '#', 'i', 2, 'L', 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 'L', 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-                std::vector<uint8_t> v_D = {'[', '#', 'i', 2, 'D', 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a, 'D', 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a};
-                std::vector<uint8_t> v_S = {'[', '#', 'i', 2, 'S', 'i', 1, 'a', 'S', 'i', 1, 'a'};
+                std::vector<uint8_t> const v_T = {'[', '#', 'i', 2, 'T', 'T'};
+                std::vector<uint8_t> const v_F = {'[', '#', 'i', 2, 'F', 'F'};
+                std::vector<uint8_t> const v_Z = {'[', '#', 'i', 2, 'Z', 'Z'};
+                std::vector<uint8_t> const v_i = {'[', '#', 'i', 2, 'i', 0x7F, 'i', 0x7F};
+                std::vector<uint8_t> const v_U = {'[', '#', 'i', 2, 'U', 0xFF, 'U', 0xFF};
+                std::vector<uint8_t> const v_I = {'[', '#', 'i', 2, 'I', 0x7F, 0xFF, 'I', 0x7F, 0xFF};
+                std::vector<uint8_t> const v_l = {'[', '#', 'i', 2, 'l', 0x7F, 0xFF, 0xFF, 0xFF, 'l', 0x7F, 0xFF, 0xFF, 0xFF};
+                std::vector<uint8_t> const v_L = {'[', '#', 'i', 2, 'L', 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 'L', 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+                std::vector<uint8_t> const v_D = {'[', '#', 'i', 2, 'D', 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a, 'D', 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a};
+                std::vector<uint8_t> const v_S = {'[', '#', 'i', 2, 'S', 'i', 1, 'a', 'S', 'i', 1, 'a'};
                 std::vector<uint8_t> const v_C = {'[', '#', 'i', 2, 'C', 'a', 'C', 'a'};
 
                 // check if vector is parsed correctly
@@ -1748,16 +1778,16 @@ TEST_CASE("UBJSON")
             {
                 // create vector with two elements of the same type
                 std::vector<uint8_t> const v_N = {'[', '$', 'N', '#', 'i', 2};
-                std::vector<uint8_t> v_T = {'[', '$', 'T', '#', 'i', 2};
-                std::vector<uint8_t> v_F = {'[', '$', 'F', '#', 'i', 2};
-                std::vector<uint8_t> v_Z = {'[', '$', 'Z', '#', 'i', 2};
-                std::vector<uint8_t> v_i = {'[', '$', 'i', '#', 'i', 2, 0x7F, 0x7F};
-                std::vector<uint8_t> v_U = {'[', '$', 'U', '#', 'i', 2, 0xFF, 0xFF};
-                std::vector<uint8_t> v_I = {'[', '$', 'I', '#', 'i', 2, 0x7F, 0xFF, 0x7F, 0xFF};
-                std::vector<uint8_t> v_l = {'[', '$', 'l', '#', 'i', 2, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF};
-                std::vector<uint8_t> v_L = {'[', '$', 'L', '#', 'i', 2, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-                std::vector<uint8_t> v_D = {'[', '$', 'D', '#', 'i', 2, 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a, 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a};
-                std::vector<uint8_t> v_S = {'[', '$', 'S', '#', 'i', 2, 'i', 1, 'a', 'i', 1, 'a'};
+                std::vector<uint8_t> const v_T = {'[', '$', 'T', '#', 'i', 2};
+                std::vector<uint8_t> const v_F = {'[', '$', 'F', '#', 'i', 2};
+                std::vector<uint8_t> const v_Z = {'[', '$', 'Z', '#', 'i', 2};
+                std::vector<uint8_t> const v_i = {'[', '$', 'i', '#', 'i', 2, 0x7F, 0x7F};
+                std::vector<uint8_t> const v_U = {'[', '$', 'U', '#', 'i', 2, 0xFF, 0xFF};
+                std::vector<uint8_t> const v_I = {'[', '$', 'I', '#', 'i', 2, 0x7F, 0xFF, 0x7F, 0xFF};
+                std::vector<uint8_t> const v_l = {'[', '$', 'l', '#', 'i', 2, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF};
+                std::vector<uint8_t> const v_L = {'[', '$', 'L', '#', 'i', 2, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+                std::vector<uint8_t> const v_D = {'[', '$', 'D', '#', 'i', 2, 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a, 0x40, 0x09, 0x21, 0xfb, 0x4d, 0x12, 0xd8, 0x4a};
+                std::vector<uint8_t> const v_S = {'[', '$', 'S', '#', 'i', 2, 'i', 1, 'a', 'i', 1, 'a'};
                 std::vector<uint8_t> const v_C = {'[', '$', 'C', '#', 'i', 2, 'a', 'a'};
 
                 // check if vector is parsed correctly
@@ -1775,7 +1805,7 @@ TEST_CASE("UBJSON")
                 CHECK(json::from_ubjson(v_C) == json({"a", "a"}));
 
                 // roundtrip: output should be optimized
-                std::vector<uint8_t> v_empty = {'[', '#', 'i', 0};
+                std::vector<uint8_t> const v_empty = {'[', '#', 'i', 0};
                 CHECK(json::to_ubjson(json::from_ubjson(v_N), true, true) == v_empty);
                 CHECK(json::to_ubjson(json::from_ubjson(v_T), true, true) == v_T);
                 CHECK(json::to_ubjson(json::from_ubjson(v_F), true, true) == v_F);
@@ -2058,19 +2088,19 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 {
     SECTION("Null Value")
     {
-        json j = {{"passcode", nullptr}};
-        std::vector<uint8_t> v = {'{', 'i', 8, 'p', 'a', 's', 's', 'c', 'o', 'd', 'e', 'Z', '}'};
+        json const j = {{"passcode", nullptr}};
+        std::vector<uint8_t> const v = {'{', 'i', 8, 'p', 'a', 's', 's', 'c', 'o', 'd', 'e', 'Z', '}'};
         CHECK(json::to_ubjson(j) == v);
         CHECK(json::from_ubjson(v) == j);
     }
 
     SECTION("No-Op Value")
     {
-        json j = {"foo", "bar", "baz"};
-        std::vector<uint8_t> v = {'[', 'S', 'i', 3, 'f', 'o', 'o',
-                                  'S', 'i', 3, 'b', 'a', 'r',
-                                  'S', 'i', 3, 'b', 'a', 'z', ']'
-                                 };
+        json const j = {"foo", "bar", "baz"};
+        std::vector<uint8_t> const v = {'[', 'S', 'i', 3, 'f', 'o', 'o',
+                                        'S', 'i', 3, 'b', 'a', 'r',
+                                        'S', 'i', 3, 'b', 'a', 'z', ']'
+                                       };
         std::vector<uint8_t> const v2 = {'[', 'S', 'i', 3, 'f', 'o', 'o', 'N',
                                          'S', 'i', 3, 'b', 'a', 'r', 'N', 'N', 'N',
                                          'S', 'i', 3, 'b', 'a', 'z', 'N', 'N', ']'
@@ -2082,17 +2112,17 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
 
     SECTION("Boolean Types")
     {
-        json j = {{"authorized", true}, {"verified", false}};
-        std::vector<uint8_t> v = {'{', 'i', 10, 'a', 'u', 't', 'h', 'o', 'r', 'i', 'z', 'e', 'd', 'T',
-                                  'i', 8, 'v', 'e', 'r', 'i', 'f', 'i', 'e', 'd', 'F', '}'
-                                 };
+        json const j = {{"authorized", true}, {"verified", false}};
+        std::vector<uint8_t> const v = {'{', 'i', 10, 'a', 'u', 't', 'h', 'o', 'r', 'i', 'z', 'e', 'd', 'T',
+                                        'i', 8, 'v', 'e', 'r', 'i', 'f', 'i', 'e', 'd', 'F', '}'
+                                       };
         CHECK(json::to_ubjson(j) == v);
         CHECK(json::from_ubjson(v) == j);
     }
 
     SECTION("Numeric Types")
     {
-        json j =
+        json const j =
         {
             {"int8", 16},
             {"uint8", 255},
@@ -2101,22 +2131,22 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             {"int64", 9223372036854775807},
             {"float64", 113243.7863123}
         };
-        std::vector<uint8_t> v = {'{',
-                                  'i', 7, 'f', 'l', 'o', 'a', 't', '6', '4', 'D', 0x40, 0xfb, 0xa5, 0xbc, 0x94, 0xbc, 0x34, 0xcf,
-                                  'i', 5, 'i', 'n', 't', '1', '6', 'I', 0x7f, 0xff,
-                                  'i', 5, 'i', 'n', 't', '3', '2', 'l', 0x7f, 0xff, 0xff, 0xff,
-                                  'i', 5, 'i', 'n', 't', '6', '4', 'L', 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-                                  'i', 4, 'i', 'n', 't', '8', 'i', 16,
-                                  'i', 5, 'u', 'i', 'n', 't', '8', 'U', 0xff,
-                                  '}'
-                                 };
+        std::vector<uint8_t> const v = {'{',
+                                        'i', 7, 'f', 'l', 'o', 'a', 't', '6', '4', 'D', 0x40, 0xfb, 0xa5, 0xbc, 0x94, 0xbc, 0x34, 0xcf,
+                                        'i', 5, 'i', 'n', 't', '1', '6', 'I', 0x7f, 0xff,
+                                        'i', 5, 'i', 'n', 't', '3', '2', 'l', 0x7f, 0xff, 0xff, 0xff,
+                                        'i', 5, 'i', 'n', 't', '6', '4', 'L', 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                                        'i', 4, 'i', 'n', 't', '8', 'i', 16,
+                                        'i', 5, 'u', 'i', 'n', 't', '8', 'U', 0xff,
+                                        '}'
+                                       };
         CHECK(json::to_ubjson(j) == v);
         CHECK(json::from_ubjson(v) == j);
     }
 
     SECTION("Char Type")
     {
-        json j = {{"rolecode", "a"}, {"delim", ";"}};
+        json const j = {{"rolecode", "a"}, {"delim", ";"}};
         std::vector<uint8_t> const v = {'{', 'i', 5, 'd', 'e', 'l', 'i', 'm', 'C', ';', 'i', 8, 'r', 'o', 'l', 'e', 'c', 'o', 'd', 'e', 'C', 'a', '}'};
         //CHECK(json::to_ubjson(j) == v);
         CHECK(json::from_ubjson(v) == j);
@@ -2126,24 +2156,24 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
     {
         SECTION("English")
         {
-            json j = "hello";
-            std::vector<uint8_t> v = {'S', 'i', 5, 'h', 'e', 'l', 'l', 'o'};
+            json const j = "hello";
+            std::vector<uint8_t> const v = {'S', 'i', 5, 'h', 'e', 'l', 'l', 'o'};
             CHECK(json::to_ubjson(j) == v);
             CHECK(json::from_ubjson(v) == j);
         }
 
         SECTION("Russian")
         {
-            json j = "привет";
-            std::vector<uint8_t> v = {'S', 'i', 12, 0xD0, 0xBF, 0xD1, 0x80, 0xD0, 0xB8, 0xD0, 0xB2, 0xD0, 0xB5, 0xD1, 0x82};
+            json const j = "привет";
+            std::vector<uint8_t> const v = {'S', 'i', 12, 0xD0, 0xBF, 0xD1, 0x80, 0xD0, 0xB8, 0xD0, 0xB2, 0xD0, 0xB5, 0xD1, 0x82};
             CHECK(json::to_ubjson(j) == v);
             CHECK(json::from_ubjson(v) == j);
         }
 
         SECTION("Russian")
         {
-            json j = "مرحبا";
-            std::vector<uint8_t> v = {'S', 'i', 10, 0xD9, 0x85, 0xD8, 0xB1, 0xD8, 0xAD, 0xD8, 0xA8, 0xD8, 0xA7};
+            json const j = "مرحبا";
+            std::vector<uint8_t> const v = {'S', 'i', 10, 0xD9, 0x85, 0xD8, 0xB1, 0xD8, 0xAD, 0xD8, 0xA8, 0xD8, 0xA7};
             CHECK(json::to_ubjson(j) == v);
             CHECK(json::from_ubjson(v) == j);
         }
@@ -2154,8 +2184,8 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
         SECTION("size=false type=false")
         {
             // note the float has been replaced by a double
-            json j = {nullptr, true, false, 4782345193, 153.132, "ham"};
-            std::vector<uint8_t> v = {'[', 'Z', 'T', 'F', 'L', 0x00, 0x00, 0x00, 0x01, 0x1D, 0x0C, 0xCB, 0xE9, 'D', 0x40, 0x63, 0x24, 0x39, 0x58, 0x10, 0x62, 0x4e, 'S', 'i', 3, 'h', 'a', 'm', ']'};
+            json const j = {nullptr, true, false, 4782345193, 153.132, "ham"};
+            std::vector<uint8_t> const v = {'[', 'Z', 'T', 'F', 'L', 0x00, 0x00, 0x00, 0x01, 0x1D, 0x0C, 0xCB, 0xE9, 'D', 0x40, 0x63, 0x24, 0x39, 0x58, 0x10, 0x62, 0x4e, 'S', 'i', 3, 'h', 'a', 'm', ']'};
             CHECK(json::to_ubjson(j) == v);
             CHECK(json::from_ubjson(v) == j);
         }
@@ -2163,8 +2193,8 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
         SECTION("size=true type=false")
         {
             // note the float has been replaced by a double
-            json j = {nullptr, true, false, 4782345193, 153.132, "ham"};
-            std::vector<uint8_t> v = {'[', '#', 'i', 6, 'Z', 'T', 'F', 'L', 0x00, 0x00, 0x00, 0x01, 0x1D, 0x0C, 0xCB, 0xE9, 'D', 0x40, 0x63, 0x24, 0x39, 0x58, 0x10, 0x62, 0x4e, 'S', 'i', 3, 'h', 'a', 'm'};
+            json const j = {nullptr, true, false, 4782345193, 153.132, "ham"};
+            std::vector<uint8_t> const v = {'[', '#', 'i', 6, 'Z', 'T', 'F', 'L', 0x00, 0x00, 0x00, 0x01, 0x1D, 0x0C, 0xCB, 0xE9, 'D', 0x40, 0x63, 0x24, 0x39, 0x58, 0x10, 0x62, 0x4e, 'S', 'i', 3, 'h', 'a', 'm'};
             CHECK(json::to_ubjson(j, true) == v);
             CHECK(json::from_ubjson(v) == j);
         }
@@ -2172,8 +2202,8 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
         SECTION("size=true type=true")
         {
             // note the float has been replaced by a double
-            json j = {nullptr, true, false, 4782345193, 153.132, "ham"};
-            std::vector<uint8_t> v = {'[', '#', 'i', 6, 'Z', 'T', 'F', 'L', 0x00, 0x00, 0x00, 0x01, 0x1D, 0x0C, 0xCB, 0xE9, 'D', 0x40, 0x63, 0x24, 0x39, 0x58, 0x10, 0x62, 0x4e, 'S', 'i', 3, 'h', 'a', 'm'};
+            json const j = {nullptr, true, false, 4782345193, 153.132, "ham"};
+            std::vector<uint8_t> const v = {'[', '#', 'i', 6, 'Z', 'T', 'F', 'L', 0x00, 0x00, 0x00, 0x01, 0x1D, 0x0C, 0xCB, 0xE9, 'D', 0x40, 0x63, 0x24, 0x39, 0x58, 0x10, 0x62, 0x4e, 'S', 'i', 3, 'h', 'a', 'm'};
             CHECK(json::to_ubjson(j, true, true) == v);
             CHECK(json::from_ubjson(v) == j);
         }
@@ -2183,7 +2213,7 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
     {
         SECTION("size=false type=false")
         {
-            json j =
+            json const j =
             {
                 {
                     "post", {
@@ -2194,20 +2224,20 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
                     }
                 }
             };
-            std::vector<uint8_t> v = {'{', 'i', 4, 'p', 'o', 's', 't', '{',
-                                      'i', 6, 'a', 'u', 't', 'h', 'o', 'r', 'S', 'i', 6, 'r', 'k', 'a', 'l', 'l', 'a',
-                                      'i', 4, 'b', 'o', 'd', 'y', 'S', 'i', 16, 'I', ' ', 't', 'o', 't', 'a', 'l', 'l', 'y', ' ', 'a', 'g', 'r', 'e', 'e', '!',
-                                      'i', 2, 'i', 'd', 'I', 0x04, 0x71,
-                                      'i', 9, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 'L', 0x00, 0x00, 0x01, 0x3D, 0xB1, 0x78, 0x66, 0x60,
-                                      '}', '}'
-                                     };
+            std::vector<uint8_t> const v = {'{', 'i', 4, 'p', 'o', 's', 't', '{',
+                                            'i', 6, 'a', 'u', 't', 'h', 'o', 'r', 'S', 'i', 6, 'r', 'k', 'a', 'l', 'l', 'a',
+                                            'i', 4, 'b', 'o', 'd', 'y', 'S', 'i', 16, 'I', ' ', 't', 'o', 't', 'a', 'l', 'l', 'y', ' ', 'a', 'g', 'r', 'e', 'e', '!',
+                                            'i', 2, 'i', 'd', 'I', 0x04, 0x71,
+                                            'i', 9, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 'L', 0x00, 0x00, 0x01, 0x3D, 0xB1, 0x78, 0x66, 0x60,
+                                            '}', '}'
+                                           };
             CHECK(json::to_ubjson(j) == v);
             CHECK(json::from_ubjson(v) == j);
         }
 
         SECTION("size=true type=false")
         {
-            json j =
+            json const j =
             {
                 {
                     "post", {
@@ -2218,19 +2248,19 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
                     }
                 }
             };
-            std::vector<uint8_t> v = {'{', '#', 'i', 1, 'i', 4, 'p', 'o', 's', 't', '{', '#', 'i', 4,
-                                      'i', 6, 'a', 'u', 't', 'h', 'o', 'r', 'S', 'i', 6, 'r', 'k', 'a', 'l', 'l', 'a',
-                                      'i', 4, 'b', 'o', 'd', 'y', 'S', 'i', 16, 'I', ' ', 't', 'o', 't', 'a', 'l', 'l', 'y', ' ', 'a', 'g', 'r', 'e', 'e', '!',
-                                      'i', 2, 'i', 'd', 'I', 0x04, 0x71,
-                                      'i', 9, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 'L', 0x00, 0x00, 0x01, 0x3D, 0xB1, 0x78, 0x66, 0x60
-                                     };
+            std::vector<uint8_t> const v = {'{', '#', 'i', 1, 'i', 4, 'p', 'o', 's', 't', '{', '#', 'i', 4,
+                                            'i', 6, 'a', 'u', 't', 'h', 'o', 'r', 'S', 'i', 6, 'r', 'k', 'a', 'l', 'l', 'a',
+                                            'i', 4, 'b', 'o', 'd', 'y', 'S', 'i', 16, 'I', ' ', 't', 'o', 't', 'a', 'l', 'l', 'y', ' ', 'a', 'g', 'r', 'e', 'e', '!',
+                                            'i', 2, 'i', 'd', 'I', 0x04, 0x71,
+                                            'i', 9, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 'L', 0x00, 0x00, 0x01, 0x3D, 0xB1, 0x78, 0x66, 0x60
+                                           };
             CHECK(json::to_ubjson(j, true) == v);
             CHECK(json::from_ubjson(v) == j);
         }
 
         SECTION("size=true type=true")
         {
-            json j =
+            json const j =
             {
                 {
                     "post", {
@@ -2241,12 +2271,12 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
                     }
                 }
             };
-            std::vector<uint8_t> v = {'{', '$', '{', '#', 'i', 1, 'i', 4, 'p', 'o', 's', 't', '#', 'i', 4,
-                                      'i', 6, 'a', 'u', 't', 'h', 'o', 'r', 'S', 'i', 6, 'r', 'k', 'a', 'l', 'l', 'a',
-                                      'i', 4, 'b', 'o', 'd', 'y', 'S', 'i', 16, 'I', ' ', 't', 'o', 't', 'a', 'l', 'l', 'y', ' ', 'a', 'g', 'r', 'e', 'e', '!',
-                                      'i', 2, 'i', 'd', 'I', 0x04, 0x71,
-                                      'i', 9, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 'L', 0x00, 0x00, 0x01, 0x3D, 0xB1, 0x78, 0x66, 0x60
-                                     };
+            std::vector<uint8_t> const v = {'{', '$', '{', '#', 'i', 1, 'i', 4, 'p', 'o', 's', 't', '#', 'i', 4,
+                                            'i', 6, 'a', 'u', 't', 'h', 'o', 'r', 'S', 'i', 6, 'r', 'k', 'a', 'l', 'l', 'a',
+                                            'i', 4, 'b', 'o', 'd', 'y', 'S', 'i', 16, 'I', ' ', 't', 'o', 't', 'a', 'l', 'l', 'y', ' ', 'a', 'g', 'r', 'e', 'e', '!',
+                                            'i', 2, 'i', 'd', 'I', 0x04, 0x71,
+                                            'i', 9, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 'L', 0x00, 0x00, 0x01, 0x3D, 0xB1, 0x78, 0x66, 0x60
+                                           };
             CHECK(json::to_ubjson(j, true, true) == v);
             CHECK(json::from_ubjson(v) == j);
         }
@@ -2259,15 +2289,15 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("No Optimization")
             {
                 // note the floats have been replaced by doubles
-                json j = {29.97, 31.13, 67.0, 2.113, 23.888};
-                std::vector<uint8_t> v = {'[',
-                                          'D', 0x40, 0x3d, 0xf8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
-                                          'D', 0x40, 0x3f, 0x21, 0x47, 0xae, 0x14, 0x7a, 0xe1,
-                                          'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          'D', 0x40, 0x00, 0xe7, 0x6c, 0x8b, 0x43, 0x95, 0x81,
-                                          'D', 0x40, 0x37, 0xe3, 0x53, 0xf7, 0xce, 0xd9, 0x17,
-                                          ']'
-                                         };
+                json const j = {29.97, 31.13, 67.0, 2.113, 23.888};
+                std::vector<uint8_t> const v = {'[',
+                                                'D', 0x40, 0x3d, 0xf8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
+                                                'D', 0x40, 0x3f, 0x21, 0x47, 0xae, 0x14, 0x7a, 0xe1,
+                                                'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                'D', 0x40, 0x00, 0xe7, 0x6c, 0x8b, 0x43, 0x95, 0x81,
+                                                'D', 0x40, 0x37, 0xe3, 0x53, 0xf7, 0xce, 0xd9, 0x17,
+                                                ']'
+                                               };
                 CHECK(json::to_ubjson(j) == v);
                 CHECK(json::from_ubjson(v) == j);
             }
@@ -2275,14 +2305,14 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with count")
             {
                 // note the floats have been replaced by doubles
-                json j = {29.97, 31.13, 67.0, 2.113, 23.888};
-                std::vector<uint8_t> v = {'[', '#', 'i', 5,
-                                          'D', 0x40, 0x3d, 0xf8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
-                                          'D', 0x40, 0x3f, 0x21, 0x47, 0xae, 0x14, 0x7a, 0xe1,
-                                          'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          'D', 0x40, 0x00, 0xe7, 0x6c, 0x8b, 0x43, 0x95, 0x81,
-                                          'D', 0x40, 0x37, 0xe3, 0x53, 0xf7, 0xce, 0xd9, 0x17
-                                         };
+                json const j = {29.97, 31.13, 67.0, 2.113, 23.888};
+                std::vector<uint8_t> const v = {'[', '#', 'i', 5,
+                                                'D', 0x40, 0x3d, 0xf8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
+                                                'D', 0x40, 0x3f, 0x21, 0x47, 0xae, 0x14, 0x7a, 0xe1,
+                                                'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                'D', 0x40, 0x00, 0xe7, 0x6c, 0x8b, 0x43, 0x95, 0x81,
+                                                'D', 0x40, 0x37, 0xe3, 0x53, 0xf7, 0xce, 0xd9, 0x17
+                                               };
                 CHECK(json::to_ubjson(j, true) == v);
                 CHECK(json::from_ubjson(v) == j);
             }
@@ -2290,14 +2320,14 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with type & count")
             {
                 // note the floats have been replaced by doubles
-                json j = {29.97, 31.13, 67.0, 2.113, 23.888};
-                std::vector<uint8_t> v = {'[', '$', 'D', '#', 'i', 5,
-                                          0x40, 0x3d, 0xf8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
-                                          0x40, 0x3f, 0x21, 0x47, 0xae, 0x14, 0x7a, 0xe1,
-                                          0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x40, 0x00, 0xe7, 0x6c, 0x8b, 0x43, 0x95, 0x81,
-                                          0x40, 0x37, 0xe3, 0x53, 0xf7, 0xce, 0xd9, 0x17
-                                         };
+                json const j = {29.97, 31.13, 67.0, 2.113, 23.888};
+                std::vector<uint8_t> const v = {'[', '$', 'D', '#', 'i', 5,
+                                                0x40, 0x3d, 0xf8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
+                                                0x40, 0x3f, 0x21, 0x47, 0xae, 0x14, 0x7a, 0xe1,
+                                                0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                0x40, 0x00, 0xe7, 0x6c, 0x8b, 0x43, 0x95, 0x81,
+                                                0x40, 0x37, 0xe3, 0x53, 0xf7, 0xce, 0xd9, 0x17
+                                               };
                 CHECK(json::to_ubjson(j, true, true) == v);
                 CHECK(json::from_ubjson(v) == j);
             }
@@ -2308,13 +2338,13 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("No Optimization")
             {
                 // note the floats have been replaced by doubles
-                json j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
-                std::vector<uint8_t> v = {'{',
-                                          'i', 3, 'a', 'l', 't', 'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          'i', 3, 'l', 'a', 't', 'D', 0x40, 0x3d, 0xf9, 0xdb, 0x22, 0xd0, 0xe5, 0x60,
-                                          'i', 4, 'l', 'o', 'n', 'g', 'D', 0x40, 0x3f, 0x21, 0x89, 0x37, 0x4b, 0xc6, 0xa8,
-                                          '}'
-                                         };
+                json const j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
+                std::vector<uint8_t> const v = {'{',
+                                                'i', 3, 'a', 'l', 't', 'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                'i', 3, 'l', 'a', 't', 'D', 0x40, 0x3d, 0xf9, 0xdb, 0x22, 0xd0, 0xe5, 0x60,
+                                                'i', 4, 'l', 'o', 'n', 'g', 'D', 0x40, 0x3f, 0x21, 0x89, 0x37, 0x4b, 0xc6, 0xa8,
+                                                '}'
+                                               };
                 CHECK(json::to_ubjson(j) == v);
                 CHECK(json::from_ubjson(v) == j);
             }
@@ -2322,12 +2352,12 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with count")
             {
                 // note the floats have been replaced by doubles
-                json j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
-                std::vector<uint8_t> v = {'{', '#', 'i', 3,
-                                          'i', 3, 'a', 'l', 't', 'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          'i', 3, 'l', 'a', 't', 'D', 0x40, 0x3d, 0xf9, 0xdb, 0x22, 0xd0, 0xe5, 0x60,
-                                          'i', 4, 'l', 'o', 'n', 'g', 'D', 0x40, 0x3f, 0x21, 0x89, 0x37, 0x4b, 0xc6, 0xa8
-                                         };
+                json const j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
+                std::vector<uint8_t> const v = {'{', '#', 'i', 3,
+                                                'i', 3, 'a', 'l', 't', 'D', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                'i', 3, 'l', 'a', 't', 'D', 0x40, 0x3d, 0xf9, 0xdb, 0x22, 0xd0, 0xe5, 0x60,
+                                                'i', 4, 'l', 'o', 'n', 'g', 'D', 0x40, 0x3f, 0x21, 0x89, 0x37, 0x4b, 0xc6, 0xa8
+                                               };
                 CHECK(json::to_ubjson(j, true) == v);
                 CHECK(json::from_ubjson(v) == j);
             }
@@ -2335,12 +2365,12 @@ TEST_CASE("Universal Binary JSON Specification Examples 1")
             SECTION("Optimized with type & count")
             {
                 // note the floats have been replaced by doubles
-                json j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
-                std::vector<uint8_t> v = {'{', '$', 'D', '#', 'i', 3,
-                                          'i', 3, 'a', 'l', 't', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          'i', 3, 'l', 'a', 't', 0x40, 0x3d, 0xf9, 0xdb, 0x22, 0xd0, 0xe5, 0x60,
-                                          'i', 4, 'l', 'o', 'n', 'g', 0x40, 0x3f, 0x21, 0x89, 0x37, 0x4b, 0xc6, 0xa8
-                                         };
+                json const j = { {"lat", 29.976}, {"long", 31.131}, {"alt", 67.0} };
+                std::vector<uint8_t> const v = {'{', '$', 'D', '#', 'i', 3,
+                                                'i', 3, 'a', 'l', 't', 0x40, 0x50, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                'i', 3, 'l', 'a', 't', 0x40, 0x3d, 0xf9, 0xdb, 0x22, 0xd0, 0xe5, 0x60,
+                                                'i', 4, 'l', 'o', 'n', 'g', 0x40, 0x3f, 0x21, 0x89, 0x37, 0x4b, 0xc6, 0xa8
+                                               };
                 CHECK(json::to_ubjson(j, true, true) == v);
                 CHECK(json::from_ubjson(v) == j);
             }
@@ -2455,10 +2485,10 @@ TEST_CASE("UBJSON roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                json const j1 = json::parse(f_json);
 
                 // parse UBJSON file
-                auto packed = utils::read_binary_file(filename + ".ubjson");
+                auto const packed = utils::read_binary_file(filename + ".ubjson");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_ubjson(packed));
 
@@ -2470,7 +2500,7 @@ TEST_CASE("UBJSON roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::ifstream");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                json const j1 = json::parse(f_json);
 
                 // parse UBJSON file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
@@ -2488,7 +2518,7 @@ TEST_CASE("UBJSON roundtrips" * doctest::skip())
                 json j1 = json::parse(f_json);
 
                 // parse UBJSON file
-                auto packed = utils::read_binary_file(filename + ".ubjson");
+                auto const packed = utils::read_binary_file(filename + ".ubjson");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_ubjson({packed.data(), packed.size()}));
 
@@ -2503,7 +2533,7 @@ TEST_CASE("UBJSON roundtrips" * doctest::skip())
                 json const j1 = json::parse(f_json);
 
                 // parse UBJSON file
-                auto packed = utils::read_binary_file(filename + ".ubjson");
+                auto const packed = utils::read_binary_file(filename + ".ubjson");
 
                 {
                     INFO_WITH_TEMP(filename + ": output adapters: std::vector<uint8_t>");

--- a/tests/thirdparty/doctest/doctest_compatibility.h
+++ b/tests/thirdparty/doctest/doctest_compatibility.h
@@ -20,7 +20,7 @@
 // doctest doesn't support THROWS_WITH for std::string out of the box (has to include <string>...)
 #define CHECK_THROWS_WITH_STD_STR_IMPL(expr, str, var_name)                    \
     do {                                                                       \
-        std::string var_name = str;                                            \
+        const std::string var_name = str;                                      \
         CHECK_THROWS_WITH(expr, var_name.c_str());                             \
     } while (false)
 #define CHECK_THROWS_WITH_STD_STR(expr, str)                                   \


### PR DESCRIPTION
Helping you out a little with some manual `const` edits.