### PR TITLE
Added support for pretty printing predicate

### DIFF
--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -110,6 +110,43 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
+        auto predicate = [pretty_print](const BasicJsonType&, int) { return pretty_print; };
+        dump_configured(val, ensure_ascii, indent_step, current_indent, predicate);
+    }
+
+    /*!
+    @brief internal implementation of the serialization function
+
+    This function is called by the public member function dump and organizes
+    the serialization internally. The indentation level is propagated as
+    additional parameter. In case of arrays and objects, the function is
+    called recursively. If uses a predicate to decide whether to avoid pretty
+    printing a subtree. If the predicate returns false, pretty printing is
+    avoided for the whole tree, otherwise the current value is pretty printed
+    and the function is reevaluated for nested values.
+
+    - strings and object keys are escaped using `escape_string()`
+    - integer numbers are converted implicitly via `operator<<`
+    - floating-point numbers are converted to a string using `"%g"` format
+    - binary values are serialized as objects containing the subtype and the
+      byte array
+
+    @param[in] val               value to serialize
+    @param[in] pretty_print      whether the output shall be pretty-printed based 
+    on the value and current identation
+    @param[in] ensure_ascii If @a ensure_ascii is true, all non-ASCII characters
+    in the output are escaped with `\uXXXX` sequences, and the result consists
+    of ASCII characters only.
+    @param[in] indent_step       the indent level
+    @param[in] current_indent    the current indent level (only used internally)
+    */
+    template<typename PrettyPrintPredicate>
+    void dump_configured(const BasicJsonType& val,
+              const bool ensure_ascii,
+              const unsigned int indent_step,
+              const unsigned int current_indent,
+              const PrettyPrintPredicate& pretty_print)
+    {
         switch (val.m_type)
         {
             case value_t::object:
@@ -120,7 +157,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print)
+                if (pretty_print(val, current_indent))
                 {
                     o->write_characters("{\n", 2);
 
@@ -139,7 +176,7 @@ class serializer
                         o->write_character('\"');
                         dump_escaped(i->first, ensure_ascii);
                         o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                        dump_configured(i->second, ensure_ascii, indent_step, new_indent, pretty_print);
                         o->write_characters(",\n", 2);
                     }
 
@@ -150,7 +187,7 @@ class serializer
                     o->write_character('\"');
                     dump_escaped(i->first, ensure_ascii);
                     o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                    dump_configured(i->second, ensure_ascii, indent_step, new_indent, pretty_print);
 
                     o->write_character('\n');
                     o->write_characters(indent_string.c_str(), current_indent);
@@ -193,7 +230,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print)
+                if (pretty_print(val, current_indent))
                 {
                     o->write_characters("[\n", 2);
 
@@ -206,17 +243,18 @@ class serializer
 
                     // first n-1 elements
                     for (auto i = val.m_value.array->cbegin();
-                            i != val.m_value.array->cend() - 1; ++i)
+                         i != val.m_value.array->cend() - 1;
+                         ++i)
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
+                        dump_configured(*i, ensure_ascii, indent_step, new_indent, pretty_print);
                         o->write_characters(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_value.array->empty());
                     o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    dump_configured(val.m_value.array->back(), ensure_ascii, indent_step, new_indent, pretty_print);
 
                     o->write_character('\n');
                     o->write_characters(indent_string.c_str(), current_indent);
