### PR TITLE
Support Apple's Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 /localhost.pem
 /localhost-key.pem
 /serve_header.yml
+
+# Swift Package Manager build directory
+/.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "nlohmann-json",
+     platforms: [
+        .iOS(.v11), .macOS(.v10_13), .tvOS(.v11), .watchOS(.v4)
+    ],
+    products: [
+        .library(name: "nlohmann-json", targets: ["nlohmann-json"]),
+    ],
+    targets: [
+        .target(
+            name: "nlohmann-json",
+            path: "single_include/nlohmann",
+            publicHeadersPath: "."
+        ),
+    ],
+    cxxLanguageStandard: .cxx11
+)

--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,10 @@ If you are using [cget](https://cget.readthedocs.io/en/latest/), you can install
 
 If you are using [CocoaPods](https://cocoapods.org), you can use the library by adding pod `"nlohmann_json", '~>3.1.2'` to your podfile (see [an example](https://bitbucket.org/benman/nlohmann_json-cocoapod/src/master/)). Please file issues [here](https://bitbucket.org/benman/nlohmann_json-cocoapod/issues?status=new&status=open).
 
+If you are using [Swift Package Manager](https://swift.org/package-manager/), you can use the library by adding a link to this repository.
+```swift
+```
+
 If you are using [NuGet](https://www.nuget.org), you can use the package [nlohmann.json](https://www.nuget.org/packages/nlohmann.json/). Please check [this extensive description](https://github.com/nlohmann/json/issues/1132#issuecomment-452250255) on how to use the package. Please file issues [here](https://github.com/hnkb/nlohmann-json-nuget/issues).
 
 If you are using [conda](https://conda.io/), you can use the package [nlohmann_json](https://github.com/conda-forge/nlohmann_json-feedstock) from [conda-forge](https://conda-forge.org) executing `conda install -c conda-forge nlohmann_json`. Please file issues [here](https://github.com/conda-forge/nlohmann_json-feedstock/issues).

--- a/single_include/nlohmann/_SwiftPackageManagerFile.cpp
+++ b/single_include/nlohmann/_SwiftPackageManagerFile.cpp
@@ -1,0 +1,3 @@
+// Umbrella source file for the Swift Package Manager
+
+ #include <json.hpp>


### PR DESCRIPTION
**Reason**
- Main way to develop under Apple's platforms is using SPM

**Changes**
- Added Package.swift
- Added _SwiftPackageManagerFile.cpp to single_include/nlohmann in order SPM to see it as a C++ source file
- Added .build to .gitignore

**Context**
- SPM is a package manager for Swift and C-based languages. It is the main way to develop under Apple's platforms. It is also used to build Swift packages for Linux.

[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
