### PR TITLE
Add serialization-only user defined type macros

### DIFF
--- a/docs/examples/nlohmann_define_type_intrusive_only_serialize_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_only_serialize_explicit.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using namespace nlohmann::literals;
+
+namespace ns
+{
+class person
+{
+  private:
+    std::string name = "John Doe";
+    std::string address = "123 Fake St";
+    int age = -1;
+
+  public:
+    // No default constructor
+    person(std::string name_, std::string address_, int age_)
+        : name(std::move(name_)), address(std::move(address_)), age(age_)
+    {}
+
+    friend void to_json(nlohmann::json& nlohmann_json_j, const person& nlohmann_json_t)
+    {
+        nlohmann_json_j["name"] = nlohmann_json_t.name;
+        nlohmann_json_j["address"] = nlohmann_json_t.address;
+        nlohmann_json_j["age"] = nlohmann_json_t.age;
+    }
+};
+} // namespace ns
+
+int main()
+{
+    ns::person p = {"Ned Flanders", "744 Evergreen Terrace", 60};
+
+    // serialization: person -> json
+    json j = p;
+    std::cout << "serialization: " << j << std::endl;
+}

--- a/docs/examples/nlohmann_define_type_intrusive_only_serialize_explicit.output
+++ b/docs/examples/nlohmann_define_type_intrusive_only_serialize_explicit.output
@@ -1,0 +1,1 @@
+serialization: {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}

--- a/docs/examples/nlohmann_define_type_intrusive_only_serialize_macro.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_only_serialize_macro.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using namespace nlohmann::literals;
+
+namespace ns
+{
+class person
+{
+  private:
+    std::string name = "John Doe";
+    std::string address = "123 Fake St";
+    int age = -1;
+
+  public:
+    // No default constructor
+    person(std::string name_, std::string address_, int age_)
+        : name(std::move(name_)), address(std::move(address_)), age(age_)
+    {}
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(person, name, address, age)
+};
+} // namespace ns
+
+int main()
+{
+    ns::person p = {"Ned Flanders", "744 Evergreen Terrace", 60};
+
+    // serialization: person -> json
+    json j = p;
+    std::cout << "serialization: " << j << std::endl;
+}

--- a/docs/examples/nlohmann_define_type_intrusive_only_serialize_macro.output
+++ b/docs/examples/nlohmann_define_type_intrusive_only_serialize_macro.output
@@ -1,0 +1,1 @@
+serialization: {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}

--- a/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_explicit.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using namespace nlohmann::literals;
+
+namespace ns
+{
+struct person
+{
+    std::string name;
+    std::string address;
+    int age;
+};
+
+void to_json(nlohmann::json& nlohmann_json_j, const person& nlohmann_json_t)
+{
+    nlohmann_json_j["name"] = nlohmann_json_t.name;
+    nlohmann_json_j["address"] = nlohmann_json_t.address;
+    nlohmann_json_j["age"] = nlohmann_json_t.age;
+}
+} // namespace ns
+
+int main()
+{
+    ns::person p = {"Ned Flanders", "744 Evergreen Terrace", 60};
+
+    // serialization: person -> json
+    json j = p;
+    std::cout << "serialization: " << j << std::endl;
+}

--- a/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_explicit.output
+++ b/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_explicit.output
@@ -1,0 +1,1 @@
+serialization: {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}

