### PR TITLE
refactor(tests): use prefix instead of postfix operators

### DIFF
--- a/tests/src/unit-class_const_iterator.cpp
+++ b/tests/src/unit-class_const_iterator.cpp
@@ -197,7 +197,7 @@ TEST_CASE("const_iterator class")
                 json const j(json::value_t::null);
                 json::const_iterator it = j.cbegin();
                 CHECK((it.m_it.primitive_iterator.m_it == 1));
-                it++;
+                ++it;
                 CHECK((it.m_it.primitive_iterator.m_it != 0 && it.m_it.primitive_iterator.m_it != 1));
             }
 
@@ -206,9 +206,9 @@ TEST_CASE("const_iterator class")
                 json const j(17);
                 json::const_iterator it = j.cbegin();
                 CHECK((it.m_it.primitive_iterator.m_it == 0));
-                it++;
+                ++it;
                 CHECK((it.m_it.primitive_iterator.m_it == 1));
-                it++;
+                ++it;
                 CHECK((it.m_it.primitive_iterator.m_it != 0 && it.m_it.primitive_iterator.m_it != 1));
             }
 
@@ -217,7 +217,7 @@ TEST_CASE("const_iterator class")
                 json const j({{"foo", "bar"}});
                 json::const_iterator it = j.cbegin();
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->begin()));
-                it++;
+                ++it;
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->end()));
             }
 
@@ -226,16 +226,16 @@ TEST_CASE("const_iterator class")
                 json const j({1, 2, 3, 4});
                 json::const_iterator it = j.cbegin();
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->begin()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->end()));
             }
@@ -306,9 +306,9 @@ TEST_CASE("const_iterator class")
                 json const j(17);
                 json::const_iterator it = j.cend();
                 CHECK((it.m_it.primitive_iterator.m_it == 1));
-                it--;
+                --it;
                 CHECK((it.m_it.primitive_iterator.m_it == 0));
-                it--;
+                --it;
                 CHECK((it.m_it.primitive_iterator.m_it != 0 && it.m_it.primitive_iterator.m_it != 1));
             }
 
@@ -317,7 +317,7 @@ TEST_CASE("const_iterator class")
                 json const j({{"foo", "bar"}});
                 json::const_iterator it = j.cend();
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->begin()));
             }
 
@@ -326,16 +326,16 @@ TEST_CASE("const_iterator class")
                 json const j({1, 2, 3, 4});
                 json::const_iterator it = j.cend();
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
             }

--- a/tests/src/unit-class_iterator.cpp
+++ b/tests/src/unit-class_iterator.cpp
@@ -187,7 +187,7 @@ TEST_CASE("iterator class")
                 json j(json::value_t::null);
                 json::iterator it = j.begin();
                 CHECK((it.m_it.primitive_iterator.m_it == 1));
-                it++;
+                ++it;
                 CHECK((it.m_it.primitive_iterator.m_it != 0 && it.m_it.primitive_iterator.m_it != 1));
             }
 
@@ -196,9 +196,9 @@ TEST_CASE("iterator class")
                 json j(17);
                 json::iterator it = j.begin();
                 CHECK((it.m_it.primitive_iterator.m_it == 0));
-                it++;
+                ++it;
                 CHECK((it.m_it.primitive_iterator.m_it == 1));
-                it++;
+                ++it;
                 CHECK((it.m_it.primitive_iterator.m_it != 0 && it.m_it.primitive_iterator.m_it != 1));
             }
 
@@ -207,7 +207,7 @@ TEST_CASE("iterator class")
                 json j({{"foo", "bar"}});
                 json::iterator it = j.begin();
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->begin()));
-                it++;
+                ++it;
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->end()));
             }
 
@@ -216,16 +216,16 @@ TEST_CASE("iterator class")
                 json j({1, 2, 3, 4});
                 json::iterator it = j.begin();
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->begin()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it++;
+                ++it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->end()));
             }
@@ -296,9 +296,9 @@ TEST_CASE("iterator class")
                 json j(17);
                 json::iterator it = j.end();
                 CHECK((it.m_it.primitive_iterator.m_it == 1));
-                it--;
+                --it;
                 CHECK((it.m_it.primitive_iterator.m_it == 0));
