### PR TITLE
Bazel: Improve support for bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 /localhost.pem
 /localhost-key.pem
 /serve_header.yml
+
+# Ignore Bazel generated files
+bazel-* 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "nlohmann_json",
+    version = "3.11.2", # Keep in sync with NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH
+    compatibility_level = 1,
+)


### PR DESCRIPTION
The Bazel build system now supports a new way of handling 3rd party dependencies, such as JSON for Modern C++. For this new way, a `MODULE.bazel` file is needed - in the long term, the `WORKSPACE.bazel` file will not be needed anymore and will be deleted in the future.