### PR TITLE
Update minimum cmake version (#4076)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.27)
 
 ##
 ## PROJECT


### PR DESCRIPTION
Resolves issue #4076 
This commit updates the minimum cmake version 3.16, since 3.5 and below will be deprecated.
- A side not to those new to cmake versioning, it goes as follows 3.1, 3.2... 3.5... 3.9, 3.10, 3.11 etc. Therefore keep in mind that 3.5 is actually lower than 3.16.