--- a/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_macro.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_macro.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using namespace nlohmann::literals;
+
+namespace ns
+{
+struct person
+{
+    std::string name;
+    std::string address;
+    int age;
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(person, name, address, age)
+} // namespace ns
+
+int main()
+{
+    ns::person p = {"Ned Flanders", "744 Evergreen Terrace", 60};
+
+    // serialization: person -> json
+    json j = p;
+    std::cout << "serialization: " << j << std::endl;
+}

--- a/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_macro.output
+++ b/docs/examples/nlohmann_define_type_non_intrusive_only_serialize_macro.output
@@ -1,0 +1,1 @@
+serialization: {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}

--- a/docs/mkdocs/docs/api/macros/index.md
+++ b/docs/mkdocs/docs/api/macros/index.md
@@ -50,9 +50,11 @@ header. See also the [macro overview page](../../features/macros.md).
 
 ## Serialization/deserialization macros
 
-- [**NLOHMANN_DEFINE_TYPE_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(type, member...)**][DefInt]
+- [**NLOHMANN_DEFINE_TYPE_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(type, member...)**
+<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(type, member...)**][DefInt]
   \- serialization/deserialization of types _with_ access to private variables
-- [**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(type, member...)**][DefNonInt]
+- [**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(type, member...)**
+<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(type, member...)**][DefNonInt]
   \- serialization/deserialization of types _without_ access to private variables
 - [**NLOHMANN_JSON_SERIALIZE_ENUM(type, ...)**](nlohmann_json_serialize_enum.md) - serialization/deserialization of enum types
 

--- a/docs/mkdocs/docs/api/macros/index.md
+++ b/docs/mkdocs/docs/api/macros/index.md
@@ -50,9 +50,9 @@ header. See also the [macro overview page](../../features/macros.md).
 
 ## Serialization/deserialization macros
 
-- [**NLOHMANN_DEFINE_TYPE_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(type, member...)**][DefInt]
+- [**NLOHMANN_DEFINE_TYPE_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(type, member...)**][DefInt]
   \- serialization/deserialization of types _with_ access to private variables
-- [**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(type, member...)**][DefNonInt]
+- [**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(type, member...)**<br>**NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(type, member...)**][DefNonInt]
   \- serialization/deserialization of types _without_ access to private variables
 - [**NLOHMANN_JSON_SERIALIZE_ENUM(type, ...)**](nlohmann_json_serialize_enum.md) - serialization/deserialization of enum types
 

--- a/docs/mkdocs/docs/api/macros/nlohmann_define_type_intrusive.md
+++ b/docs/mkdocs/docs/api/macros/nlohmann_define_type_intrusive.md
@@ -1,8 +1,9 @@
-# NLOHMANN_DEFINE_TYPE_INTRUSIVE, NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT
+# NLOHMANN_DEFINE_TYPE_INTRUSIVE, NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT, NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE
 
 ```cpp
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE(type, member...)              // (1)
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(type, member...) // (2)
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(type, member...) // (3)
 ```
 
 These macros can be used to simplify the serialization/deserialization of types if you want to use a JSON object as
@@ -16,6 +17,7 @@ parameter is the name of the class/struct, and all remaining parameters name the
 2. Will use [`value`](../basic_json/value.md) during deserialization and fall back to the default value for the
    respective type of the member variable if a key in the JSON object is missing. The generated `from_json()` function
    default constructs an object and uses its values as the defaults when calling the `value` function.
+3. Only defines the serialization. Useful in cases when the type does not have a default constructor and only serialization in required.
 
 ## Parameters
 
@@ -31,7 +33,7 @@ The macros add two friend functions to the class which take care of the serializ
 
 ```cpp
 friend void to_json(nlohmann::json&, const type&);
-friend void from_json(const nlohmann::json&, type&);
+friend void from_json(const nlohmann::json&, type&); // except (3)
 ```
 
 See examples below for the concrete generated code.
@@ -40,7 +42,7 @@ See examples below for the concrete generated code.
 
 !!! info "Prerequisites"
 
-    1. The type `type` must be default constructible. See [How can I use `get()` for non-default
+    1. The type `type` must be default constructible (except (3)). See [How can I use `get()` for non-default
        constructible/non-copyable types?][GetNonDefNonCopy] for how to overcome this limitation.
     2. The macro must be used inside the type (class/struct).
 
@@ -114,9 +116,36 @@ See examples below for the concrete generated code.
 
     Note how a default-initialized `person` object is used in the `from_json` to fill missing values.
 
+??? example "Example (3): NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE"
+    Consider the following complete example:
+
+    ```cpp hl_lines="21"
+    --8<-- "examples/nlohmann_define_type_intrusive_only_serialize_macro.cpp"
+    ```
+    
+    Output:
+    
+    ```json
+    --8<-- "examples/nlohmann_define_type_intrusive_only_serialize_macro.output"
+    ```
+
+    Notes:
+
+    - `ns::person` is non-default-constructible. This allows this macro to be used instead of 
+      `NLOHMANN_DEFINE_TYPE_INTRUSIVE` and `NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT`.
+    - `ns::person` has private member variables. This makes `NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE` applicable, but not
+      `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE`.
+    - The macro `NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE` is used _inside_ the class.
+
+    The macro is equivalent to:
+
+    ```cpp hl_lines="21 22 23 24 25 26"
+    --8<-- "examples/nlohmann_define_type_intrusive_only_serialize_explicit.cpp"
+    ```
+
 ## See also
 
-- [NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE / NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT](nlohmann_define_type_non_intrusive.md)
+- [NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE{_WITH_DEFAULT, _ONLY_SERIALIZE}](nlohmann_define_type_non_intrusive.md)
   for a similar macro that can be defined _outside_ the type.
 - [Arbitrary Type Conversions](../../features/arbitrary_types.md) for an overview.
 
@@ -124,3 +153,4 @@ See examples below for the concrete generated code.
 
 1. Added in version 3.9.0.
 2. Added in version 3.11.0.
+3. Added in version TODO.

--- a/docs/mkdocs/docs/api/macros/nlohmann_define_type_intrusive.md
+++ b/docs/mkdocs/docs/api/macros/nlohmann_define_type_intrusive.md
@@ -110,7 +110,7 @@ See examples below for the concrete generated code.
 
     The macro is equivalent to:
 
-    ```cpp hl_lines="21 22 23 24 25 26 27 28 29 30 31 32 33 34 35"
+    ```cpp hl_lines="22 23 24 25 26 27 28 29 30 31 32 33 34 35"
     --8<-- "examples/nlohmann_define_type_intrusive_with_default_explicit.cpp"
     ```
 
@@ -119,7 +119,7 @@ See examples below for the concrete generated code.
 ??? example "Example (3): NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE"
     Consider the following complete example:
 
-    ```cpp hl_lines="21"
+    ```cpp hl_lines="22"
     --8<-- "examples/nlohmann_define_type_intrusive_only_serialize_macro.cpp"
     ```
     
@@ -139,7 +139,7 @@ See examples below for the concrete generated code.
 
     The macro is equivalent to:
 
-    ```cpp hl_lines="21 22 23 24 25 26"
+    ```cpp hl_lines="22 22 23 24 25 26 27"
     --8<-- "examples/nlohmann_define_type_intrusive_only_serialize_explicit.cpp"
     ```
 

--- a/docs/mkdocs/docs/api/macros/nlohmann_define_type_non_intrusive.md
+++ b/docs/mkdocs/docs/api/macros/nlohmann_define_type_non_intrusive.md
@@ -1,8 +1,9 @@
-# NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE, NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT
+# NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE, NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT, NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE
 
 ```cpp
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(type, member...)              // (1)
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(type, member...) // (2)
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(type, member...) // (3)
 ```
 
 These macros can be used to simplify the serialization/deserialization of types if you want to use a JSON object as
@@ -16,6 +17,7 @@ parameter is the name of the class/struct, and all remaining parameters name the
 2. Will use [`value`](../basic_json/value.md) during deserialization and fall back to the default value for the
    respective type of the member variable if a key in the JSON object is missing. The generated `from_json()` function
    default constructs an object and uses its values as the defaults when calling the `value` function.
+3. Only defines the serialization. Useful in cases when the type does not have a default constructor and only serialization in required.
 
 ## Parameters
 
@@ -31,7 +33,7 @@ The macros add two functions to the namespace which take care of the serializati
 
 ```cpp
 void to_json(nlohmann::json&, const type&);
-void from_json(const nlohmann::json&, type&);
+void from_json(const nlohmann::json&, type&); // except (3)
 ```
 
 See examples below for the concrete generated code.
@@ -40,7 +42,7 @@ See examples below for the concrete generated code.
 
 !!! info "Prerequisites"
 
-    1. The type `type` must be default constructible. See [How can I use `get()` for non-default constructible/non-copyable types?][GetNonDefNonCopy]
+    1. The type `type` must be default constructible (except (3). See [How can I use `get()` for non-default constructible/non-copyable types?][GetNonDefNonCopy]
        for how to overcome this limitation.
     2. The macro must be used outside the type (class/struct).
     3. The passed members must be public.
@@ -115,9 +117,36 @@ See examples below for the concrete generated code.
 
     Note how a default-initialized `person` object is used in the `from_json` to fill missing values.
 
+??? example "Example (3): NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE"
+
+    Consider the following complete example:
+
+    ```cpp hl_lines="15"
+    --8<-- "examples/nlohmann_define_type_non_intrusive_only_serialize_macro.cpp"
+    ```
+    
+    Output:
+    
+    ```json
+    --8<-- "examples/nlohmann_define_type_non_intrusive_only_serialize_macro.output"
+    ```
+
+    Notes:
+
+    - `ns::person` is non-default-constructible. This allows this macro to be used instead of 
+      `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE` and `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT`.
+    - `ns::person` has only public member variables. This makes `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE` applicable.
+    - The macro `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE` is used _outside_ the class, but _inside_ its namespace `ns`.
+
+    The macro is equivalent to:
+
+    ```cpp hl_lines="15 16 17 18 19 20"
+    --8<-- "examples/nlohmann_define_type_non_intrusive_only_serialize_explicit.cpp"
+    ```
+
 ## See also
 
-- [NLOHMANN_DEFINE_TYPE_INTRUSIVE / NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT](nlohmann_define_type_intrusive.md)
+- [NLOHMANN_DEFINE_TYPE_INTRUSIVE{_WITH_DEFAULT, _ONLY_SERIALIZE}](nlohmann_define_type_intrusive.md)
   for a similar macro that can be defined _inside_ the type.
 - [Arbitrary Type Conversions](../../features/arbitrary_types.md) for an overview.
 
@@ -125,3 +154,4 @@ See examples below for the concrete generated code.
 
 1. Added in version 3.9.0.
 2. Added in version 3.11.0.
+3. Added in version TODO.

--- a/docs/mkdocs/docs/api/macros/nlohmann_define_type_non_intrusive.md
+++ b/docs/mkdocs/docs/api/macros/nlohmann_define_type_non_intrusive.md
@@ -90,7 +90,7 @@ See examples below for the concrete generated code.
 
     Consider the following complete example:
 
-    ```cpp hl_lines="21"
+    ```cpp hl_lines="22"
     --8<-- "examples/nlohmann_define_type_non_intrusive_with_default_macro.cpp"
     ```
     
@@ -111,7 +111,7 @@ See examples below for the concrete generated code.
 
     The macro is equivalent to:
 
-    ```cpp hl_lines="21 22 23 24 25 26 27 28 29 30 31 32 33 34"
+    ```cpp hl_lines="22 23 24 25 26 27 28 29 30 31 32 33 34 35"
     --8<-- "examples/nlohmann_define_type_non_intrusive_with_default_explicit.cpp"
     ```
 
@@ -121,7 +121,7 @@ See examples below for the concrete generated code.
 
     Consider the following complete example:
 
-    ```cpp hl_lines="15"
+    ```cpp hl_lines="16"
     --8<-- "examples/nlohmann_define_type_non_intrusive_only_serialize_macro.cpp"
     ```
     
@@ -140,7 +140,7 @@ See examples below for the concrete generated code.
 
     The macro is equivalent to:
 
-    ```cpp hl_lines="15 16 17 18 19 20"
+    ```cpp hl_lines="16 17 18 19 20 21"
     --8<-- "examples/nlohmann_define_type_non_intrusive_only_serialize_explicit.cpp"
     ```
 

--- a/docs/mkdocs/docs/features/macros.md
+++ b/docs/mkdocs/docs/features/macros.md
@@ -119,6 +119,13 @@ an object and uses its values as the defaults when calling the [`value`](../api/
 
 See [full documentation of `NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT`](../api/macros/nlohmann_define_type_intrusive.md).
 
+## `NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(type, member...)`
+
+This macro is similar to `NLOHMANN_DEFINE_TYPE_INTRUSIVE` except that it defines only the serialization code. This is
+useful when the user type does not have a default constructor and only the serialization is required.
+
+See [full documentation of `NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE`](../api/macros//nlohmann_define_type_intrusive.md).
+
 ## `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(type, member...)`
 
 This macro can be used to simplify the serialization/deserialization of types if (1) want to use a JSON object as
@@ -137,6 +144,13 @@ missing value in the JSON object, but can throw due to a mismatched type. The `f
 an object and uses its values as the defaults when calling the [`value`](../api/basic_json/value.md) function.
 
 See [full documentation of `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT`](../api/macros/nlohmann_define_type_non_intrusive.md).
+
+## `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(type, member...)`
+
+This macro is similar to `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE` except that it defines only the serialization code. This is
+useful when the user type does not have a default constructor and only the serialization is required.
+
+See [full documentation of `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE`](../api/macros//nlohmann_define_type_non_intrusive.md).
 
 ## `NLOHMANN_JSON_SERIALIZE_ENUM(type, ...)`
 

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -406,6 +406,9 @@
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj{}; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
+
 /*!
 @brief macro
 @def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
@@ -414,6 +417,9 @@
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
 
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2758,6 +2758,9 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj{}; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
+
 /*!
 @brief macro
 @def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
@@ -2766,6 +2769,9 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
 
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -292,7 +292,7 @@ class person_without_default_constructor_1
 
     person_without_default_constructor_1(std::string name_, int age_)
         : name{std::move(name_)}
-        , age{std::move(age_)}
+        , age{age_}
     {}
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_1, name, age)
@@ -311,7 +311,7 @@ class person_without_default_constructor_2
 
     person_without_default_constructor_2(std::string name_, int age_)
         : name{std::move(name_)}
-        , age{std::move(age_)}
+        , age{age_}
     {}
 };
 
@@ -463,7 +463,7 @@ TEST_CASE_TEMPLATE("Serialization of non-default-constructible classes via NLOHM
             CHECK(json(person).dump() == "{\"age\":1,\"name\":\"Erik\"}");
 
             // serialization of a container with objects
-            std::vector<T> two_persons
+            std::vector<T> const two_persons
             {
                 {"Erik", 1},
                 {"Kyle", 2}

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -295,7 +295,7 @@ class person_without_default_constructor_1
         , age{std::move(age_)}
     {}
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_1, name, age);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_1, name, age)
 };
 
 class person_without_default_constructor_2
@@ -315,7 +315,7 @@ class person_without_default_constructor_2
     {}
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_2, name, age);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_2, name, age)
 
 } // namespace persons
 

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -279,6 +279,44 @@ class person_with_public_alphabet
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person_with_public_alphabet, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
 
+class person_without_default_constructor_1
+{
+  public:
+    std::string name;
+    int age;
+
+    bool operator==(const person_without_default_constructor_1& other) const
+    {
+        return name == other.name && age == other.age;
+    }
+
+    person_without_default_constructor_1(std::string name_, int age_)
+        : name{std::move(name_)}
+        , age{std::move(age_)}
+    {}
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_1, name, age);
+};
+
+class person_without_default_constructor_2
+{
+  public:
+    std::string name;
+    int age;
+
+    bool operator==(const person_without_default_constructor_2& other) const
+    {
+        return name == other.name && age == other.age;
+    }
+
+    person_without_default_constructor_2(std::string name_, int age_)
+        : name{std::move(name_)}
+        , age{std::move(age_)}
+    {}
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(person_without_default_constructor_2, name, age);
+
 } // namespace persons
 
 TEST_CASE_TEMPLATE("Serialization/deserialization via NLOHMANN_DEFINE_TYPE_INTRUSIVE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE", T,
@@ -409,6 +447,28 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
             j2.get_to(obj2);
             bool ok = (obj1 == obj2);
             CHECK(ok);
+        }
+    }
+}
+
+TEST_CASE_TEMPLATE("Serialization of non-default-constructible classes via NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE and NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE", T,
+                   persons::person_without_default_constructor_1,
+                   persons::person_without_default_constructor_2)
+{
+    SECTION("person")
+    {
+        {
+            // serialization of a single object
+            T person{"Erik", 1};
+            CHECK(json(person).dump() == "{\"age\":1,\"name\":\"Erik\"}");
+
+            // serialization of a container with objects
+            std::vector<T> two_persons
+            {
+                {"Erik", 1},
+                {"Kyle", 2}
+            };
+            CHECK(json(two_persons).dump() == "[{\"age\":1,\"name\":\"Erik\"},{\"age\":2,\"name\":\"Kyle\"}]");
         }
     }
 }


### PR DESCRIPTION
This pull requests adds `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE` and `NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE` macros.

Suppose we have a non-default-constructible type `person` and another type that contains a field of type `person`. For example:
```cpp
#include <nlohmann/json.hpp>

#include <string>
#include <vector>

struct person {
    std::string name;
    int age;

    person(std::string name, int age)
        : name{std::move(name)}
        , age{age}
    {}
};

struct persons {
    std::vector<person> list;
};

NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person, name, age);
NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(persons, list);
```
An attempt to use the `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE` macro to generate serialization/deserialization code will lead to a compilation error:
```
test.cpp: In function ‘void from_json(const json&, persons&)’:
include/nlohmann/detail/macro_scope.hpp:385:81: error: no matching function for call to ‘nlohmann::json_abi_v3_11_2::basic_json<>::get_to(std::vector<person>&) const’
  385 | #define NLOHMANN_JSON_FROM(v1) nlohmann_json_j.at(#v1).get_to(nlohmann_json_t.v1);
```

`README.md` provides an example how to fix this by providing a specialization of `adl_serializer`. However, this requires writing quite a bit of code and might even be unnecessary in cases when we only need serialization without deserialization.

In this situations, we can use added macros to generate only `to_json` functions.
```cpp
NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(person, name, age);
NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(persons, list);
```

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
