### PR TITLE
Clean up custom base class

### DIFF
--- a/docs/examples/as_base_class.cpp
+++ b/docs/examples/as_base_class.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+class base_class_with_shadowed_members
+{
+  public:
+
+    int m_value = 43;
+
+    const char* type_name() const noexcept
+    {
+        return "my_name";
+    }
+};
+
+using json = nlohmann::basic_json <
+             std::map,
+             std::vector,
+             std::string,
+             bool,
+             std::int64_t,
+             std::uint64_t,
+             double,
+             std::allocator,
+             nlohmann::adl_serializer,
+             std::vector<std::uint8_t>,
+             base_class_with_shadowed_members
+             >;
+
+int main()
+{
+    json j;
+
+    //access the shadowing method
+    std::cout << j.type_name() << "\n";
+
+    //access the shadowed method and member variable
+    std::cout << j.as_base_class().type_name() << "\n";
+    std::cout << j.as_base_class().m_value << "\n";
+}

--- a/docs/examples/as_base_class.output
+++ b/docs/examples/as_base_class.output
@@ -1,0 +1,3 @@
+null
+my_name
+43

--- a/docs/mkdocs/docs/api/basic_json/as_base_class.md
+++ b/docs/mkdocs/docs/api/basic_json/as_base_class.md
@@ -1,0 +1,32 @@
+# <small>nlohmann::basic_json::</small>as_base_class
+
+```cpp
+json_base_class_t& as_base_class();
+const json_base_class_t& as_base_class() const;
+```
+
+Returns this object casted to [json_base_class_t](json_base_class_t.md).
+
+## Return value
+
+This object casted to [json_base_class_t](json_base_class_t.md).
+
+## Examples
+
+??? example
+
+    Use `as_base_class` to access shadowed methods and member variables defined in [json_base_class_t](json_base_class_t.md).
+    
+    ```cpp
+    --8<-- "examples/as_base_class.cpp"
+    ```
+    
+    Output:
+    
+    ```json
+    --8<-- "examples/as_base_class.output"
+    ```
+
+## Version history
+
+Added in version ???.???.???

--- a/docs/mkdocs/docs/api/basic_json/index.md
+++ b/docs/mkdocs/docs/api/basic_json/index.md
@@ -151,6 +151,7 @@ The class satisfies the following concept requirements:
 - [**array**](array_t.md) (_static_) - explicitly create an array
 - [**binary**](binary.md) (_static_) - explicitly create a binary array
 - [**object**](object_t.md) (_static_) - explicitly create an object
+- [**as_base_class**](as_base_class.md) - cast this object to [json_base_class_t](json_base_class_t.md)
 
 ### Object inspection
 

--- a/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
+++ b/docs/mkdocs/docs/api/basic_json/json_base_class_t.md
@@ -7,6 +7,12 @@ using json_base_class_t = detail::json_base_class<CustomBaseClass>;
 The base class used to inject custom functionality into each instance of `basic_json`.
 Examples of such functionality might be metadata, additional member functions (e.g., visitors), or other application-specific code.
 
+!!! warning "Name conflicts when using generic names"
+
+    Tt is possible for name shadowing to occur since `nlohmann::basic_json` is derived from this class.
+    If this happens, the correct method or member variable can be accessed by either casting the json object to the base class or calling [as_base_class](as_base_class.md).
+    When updating to a new version of this library a previously available member might be shadowed by a new member of `nlohmann::basic_json`.
+
 ## Template parameters
 
 `CustomBaseClass`

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
         - 'accept': api/basic_json/accept.md
         - 'array': api/basic_json/array.md
         - 'array_t': api/basic_json/array_t.md
+        - 'as_base_class' : api/basic_json/as_base_class.md
         - 'at': api/basic_json/at.md
         - 'back': api/basic_json/back.md
         - 'begin': api/basic_json/begin.md

--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -1,3 +1,11 @@
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.2
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include <type_traits> // conditional, is_same

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5155,6 +5155,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     }
 
     /// @}
+
+    json_base_class_t& as_base_class()
+    {
+        return static_cast<json_base_class_t&>(*this);
+    }
+
+    const json_base_class_t& as_base_class() const
+    {
+        return static_cast<const json_base_class_t&>(*this);
+    }
 };
 
 /// @brief user-defined to_string function for JSON values

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13678,6 +13678,14 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/primitive_iterator.hpp>
 
 // #include <nlohmann/detail/json_custom_base_class.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.2
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
 
 
 #include <type_traits> // conditional, is_same

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -24379,6 +24379,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     }
 
     /// @}
+
+    json_base_class_t& as_base_class()
+    {
+        return static_cast<json_base_class_t&>(*this);
+    }
+
+    const json_base_class_t& as_base_class() const
+    {
+        return static_cast<const json_base_class_t&>(*this);
+    }
 };
 
 /// @brief user-defined to_string function for JSON values

--- a/tests/src/unit-custom-base-class.cpp
+++ b/tests/src/unit-custom-base-class.cpp
@@ -1,31 +1,11 @@
-/*
-    __ _____ _____ _____
- __|  |   __|     |   | |  JSON for Modern C++ (test suite)
-|  |  |__   |  |  | | | |  version 3.10.2
-|_____|_____|_____|_|___|  https://github.com/nlohmann/json
-
-Licensed under the MIT License <http://opensource.org/licenses/MIT>.
-SPDX-License-Identifier: MIT
-Copyright (c) 2013-2019 Niels Lohmann <http://nlohmann.me>.
-
-Permission is hereby  granted, free of charge, to any  person obtaining a copy
-of this software and associated  documentation files (the "Software"), to deal
-in the Software  without restriction, including without  limitation the rights
-to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
-copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
-IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
-FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
-AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
-LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++ (supporting code)
+// |  |  |__   |  |  | | | |  version 3.11.2
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// Copyright (c) 2013-2019 Niels Lohmann <http://nlohmann.me>.
+// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
 
 #include <set>
 #include <sstream>


### PR DESCRIPTION
(Second part of the points listed in https://github.com/nlohmann/json/pull/3110#issuecomment-1229141478, the rest is done in a different PR to prevent mixing of separate issues / features)

* Warn users about potential conflicts with newer versions, i.e., base members should avoid generic names to avoid clashes with future member additions to basic_json.
* (Run reuse.)

Also adds a new method `as_base_class` to make it easier to access members of a custom base class shadowed by `nlohmann::basic_json`

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
