### PR TITLE
feat: Rebase `feature/optional` to `develop`

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -53,7 +53,7 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
     }
     else
     {
-        opt = j.template get<T>();
+        opt.emplace(j.template get<T>());
     }
 }
 #endif

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -44,6 +44,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 }
 
 #ifdef JSON_HAS_CPP_17
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
@@ -56,7 +57,9 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
         opt.emplace(j.template get<T>());
     }
 }
-#endif
+
+#endif // JSON_USE_IMPLICIT_CONVERSIONS
+#endif // JSON_HAS_CPP_17
 
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -21,7 +21,11 @@
 #include <valarray> // valarray
 
 #ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
 #endif
 
 #include <nlohmann/detail/exceptions.hpp>

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -13,12 +13,16 @@
 #include <forward_list> // forward_list
 #include <iterator> // inserter, front_inserter, end
 #include <map> // map
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #include <string> // string
 #include <tuple> // tuple, make_tuple
 #include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
 #include <unordered_map> // unordered_map
 #include <utility> // pair, declval
 #include <valarray> // valarray
+
 
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -20,6 +20,10 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
+
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
@@ -42,6 +46,21 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
     }
     n = nullptr;
 }
+
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if (j.is_null())
+    {
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt = j.template get<T>();
+    }
+}
+#endif
 
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -20,14 +20,6 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
-
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -18,7 +18,11 @@
 #include <vector> // vector
 
 #ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
 #endif
 
 #include <nlohmann/detail/iterators/iteration_proxy.hpp>

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -17,6 +17,10 @@
 #include <valarray> // valarray
 #include <vector> // vector
 
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
+
 #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
@@ -259,6 +263,22 @@ struct external_constructor<value_t::object>
 /////////////
 // to_json //
 /////////////
+
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+void to_json(BasicJsonType& j, const std::optional<T>& opt)
+{
+    if (opt.has_value())
+    {
+        j = *opt;
+    }
+    else
+    {
+        j = nullptr;
+    }
+}
+#endif
 
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -10,6 +10,9 @@
 
 #include <algorithm> // copy
 #include <iterator> // begin, end
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #include <string> // string
 #include <tuple> // tuple, get
 #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -17,14 +17,6 @@
 #include <valarray> // valarray
 #include <vector> // vector
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
-
 #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -47,6 +47,10 @@
     #define JSON_HAS_CPP_11
 #endif
 
+#ifdef JSON_HAS_CPP_17
+    #include <optional>
+#endif
+
 // disable float-equal warnings on GCC/clang
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic push
@@ -157,10 +161,6 @@
     #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
     #define JSON_NO_UNIQUE_ADDRESS
-
-#ifdef JSON_HAS_CPP_17
-    #include <optional>
-#endif
 
 // disable documentation warnings on clang
 #if defined(__clang__)

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -153,11 +153,7 @@
     #define JSON_NO_UNIQUE_ADDRESS
 
 #ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
+    #include <optional>
 #endif
 
 // disable float-equal warnings on GCC/clang

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -51,12 +51,6 @@
     #include <optional>
 #endif
 
-// disable float-equal warnings on GCC/clang
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wfloat-equal"
-#endif
-
 #ifdef __has_include
     #if __has_include(<version>)
         #include <version>

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -47,10 +47,6 @@
     #define JSON_HAS_CPP_11
 #endif
 
-#ifdef JSON_HAS_CPP_17
-    #include <optional>
-#endif
-
 #ifdef __has_include
     #if __has_include(<version>)
         #include <version>

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -151,6 +151,20 @@
     #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
     #define JSON_NO_UNIQUE_ADDRESS
+
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
+// disable float-equal warnings on GCC/clang
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"
+>>>>>>> 1b846c9d (Use JSON_HAS_CPP_17 only after it has been defined)
 #endif
 
 // disable documentation warnings on clang

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -161,6 +161,7 @@
     #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
     #define JSON_NO_UNIQUE_ADDRESS
+#endif
 
 // disable documentation warnings on clang
 #if defined(__clang__)

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -47,6 +47,12 @@
     #define JSON_HAS_CPP_11
 #endif
 
+// disable float-equal warnings on GCC/clang
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #ifdef __has_include
     #if __has_include(<version>)
         #include <version>
@@ -154,13 +160,6 @@
 
 #ifdef JSON_HAS_CPP_17
     #include <optional>
