### PR TITLE
use get_to instead of get for array as inplace assignment to avoid ca…

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -186,7 +186,9 @@ auto from_json(const BasicJsonType& j, T (&arr)[N])  // NOLINT(cppcoreguidelines
 {
     for (std::size_t i = 0; i < N; ++i)
     {
-        arr[i] = j.at(i).template get<T>();
+        // inplace assignment to avoid calling constructor and losing the data of its  members
+        // arr[i] = j.at(i).template get<T>();
+        j.at(i).get_to(arr[i]);
     }
 }
 
@@ -203,7 +205,9 @@ auto from_json_array_impl(const BasicJsonType& j, std::array<T, N>& arr,
 {
     for (std::size_t i = 0; i < N; ++i)
     {
-        arr[i] = j.at(i).template get<T>();
+        // inplace assignment to avoid calling constructor and losing the data of its  members
+        // arr[i] = j.at(i).template get<T>();
+        j.at(i).get_to(arr[i]);
     }
 }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4746,7 +4746,9 @@ auto from_json(const BasicJsonType& j, T (&arr)[N])  // NOLINT(cppcoreguidelines
 {
     for (std::size_t i = 0; i < N; ++i)
     {
-        arr[i] = j.at(i).template get<T>();
+        // inplace assignment to avoid calling constructor and losing the data of its  members
+        // arr[i] = j.at(i).template get<T>();
+        j.at(i).get_to(arr[i]);
     }
 }
 
@@ -4763,7 +4765,9 @@ auto from_json_array_impl(const BasicJsonType& j, std::array<T, N>& arr,
 {
     for (std::size_t i = 0; i < N; ++i)
     {
-        arr[i] = j.at(i).template get<T>();
+        // inplace assignment to avoid calling constructor and losing the data of its  members
+        // arr[i] = j.at(i).template get<T>();
+        j.at(i).get_to(arr[i]);
     }
 }
 

--- a/tests/src/unit-inplace_array.cpp
+++ b/tests/src/unit-inplace_array.cpp
@@ -1,0 +1,79 @@
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++ (supporting code)
+// |  |  |__   |  |  | | | |  version 3.11.2
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+#include "doctest_compatibility.h"
+
+#include <array>
+#include <string>
+#include <iostream>
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using ordered_json = nlohmann::ordered_json;
+
+
+class Person
+{
+  public:
+    //Person(){ std::cout<<"Person constructor\n";}
+    int age;
+    std::string name;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(Person, name, age);
+
+    int count{1};   // the data must not be reset
+};
+
+class SchoolA
+{
+  public:
+    //SchoolA(){ std::cout<<"School constructor\n";}
+    std::array<Person, 2> persons;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(SchoolA, persons);
+};
+class SchoolB
+{
+  public:
+    //SchoolB(){ std::cout<<"School constructor\n";}
+
+    Person persons[2];
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(SchoolB, persons);
+};
+
+
+TEST_CASE("inplace_array<nlohmann::json>")
+{
+
+    json obj = R"({"persons":[{"age":100, "name":"alex"}, {"age":200, "name":"edmond"}]})"_json;
+
+    {
+        SchoolA   s;
+        from_json(obj, s);
+        CHECK(s.persons[0].age == 100);
+
+        s.persons[0].count = 88;
+
+        from_json(obj, s);
+        CHECK(s.persons[0].count == 88);
+    }
+
+    {
+        SchoolB   s;
+        from_json(obj, s);
+
+        CHECK(s.persons[0].age == 100);
+
+        s.persons[0].count = 88;
+
+        from_json(obj, s);
+        CHECK(s.persons[0].count == 88);
+    }
+
+}


### PR DESCRIPTION
use get_to instead of get for array as inplace assignment to avoid calling constructor and losing the data

Inplace assignment could keep the value of data member as the below use case
```
class Person
{
  public:
    //Person(){ std::cout<<"Person constructor\n";}
    int age;
    std::string name;
    NLOHMANN_DEFINE_TYPE_INTRUSIVE(Person, name, age);

    int count{1};   // the data must not be reset
};

class SchoolA
{
  public:
    //SchoolA(){ std::cout<<"School constructor\n";}
    std::array<Person, 2> persons;

    NLOHMANN_DEFINE_TYPE_INTRUSIVE(SchoolA, persons);
};

  json obj = R"({"persons":[{"age":100, "name":"alex"}, {"age":200, "name":"edmond"}]})"_json;


 SchoolA   s;
 from_json(obj, s);
 CHECK(s.persons[0].age == 100);

 s.persons[0].count = 88;

 from_json(obj, s);
 CHECK(s.persons[0].count == 88);

```


* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