-                it--;
+                --it;
                 CHECK((it.m_it.primitive_iterator.m_it != 0 && it.m_it.primitive_iterator.m_it != 1));
             }
 
@@ -307,7 +307,7 @@ TEST_CASE("iterator class")
                 json j({{"foo", "bar"}});
                 json::iterator it = j.end();
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.object_iterator == it.m_object->m_value.object->begin()));
             }
 
@@ -316,16 +316,16 @@ TEST_CASE("iterator class")
                 json j({1, 2, 3, 4});
                 json::iterator it = j.end();
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
-                it--;
+                --it;
                 CHECK((it.m_it.array_iterator == it.m_object->m_value.array->begin()));
                 CHECK((it.m_it.array_iterator != it.m_object->m_value.array->end()));
             }

--- a/tests/src/unit-iterators1.cpp
+++ b/tests/src/unit-iterators1.cpp
@@ -36,11 +36,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.end());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.begin());
                 CHECK(it == j.end());
 
-                it--;
+                --it;
                 CHECK(it == j.begin());
                 CHECK(it != j.end());
                 CHECK(*it == j);
@@ -61,11 +61,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.begin());
                 CHECK(it == j_const.end());
 
-                it--;
+                --it;
                 CHECK(it == j_const.begin());
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
@@ -86,11 +86,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.cend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.cbegin());
                 CHECK(it == j.cend());
 
-                it--;
+                --it;
                 CHECK(it == j.cbegin());
                 CHECK(it != j.cend());
                 CHECK(*it == j);
@@ -111,11 +111,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.cbegin());
                 CHECK(it == j_const.cend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.cbegin());
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
@@ -136,11 +136,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.rend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.rbegin());
                 CHECK(it == j.rend());
 
-                it--;
+                --it;
                 CHECK(it == j.rbegin());
                 CHECK(it != j.rend());
                 CHECK(*it == j);
@@ -161,11 +161,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.crend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.crbegin());
                 CHECK(it == j.crend());
 
-                it--;
+                --it;
                 CHECK(it == j.crbegin());
                 CHECK(it != j.crend());
                 CHECK(*it == j);
@@ -186,11 +186,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.crbegin());
                 CHECK(it == j_const.crend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.crbegin());
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
@@ -342,11 +342,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.end());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.begin());
                 CHECK(it == j.end());
 
-                it--;
+                --it;
                 CHECK(it == j.begin());
                 CHECK(it != j.end());
                 CHECK(*it == j);
@@ -367,11 +367,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.begin());
                 CHECK(it == j_const.end());
 
-                it--;
+                --it;
                 CHECK(it == j_const.begin());
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
@@ -392,11 +392,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.cend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.cbegin());
                 CHECK(it == j.cend());
 
-                it--;
+                --it;
                 CHECK(it == j.cbegin());
                 CHECK(it != j.cend());
                 CHECK(*it == j);
@@ -417,11 +417,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.cbegin());
                 CHECK(it == j_const.cend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.cbegin());
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
@@ -442,11 +442,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.rend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.rbegin());
                 CHECK(it == j.rend());
 
-                it--;
+                --it;
                 CHECK(it == j.rbegin());
                 CHECK(it != j.rend());
                 CHECK(*it == j);
@@ -467,11 +467,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.crend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.crbegin());
                 CHECK(it == j.crend());
 
-                it--;
+                --it;
                 CHECK(it == j.crbegin());
                 CHECK(it != j.crend());
                 CHECK(*it == j);
@@ -492,11 +492,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.crbegin());
                 CHECK(it == j_const.crend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.crbegin());
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
@@ -908,11 +908,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.end());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.begin());
                 CHECK(it == j.end());
 
-                it--;
+                --it;
                 CHECK(it == j.begin());
                 CHECK(it != j.end());
                 CHECK(*it == j);
@@ -933,11 +933,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.begin());
                 CHECK(it == j_const.end());
 
-                it--;
+                --it;
                 CHECK(it == j_const.begin());
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
@@ -958,11 +958,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.cend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.cbegin());
                 CHECK(it == j.cend());
 
-                it--;
+                --it;
                 CHECK(it == j.cbegin());
                 CHECK(it != j.cend());
                 CHECK(*it == j);