-#endif
-
-// disable float-equal warnings on GCC/clang
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wfloat-equal"
->>>>>>> 1b846c9d (Use JSON_HAS_CPP_17 only after it has been defined)
 #endif
 
 // disable documentation warnings on clang

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -170,7 +170,11 @@
 #include <valarray> // valarray
 
 #ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
 #endif
 
 // #include <nlohmann/detail/exceptions.hpp>
@@ -5189,7 +5193,11 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <vector> // vector
 
 #ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
 #endif
 
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2508,12 +2508,6 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #include <optional>
 #endif
 
-// disable float-equal warnings on GCC/clang
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wfloat-equal"
-#endif
-
 // disable documentation warnings on clang
 #if defined(__clang__)
     #pragma clang diagnostic push

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4706,6 +4706,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 }
 
 #ifdef JSON_HAS_CPP_17
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
@@ -4718,7 +4719,9 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
         opt.emplace(j.template get<T>());
     }
 }
-#endif
+
+#endif // JSON_USE_IMPLICIT_CONVERSIONS
+#endif // JSON_HAS_CPP_17
 
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2503,6 +2503,7 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
     #define JSON_NO_UNIQUE_ADDRESS
+#endif
 
 #ifdef JSON_HAS_CPP_17
     #include <optional>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -169,6 +169,10 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
+
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
@@ -4696,6 +4700,21 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
     n = nullptr;
 }
 
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if (j.is_null())
+    {
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt = j.template get<T>();
+    }
+}
+#endif
+
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,
            enable_if_t < std::is_arithmetic<ArithmeticType>::value&&
@@ -5168,6 +5187,10 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <utility> // move, forward, declval, pair
 #include <valarray> // valarray
 #include <vector> // vector
+
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 //     __ _____ _____ _____
@@ -5662,6 +5685,22 @@ struct external_constructor<value_t::object>
 /////////////
 // to_json //
 /////////////
+
+#ifdef JSON_HAS_CPP_17
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+void to_json(BasicJsonType& j, const std::optional<T>& opt)
+{
+    if (opt.has_value())
+    {
+        j = *opt;
+    }
+    else
+    {
+        j = nullptr;
+    }
+}
+#endif
 
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2505,11 +2505,7 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #define JSON_NO_UNIQUE_ADDRESS
 
 #ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
+    #include <optional>
 #endif
 
 // disable float-equal warnings on GCC/clang

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2512,7 +2512,6 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wfloat-equal"
->>>>>>> 1b846c9d (Use JSON_HAS_CPP_17 only after it has been defined)
 #endif
 
 // disable documentation warnings on clang
@@ -4716,7 +4715,7 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
     }
     else
     {
-        opt = j.template get<T>();
+        opt.emplace(j.template get<T>());
     }
 }
 #endif

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -169,14 +169,6 @@
 #include <utility> // pair, declval
 #include <valarray> // valarray
 
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
-
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
@@ -2511,6 +2503,20 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
     #define JSON_NO_UNIQUE_ADDRESS
+
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
+// disable float-equal warnings on GCC/clang
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"
+>>>>>>> 1b846c9d (Use JSON_HAS_CPP_17 only after it has been defined)
 #endif
 
 // disable documentation warnings on clang
@@ -5191,14 +5197,6 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <utility> // move, forward, declval, pair
 #include <valarray> // valarray
 #include <vector> // vector
-
-#ifdef JSON_HAS_CPP_17
-    #if __has_include(<optional>)
-        #include <optional>
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-    #endif
-#endif
 
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 //     __ _____ _____ _____

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -162,12 +162,16 @@
 #include <forward_list> // forward_list
 #include <iterator> // inserter, front_inserter, end
 #include <map> // map
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #include <string> // string
 #include <tuple> // tuple, make_tuple
 #include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
 #include <unordered_map> // unordered_map
 #include <utility> // pair, declval
 #include <valarray> // valarray
+
 
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
@@ -2503,10 +2507,6 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
     #define JSON_NO_UNIQUE_ADDRESS
-#endif
-
-#ifdef JSON_HAS_CPP_17
-    #include <optional>
 #endif
 
 // disable documentation warnings on clang
@@ -5184,6 +5184,9 @@ NLOHMANN_JSON_NAMESPACE_END
 
 #include <algorithm> // copy
 #include <iterator> // begin, end
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #include <string> // string
 #include <tuple> // tuple, get
 #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -172,10 +172,8 @@ TEST_CASE("value conversion")
         }
     }
 
-<<<<<<< HEAD:tests/src/unit-conversions.cpp
 #if JSON_USE_IMPLICIT_CONVERSIONS