@@ -254,7 +292,7 @@ class serializer
 
             case value_t::binary:
             {
-                if (pretty_print)
+                if (pretty_print(val, current_indent))
                 {
                     o->write_characters("{\n", 2);
 

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -110,7 +110,10 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
-        auto predicate = [pretty_print](const BasicJsonType&, int) { return pretty_print; };
+        auto predicate = [pretty_print](const BasicJsonType&, int)
+        {
+            return pretty_print;
+        };
         dump_configured(val, ensure_ascii, indent_step, current_indent, predicate);
     }
 
@@ -132,7 +135,7 @@ class serializer
       byte array
 
     @param[in] val               value to serialize
-    @param[in] pretty_print      whether the output shall be pretty-printed based 
+    @param[in] pretty_print      whether the output shall be pretty-printed based
     on the value and current identation
     @param[in] ensure_ascii If @a ensure_ascii is true, all non-ASCII characters
     in the output are escaped with `\uXXXX` sequences, and the result consists
@@ -142,10 +145,10 @@ class serializer
     */
     template<typename PrettyPrintPredicate>
     void dump_configured(const BasicJsonType& val,
-              const bool ensure_ascii,
-              const unsigned int indent_step,
-              const unsigned int current_indent,
-              const PrettyPrintPredicate& pretty_print)
+                         const bool ensure_ascii,
+                         const unsigned int indent_step,
+                         const unsigned int current_indent,
+                         const PrettyPrintPredicate& pretty_print)
     {
         switch (val.m_type)
         {
@@ -243,8 +246,8 @@ class serializer
 
                     // first n-1 elements
                     for (auto i = val.m_value.array->cbegin();
-                         i != val.m_value.array->cend() - 1;
-                         ++i)
+                            i != val.m_value.array->cend() - 1;
+                            ++i)
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
                         dump_configured(*i, ensure_ascii, indent_step, new_indent, pretty_print);

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -160,7 +160,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print(val, current_indent))
+                if (pretty_print(val, static_cast<int>(current_indent)))
                 {
                     o->write_characters("{\n", 2);
 
@@ -233,7 +233,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print(val, current_indent))
+                if (pretty_print(val, static_cast<int>(current_indent)))
                 {
                     o->write_characters("[\n", 2);
 
@@ -295,7 +295,7 @@ class serializer
 
             case value_t::binary:
             {
-                if (pretty_print(val, current_indent))
+                if (pretty_print(val, static_cast<int>(current_indent)))
                 {
                     o->write_characters("{\n", 2);
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1267,7 +1267,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const bool ensure_ascii = false,
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
-        return dump(indent, indent_char, ensure_ascii, error_handler, [](basic_json const&, int) {return true;});
+        return dump(indent, indent_char, ensure_ascii, error_handler, [](basic_json const&, int)
+        {
+            return true;
+        });
     }
 
     /// @name object inspection

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1267,21 +1267,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const bool ensure_ascii = false,
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
-        string_t result;
-        serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
-
-        if (indent >= 0)
-        {
-            s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
-        }
-        else
-        {
-            s.dump(*this, false, ensure_ascii, 0);
-        }
-
-        return result;
+        return dump(indent, indent_char, ensure_ascii, error_handler, [](basic_json const&, int) {return true;});
     }
 
+    /// @name object inspection
+    /// Functions to inspect the type of a JSON value.
+    /// @{
+
+    /// @brief serialization
+    /// @sa https://json.nlohmann.me/api/basic_json/dump/
     template <typename PrettyPrintPredicate>
     string_t dump(const int indent,
                   const char indent_char,

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1282,6 +1282,28 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         return result;
     }
 
+    template <typename PrettyPrintPredicate>
+    string_t dump(const int indent,
+                  const char indent_char,
+                  const bool ensure_ascii,
+                  const error_handler_t error_handler,
+                  const PrettyPrintPredicate& pretty_print) const
+    {
+        string_t result;
+        serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
+
+        if (indent >= 0)
+        {
+            s.dump_configured(*this, ensure_ascii, static_cast<unsigned int>(indent), 0, pretty_print);
+        }
+        else
+        {
+            s.dump(*this, false, ensure_ascii, 0);
+        }
+
+        return result;
+    }
+
     /// @brief return the type of the JSON value (explicit)
     /// @sa https://json.nlohmann.me/api/basic_json/type/
     constexpr value_t type() const noexcept

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18032,6 +18032,46 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
+        auto predicate = [pretty_print](const BasicJsonType&, int)
+        {
+            return pretty_print;
+        };
+        dump_configured(val, ensure_ascii, indent_step, current_indent, predicate);
+    }
+
+    /*!
+    @brief internal implementation of the serialization function
+
+    This function is called by the public member function dump and organizes
+    the serialization internally. The indentation level is propagated as
+    additional parameter. In case of arrays and objects, the function is
+    called recursively. If uses a predicate to decide whether to avoid pretty
+    printing a subtree. If the predicate returns false, pretty printing is
+    avoided for the whole tree, otherwise the current value is pretty printed
+    and the function is reevaluated for nested values.
+
+    - strings and object keys are escaped using `escape_string()`
+    - integer numbers are converted implicitly via `operator<<`
+    - floating-point numbers are converted to a string using `"%g"` format
+    - binary values are serialized as objects containing the subtype and the
+      byte array
+
+    @param[in] val               value to serialize
+    @param[in] pretty_print      whether the output shall be pretty-printed based
+    on the value and current identation
+    @param[in] ensure_ascii If @a ensure_ascii is true, all non-ASCII characters
+    in the output are escaped with `\uXXXX` sequences, and the result consists
+    of ASCII characters only.
+    @param[in] indent_step       the indent level
+    @param[in] current_indent    the current indent level (only used internally)
+    */
+    template<typename PrettyPrintPredicate>
+    void dump_configured(const BasicJsonType& val,
+                         const bool ensure_ascii,
+                         const unsigned int indent_step,
+                         const unsigned int current_indent,
+                         const PrettyPrintPredicate& pretty_print)
+    {
         switch (val.m_type)
         {
             case value_t::object:
@@ -18042,7 +18082,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print)
+                if (pretty_print(val, current_indent))
                 {
                     o->write_characters("{\n", 2);
 
@@ -18061,7 +18101,7 @@ class serializer
                         o->write_character('\"');
                         dump_escaped(i->first, ensure_ascii);
                         o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                        dump_configured(i->second, ensure_ascii, indent_step, new_indent, pretty_print);
                         o->write_characters(",\n", 2);
                     }
 
@@ -18072,7 +18112,7 @@ class serializer
                     o->write_character('\"');
                     dump_escaped(i->first, ensure_ascii);
                     o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                    dump_configured(i->second, ensure_ascii, indent_step, new_indent, pretty_print);
 
                     o->write_character('\n');
                     o->write_characters(indent_string.c_str(), current_indent);
@@ -18115,7 +18155,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print)
+                if (pretty_print(val, current_indent))
                 {
                     o->write_characters("[\n", 2);
 
@@ -18128,17 +18168,18 @@ class serializer
 
                     // first n-1 elements
                     for (auto i = val.m_value.array->cbegin();
-                            i != val.m_value.array->cend() - 1; ++i)
+                            i != val.m_value.array->cend() - 1;
+                            ++i)
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
+                        dump_configured(*i, ensure_ascii, indent_step, new_indent, pretty_print);
                         o->write_characters(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_value.array->empty());
                     o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    dump_configured(val.m_value.array->back(), ensure_ascii, indent_step, new_indent, pretty_print);
 
                     o->write_character('\n');
                     o->write_characters(indent_string.c_str(), current_indent);
