### PR TITLE
Add helper types to make it easier to create a basic_json type with modified template parameters

### DIFF
--- a/docs/examples/json_base_class_t.cpp
+++ b/docs/examples/json_base_class_t.cpp
@@ -13,19 +13,7 @@ class visitor_adaptor_with_metadata
     void do_visit(const Ptr& ptr, const Fnc& fnc) const;
 };
 
-using json = nlohmann::basic_json <
-             std::map,
-             std::vector,
-             std::string,
-             bool,
-             std::int64_t,
-             std::uint64_t,
-             double,
-             std::allocator,
-             nlohmann::adl_serializer,
-             std::vector<std::uint8_t>,
-             visitor_adaptor_with_metadata
-             >;
+using json = nlohmann::json::with_changed_base_class_t<visitor_adaptor_with_metadata>;
 
 template <class Fnc>
 void visitor_adaptor_with_metadata::visit(const Fnc& fnc) const

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -175,6 +175,65 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// SAX interface type, see @ref nlohmann::json_sax
     using json_sax_t = json_sax<basic_json>;
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // utility templates to create a json type with different template parameters //
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /// Json type using a different type for storing objects
+    template<template<typename, typename, typename...> class ObjectType2>
+    using with_changed_object_t = basic_json<ObjectType2, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing arrays
+    template<template<typename, typename...> class ArrayType2>
+    using with_changed_array_t =  basic_json<ObjectType, ArrayType2, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing strings
+    template<class StringType2>
+    using with_changed_string_t =  basic_json<ObjectType, ArrayType, StringType2, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing booleans
+    template<class BooleanType2>
+    using with_changed_boolean_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType2,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing signed integers
+    template<class NumberIntegerType2>
+    using with_changed_integer_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType2, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing unsigned integers
+    template<class NumberUnsignedType2>
+    using with_changed_unsigned_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType2, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing floating point numbers
+    template<class NumberFloatType2>
+    using with_changed_float_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType2, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type as base allocator
+    template<template<typename> class AllocatorType2>
+    using with_changed_allocator_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType2, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type as json serializer
+    template<template<typename, typename = void> class JSONSerializer2>
+    using with_changed_json_serializer_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer2, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing binary data
+    template<class BinaryType2>
+    using with_changed_binary_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType2, CustomBaseClass>;
+
+    /// Json type using a different type as base class
+    template<class CustomBaseClass2>
+    using with_changed_base_class_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+          NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass2>;
+
     ////////////////
     // exceptions //
     ////////////////

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19391,6 +19391,65 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// SAX interface type, see @ref nlohmann::json_sax
     using json_sax_t = json_sax<basic_json>;
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // utility templates to create a json type with different template parameters //
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /// Json type using a different type for storing objects
+    template<template<typename, typename, typename...> class ObjectType2>
+    using with_changed_object_t = basic_json<ObjectType2, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing arrays
+    template<template<typename, typename...> class ArrayType2>
+    using with_changed_array_t =  basic_json<ObjectType, ArrayType2, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing strings
+    template<class StringType2>
+    using with_changed_string_t =  basic_json<ObjectType, ArrayType, StringType2, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing booleans
+    template<class BooleanType2>
+    using with_changed_boolean_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType2,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing signed integers
+    template<class NumberIntegerType2>
+    using with_changed_integer_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType2, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing unsigned integers
+    template<class NumberUnsignedType2>
+    using with_changed_unsigned_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType2, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing floating point numbers
+    template<class NumberFloatType2>
+    using with_changed_float_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType2, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type as base allocator
+    template<template<typename> class AllocatorType2>
+    using with_changed_allocator_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType2, JSONSerializer, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type as json serializer
+    template<template<typename, typename = void> class JSONSerializer2>
+    using with_changed_json_serializer_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer2, BinaryType, CustomBaseClass>;
+
+    /// Json type using a different type for storing binary data
+    template<class BinaryType2>
+    using with_changed_binary_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType2, CustomBaseClass>;
+
+    /// Json type using a different type as base class
+    template<class CustomBaseClass2>
+    using with_changed_base_class_t =  basic_json<ObjectType, ArrayType, StringType, BooleanType,
+            NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType, CustomBaseClass2>;
+
     ////////////////
     // exceptions //
     ////////////////

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -42,14 +42,7 @@ TEST_CASE("bad_alloc")
     SECTION("bad_alloc")
     {
         // create JSON type using the throwing allocator
-        using bad_json = nlohmann::basic_json<std::map,
-              std::vector,
-              std::string,
-              bool,
-              std::int64_t,
-              std::uint64_t,
-              double,
-              bad_allocator>;
+        using bad_json = nlohmann::json::with_changed_allocator_t<bad_allocator>;
 
         // creating an object should throw
         CHECK_THROWS_AS(bad_json(bad_json::value_t::object), std::bad_alloc&);
@@ -123,14 +116,7 @@ void my_allocator_clean_up(T* p)
 TEST_CASE("controlled bad_alloc")
 {
     // create JSON type using the throwing allocator
-    using my_json = nlohmann::basic_json<std::map,
-          std::vector,
-          std::string,
-          bool,
-          std::int64_t,
-          std::uint64_t,
-          double,
-          my_allocator>;
+    using my_json = nlohmann::json::with_changed_allocator_t<my_allocator>;
 
     SECTION("class json_value")
     {
@@ -247,14 +233,7 @@ TEST_CASE("bad my_allocator::construct")
 {
     SECTION("my_allocator::construct doesn't forward")
     {
-        using bad_alloc_json = nlohmann::basic_json<std::map,
-              std::vector,
-              std::string,
-              bool,
-              std::int64_t,
-              std::uint64_t,
-              double,
-              allocator_no_forward>;
+        using bad_alloc_json = nlohmann::json::with_changed_allocator_t<allocator_no_forward>;
 
         bad_alloc_json j;
         j["test"] = bad_alloc_json::array_t();

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -169,16 +169,7 @@ void int_to_string(alt_string& target, std::size_t value)
     target = std::to_string(value).c_str();
 }
 
-using alt_json = nlohmann::basic_json <
-                 std::map,
-                 std::vector,
-                 alt_string,
-                 bool,
-                 std::int64_t,
-                 std::uint64_t,
-                 double,
-                 std::allocator,
-                 nlohmann::adl_serializer >;
+using alt_json = nlohmann::json::with_changed_string_t<alt_string>;
 
 
 bool operator<(const char* op1, const alt_string& op2) noexcept

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -55,20 +55,7 @@ class json_metadata
 };
 
 template<class T>
-using json_with_metadata =
-    nlohmann::basic_json <
-    std::map,
-    std::vector,
-    std::string,
-    bool,
-    std::int64_t,
-    std::uint64_t,
-    double,
-    std::allocator,
-    nlohmann::adl_serializer,
-    std::vector<std::uint8_t>,
-    json_metadata<T>
-    >;
+using json_with_metadata = nlohmann::json::with_changed_base_class_t<json_metadata<T>>;
 
 TEST_CASE("JSON Node Metadata")
 {
@@ -215,19 +202,7 @@ class visitor_adaptor
     void do_visit(const Ptr& ptr, const Fnc& fnc) const;
 };
 
-using json_with_visitor_t = nlohmann::basic_json <
-                            std::map,
-                            std::vector,
-                            std::string,
-                            bool,
-                            std::int64_t,
-                            std::uint64_t,
-                            double,
-                            std::allocator,
-                            nlohmann::adl_serializer,
-                            std::vector<std::uint8_t>,
-                            visitor_adaptor
-                            >;
+using json_with_visitor_t = nlohmann::json::with_changed_base_class_t<visitor_adaptor>;
 
 
 template <class Fnc>

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -640,8 +640,7 @@ static std::ostream& operator<<(std::ostream& os, small_pod l)
 TEST_CASE("custom serializer for pods" * doctest::test_suite("udt"))
 {
     using custom_json =
-        nlohmann::basic_json<std::map, std::vector, std::string, bool,
-        std::int64_t, std::uint64_t, double, std::allocator, pod_serializer>;
+        nlohmann::json::with_changed_json_serializer_t<pod_serializer>;
 
     auto p = udt::small_pod{42, '/', 42};
     custom_json const j = p;
@@ -659,7 +658,7 @@ TEST_CASE("custom serializer for pods" * doctest::test_suite("udt"))
 template <typename T, typename>
 struct another_adl_serializer;
 
-using custom_json = nlohmann::basic_json<std::map, std::vector, std::string, bool, std::int64_t, std::uint64_t, double, std::allocator, another_adl_serializer>;
+using custom_json = nlohmann::json::with_changed_json_serializer_t<another_adl_serializer>;
 
 template <typename T, typename>
 struct another_adl_serializer


### PR DESCRIPTION
(First part of the points listed in https://github.com/nlohmann/json/pull/3110#issuecomment-1229141478, the rest is done in a different PR to prevent mixing of separate issues / features)

    Make specifying a base class easier/less verbose.

This PR adds member templates to `nlohmann::json` which can be used to create a `basic_json`  type with one replaced template parameter (e.g. `nlohmann::json::with_changed_json_serializer_t<T>`).

Tests and examples were modified to use those templates (except for regression tests).

Open questions from my side:

* Should we add something like this? (I think so, but what is your opinion?)
* Should we go with the current names (`with_changed_*`) or rather use something else (e.g. `with_*`)?

In case this will be added, i will write the documentation.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
