### PR TITLE
Added to tests the file unit-algorithm.cpp (c++ 11) functions from algorithm library

### DIFF
--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -306,7 +306,7 @@ TEST_CASE("algorithms")
         }
     }
 
-    /*
+
     SECTION("copy")
     {
         SECTION("copy without if")
@@ -321,12 +321,13 @@ TEST_CASE("algorithms")
         SECTION("copy if")
         {
             json dest_arr;
-            const json source_arr = {0,3,6,9,12,15,20};
+            const json source_arr = {0, 3, 6, 9, 12, 15, 20};
 
 
-            std::copy_if(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr), [](const json& _value) {
+            std::copy_if(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr), [](const json & _value)
+            {
                 return _value.get<int>() % 3 == 0;
-             });
+            });
             CHECK(dest_arr == json({0, 3, 6, 9, 12, 15}));
         }
         SECTION("copy n")
@@ -341,7 +342,6 @@ TEST_CASE("algorithms")
         }
 
     }
-    */
 
 
 

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -313,13 +313,6 @@ TEST_CASE("algorithms")
             CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
         }
 
-        SECTION("char")
-        {
-            const std::vector<char> arr(10);
-            json json_arr(arr);
-            std::iota(json_arr.begin(), json_arr.end(), '0');
-            CHECK(json_arr == json({'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}));
-        }
     }
 
     SECTION("copy")
@@ -346,12 +339,12 @@ TEST_CASE("algorithms")
         }
         SECTION("copy n")
         {
-            const json source_arr = {'1', '2', '3', '4', '5', '6', '7'};
+            const json source_arr = {0, 1, 2, 3, 4, 5, 6, 7};
             json dest_arr;
             const unsigned char numToCopy = 2;
 
             std::copy_n(source_arr.begin(), numToCopy, std::back_inserter(dest_arr));
-            CHECK(dest_arr == json{'1','2'});  
+            CHECK(dest_arr == json{0, 1});  
 
         }
         

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -294,4 +294,70 @@ TEST_CASE("algorithms")
         std::sort_heap(j_array.begin(), j_array.end());
         CHECK(j_array == json({false, true, 3, 13, 29, {{"one", 1}, {"two", 2}}, {1, 2, 3}, "baz", "foo"}));
     }