-=======
->>>>>>> df30a0ea (:construction: conversions for std::optional):test/src/unit-conversions.cpp
+
     SECTION("get an object (implicit)")
     {
         const json::object_t o_reference = {{"object", json::object()},
@@ -1592,10 +1590,9 @@ TEST_CASE("JSON to enum mapping")
     }
 }
 
-<<<<<<< HEAD:tests/src/unit-conversions.cpp
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-=======
+
 #ifdef JSON_HAS_CPP_17
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
 TEST_CASE("std::optional")
 {
     SECTION("null")
@@ -1631,7 +1628,7 @@ TEST_CASE("std::optional")
         std::optional<int> opt_int = 1;
 
         CHECK(json(opt_int) == j_number);
-        CHECK(std::optional<int>(j_number) == opt_int);
+        CHECK(j_number.get<std::optional<int>>() == opt_int);
     }
 
     SECTION("array")
@@ -1640,7 +1637,7 @@ TEST_CASE("std::optional")
         std::vector<std::optional<int>> opt_array = {{1, 2, std::nullopt}};
 
         CHECK(json(opt_array) == j_array);
-        CHECK(std::vector<std::optional<int>>(j_array) == opt_array);
+        CHECK(j_array.get<std::vector<std::optional<int>>>() == opt_array);
     }
 
     SECTION("object")
@@ -1653,4 +1650,13 @@ TEST_CASE("std::optional")
     }
 }
 #endif
->>>>>>> df30a0ea (:construction: conversions for std::optional):test/src/unit-conversions.cpp
+#endif
+
+#ifdef JSON_HAS_CPP_17
+    #undef JSON_HAS_CPP_17
+#endif
+
+#ifdef JSON_HAS_CPP_14
+    #undef JSON_HAS_CPP_14
+#endif
+DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1604,7 +1604,7 @@ TEST_CASE("std::optional")
         std::optional<std::string> opt_null;
 
         CHECK(json(opt_null) == j_null);
-        CHECK(std::optional<std::string>(j_null) == std::nullopt);
+        CHECK(j_null.get<std::optional<std::string>>() == std::nullopt);
     }
 
     SECTION("string")

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1597,7 +1597,7 @@ TEST_CASE("std::optional")
         std::optional<std::string> opt_null;
 
         CHECK(json(opt_null) == j_null);
-        //CHECK(std::optional<std::string>(j_null) == std::nullopt);
+        CHECK(std::optional<std::string>(j_null) == std::nullopt);
     }
 
     SECTION("string")

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -40,8 +40,15 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
     #define JSON_HAS_CPP_14
 #endif
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 #if defined(JSON_HAS_CPP_17)
-    #include <optional>
     #include <string_view>
 #endif
 

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1629,21 +1629,20 @@ TEST_CASE("std::optional")
 
     SECTION("array")
     {
-        json j_array = {1, 2, 3};
-        std::optional<std::vector<int>> opt_array = {{1, 2, 3}};
+        json j_array = {1, 2, nullptr};
+        std::vector<std::optional<int>> opt_array = {{1, 2, std::nullopt}};
 
         CHECK(json(opt_array) == j_array);
-        CHECK(std::optional<std::vector<int>>(j_array) == opt_array);
+        CHECK(std::vector<std::optional<int>>(j_array) == opt_array);
     }
 
     SECTION("object")
     {
-        json j_object = {{"one", 1}, {"two", 2}};
-        std::map<std::string, int> m {{"one", 1}, {"two", 2}};
-        std::optional<std::map<std::string, int>> opt_object = m;
+        json j_object = {{"one", 1}, {"two", 2}, {"zero", nullptr}};
+        std::map<std::string, std::optional<int>> opt_object {{"one", 1}, {"two", 2}, {"zero", std::nullopt}};
 
         CHECK(json(opt_object) == j_object);
-        CHECK(std::optional<std::map<std::string, int>>(j_object) == opt_object);
+        CHECK(std::map<std::string, std::optional<int>>(j_object) == opt_object);
     }
 }
 #endif

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -28,9 +28,22 @@ using nlohmann::json;
 #include <unordered_set>
 #include <valarray>
 
+
 // NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
+
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+    #define JSON_HAS_CPP_17
+    #define JSON_HAS_CPP_14
+#elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
+    #define JSON_HAS_CPP_14
+#endif
+
+#if defined(JSON_HAS_CPP_17)
+    #include <optional>
+    #include <string_view>
+#endif
 
 TEST_CASE("value conversion")
 {
@@ -152,7 +165,10 @@ TEST_CASE("value conversion")
         }
     }
 
+<<<<<<< HEAD:tests/src/unit-conversions.cpp
 #if JSON_USE_IMPLICIT_CONVERSIONS
