### PR TITLE
PlatformIO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,27 @@ CPMAddPackage(
     VERSION 3.9.1)
 ```
 
+If you are using [PlatformIO](https://platformio.org/) you can add this repo directly to your `platformio.ini` like this:
+
+```ini
+[env:your_env_name]
+lib_deps =
+  nlohmann-json=https://github.com/nlohmann/json.git
+```
+
+or you can include it as a dependency in your `library.json` like this:
+
+```json
+…
+  "dependencies": [
+    {
+      "name": "nlohmann-json",
+      "version": "https://github.com/pidpawel/json.git"
+    }
+  ]
+ …
+```
+
 ### Pkg-config
 
 If you are using bare Makefiles, you can use `pkg-config` to generate the include flags that point to where the library is installed:

--- a/README.md
+++ b/README.md
@@ -1374,7 +1374,7 @@ or you can include it as a dependency in your `library.json` like this:
   "dependencies": [
     {
       "name": "nlohmann-json",
-      "version": "https://github.com/pidpawel/json.git"
+      "version": "https://github.com/nlohmann/json.git"
     }
   ]
  …

--- a/library.json
+++ b/library.json
@@ -29,5 +29,9 @@
   "examples": [
     "https://github.com/nlohmann/json/tree/develop/docs/examples"
   ],
-  "include": "single_include/nlohmann/json.hpp"
+  "include": "single_include/nlohmann/json.hpp",
+  "build": {
+    "flags": ["-std=c++11"],
+    "srcFilter": ["-<**/*>"]
+  }
 }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,33 @@
+{
+  "name": "nlohmann-json",
+  "version": "3.11.2",
+  "description": "JSON for Modern C++",
+  "keywords": [
+    "json",
+    "serialization",
+    "deserialization",
+    "parser",
+    "generator",
+    "C++"
+  ],
+  "authors": [
+    {
+      "name": "Niels Lohmann",
+      "email": "mail@nlohmann.me",
+      "url": "https://github.com/nlohmann"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nlohmann/json.git"
+  },
+  "homepage": "https://nlohmann.github.io/json/",
+  "license": "MIT",
+  "dependencies": [],
+  "frameworks": "*",
+  "platforms": "*",
+  "examples": [
+    "https://github.com/nlohmann/json/tree/develop/docs/examples"
+  ],
+  "include": "single_include/nlohmann/json.hpp"
+}

--- a/library.json
+++ b/library.json
@@ -29,9 +29,9 @@
   "examples": [
     "https://github.com/nlohmann/json/tree/develop/docs/examples"
   ],
-  "include": "single_include/nlohmann/json.hpp",
   "build": {
     "flags": ["-std=c++11"],
-    "srcFilter": ["-<**/*>"]
+    "srcFilter": ["-<**/*>"],
+    "includeDir": "single_include"
   }
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,5 @@
 {
   "name": "nlohmann-json",
-  "version": "3.11.2",
   "description": "JSON for Modern C++",
   "keywords": [
     "json",
@@ -8,7 +7,8 @@
     "deserialization",
     "parser",
     "generator",
-    "C++"
+    "C++",
+    "modern"
   ],
   "authors": [
     {
@@ -30,7 +30,6 @@
     "https://github.com/nlohmann/json/tree/develop/docs/examples"
   ],
   "build": {
-    "flags": ["-std=c++11"],
     "srcFilter": ["-<**/*>"],
     "includeDir": "single_include"
   }


### PR DESCRIPTION
First of all **thank you** for this amazing library. I really do enjoy working with it.

Secondly this pull request is my stab at adding this library to a PlatformIO environment. PlatformIO is a tool that streamlines environment setup for embedded development. It takes care of things like getting proper compiler variant, setting up all the required compiler flags, linker scripts, etc. It even does some IDE setup, if needed. If that weren't enough it also manages libraries and project dependencies reasonably well. This is where this PR comes in.

Each of the PlatformIO libraries needs a `library.json` file (which this PR includes) and may be uploaded to PlatformIO's registry (https://registry.platformio.org/) (which this PR does not). Technically uploading to said registry is recommended and makes the libraries slightly easier for users to use, but it requires setting up accounts and regular uploads to said service (which would require a CI changes to be sustainable) so I decided not to include it right now. If the current solution will gain traction among users I can help with setting all the "proper" channels.

I also edited `README.md` - my changes are in the section Package managers despite PlatformIO technically being closer to a build system due to the said "registry" feature above, which I hope this library make into one day.

Sorry for the multiple commits in the PR - I kinda couldn't resist testing the GitHub's online editor for a single JSON ;-) file change.

Let me know what you think and have a wonderful day
Paweł