### PR TITLE
Capture exceptions by const& in docs.

### DIFF
--- a/docs/examples/at__json_pointer.cpp
+++ b/docs/examples/at__json_pointer.cpp
@@ -42,7 +42,7 @@ int main()
         // try to use an array index with leading '0'
         json::reference ref = j.at("/array/01"_json_pointer);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -53,7 +53,7 @@ int main()
         // try to use an array index that is not a number
         json::reference ref = j.at("/array/one"_json_pointer);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -64,7 +64,7 @@ int main()
         // try to use an invalid array index
         json::reference ref = j.at("/array/4"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -75,7 +75,7 @@ int main()
         // try to use the array index '-'
         json::reference ref = j.at("/array/-"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -86,7 +86,7 @@ int main()
         // try to use a JSON pointer to a nonexistent object key
         json::const_reference ref = j.at("/foo"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -97,7 +97,7 @@ int main()
         // try to use a JSON pointer that cannot be resolved
         json::reference ref = j.at("/number/foo"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/at__json_pointer_const.cpp
+++ b/docs/examples/at__json_pointer_const.cpp
@@ -29,7 +29,7 @@ int main()
         // try to use an array index that is not a number
         json::const_reference ref = j.at("/array/one"_json_pointer);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -40,7 +40,7 @@ int main()
         // try to use an invalid array index
         json::const_reference ref = j.at("/array/4"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -51,7 +51,7 @@ int main()
         // try to use the array index '-'
         json::const_reference ref = j.at("/array/-"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -62,7 +62,7 @@ int main()
         // try to use a JSON pointer to a nonexistent object key
         json::const_reference ref = j.at("/foo"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -73,7 +73,7 @@ int main()
         // try to use a JSON pointer that cannot be resolved
         json::const_reference ref = j.at("/number/foo"_json_pointer);
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/at__keytype.c++17.cpp
+++ b/docs/examples/at__keytype.c++17.cpp
@@ -32,7 +32,7 @@ int main()
         json str = "I am a string";
         str.at("the good"sv) = "Another string";
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -43,7 +43,7 @@ int main()
         // try to write at a nonexisting key using string_view
         object.at("the fast"sv) = "il rapido";
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/at__keytype_const.c++17.cpp
+++ b/docs/examples/at__keytype_const.c++17.cpp
@@ -26,7 +26,7 @@ int main()
         const json str = "I am a string";
         std::cout << str.at("the good"sv) << '\n';
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -37,7 +37,7 @@ int main()
         // try to read from a nonexisting key using string_view
         std::cout << object.at("the fast"sv) << '\n';
     }
-    catch (json::out_of_range)
+    catch (const json::out_of_range)
     {
         std::cout << "out of range" << '\n';
     }

--- a/docs/examples/at__object_t_key_type.cpp
+++ b/docs/examples/at__object_t_key_type.cpp
@@ -30,7 +30,7 @@ int main()
         json str = "I am a string";
         str.at("the good") = "Another string";
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -41,7 +41,7 @@ int main()
         // try to write at a nonexisting key
         object.at("the fast") = "il rapido";
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/at__object_t_key_type_const.cpp
+++ b/docs/examples/at__object_t_key_type_const.cpp
@@ -24,7 +24,7 @@ int main()
         const json str = "I am a string";
         std::cout << str.at("the good") << '\n';
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -35,7 +35,7 @@ int main()
         // try to read from a nonexisting key
         std::cout << object.at("the fast") << '\n';
     }
-    catch (json::out_of_range)
+    catch (const json::out_of_range)
     {
         std::cout << "out of range" << '\n';
     }

--- a/docs/examples/at__size_type.cpp
+++ b/docs/examples/at__size_type.cpp
@@ -25,7 +25,7 @@ int main()
         json str = "I am a string";
         str.at(0) = "Another string";
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -36,7 +36,7 @@ int main()
         // try to write beyond the array limit
         array.at(5) = "sixth";
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/at__size_type_const.cpp
+++ b/docs/examples/at__size_type_const.cpp
@@ -19,7 +19,7 @@ int main()
         const json str = "I am a string";
         std::cout << str.at(0) << '\n';
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -30,7 +30,7 @@ int main()
         // try to read beyond the array limit
         std::cout << array.at(5) << '\n';
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/back.cpp
+++ b/docs/examples/back.cpp
@@ -31,7 +31,7 @@ int main()
         json j_null;
         j_null.back();
     }
-    catch (json::invalid_iterator& e)
+    catch (const json::invalid_iterator& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/basic_json__InputIt_InputIt.cpp
+++ b/docs/examples/basic_json__InputIt_InputIt.cpp
@@ -25,7 +25,7 @@ int main()
     {
         json j_invalid(j_number.begin() + 1, j_number.end());
     }
-    catch (json::invalid_iterator& e)
+    catch (const json::invalid_iterator& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/cbor_tag_handler_t.cpp
+++ b/docs/examples/cbor_tag_handler_t.cpp
@@ -13,7 +13,7 @@ int main()
     {
         auto b_throw_on_tag = json::from_cbor(vec, true, true, json::cbor_tag_handler_t::error);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << std::endl;
     }

--- a/docs/examples/contains__json_pointer.cpp
+++ b/docs/examples/contains__json_pointer.cpp
@@ -26,7 +26,7 @@ int main()
         // try to use an array index with leading '0'
         j.contains("/array/01"_json_pointer);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -36,7 +36,7 @@ int main()
         // try to use an array index that is not a number
         j.contains("/array/one"_json_pointer);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/diagnostics_extended.cpp
+++ b/docs/examples/diagnostics_extended.cpp
@@ -15,7 +15,7 @@ int main()
     {
         int housenumber = j["address"]["housenumber"];
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/diagnostics_standard.cpp
+++ b/docs/examples/diagnostics_standard.cpp
@@ -13,7 +13,7 @@ int main()
     {
         int housenumber = j["address"]["housenumber"];
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/dump.cpp
+++ b/docs/examples/dump.cpp
@@ -35,7 +35,7 @@ int main()
     {
         std::cout << j_invalid.dump() << std::endl;
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << std::endl;
     }

--- a/docs/examples/error_handler_t.cpp
+++ b/docs/examples/error_handler_t.cpp
@@ -11,7 +11,7 @@ int main()
     {
         std::cout << j_invalid.dump() << std::endl;
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << std::endl;
     }

--- a/docs/examples/exception.cpp
+++ b/docs/examples/exception.cpp
@@ -11,7 +11,7 @@ int main()
         json j = {{"foo", "bar"}};
         json k = j.at("non-existing");
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         // output exception information
         std::cout << "message: " << e.what() << '\n'

--- a/docs/examples/get_ref.cpp
+++ b/docs/examples/get_ref.cpp
@@ -20,7 +20,7 @@ int main()
     {
         auto r3 = value.get_ref<json::number_float_t&>();
     }
-    catch (json::type_error& ex)
+    catch (const json::type_error& ex)
     {
         std::cout << ex.what() << '\n';
     }

--- a/docs/examples/invalid_iterator.cpp
+++ b/docs/examples/invalid_iterator.cpp
@@ -12,7 +12,7 @@ int main()
         json::iterator it = j.begin();
         auto k = it.key();
     }
-    catch (json::invalid_iterator& e)
+    catch (const json::invalid_iterator& e)
     {
         // output exception information
         std::cout << "message: " << e.what() << '\n'

--- a/docs/examples/json_pointer.cpp
+++ b/docs/examples/json_pointer.cpp
@@ -20,7 +20,7 @@ int main()
     {
         json::json_pointer p9("foo");
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -30,7 +30,7 @@ int main()
     {
         json::json_pointer p10("/foo/~");
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }
@@ -40,7 +40,7 @@ int main()
     {
         json::json_pointer p11("/foo/~3");
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/nlohmann_define_type_intrusive_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_explicit.cpp
@@ -53,7 +53,7 @@ int main()
     {
         auto p3 = j3.template get<ns::person>();
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         std::cout << "deserialization failed: " << e.what() << std::endl;
     }

--- a/docs/examples/nlohmann_define_type_intrusive_macro.cpp
+++ b/docs/examples/nlohmann_define_type_intrusive_macro.cpp
@@ -41,7 +41,7 @@ int main()
     {
         auto p3 = j3.template get<ns::person>();
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         std::cout << "deserialization failed: " << e.what() << std::endl;
     }

--- a/docs/examples/nlohmann_define_type_non_intrusive_explicit.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_explicit.cpp
@@ -46,7 +46,7 @@ int main()
     {
         auto p3 = j3.template get<ns::person>();
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         std::cout << "deserialization failed: " << e.what() << std::endl;
     }

--- a/docs/examples/nlohmann_define_type_non_intrusive_macro.cpp
+++ b/docs/examples/nlohmann_define_type_non_intrusive_macro.cpp
@@ -34,7 +34,7 @@ int main()
     {
         auto p3 = j3.template get<ns::person>();
     }
-    catch (json::exception& e)
+    catch (const json::exception& e)
     {
         std::cout << "deserialization failed: " << e.what() << std::endl;
     }

--- a/docs/examples/object.cpp
+++ b/docs/examples/object.cpp
@@ -21,7 +21,7 @@ int main()
         // can only create an object from a list of pairs
         json j_invalid_object = json::object({{ "one", 1, 2 }});
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/operator__ValueType.cpp
+++ b/docs/examples/operator__ValueType.cpp
@@ -53,7 +53,7 @@ int main()
     {
         bool v1 = json_types["string"];
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         std::cout << e.what() << '\n';
     }

--- a/docs/examples/other_error.cpp
+++ b/docs/examples/other_error.cpp
@@ -21,7 +21,7 @@ int main()
         }])"_json;
         value.patch(patch);
     }
-    catch (json::other_error& e)
+    catch (const json::other_error& e)
     {
         // output exception information
         std::cout << "message: " << e.what() << '\n'

--- a/docs/examples/out_of_range.cpp
+++ b/docs/examples/out_of_range.cpp
@@ -11,7 +11,7 @@ int main()
         json j = {1, 2, 3, 4};
         j.at(4) = 10;
     }
-    catch (json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         // output exception information
         std::cout << "message: " << e.what() << '\n'

--- a/docs/examples/parse__allow_exceptions.cpp
+++ b/docs/examples/parse__allow_exceptions.cpp
@@ -17,7 +17,7 @@ int main()
     {
         json j = json::parse(text);
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         std::cout << e.what() << std::endl;
     }

--- a/docs/examples/parse_error.cpp
+++ b/docs/examples/parse_error.cpp
@@ -10,7 +10,7 @@ int main()
         // parsing input with a syntax error
         json::parse("[1,2,3,]");
     }
-    catch (json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         // output exception information
         std::cout << "message: " << e.what() << '\n'

--- a/docs/examples/type_error.cpp
+++ b/docs/examples/type_error.cpp
@@ -11,7 +11,7 @@ int main()
         json j = "string";
         j.push_back("another string");
     }
-    catch (json::type_error& e)
+    catch (const json::type_error& e)
     {
         // output exception information
         std::cout << "message: " << e.what() << '\n'


### PR DESCRIPTION
Hi,

The [core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Re-exception-ref) recommend catching by `const&` for all but very small value types. One of my colleagues filed a PR internally with `catch (nlohmann::json::type_error& e)`, instead of `catch (const nlohmann::json::type_error& e)`, with the explanation that it was copied from the documentation. The error here holds a string however, so it is not a simple type that fits in a single register, I think `const &` is appropriate. This PR updates the documentation's exception catching to be all const.

Automated replace performed with the following command:
```
find ./ -type f -name *.cpp -print0 | xargs -0 sed -i -e 's|catch (json|catch (const json|g'
```


* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

