### PR TITLE
gcc-13 compile failure fix rebind for custom allocators

### DIFF
--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -21,8 +21,9 @@ struct bad_allocator : std::allocator<T>
     using std::allocator<T>::allocator;
 
     template<typename U>
-    struct rebind {
-      using other = bad_allocator<U>;
+    struct rebind
+    {
+        using other = bad_allocator<U>;
     };
 
     template<class... Args>

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -20,6 +20,11 @@ struct bad_allocator : std::allocator<T>
 {
     using std::allocator<T>::allocator;
 
+    template<typename U>
+    struct rebind {
+      using other = bad_allocator<U>;
+    };
+
     template<class... Args>
     void construct(T* /*unused*/, Args&& ... /*unused*/)
     {

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -188,8 +188,9 @@ template<class T>
 class my_allocator : public std::allocator<T>
 {
     template<typename U>
-    struct rebind {
-      using other = my_allocator<U>;
+    struct rebind
+    {
+        using other = my_allocator<U>;
     };
 
   public:

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -187,6 +187,11 @@ std::string* sax_no_exception::error_string = nullptr;
 template<class T>
 class my_allocator : public std::allocator<T>
 {
+    template<typename U>
+    struct rebind {
+      using other = my_allocator<U>;
+    };
+
   public:
     using std::allocator<T>::allocator;
 };


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]
tests are failing for gcc-13 because of an static_assert added in allocators. To mitigate the build failure
we need to add a struct rebind to custom allocators as per gcc.gnu.org/bugzilla/show_bug.cgi?id=72792
* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
