### PR TITLE
Conditional Compilation for C++17 Compatibility

### DIFF
--- a/docs/examples/operator_spaceship__const_reference.c++20.cpp
+++ b/docs/examples/operator_spaceship__const_reference.c++20.cpp
@@ -1,3 +1,4 @@
+#if __cplusplus >= 202002L
 #include <compare>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -38,3 +39,4 @@ int main()
     std::cout << string << " <=> " << number << " := " << to_string(string <=> number) << '\n'; // *NOPAD*
     std::cout << string << " <=> " << discarded << " := " << to_string(string <=> discarded) << '\n'; // *NOPAD*
 }
+#endif

--- a/docs/examples/operator_spaceship__scalartype.c++20.cpp
+++ b/docs/examples/operator_spaceship__scalartype.c++20.cpp
@@ -1,3 +1,4 @@
+#if __cplusplus >= 202002L
 #include <compare>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -38,3 +39,4 @@ int main()
     std::cout << number << " <=> " << nan << " := " << to_string(number <=> nan) << '\n'; // *NOPAD*
     std::cout << string << " <=> " << 17 << " := " << to_string(string <=> 17) << '\n'; // *NOPAD*
 }
+#endif


### PR DESCRIPTION
This pull request wraps two specific files in a conditional compilation block to allow builds using the C++17 standard. The goal is to enhance compatibility without affecting existing functionality.

Motivation:
I am utilizing this library in a PlatformIO project that uses C++17 for both native CI/CD and testing purposes. While I understand that the library aims to use the latest C++ standards, there are scenarios where projects may need to use older but still widely-used standards like C++17.

Changes:
Wrapped the offending code in #if __cplusplus >= 202002L ... #endif blocks to allow compilation under C++17.
Benefits:
Increases the library's compatibility with projects that are not yet able to migrate to C++20.
Allows for more diverse usage in larger codebases that may be using multiple C++ standards.
No impact on existing functionality when used in a C++20 environment.
Alternative Considered:
An alternative could be to completely exclude these files during the build process, but conditional compilation offers a less invasive approach.
* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