+
+    SECTION("iota")
+    {
+        SECTION("int")
+        {
+            std::vector<int> arr(10);
+            json json_arr(arr);
+            std::iota(json_arr.begin(), json_arr.end(), 0);
+            CHECK(json_arr == json({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        }
+
+        SECTION("double")
+        {
+            std::vector<double> arr(10);
+            json json_arr(arr);
+            std::iota(json_arr.begin(), json_arr.end(), 0.5);
+            CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
+        }
+
+        SECTION("char")
+        {
+            std::vector<char> arr(10);
+            json json_arr(arr);
+            std::iota(json_arr.begin(), json_arr.end(), '0');
+            CHECK(json_arr == json({'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}));
+        }
+    }
+
+    SECTION("copy")
+    {
+        SECTION("copy without if")
+        {
+            json dest_arr;
+            json source_arr = {1, 2, 3, 4};
+
+            std::copy(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr));
+
+            CHECK(dest_arr == source_arr);
+        }
+        SECTION("copy if")
+        {
+            json dest_arr;
+            json source_arr = {0,3,6,9,12,15,20};
+            auto condition = [](int x) {
+                return x % 3 == 0;
+            };
+
+            std::copy_if(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr), condition);
+            CHECK(dest_arr == json({0, 3, 6, 9, 12, 15}));               
+        }
+        SECTION("copy n")
+        {
+            json source_arr = {'1', '2', '3', '4', '5', '6', '7'};
+            json dest_arr;
+            const unsigned char numToCopy = 2;
+
+            std::copy_n(source_arr.begin(), numToCopy, std::back_inserter(dest_arr));
+            CHECK(dest_arr == json{'1','2'});  
+
+        }
+        
+    }
+    
+
+
+
 }

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -310,7 +310,6 @@ TEST_CASE("algorithms")
             std::iota(json_arr.begin(), json_arr.end(), 0.5);
             CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
         }
-
     }
 
     /*

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -299,16 +299,14 @@ TEST_CASE("algorithms")
     {
         SECTION("int")
         {
-            const std::vector<int> arr(10);
-            json json_arr(arr);
+            json json_arr = {0, 5, 2, 4, 10, 20, 30, 40, 50, 1};
             std::iota(json_arr.begin(), json_arr.end(), 0);
             CHECK(json_arr == json({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
         }
 
         SECTION("double")
         {
-            const std::vector<double> arr(10);
-            json json_arr(arr);
+            json json_arr = {0.5, 51, 2.53, 4.1, 10.43, 20.12, 30.5, 140, 50.50, 1};
             std::iota(json_arr.begin(), json_arr.end(), 0.5);
             CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
         }

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -300,15 +300,9 @@ TEST_CASE("algorithms")
         SECTION("int")
         {
             json json_arr = {0, 5, 2, 4, 10, 20, 30, 40, 50, 1};
-            std::iota(json_arr.begin(), json_arr.end(), 0);
+            const int number = 0;
+            std::iota(json_arr.begin(), json_arr.end(), number);
             CHECK(json_arr == json({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
-        }
-
-        SECTION("double")
-        {
-            json json_arr = {0.5, 51, 2.53, 4.1, 10.43, 20.12, 30.5, 140, 50.50, 1};
-            std::iota(json_arr.begin(), json_arr.end(), 0.5);
-            CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
         }
     }
 

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -299,7 +299,7 @@ TEST_CASE("algorithms")
     {
         SECTION("int")
         {
-            std::vector<int> arr(10);
+            const std::vector<int> arr(10);
             json json_arr(arr);
             std::iota(json_arr.begin(), json_arr.end(), 0);
             CHECK(json_arr == json({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
@@ -307,7 +307,7 @@ TEST_CASE("algorithms")
 
         SECTION("double")
         {
-            std::vector<double> arr(10);
+            const std::vector<double> arr(10);
             json json_arr(arr);
             std::iota(json_arr.begin(), json_arr.end(), 0.5);
             CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
@@ -315,7 +315,7 @@ TEST_CASE("algorithms")
 
         SECTION("char")
         {
-            std::vector<char> arr(10);
+            const std::vector<char> arr(10);
             json json_arr(arr);
             std::iota(json_arr.begin(), json_arr.end(), '0');
             CHECK(json_arr == json({'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}));
@@ -327,7 +327,7 @@ TEST_CASE("algorithms")
         SECTION("copy without if")
         {
             json dest_arr;
-            json source_arr = {1, 2, 3, 4};
+            const json source_arr = {1, 2, 3, 4};
 
             std::copy(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr));
 
@@ -336,17 +336,17 @@ TEST_CASE("algorithms")
         SECTION("copy if")
         {
             json dest_arr;
-            json source_arr = {0,3,6,9,12,15,20};
-            auto condition = [](int x) {
-                return x % 3 == 0;
-            };
-
-            std::copy_if(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr), condition);
+            const json source_arr = {0,3,6,9,12,15,20};
+            
+           
+            std::copy_if(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr), [](const json& _value) {
+                return _value.get<int>() % 3 == 0;
+             });
             CHECK(dest_arr == json({0, 3, 6, 9, 12, 15}));               
         }
         SECTION("copy n")
         {
-            json source_arr = {'1', '2', '3', '4', '5', '6', '7'};
+            const json source_arr = {'1', '2', '3', '4', '5', '6', '7'};
             json dest_arr;
             const unsigned char numToCopy = 2;
 

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -300,9 +300,21 @@ TEST_CASE("algorithms")
         SECTION("int")
         {
             json json_arr = {0, 5, 2, 4, 10, 20, 30, 40, 50, 1};
-            const int number = 0;
-            std::iota(json_arr.begin(), json_arr.end(), number);
+            std::iota(json_arr.begin(), json_arr.end(), 0);
             CHECK(json_arr == json({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        }
+        SECTION("double")
+        {
+            json json_arr = {0.5, 1.5, 1.3, 4.1, 10.2, 20.5, 30.6, 40.1, 50.22, 1.5};
+            std::iota(json_arr.begin(), json_arr.end(), 0.5);
+            CHECK(json_arr == json({0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5}));
+        }
+
+        SECTION("char")
+        {
+            json json_arr = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '0', '1'};
+            std::iota(json_arr.begin(), json_arr.end(), '0');
+            CHECK(json_arr == json({'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}));
         }
     }
 
@@ -340,7 +352,15 @@ TEST_CASE("algorithms")
             CHECK(dest_arr == json{0, 1});
 
         }
+        SECTION("copy n chars")
+        {
+            const json source_arr = {'1', '2', '3', '4', '5', '6', '7'};
+            json dest_arr;
+            const unsigned char numToCopy = 4;
 
+            std::copy_n(source_arr.begin(), numToCopy, std::back_inserter(dest_arr));
+            CHECK(dest_arr == json{'1', '2', '3', '4'});
+        }
     }
 
 

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -322,12 +322,12 @@ TEST_CASE("algorithms")
         {
             json dest_arr;
             const json source_arr = {0,3,6,9,12,15,20};
-            
-           
+
+
             std::copy_if(source_arr.begin(), source_arr.end(), std::back_inserter(dest_arr), [](const json& _value) {
                 return _value.get<int>() % 3 == 0;
              });
-            CHECK(dest_arr == json({0, 3, 6, 9, 12, 15}));               
+            CHECK(dest_arr == json({0, 3, 6, 9, 12, 15}));
         }
         SECTION("copy n")
         {
@@ -336,10 +336,10 @@ TEST_CASE("algorithms")
             const unsigned char numToCopy = 2;
 
             std::copy_n(source_arr.begin(), numToCopy, std::back_inserter(dest_arr));
-            CHECK(dest_arr == json{0, 1});  
+            CHECK(dest_arr == json{0, 1});
 
         }
-        
+
     }
     */
 

--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -315,6 +315,7 @@ TEST_CASE("algorithms")
 
     }
 
+    /*
     SECTION("copy")
     {
         SECTION("copy without if")
@@ -349,7 +350,7 @@ TEST_CASE("algorithms")
         }
         
     }
-    
+    */
 
 
 


### PR DESCRIPTION
Added new tests to the file unit-algorithm.cpp (c++ 11) that were missing at the test:

1. iota
2. copy
3. copy if
4. copy n

[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
