### PR TITLE
Use template get instead of get in examples

### DIFF
--- a/docs/examples/from_json__default_constructible.cpp
+++ b/docs/examples/from_json__default_constructible.cpp
@@ -31,7 +31,7 @@ int main()
     j["address"] = "744 Evergreen Terrace";
     j["age"] = 60;
 
-    auto p = j.get<ns::person>();
+    auto p = j.template get<ns::person>();
 
     std::cout << p.name << " (" << p.age << ") lives in " << p.address << std::endl;
 }

--- a/docs/examples/from_json__non_default_constructible.cpp
+++ b/docs/examples/from_json__non_default_constructible.cpp
@@ -47,7 +47,7 @@ int main()
     j["address"] = "744 Evergreen Terrace";
     j["age"] = 60;
 
-    auto p = j.get<ns::person>();
+    auto p = j.template get<ns::person>();
 
     std::cout << p.name << " (" << p.age << ") lives in " << p.address << std::endl;
 }

--- a/docs/examples/get__PointerType.cpp
+++ b/docs/examples/get__PointerType.cpp
@@ -9,11 +9,11 @@ int main()
     json value = 17;
 
     // explicitly getting pointers
-    auto p1 = value.get<const json::number_integer_t*>();
-    auto p2 = value.get<json::number_integer_t*>();
-    auto p3 = value.get<json::number_integer_t* const>();
-    auto p4 = value.get<const json::number_integer_t* const>();
-    auto p5 = value.get<json::number_float_t*>();
+    auto p1 = value.template get<const json::number_integer_t*>();
+    auto p2 = value.template get<json::number_integer_t*>();
+    auto p3 = value.template get<json::number_integer_t* const>();
+    auto p4 = value.template get<const json::number_integer_t* const>();
+    auto p5 = value.template get<json::number_float_t*>();
 
     // print the pointees
     std::cout << *p1 << ' ' << *p2 << ' ' << *p3 << ' ' << *p4 << '\n';

--- a/docs/examples/get__ValueType_const.cpp
+++ b/docs/examples/get__ValueType_const.cpp
@@ -22,14 +22,14 @@ int main()
     };
 
     // use explicit conversions
-    auto v1 = json_types["boolean"].get<bool>();
-    auto v2 = json_types["number"]["integer"].get<int>();
-    auto v3 = json_types["number"]["integer"].get<short>();
-    auto v4 = json_types["number"]["floating-point"].get<float>();
-    auto v5 = json_types["number"]["floating-point"].get<int>();
-    auto v6 = json_types["string"].get<std::string>();
-    auto v7 = json_types["array"].get<std::vector<short>>();
-    auto v8 = json_types.get<std::unordered_map<std::string, json>>();
+    auto v1 = json_types["boolean"].template get<bool>();
+    auto v2 = json_types["number"]["integer"].template get<int>();
+    auto v3 = json_types["number"]["integer"].template get<short>();
+    auto v4 = json_types["number"]["floating-point"].template get<float>();
+    auto v5 = json_types["number"]["floating-point"].template get<int>();
+    auto v6 = json_types["string"].template get<std::string>();
+    auto v7 = json_types["array"].template get<std::vector<short>>();
+    auto v8 = json_types.template get<std::unordered_map<std::string, json>>();
 
     // print the conversion results
     std::cout << v1 << '\n';

