### PR TITLE
Only expose `include/nlohmann/json.hpp` as public header in Bazel BUILD file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 cc_library(
     name = "json",
-    hdrs = [
+    srcs = [
         "include/nlohmann/adl_serializer.hpp",
         "include/nlohmann/byte_container_with_subtype.hpp",
         "include/nlohmann/detail/abi_macros.hpp",
@@ -41,12 +41,12 @@ cc_library(
         "include/nlohmann/detail/string_concat.hpp",
         "include/nlohmann/detail/string_escape.hpp",
         "include/nlohmann/detail/value_t.hpp",
-        "include/nlohmann/json.hpp",
         "include/nlohmann/json_fwd.hpp",
         "include/nlohmann/ordered_map.hpp",
         "include/nlohmann/thirdparty/hedley/hedley.hpp",
         "include/nlohmann/thirdparty/hedley/hedley_undef.hpp",
     ],
+    hdrs = ["include/nlohmann/json.hpp"],
     includes = ["include"],
     visibility = ["//visibility:public"],
     alwayslink = True,

--- a/cmake/scripts/gen_bazel_build_file.cmake
+++ b/cmake/scripts/gen_bazel_build_file.cmake
@@ -4,11 +4,12 @@ set(PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
 set(BUILD_FILE "${PROJECT_ROOT}/BUILD.bazel")
 
 file(GLOB_RECURSE HEADERS LIST_DIRECTORIES false RELATIVE "${PROJECT_ROOT}" "include/*.hpp")
+list(REMOVE_ITEM HEADERS "include/nlohmann/json.hpp")
 
 file(WRITE "${BUILD_FILE}" [=[
 cc_library(
     name = "json",
-    hdrs = [
+    srcs = [
 ]=])
 
 foreach(header ${HEADERS})
@@ -17,6 +18,7 @@ endforeach()
 
 file(APPEND "${BUILD_FILE}" [=[
     ],
+    hdrs = ["include/nlohmann/json.hpp"],
     includes = ["include"],
     visibility = ["//visibility:public"],
     alwayslink = True,


### PR DESCRIPTION
All other headers are not meant to be included by a client of this library and should be declared in `srcs`.

This uses https://github.com/bazelbuild/rules_swift/blob/40c36c936c9c80b4aefa3f008ecf99dbe002be2c/third_party/com_github_nlohmann_json/BUILD.overlay as a reference.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).