@@ -983,11 +983,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.cbegin());
                 CHECK(it == j_const.cend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.cbegin());
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
@@ -1008,11 +1008,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.rend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.rbegin());
                 CHECK(it == j.rend());
 
-                it--;
+                --it;
                 CHECK(it == j.rbegin());
                 CHECK(it != j.rend());
                 CHECK(*it == j);
@@ -1033,11 +1033,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.crend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.crbegin());
                 CHECK(it == j.crend());
 
-                it--;
+                --it;
                 CHECK(it == j.crbegin());
                 CHECK(it != j.crend());
                 CHECK(*it == j);
@@ -1058,11 +1058,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.crbegin());
                 CHECK(it == j_const.crend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.crbegin());
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
@@ -1106,11 +1106,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.end());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.begin());
                 CHECK(it == j.end());
 
-                it--;
+                --it;
                 CHECK(it == j.begin());
                 CHECK(it != j.end());
                 CHECK(*it == j);
@@ -1131,11 +1131,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.begin());
                 CHECK(it == j_const.end());
 
-                it--;
+                --it;
                 CHECK(it == j_const.begin());
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
@@ -1156,11 +1156,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.cend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.cbegin());
                 CHECK(it == j.cend());
 
-                it--;
+                --it;
                 CHECK(it == j.cbegin());
                 CHECK(it != j.cend());
                 CHECK(*it == j);
@@ -1181,11 +1181,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.cbegin());
                 CHECK(it == j_const.cend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.cbegin());
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
@@ -1206,11 +1206,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.rend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.rbegin());
                 CHECK(it == j.rend());
 
-                it--;
+                --it;
                 CHECK(it == j.rbegin());
                 CHECK(it != j.rend());
                 CHECK(*it == j);
@@ -1231,11 +1231,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.crend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.crbegin());
                 CHECK(it == j.crend());
 
-                it--;
+                --it;
                 CHECK(it == j.crbegin());
                 CHECK(it != j.crend());
                 CHECK(*it == j);
@@ -1256,11 +1256,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.crbegin());
                 CHECK(it == j_const.crend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.crbegin());
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
@@ -1304,11 +1304,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.end());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.begin());
                 CHECK(it == j.end());
 
-                it--;
+                --it;
                 CHECK(it == j.begin());
                 CHECK(it != j.end());
                 CHECK(*it == j);
@@ -1329,11 +1329,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.begin());
                 CHECK(it == j_const.end());
 
-                it--;
+                --it;
                 CHECK(it == j_const.begin());
                 CHECK(it != j_const.end());
                 CHECK(*it == j_const);
@@ -1354,11 +1354,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.cend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.cbegin());
                 CHECK(it == j.cend());
 
-                it--;
+                --it;
                 CHECK(it == j.cbegin());
                 CHECK(it != j.cend());
                 CHECK(*it == j);
@@ -1379,11 +1379,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.cbegin());
                 CHECK(it == j_const.cend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.cbegin());
                 CHECK(it != j_const.cend());
                 CHECK(*it == j_const);
@@ -1404,11 +1404,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.rend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.rbegin());
                 CHECK(it == j.rend());
 
-                it--;
+                --it;
                 CHECK(it == j.rbegin());
                 CHECK(it != j.rend());
                 CHECK(*it == j);
@@ -1429,11 +1429,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j.crend());
                 CHECK(*it == j);
 
-                it++;
+                ++it;
                 CHECK(it != j.crbegin());
                 CHECK(it == j.crend());
 
-                it--;
+                --it;
                 CHECK(it == j.crbegin());
                 CHECK(it != j.crend());
                 CHECK(*it == j);
@@ -1454,11 +1454,11 @@ TEST_CASE("iterators 1")
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);
 
-                it++;
+                ++it;
                 CHECK(it != j_const.crbegin());
                 CHECK(it == j_const.crend());
 
-                it--;
+                --it;
                 CHECK(it == j_const.crbegin());
                 CHECK(it != j_const.crend());
                 CHECK(*it == j_const);


### PR DESCRIPTION
Using prefix operator over postfix operator when it is not used is more efficient because it only changes the current value without creating a copy of it. 