--- a/docs/examples/nlohmann_define_type_intrusive_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_explicit.cpp
@@ -45,13 +45,13 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
     try
     {
-        auto p3 = j3.get<ns::person>();
+        auto p3 = j3.template get<ns::person>();
     }
     catch (json::exception& e)
     {

--- a/docs/examples/nlohmann_define_type_intrusive_macro.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_macro.cpp
@@ -33,13 +33,13 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
     try
     {
-        auto p3 = j3.get<ns::person>();
+        auto p3 = j3.template get<ns::person>();
     }
     catch (json::exception& e)
     {

--- a/docs/examples/nlohmann_define_type_intrusive_with_default_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_with_default_explicit.cpp
@@ -46,10 +46,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.get<ns::person>();
+    auto p3 = j3.template get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/examples/nlohmann_define_type_intrusive_with_default_macro.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_with_default_macro.cpp
@@ -33,10 +33,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.get<ns::person>();
+    auto p3 = j3.template get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/examples/nlohmann_define_type_non_intrusive_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_explicit.cpp
@@ -38,13 +38,13 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
     try
     {
-        auto p3 = j3.get<ns::person>();
+        auto p3 = j3.template get<ns::person>();
     }
     catch (json::exception& e)
     {

--- a/docs/examples/nlohmann_define_type_non_intrusive_macro.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_macro.cpp
@@ -26,13 +26,13 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
     try
     {
-        auto p3 = j3.get<ns::person>();
+        auto p3 = j3.template get<ns::person>();
     }
     catch (json::exception& e)
     {

--- a/docs/examples/nlohmann_define_type_non_intrusive_with_default_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_with_default_explicit.cpp
@@ -44,10 +44,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.get<ns::person>();
+    auto p3 = j3.template get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/examples/nlohmann_define_type_non_intrusive_with_default_macro.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_with_default_macro.cpp
@@ -31,10 +31,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.get<ns::person>();
+    auto p2 = j2.template get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.get<ns::person>();
+    auto p3 = j3.template get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/examples/nlohmann_json_serialize_enum.cpp
+++ b/docs/examples/nlohmann_json_serialize_enum.cpp
@@ -44,16 +44,16 @@ int main()
     // deserialization
     json j_running = "running";
     json j_blue = "blue";
-    auto running = j_running.get<ns::TaskState>();
-    auto blue = j_blue.get<ns::Color>();
+    auto running = j_running.template get<ns::TaskState>();
+    auto blue = j_blue.template get<ns::Color>();
     std::cout << j_running << " -> " << running
               << ", " << j_blue << " -> " << static_cast<int>(blue) << std::endl;
 
     // deserializing undefined JSON value to enum
     // (where the first map entry above is the default)
     json j_pi = 3.14;
-    auto invalid = j_pi.get<ns::TaskState>();
-    auto unknown = j_pi.get<ns::Color>();
+    auto invalid = j_pi.template get<ns::TaskState>();
+    auto unknown = j_pi.template get<ns::Color>();
     std::cout << j_pi << " -> " << invalid << ", "
               << j_pi << " -> " << static_cast<int>(unknown) << std::endl;
 }

--- a/docs/examples/nlohmann_json_serialize_enum_2.cpp
+++ b/docs/examples/nlohmann_json_serialize_enum_2.cpp
@@ -26,8 +26,8 @@ int main()
 
     // deserialization
     json j_rot = "rot";
-    auto rot = j_rot.get<ns::Color>();
-    auto red = j_red.get<ns::Color>();
+    auto rot = j_rot.template get<ns::Color>();
+    auto red = j_red.template get<ns::Color>();
     std::cout << j_rot << " -> " << static_cast<int>(rot) << std::endl;
     std::cout << j_red << " -> " << static_cast<int>(red) << std::endl;
 }

--- a/docs/mkdocs/docs/api/adl_serializer/from_json.md
+++ b/docs/mkdocs/docs/api/adl_serializer/from_json.md
@@ -37,7 +37,7 @@ Copy of the JSON value, converted to `ValueType`
 ??? example "Example: (1) Default-constructible type"
 
     The example below shows how a `from_json` function can be implemented for a user-defined type. This function is
-    called by the `adl_serializer` when `get<ns::person>()` is called.
+    called by the `adl_serializer` when `template get<ns::person>()` is called.
         
     ```cpp
     --8<-- "examples/from_json__default_constructible.cpp"

--- a/docs/mkdocs/docs/api/macros/json_disable_enum_serialization.md
+++ b/docs/mkdocs/docs/api/macros/json_disable_enum_serialization.md
@@ -53,7 +53,7 @@ The default value is `0`.
         const json j = Choice::first; 
 
         // normally invokes from_json parse function but with JSON_DISABLE_ENUM_SERIALIZATION defined, it does not
-        Choice ch = j.get<Choice>();
+        Choice ch = j.template get<Choice>();
     }
     ```
 
@@ -86,7 +86,7 @@ The default value is `0`.
         const json j = Choice::first; 
 
         // uses user-defined from_json function defined by macro
-        Choice ch = j.get<Choice>();
+        Choice ch = j.template get<Choice>();
     }
     ```
 
@@ -109,7 +109,7 @@ The default value is `0`.
 
     void from_json(const json& j, Choice& ch)
     {
-        auto value = j.get<std::string>();
+        auto value = j.template get<std::string>();
         if (value == "first")
         {
             ch = Choice::first;
@@ -122,7 +122,7 @@ The default value is `0`.
 
     void to_json(json& j, const Choice& ch)
     {
-        auto value = j.get<std::string>();
+        auto value = j.template get<std::string>();
         if (value == "first")
         {
             ch = Choice::first;
@@ -139,7 +139,7 @@ The default value is `0`.
         const json j = Choice::first; 
 
         // uses user-defined from_json function
-        Choice ch = j.get<Choice>();
+        Choice ch = j.template get<Choice>();
     }
     ```
 

--- a/docs/mkdocs/docs/api/macros/json_use_implicit_conversions.md
+++ b/docs/mkdocs/docs/api/macros/json_use_implicit_conversions.md
@@ -46,7 +46,7 @@ By default, implicit conversions are enabled.
 
     ```cpp
     json j = "Hello, world!";
-    auto s = j.get<std::string>();
+    auto s = j.template get<std::string>();
     ```
 
 ## See also

--- a/docs/mkdocs/docs/api/macros/nlohmann_json_serialize_enum.md
+++ b/docs/mkdocs/docs/api/macros/nlohmann_json_serialize_enum.md
@@ -37,7 +37,7 @@ inline void from_json(const BasicJsonType& j, type& e);
 
 !!! important "Important notes"
 
-    - When using [`get<ENUM_TYPE>()`](../basic_json/get.md), undefined JSON values will default to the first specified
+    - When using [`template get<ENUM_TYPE>()`](../basic_json/get.md), undefined JSON values will default to the first specified
       conversion. Select this default pair carefully. See example 1 below.
     - If an enum or JSON value is specified in multiple conversions, the first matching conversion from the top of the
       list will be returned when converting to or from JSON. See example 2 below.

--- a/docs/mkdocs/docs/features/arbitrary_types.md
+++ b/docs/mkdocs/docs/features/arbitrary_types.md
@@ -24,9 +24,9 @@ j["age"] = p.age;
 
 // convert from JSON: copy each value from the JSON object
 ns::person p {
-    j["name"].get<std::string>(),
-    j["address"].get<std::string>(),
-    j["age"].get<int>()
+    j["name"].template get<std::string>(),
+    j["address"].template get<std::string>(),
+    j["age"].template get<int>()
 };
 ```
 
@@ -43,7 +43,7 @@ std::cout << j << std::endl;
 // {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}
 
 // conversion: json -> person
-auto p2 = j.get<ns::person>();
+auto p2 = j.template get<ns::person>();
 
 // that's it
 assert(p == p2);
@@ -70,13 +70,13 @@ namespace ns {
 ```
 
 That's all! When calling the `json` constructor with your type, your custom `to_json` method will be automatically called.
-Likewise, when calling `get<your_type>()` or `get_to(your_type&)`, the `from_json` method will be called.
+Likewise, when calling `template get<your_type>()` or `get_to(your_type&)`, the `from_json` method will be called.
 
 Some important things:
 
 * Those methods **MUST** be in your type's namespace (which can be the global namespace), or the library will not be able to locate them (in this example, they are in namespace `ns`, where `person` is defined).
 * Those methods **MUST** be available (e.g., proper headers must be included) everywhere you use these conversions. Look at [issue 1108](https://github.com/nlohmann/json/issues/1108) for errors that may occur otherwise.
-* When using `get<your_type>()`, `your_type` **MUST** be [DefaultConstructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible). (There is a way to bypass this requirement described later.)
+* When using `template get<your_type>()`, `your_type` **MUST** be [DefaultConstructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible). (There is a way to bypass this requirement described later.)
 * In function `from_json`, use function [`at()`](../api/basic_json/at.md) to access the object values rather than `operator[]`. In case a key does not exist, `at` throws an exception that you can handle, whereas `operator[]` exhibits undefined behavior.
 * You do not need to add serializers or deserializers for STL types like `std::vector`: the library already implements these.
 
@@ -171,7 +171,7 @@ struct adl_serializer<boost::optional<T>> {
         if (j.is_null()) {
             opt = boost::none;
         } else {
-            opt = j.get<T>(); // same as above, but with
+            opt = j.template get<T>(); // same as above, but with
                               // adl_serializer<T>::from_json
         }
     }
@@ -204,7 +204,7 @@ namespace nlohmann {
         // note: the return type is no longer 'void', and the method only takes
         // one argument
         static move_only_type from_json(const json& j) {
-            return {j.get<int>()};
+            return {j.template get<int>()};
         }
 
         // Here's the catch! You must provide a to_json method! Otherwise, you
@@ -268,7 +268,7 @@ struct bad_serializer
     static void to_json(const BasicJsonType& j, T& value) {
       // this calls BasicJsonType::json_serializer<T>::from_json(j, value);
       // if BasicJsonType::json_serializer == bad_serializer ... oops!
-      value = j.template get<T>(); // oops!
+      value = j.template template get<T>(); // oops!
     }
 };
 ```

--- a/docs/mkdocs/docs/features/enum_conversion.md
+++ b/docs/mkdocs/docs/features/enum_conversion.md
@@ -36,11 +36,11 @@ assert(j == "stopped");
 
 // json string to enum
 json j3 = "running";
-assert(j3.get<TaskState>() == TS_RUNNING);
+assert(j3.template get<TaskState>() == TS_RUNNING);
 
 // undefined json value to enum (where the first map entry above is the default)
 json jPi = 3.14;
-assert(jPi.get<TaskState>() == TS_INVALID );
+assert(jPi.template get<TaskState>() == TS_INVALID );
 ```
 
 ## Notes
@@ -54,7 +54,7 @@ Just as in [Arbitrary Type Conversions](arbitrary_types.md) above,
 
 Other Important points:
 
-- When using `get<ENUM_TYPE>()`, undefined JSON values will default to the first pair specified in your map. Select this
+- When using `template get<ENUM_TYPE>()`, undefined JSON values will default to the first pair specified in your map. Select this
   default pair carefully.
 - If an enum or JSON value is specified more than once in your map, the first matching occurrence from the top of the
   map will be returned when converting to or from JSON.

--- a/docs/mkdocs/docs/features/types/number_handling.md
+++ b/docs/mkdocs/docs/features/types/number_handling.md
@@ -235,9 +235,9 @@ integers, and  between integers and floating-point values to integers. This beha
 !!! warning "Unconditional number conversions"
 
     ```cpp hl_lines="3"
-    double d = 42.3;                          // non-integer double value 42.3
-    json jd = d;                              // stores double value 42.3
-    std::int64_t i = jd.get<std::int64_t>();  // now i==42; no warning or error is produced
+    double d = 42.3;                                   // non-integer double value 42.3
+    json jd = d;                                       // stores double value 42.3
+    std::int64_t i = jd.template get<std::int64_t>();  // now i==42; no warning or error is produced
     ```
 
     Note the last line with throw a [`json.exception.type_error.302`](../../home/exceptions.md#jsonexceptiontype_error302)
@@ -259,7 +259,7 @@ The rationale is twofold:
     if (jd.is_number_integer())
     {
         // if so, do the conversion and use i
-        std::int64_t i = jd.get<std::int64_t>();
+        std::int64_t i = jd.template get<std::int64_t>();
         // ...
     }
     else

--- a/docs/mkdocs/docs/integration/migration_guide.md
+++ b/docs/mkdocs/docs/integration/migration_guide.md
@@ -187,7 +187,7 @@ conversions with calls to [`get`](../api/basic_json/get.md), [`get_to`](../api/b
 
       ```cpp
       nlohmann::json j = "Hello, world!";
-      auto s = j.get<std::string>();
+      auto s = j.template get<std::string>();
       ```
 
 === "Future-proof (alternative)"


### PR DESCRIPTION
https://github.com/nlohmann/json/issues/4038

[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