+=======
+>>>>>>> df30a0ea (:construction: conversions for std::optional):test/src/unit-conversions.cpp
     SECTION("get an object (implicit)")
     {
         const json::object_t o_reference = {{"object", json::object()},
@@ -1569,4 +1585,66 @@ TEST_CASE("JSON to enum mapping")
     }
 }
 
+<<<<<<< HEAD:tests/src/unit-conversions.cpp
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
+=======
+#ifdef JSON_HAS_CPP_17
+TEST_CASE("std::optional")
+{
+    SECTION("null")
+    {
+        json j_null;
+        std::optional<std::string> opt_null;
+
+        CHECK(json(opt_null) == j_null);
+        //CHECK(std::optional<std::string>(j_null) == std::nullopt);
+    }
+
+    SECTION("string")
+    {
+        json j_string = "string";
+        std::optional<std::string> opt_string = "string";
+
+        CHECK(json(opt_string) == j_string);
+        CHECK(std::optional<std::string>(j_string) == opt_string);
+    }
+
+    SECTION("bool")
+    {
+        json j_bool = true;
+        std::optional<bool> opt_bool = true;
+
+        CHECK(json(opt_bool) == j_bool);
+        CHECK(std::optional<bool>(j_bool) == opt_bool);
+    }
+
+    SECTION("number")
+    {
+        json j_number = 1;
+        std::optional<int> opt_int = 1;
+
+        CHECK(json(opt_int) == j_number);
+        CHECK(std::optional<int>(j_number) == opt_int);
+    }
+
+    SECTION("array")
+    {
+        json j_array = {1, 2, 3};
+        std::optional<std::vector<int>> opt_array = {{1, 2, 3}};
+
+        CHECK(json(opt_array) == j_array);
+        CHECK(std::optional<std::vector<int>>(j_array) == opt_array);
+    }
+
+    SECTION("object")
+    {
+        json j_object = {{"one", 1}, {"two", 2}};
+        std::map<std::string, int> m {{"one", 1}, {"two", 2}};
+        std::optional<std::map<std::string, int>> opt_object = m;
+
+        CHECK(json(opt_object) == j_object);
+        CHECK(std::optional<std::map<std::string, int>>(j_object) == opt_object);
+    }
+}
+#endif
+>>>>>>> df30a0ea (:construction: conversions for std::optional):test/src/unit-conversions.cpp

--- a/tests/src/unit-readme.cpp
+++ b/tests/src/unit-readme.cpp
@@ -171,7 +171,7 @@ TEST_CASE("README" * doctest::skip())
 
             // find an entry
             CHECK(o.find("foo") != o.end());
-            if (o.find("foo") != o.end())
+            if (o.contains("foo"))
             {
                 // there is an entry with key "foo"
             }

--- a/tests/src/unit-readme.cpp
+++ b/tests/src/unit-readme.cpp
@@ -171,7 +171,7 @@ TEST_CASE("README" * doctest::skip())
 
             // find an entry
             CHECK(o.find("foo") != o.end());
-            if (o.contains("foo"))
+            if (o.find("foo") != o.end()) // NOLINT(readability-container-contains)
             {
                 // there is an entry with key "foo"
             }


### PR DESCRIPTION
Rebasing `feature/optional` in attempt to revive this PR, referring to https://github.com/nlohmann/json/pull/2117.

Sorry for long time between responses.

I may have been going forward with this the "wrong" way, so I apologize in advance.

Please let me know if this should be handled differently.

## TODO
There is one test that is failing: Conversions from a default initialized `nlohmann::json` to `std::optional<T>` seems to fail. In the test case below, the last assertion fails with an exception. This is tested on Arch Linux with GCC 13.1.1.

I was not able to figure out how to fix this so I need some assistance here.

```
/home/fredrik/dev/github/cpp/fredriksd/json/tests/src/unit-conversions.cpp:1573:
TEST CASE:  std::optional
  null

/home/fredrik/dev/github/cpp/fredriksd/json/tests/src/unit-conversions.cpp:1573: ERROR: test case THREW exception: exception thrown in subcase - will translate later when the whole test case has been exited (cannot translate while there is an active exception)

===============================================================================
/home/fredrik/dev/github/cpp/fredriksd/json/tests/src/unit-conversions.cpp:1573:
TEST CASE:  std::optional

DEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):
  null

/home/fredrik/dev/github/cpp/fredriksd/json/tests/src/unit-conversions.cpp:1573: ERROR: test case THREW exception: [json.exception.type_error.302] type must be string, but is null
```