@@ -18176,7 +18217,7 @@ class serializer
 
             case value_t::binary:
             {
-                if (pretty_print)
+                if (pretty_print(val, current_indent))
                 {
                     o->write_characters("{\n", 2);
 
@@ -20483,12 +20524,31 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const bool ensure_ascii = false,
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
+        return dump(indent, indent_char, ensure_ascii, error_handler, [](basic_json const&, int)
+        {
+            return true;
+        });
+    }
+
+    /// @name object inspection
+    /// Functions to inspect the type of a JSON value.
+    /// @{
+
+    /// @brief serialization
+    /// @sa https://json.nlohmann.me/api/basic_json/dump/
+    template <typename PrettyPrintPredicate>
+    string_t dump(const int indent,
+                  const char indent_char,
+                  const bool ensure_ascii,
+                  const error_handler_t error_handler,
+                  const PrettyPrintPredicate& pretty_print) const
+    {
         string_t result;
         serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
 
         if (indent >= 0)
         {
-            s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
+            s.dump_configured(*this, ensure_ascii, static_cast<unsigned int>(indent), 0, pretty_print);
         }
         else
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18082,7 +18082,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print(val, current_indent))
+                if (pretty_print(val, static_cast<int>(current_indent)))
                 {
                     o->write_characters("{\n", 2);
 
@@ -18155,7 +18155,7 @@ class serializer
                     return;
                 }
 
-                if (pretty_print(val, current_indent))
+                if (pretty_print(val, static_cast<int>(current_indent)))
                 {
                     o->write_characters("[\n", 2);
 
@@ -18217,7 +18217,7 @@ class serializer
 
             case value_t::binary:
             {
-                if (pretty_print(val, current_indent))
+                if (pretty_print(val, static_cast<int>(current_indent)))
                 {
                     o->write_characters("{\n", 2);
 

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -81,9 +81,12 @@ TEST_CASE("serialization")
     {
         SECTION("no pretty primitive arrays")
         {
-            auto pretty_print = [](json const& x, int)
+            auto pretty_print = [](json const & x, int)
             {
-              return !x.is_array() || std::any_of(x.cbegin(), x.cend(), [](json const& e) { return !e.is_primitive(); });
+                return !x.is_array() || std::any_of(x.cbegin(), x.cend(), [](json const & e)
+                {
+                    return !e.is_primitive();
+                });
             };
 
             const json j = {{"foo", {1, 2, 3}}};

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -79,6 +79,17 @@ TEST_CASE("serialization")
 
     SECTION("dump")
     {
+        SECTION("no pretty primitive arrays")
+        {
+            auto pretty_print = [](json const& x, int)
+            {
+              return !x.is_array() || std::any_of(x.cbegin(), x.cend(), [](json const& e) { return !e.is_primitive(); });
+            };
+
+            const json j = {{"foo", {1, 2, 3}}};
+            CHECK(j.dump(1, ' ', false, json::error_handler_t::strict, pretty_print) == "{\n \"foo\": [1,2,3]\n}");
+        }
+
         SECTION("invalid character")
         {
             const json j = "ä\xA9ü";


### PR DESCRIPTION
I have a few json formats that contain a lot of primitive data arrays, and the current pretty printing features would either add too many or too few newlines to make them human-readable. To take the example from the unit test, I want this:
```
{
  "foo": [1,2,3]
}
```
instead of the 'too compressed' `{"foo":[1,2,3]}` or the 'too spacious'
```
{
  "foo": [
    1,
    2,
    3]
}
```
This PR proposes injecting a custom predicate into dump to let the user decide when to pretty print with indentation and when not to. This way, the user can define predicates based on the contents (e.g. arrays with all primitive types, or objects with just one key or anything beyond indentation level 6).
I'm pretty happy with the changes to serializer, except for the name `dump_configured`, but I'm not too happy with the quasi duplication in `basic_json`, but I did not want to resort to SFINEA to select the correct overload. Should the old overload instead call the new one? 
* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
