### PR TITLE
using allocator for bson

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -62,7 +62,8 @@ static inline bool little_endianness(int num = 1) noexcept
 /*!
 @brief deserialization of CBOR, MessagePack, and UBJSON values
 */
-template<typename BasicJsonType, typename InputAdapterType, typename SAX = json_sax_dom_parser<BasicJsonType>>
+template<typename BasicJsonType, typename InputAdapterType, typename Allocator = std::allocator<  InputAdapterType>
+         , typename SAX = json_sax_dom_parser<BasicJsonType, Allocator>>
 class binary_reader
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
@@ -2694,7 +2695,7 @@ class binary_reader
 
         // parse number string
         using ia_type = decltype(detail::input_adapter(number_vector));
-        auto number_lexer = detail::lexer<BasicJsonType, ia_type>(detail::input_adapter(number_vector), false);
+        auto number_lexer = detail::lexer<BasicJsonType, ia_type, Allocator>(detail::input_adapter(number_vector), false);
         const auto result_number = number_lexer.scan();
         const auto number_string = number_lexer.get_token_string();
         const auto result_remainder = number_lexer.scan();
@@ -2714,7 +2715,7 @@ class binary_reader
             case token_type::value_unsigned:
                 return sax->number_unsigned(number_lexer.get_number_unsigned());
             case token_type::value_float:
-                return sax->number_float(number_lexer.get_number_float(), std::move(number_string));
+                return sax->number_float(number_lexer.get_number_float(), std::move(static_cast<string_t>(number_string)));
             case token_type::uninitialized:
             case token_type::literal_true:
             case token_type::literal_false:
@@ -3001,8 +3002,8 @@ class binary_reader
 };
 
 #ifndef JSON_HAS_CPP_17
-    template<typename BasicJsonType, typename InputAdapterType, typename SAX>
-    constexpr std::size_t binary_reader<BasicJsonType, InputAdapterType, SAX>::npos;
+    template<typename BasicJsonType, typename InputAdapterType, typename Allocator, typename SAX>
+    constexpr std::size_t binary_reader<BasicJsonType, InputAdapterType, Allocator, SAX>::npos;
 #endif
 
 }  // namespace detail

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -62,8 +62,8 @@ static inline bool little_endianness(int num = 1) noexcept
 /*!
 @brief deserialization of CBOR, MessagePack, and UBJSON values
 */
-template<typename BasicJsonType, typename InputAdapterType, typename Allocator = std::allocator<  BasicJsonType*>
-         , typename SAX = json_sax_dom_parser<BasicJsonType, Allocator>>
+template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson = std::allocator<  BasicJsonType*>, typename AllocatorChar = std::allocator< typename InputAdapterType::char_type>
+         , typename SAX = json_sax_dom_parser<BasicJsonType, AllocatorJson>>
 class binary_reader
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
@@ -2695,7 +2695,7 @@ class binary_reader
 
         // parse number string
         using ia_type = decltype(detail::input_adapter(number_vector));
-        auto number_lexer = detail::lexer<BasicJsonType, ia_type, Allocator>(detail::input_adapter(number_vector), false);
+        auto number_lexer = detail::lexer<BasicJsonType, ia_type, AllocatorChar>(detail::input_adapter(number_vector), false);
         const auto result_number = number_lexer.scan();
         const auto number_string = number_lexer.get_token_string();
         const auto result_remainder = number_lexer.scan();
@@ -3002,8 +3002,8 @@ class binary_reader
 };
 
 #ifndef JSON_HAS_CPP_17
-    template<typename BasicJsonType, typename InputAdapterType, typename Allocator, typename SAX>
-    constexpr std::size_t binary_reader<BasicJsonType, InputAdapterType, Allocator, SAX>::npos;
+    template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson, typename  AllocatorChar, typename SAX>
+    constexpr std::size_t binary_reader<BasicJsonType, InputAdapterType, AllocatorJson, AllocatorChar, SAX>::npos;
 #endif
 
 }  // namespace detail

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -62,7 +62,7 @@ static inline bool little_endianness(int num = 1) noexcept
 /*!
 @brief deserialization of CBOR, MessagePack, and UBJSON values
 */
-template<typename BasicJsonType, typename InputAdapterType, typename Allocator = std::allocator<  InputAdapterType>
+template<typename BasicJsonType, typename InputAdapterType, typename Allocator = std::allocator<  BasicJsonType*>
          , typename SAX = json_sax_dom_parser<BasicJsonType, Allocator>>
 class binary_reader
 {

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -20,6 +20,7 @@
 #include <string> // char_traits, string
 #include <utility> // make_pair, move
 #include <vector> // vector
+#include <memory>
 
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/input/input_adapters.hpp>

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -157,7 +157,7 @@ constructor contains the parsed value.
 
 @tparam BasicJsonType  the JSON type
 */
-template<typename BasicJsonType>
+template<typename BasicJsonType, typename Allocator = std::allocator<BasicJsonType*>>
 class json_sax_dom_parser
 {
   public:
@@ -331,7 +331,7 @@ class json_sax_dom_parser
     /// the parsed JSON value
     BasicJsonType& root;
     /// stack to model hierarchy of values
-    std::vector<BasicJsonType*> ref_stack {};
+    std::vector<BasicJsonType*, Allocator> ref_stack {};
     /// helper to hold the reference for the next object element
     BasicJsonType* object_element = nullptr;
     /// whether a syntax error occurred

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -12,6 +12,7 @@
 #include <string> // string
 #include <utility> // move
 #include <vector> // vector
+#include <memory>
 
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -17,6 +17,7 @@
 #include <string> // char_traits, string
 #include <utility> // move
 #include <vector> // vector
+#include <memory>
 
 #include <nlohmann/detail/input/input_adapters.hpp>
 #include <nlohmann/detail/input/position_t.hpp>

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -107,7 +107,7 @@ class lexer_base
 
 This class organizes the lexical analysis during JSON deserialization.
 */
-template<typename BasicJsonType, typename InputAdapterType>
+template<typename BasicJsonType, typename InputAdapterType, class Allocator = std::allocator<typename InputAdapterType::char_type>>
 class lexer : public lexer_base<BasicJsonType>
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
@@ -1611,7 +1611,7 @@ scan_number_done:
     position_t position {};
 
     /// raw input token string (for error messages)
-    std::vector<char_type> token_string {};
+    std::vector<char_type, Allocator> token_string {};
 
     /// buffer for variable-length tokens (numbers, strings)
     string_t token_buffer {};

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -56,14 +56,14 @@ using parser_callback_t =
 
 This class implements a recursive descent parser.
 */
-template<typename BasicJsonType, typename InputAdapterType>
+template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson, typename AllocatorChar >
 class parser
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
     using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
     using number_float_t = typename BasicJsonType::number_float_t;
     using string_t = typename BasicJsonType::string_t;
-    using lexer_t = lexer<BasicJsonType, InputAdapterType>;
+    using lexer_t = lexer<BasicJsonType, InputAdapterType, AllocatorChar>;
     using token_type = typename lexer_t::token_type;
 
   public:
@@ -122,7 +122,7 @@ class parser
         }
         else
         {
-            json_sax_dom_parser<BasicJsonType> sdp(result, allow_exceptions);
+            json_sax_dom_parser<BasicJsonType,  AllocatorJson> sdp(result, allow_exceptions);
             sax_parse_internal(&sdp);
 
             // in strict mode, input must be completely read
@@ -181,7 +181,7 @@ class parser
     {
         // stack to remember the hierarchy of structured values we are parsing
         // true = array; false = object
-        std::vector<bool> states;
+        std::vector<bool, AllocatorChar> states;
         // value to avoid a goto (see comment where set to true)
         bool skip_to_state_evaluation = false;
 

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -56,7 +56,7 @@ using parser_callback_t =
 
 This class implements a recursive descent parser.
 */
-template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson, typename AllocatorChar >
+template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson, typename AllocatorChar, typename  AllocatorBool>
 class parser
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
@@ -181,7 +181,8 @@ class parser
     {
         // stack to remember the hierarchy of structured values we are parsing
         // true = array; false = object
-        std::vector<bool, AllocatorChar> states;
+        std::vector<bool, AllocatorBool> states;
+
         // value to avoid a goto (see comment where set to true)
         bool skip_to_state_evaluation = false;
 

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -1110,7 +1110,7 @@ class binary_writer
 
         const std::size_t embedded_document_size = std::accumulate(std::begin(value), std::end(value), static_cast<std::size_t>(0), [&array_index](std::size_t result, const typename BasicJsonType::array_t::value_type & el)
         {
-            return result + calc_bson_element_size(std::to_string(array_index++), el);
+            return result + calc_bson_element_size(static_cast<string_t>(std::to_string(array_index++)), el);
         });
 
         return sizeof(std::int32_t) + embedded_document_size + 1ul;
@@ -1137,7 +1137,7 @@ class binary_writer
 
         for (const auto& el : value)
         {
-            write_bson_element(std::to_string(array_index++), el);
+            write_bson_element(static_cast<string_t>(std::to_string(array_index++)), el);
         }
 
         oa->write_character(to_char_type(0x00));

--- a/include/nlohmann/detail/output/output_adapters.hpp
+++ b/include/nlohmann/detail/output/output_adapters.hpp
@@ -124,7 +124,10 @@ class output_adapter
   public:
     template<typename AllocatorType = std::allocator<CharType>>
     output_adapter(std::vector<CharType, AllocatorType>& vec)
-        : oa(std::make_shared<output_vector_adapter<CharType, AllocatorType>>(vec)) {}
+    {
+        AllocatorType alloc;
+        oa = std::allocate_shared<output_vector_adapter<CharType, AllocatorType>>(alloc, vec);
+    }
 
 #ifndef JSON_NO_IO
     output_adapter(std::basic_ostream<CharType>& s)

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -4087,7 +4087,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         return format == input_format_t::json
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
-               : detail::binary_reader<basic_json, decltype(ia), allocator_type, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 
     /// @brief generate SAX events
@@ -4102,7 +4102,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         return format == input_format_t::json
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
-               : detail::binary_reader<basic_json, decltype(ia), allocator_type, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 
     /// @brief generate SAX events
@@ -4123,7 +4123,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
-               : detail::binary_reader<basic_json, decltype(ia), allocator_type, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 #ifndef JSON_NO_IO
     /// @brief deserialize from stream

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -105,16 +105,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     // can be restored when json_pointer backwards compatibility is removed
     // friend ::nlohmann::json_pointer<StringType>;
 
-    template<typename BasicJsonType, typename InputType>
+    template<typename BasicJsonType, typename InputType, typename AllocatorJson, typename AllocatorChar>
     friend class ::nlohmann::detail::parser;
     friend ::nlohmann::detail::serializer<basic_json>;
     template<typename BasicJsonType>
     friend class ::nlohmann::detail::iter_impl;
     template<typename BasicJsonType, typename CharType>
     friend class ::nlohmann::detail::binary_writer;
-    template<typename BasicJsonType, typename InputType, typename SAX>
+    template<typename BasicJsonType, typename InputType, typename Allocator, typename SAX>
     friend class ::nlohmann::detail::binary_reader;
-    template<typename BasicJsonType>
+    template<typename BasicJsonType, typename Allocator>
     friend class ::nlohmann::detail::json_sax_dom_parser;
     template<typename BasicJsonType>
     friend class ::nlohmann::detail::json_sax_dom_callback_parser;
@@ -129,14 +129,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType> parser(
-        InputAdapterType adapter,
-        detail::parser_callback_t<basic_json>cb = nullptr,
-        const bool allow_exceptions = true,
-        const bool ignore_comments = false
-    )
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( //alex
+                InputAdapterType adapter,
+                detail::parser_callback_t<basic_json>cb = nullptr,
+                const bool allow_exceptions = true,
+                const bool ignore_comments = false
+            )
     {
-        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
+        return ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);
     }
 
@@ -154,7 +154,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using output_adapter_t = ::nlohmann::detail::output_adapter_t<CharType>;
 
     template<typename InputType>
-    using binary_reader = ::nlohmann::detail::binary_reader<basic_json, InputType>;
+    using binary_reader = ::nlohmann::detail::binary_reader<basic_json, InputType, AllocatorType<basic_json*>>;
     template<typename CharType> using binary_writer = ::nlohmann::detail::binary_writer<basic_json, CharType>;
 
   JSON_PRIVATE_UNLESS_TESTED:
@@ -218,7 +218,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// the allocator type
     using allocator_type = AllocatorType<basic_json>;
-
+    using allocator_type_ptr = AllocatorType<basic_json*>;
     /// the type of an element pointer
     using pointer = typename std::allocator_traits<allocator_type>::pointer;
     /// the type of an element const pointer
@@ -566,7 +566,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             if (t == value_t::array || t == value_t::object)
             {
                 // flatten the current json_value to a heap-allocated stack
-                std::vector<basic_json> stack;
+                std::vector<basic_json, AllocatorType<basic_json>> stack;
 
                 // move the top-level items to stack
                 if (t == value_t::array)
@@ -4087,7 +4087,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         return format == input_format_t::json
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
-               : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 
     /// @brief generate SAX events
@@ -4102,7 +4102,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         return format == input_format_t::json
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
-               : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 
     /// @brief generate SAX events
@@ -4123,7 +4123,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
-               : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 #ifndef JSON_NO_IO
     /// @brief deserialize from stream
@@ -4365,7 +4365,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                 const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::cbor).sax_parse(input_format_t::cbor, &sdp, strict, tag_handler);
         return res ? result : basic_json(value_t::discarded);
@@ -4381,7 +4381,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                 const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::cbor).sax_parse(input_format_t::cbor, &sdp, strict, tag_handler);
         return res ? result : basic_json(value_t::discarded);
@@ -4406,7 +4406,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                 const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = i.get();
         // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::cbor).sax_parse(input_format_t::cbor, &sdp, strict, tag_handler);
@@ -4422,7 +4422,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                    const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::msgpack).sax_parse(input_format_t::msgpack, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4437,7 +4437,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                    const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::msgpack).sax_parse(input_format_t::msgpack, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4460,7 +4460,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                    const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = i.get();
         // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::msgpack).sax_parse(input_format_t::msgpack, &sdp, strict);
@@ -4476,7 +4476,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                   const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4491,7 +4491,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                   const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4514,7 +4514,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                   const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = i.get();
         // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
@@ -4530,7 +4530,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                   const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bjdata).sax_parse(input_format_t::bjdata, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4545,7 +4545,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                   const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bjdata).sax_parse(input_format_t::bjdata, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4560,7 +4560,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                 const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bson).sax_parse(input_format_t::bson, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4575,7 +4575,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                 const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bson).sax_parse(input_format_t::bson, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
@@ -4598,7 +4598,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                 const bool allow_exceptions = true)
     {
         basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        detail::json_sax_dom_parser<basic_json, allocator_type_ptr> sdp(result, allow_exceptions);
         auto ia = i.get();
         // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bson).sax_parse(input_format_t::bson, &sdp, strict);

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -105,7 +105,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     // can be restored when json_pointer backwards compatibility is removed
     // friend ::nlohmann::json_pointer<StringType>;
 
-    template<typename BasicJsonType, typename InputType, typename AllocatorJson, typename AllocatorChar>
+    template<typename BasicJsonType, typename InputType, typename AllocatorJson, typename AllocatorChar, typename AllocatorBool>
     friend class ::nlohmann::detail::parser;
     friend ::nlohmann::detail::serializer<basic_json>;
     template<typename BasicJsonType>
@@ -129,14 +129,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser(
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>, AllocatorType<bool>> parser(
                 InputAdapterType adapter,
                 detail::parser_callback_t<basic_json>cb = nullptr,
                 const bool allow_exceptions = true,
                 const bool ignore_comments = false
             )
     {
-        return ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>>(std::move(adapter),
+        return ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>, AllocatorType<bool>>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);
     }
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -129,7 +129,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( //alex
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( 
                 InputAdapterType adapter,
                 detail::parser_callback_t<basic_json>cb = nullptr,
                 const bool allow_exceptions = true,

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -112,7 +112,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     friend class ::nlohmann::detail::iter_impl;
     template<typename BasicJsonType, typename CharType>
     friend class ::nlohmann::detail::binary_writer;
-    template<typename BasicJsonType, typename InputType, typename Allocator, typename SAX>
+    template<typename BasicJsonType, typename InputType, typename AllocatorJson, typename AllocatorChar, typename SAX>
     friend class ::nlohmann::detail::binary_reader;
     template<typename BasicJsonType, typename Allocator>
     friend class ::nlohmann::detail::json_sax_dom_parser;
@@ -153,8 +153,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     template<typename CharType>
     using output_adapter_t = ::nlohmann::detail::output_adapter_t<CharType>;
 
-    template<typename InputType>
-    using binary_reader = ::nlohmann::detail::binary_reader<basic_json, InputType, AllocatorType<basic_json*>>;
+    template<typename InputType, typename CharType = char>
+    using binary_reader = ::nlohmann::detail::binary_reader<basic_json, InputType, AllocatorType<basic_json*>, AllocatorType<CharType>>;
     template<typename CharType> using binary_writer = ::nlohmann::detail::binary_writer<basic_json, CharType>;
 
   JSON_PRIVATE_UNLESS_TESTED:
@@ -219,6 +219,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// the allocator type
     using allocator_type = AllocatorType<basic_json>;
     using allocator_type_ptr = AllocatorType<basic_json*>;
+    using allocator_type_char = AllocatorType<char>;
     /// the type of an element pointer
     using pointer = typename std::allocator_traits<allocator_type>::pointer;
     /// the type of an element const pointer
@@ -4087,7 +4088,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         auto ia = detail::input_adapter(std::forward<InputType>(i));
         return format == input_format_t::json
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
-               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, allocator_type_char, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 
     /// @brief generate SAX events
@@ -4102,7 +4103,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         auto ia = detail::input_adapter(std::move(first), std::move(last));
         return format == input_format_t::json
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
-               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, allocator_type_char, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 
     /// @brief generate SAX events
@@ -4123,7 +4124,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
                ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
                // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
-               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+               : detail::binary_reader<basic_json, decltype(ia), allocator_type_ptr, allocator_type_char, SAX>(std::move(ia), format).sax_parse(format, sax, strict);
     }
 #ifndef JSON_NO_IO
     /// @brief deserialize from stream

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -129,7 +129,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( 
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser(
                 InputAdapterType adapter,
                 detail::parser_callback_t<basic_json>cb = nullptr,
                 const bool allow_exceptions = true,

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12160,7 +12160,7 @@ using parser_callback_t =
 
 This class implements a recursive descent parser.
 */
-template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson, typename AllocatorChar >
+template<typename BasicJsonType, typename InputAdapterType, typename AllocatorJson, typename AllocatorChar, typename  AllocatorBool>
 class parser
 {
     using number_integer_t = typename BasicJsonType::number_integer_t;
@@ -12285,7 +12285,8 @@ class parser
     {
         // stack to remember the hierarchy of structured values we are parsing
         // true = array; false = object
-        std::vector<bool, AllocatorChar> states;
+        std::vector<bool, AllocatorBool> states;
+
         // value to avoid a goto (see comment where set to true)
         bool skip_to_state_evaluation = false;
 
@@ -19326,7 +19327,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     // can be restored when json_pointer backwards compatibility is removed
     // friend ::nlohmann::json_pointer<StringType>;
 
-    template<typename BasicJsonType, typename InputType, typename AllocatorJson, typename AllocatorChar>
+    template<typename BasicJsonType, typename InputType, typename AllocatorJson, typename AllocatorChar, typename AllocatorBool>
     friend class ::nlohmann::detail::parser;
     friend ::nlohmann::detail::serializer<basic_json>;
     template<typename BasicJsonType>
@@ -19350,14 +19351,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser(
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>, AllocatorType<bool>> parser(
         InputAdapterType adapter,
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
                                  )
     {
-        return ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>>(std::move(adapter),
+        return ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>, AllocatorType<bool>>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6068,6 +6068,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <string> // char_traits, string
 #include <utility> // make_pair, move
 #include <vector> // vector
+#include <memory>
 
 // #include <nlohmann/detail/exceptions.hpp>
 
@@ -6581,6 +6582,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <string> // string
 #include <utility> // move
 #include <vector> // vector
+#include <memory>
 
 // #include <nlohmann/detail/exceptions.hpp>
 
@@ -7318,6 +7320,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <string> // char_traits, string
 #include <utility> // move
 #include <vector> // vector
+#include <memory>
 
 // #include <nlohmann/detail/input/input_adapters.hpp>
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19347,7 +19347,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( 
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser(
         InputAdapterType adapter,
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19347,7 +19347,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     using lexer = ::nlohmann::detail::lexer_base<basic_json>;
 
     template<typename InputAdapterType>
-    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( //alex
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType, AllocatorType<basic_json*>, AllocatorType<typename InputAdapterType::char_type>> parser( 
         InputAdapterType adapter,
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -262,60 +262,64 @@ TEST_CASE("bad my_allocator::construct")
     }
 }
 
-namespace{
-  template <class T>
-    struct NAlloc {
-        // Aliases and inner types
-        using value_type = T;
-        using size_type = std::size_t;
-        using difference_type = ptrdiff_t;
-        using reference = value_type&;
-        using const_reference = const value_type&;
-        using pointer = value_type*;
-        using const_pointer = const value_type*;
+namespace
+{
+template <class T>
+struct NAlloc
+{
+    // Aliases and inner types
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = ptrdiff_t;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
 
-        template <typename U>
-        struct rebind {
-            using other = NAlloc<U>;
-        };
-
-        NAlloc() :
-            alloc() {
-
-            };
-
-        virtual ~NAlloc() { }
-
-        pointer allocate(std::size_t n) {
-    #ifdef _DEBUG
-            std::cout << "NAlloc allocating " << n << " bytes\n";
-    #endif
-
-            return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
-        }
-        void deallocate(pointer p, [[maybe_unused]] std::size_t n) {
-    #ifdef _DEBUG
-            std::cout << "NAlloc deallocating " << n * sizeof *p << " bytes\n";
-    #endif
-
-            alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
-        }
-
-
-        bool operator!=(const NAlloc<T>& other) const {
-            return !(*this == other);
-        }
-        bool operator==(const NAlloc<T>& other) const {
-            return alloc == other.alloc;
-        }
-
-        my_allocator<char> alloc;
+    template <typename U>
+    struct rebind
+    {
+        using other = NAlloc<U>;
     };
 
+    NAlloc() :
+        alloc()
+    {
 
-    using OstringStream = std::basic_ostringstream<char, std::char_traits<char>, NAlloc<char>>;
-    using IstringStream = std::basic_istringstream<char, std::char_traits<char>, NAlloc<char>>;
-    typedef std::basic_string<char, std::char_traits<char>, NAlloc<char>> RtString;
+    };
+
+    virtual ~NAlloc() { }
+
+    pointer allocate(std::size_t n)
+    {
+
+
+        return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
+    }
+    void deallocate(pointer p, [[maybe_unused]] std::size_t n)
+    {
+
+
+        alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
+    }
+
+
+    bool operator!=(const NAlloc<T>& other) const
+    {
+        return !(*this == other);
+    }
+    bool operator==(const NAlloc<T>& other) const
+    {
+        return alloc == other.alloc;
+    }
+
+    my_allocator<char> alloc;
+};
+
+
+using OstringStream = std::basic_ostringstream<char, std::char_traits<char>, NAlloc<char>>;
+using IstringStream = std::basic_istringstream<char, std::char_traits<char>, NAlloc<char>>;
+typedef std::basic_string<char, std::char_traits<char>, NAlloc<char>> RtString;
 
 
 }
@@ -332,11 +336,11 @@ TEST_CASE("controlled bad_alloc_rt_string")
           double,
           my_allocator>;
 
-         
+
 
     SECTION("class json_value")
     {
-        
+
         SECTION("json_value(value_t)")
         {
             SECTION("object")

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -292,14 +292,12 @@ struct NAlloc
 
     pointer allocate(std::size_t n)
     {
-
-        m_alloc_size = n;
+     
         return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
     }
     void deallocate(pointer p, [[maybe_unused]] std::size_t n)
     {
-
-
+        m_alloc_size = n;
         alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
     }
 
@@ -344,15 +342,7 @@ TEST_CASE("controlled bad_alloc_rt_string")
 
         SECTION("json_value(value_t)")
         {
-            SECTION("object")
-            {
-                next_construct_fails = false;
-                auto t = my_json::value_t::object;
-                CHECK_NOTHROW(my_allocator_clean_up(my_json::json_value(t).object));
-                next_construct_fails = true;
-                CHECK_THROWS_AS(my_json::json_value(t), std::bad_alloc&);
-                next_construct_fails = false;
-            }
+            
             SECTION("array")
             {
                 next_construct_fails = false;

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -295,7 +295,7 @@ struct NAlloc
      
         return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
     }
-    void deallocate(pointer p, [[maybe_unused]] std::size_t n)
+    void deallocate(pointer p, std::size_t n)
     {
         m_alloc_size = n;
         alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
@@ -342,16 +342,7 @@ TEST_CASE("controlled bad_alloc_rt_string")
 
         SECTION("json_value(value_t)")
         {
-            
-            SECTION("array")
-            {
-                next_construct_fails = false;
-                auto t = my_json::value_t::array;
-                CHECK_NOTHROW(my_allocator_clean_up(my_json::json_value(t).array));
-                next_construct_fails = true;
-                CHECK_THROWS_AS(my_json::json_value(t), std::bad_alloc&);
-                next_construct_fails = false;
-            }
+                        
             SECTION("string")
             {
                 next_construct_fails = false;

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -283,7 +283,7 @@ struct NAlloc
     };
 
     NAlloc() :
-        alloc(),m_alloc_size(0)
+        alloc(), m_alloc_size(0)
     {
 
     }
@@ -292,7 +292,7 @@ struct NAlloc
 
     pointer allocate(std::size_t n)
     {
-     
+
         return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
     }
     void deallocate(pointer p, std::size_t n)
@@ -342,7 +342,7 @@ TEST_CASE("controlled bad_alloc_rt_string")
 
         SECTION("json_value(value_t)")
         {
-                        
+
             SECTION("string")
             {
                 next_construct_fails = false;

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -283,7 +283,7 @@ struct NAlloc
     };
 
     NAlloc() :
-        alloc()
+        alloc(),m_alloc_size(0)
     {
 
     }
@@ -293,7 +293,7 @@ struct NAlloc
     pointer allocate(std::size_t n)
     {
 
-
+        m_alloc_size = n;
         return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
     }
     void deallocate(pointer p, [[maybe_unused]] std::size_t n)
@@ -314,6 +314,7 @@ struct NAlloc
     }
 
     my_allocator<char> alloc;
+    std::size_t m_alloc_size;
 };
 
 

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -263,7 +263,6 @@ TEST_CASE("bad my_allocator::construct")
 }
 
 
-
 TEST_CASE("controlled bad_alloc_rt_string")
 {
     using RtString = std::basic_string<char, std::char_traits<char>, my_allocator<char>>;

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -262,71 +262,7 @@ TEST_CASE("bad my_allocator::construct")
     }
 }
 
-// namespace
-// {
-// template <class T>
-// struct NAlloc
-// {
-//     // Aliases and inner types
-//     using value_type = T;
-//     using size_type = std::size_t;
-//     using difference_type = ptrdiff_t;
-//     using reference = value_type&;
-//     using const_reference = const value_type&;
-//     using pointer = value_type*;
-//     using const_pointer = const value_type*;
 
-//     template <typename U>
-//     struct rebind
-//     {
-//         using other = NAlloc<U>;
-//     };
-
-//     NAlloc() :
-//         alloc()
-//     {
-
-//     }
-
-//     NAlloc(const NAlloc&) = default;                   // Copy constructor
-//     NAlloc(NAlloc&&) = default;                       // Move constructor
-//     NAlloc& operator=(const NAlloc& other) = default;  // Copy assignment operator
-//     NAlloc& operator=(NAlloc&&) = default;            // Move assignment operator
-
-//     virtual ~NAlloc() = default;
-
-//     pointer allocate(std::size_t n)
-//     {
-
-//         return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
-//     }
-//     void deallocate(pointer p, std::size_t n)
-//     {
-//         m_alloc_size = n;
-//         alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
-//     }
-
-
-//     bool operator!=(const NAlloc<T>& other) const
-//     {
-//         return !(*this == other);
-//     }
-//     bool operator==(const NAlloc<T>& other) const
-//     {
-//         return alloc == other.alloc;
-//     }
-
-//     my_allocator<char> alloc;
-//     std::size_t m_alloc_size {};
-// };
-
-
-// using OstringStream = std::basic_ostringstream<char, std::char_traits<char>, NAlloc<char>>;
-// using IstringStream = std::basic_istringstream<char, std::char_traits<char>, NAlloc<char>>;
-// using RtString = std::basic_string<char, std::char_traits<char>, NAlloc<char>>;
-
-
-// } //namespace
 
 TEST_CASE("controlled bad_alloc_rt_string")
 {

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -283,10 +283,15 @@ struct NAlloc
     };
 
     NAlloc() :
-        alloc(), m_alloc_size(0)
+        alloc()
     {
 
     }
+
+    NAlloc(const NAlloc&) = default;                   // Copy constructor
+    NAlloc(NAlloc&&) = default;                       // Move constructor
+    NAlloc& operator=(const NAlloc& other) = default;  // Copy assignment operator
+    NAlloc& operator=(NAlloc&&) = default;            // Move assignment operator
 
     virtual ~NAlloc() = default;
 

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -262,74 +262,75 @@ TEST_CASE("bad my_allocator::construct")
     }
 }
 
-namespace
-{
-template <class T>
-struct NAlloc
-{
-    // Aliases and inner types
-    using value_type = T;
-    using size_type = std::size_t;
-    using difference_type = ptrdiff_t;
-    using reference = value_type&;
-    using const_reference = const value_type&;
-    using pointer = value_type*;
-    using const_pointer = const value_type*;
+// namespace
+// {
+// template <class T>
+// struct NAlloc
+// {
+//     // Aliases and inner types
+//     using value_type = T;
+//     using size_type = std::size_t;
+//     using difference_type = ptrdiff_t;
+//     using reference = value_type&;
+//     using const_reference = const value_type&;
+//     using pointer = value_type*;
+//     using const_pointer = const value_type*;
 
-    template <typename U>
-    struct rebind
-    {
-        using other = NAlloc<U>;
-    };
+//     template <typename U>
+//     struct rebind
+//     {
+//         using other = NAlloc<U>;
+//     };
 
-    NAlloc() :
-        alloc()
-    {
+//     NAlloc() :
+//         alloc()
+//     {
 
-    }
+//     }
 
-    NAlloc(const NAlloc&) = default;                   // Copy constructor
-    NAlloc(NAlloc&&) = default;                       // Move constructor
-    NAlloc& operator=(const NAlloc& other) = default;  // Copy assignment operator
-    NAlloc& operator=(NAlloc&&) = default;            // Move assignment operator
+//     NAlloc(const NAlloc&) = default;                   // Copy constructor
+//     NAlloc(NAlloc&&) = default;                       // Move constructor
+//     NAlloc& operator=(const NAlloc& other) = default;  // Copy assignment operator
+//     NAlloc& operator=(NAlloc&&) = default;            // Move assignment operator
 
-    virtual ~NAlloc() = default;
+//     virtual ~NAlloc() = default;
 
-    pointer allocate(std::size_t n)
-    {
+//     pointer allocate(std::size_t n)
+//     {
 
-        return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
-    }
-    void deallocate(pointer p, std::size_t n)
-    {
-        m_alloc_size = n;
-        alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
-    }
-
-
-    bool operator!=(const NAlloc<T>& other) const
-    {
-        return !(*this == other);
-    }
-    bool operator==(const NAlloc<T>& other) const
-    {
-        return alloc == other.alloc;
-    }
-
-    my_allocator<char> alloc;
-    std::size_t m_alloc_size {};
-};
+//         return static_cast<pointer>(alloc.allocate(n));  // get memory from pool
+//     }
+//     void deallocate(pointer p, std::size_t n)
+//     {
+//         m_alloc_size = n;
+//         alloc.deallocate(static_cast<pointer>(p), 1);  // return memory to pool
+//     }
 
 
-using OstringStream = std::basic_ostringstream<char, std::char_traits<char>, NAlloc<char>>;
-using IstringStream = std::basic_istringstream<char, std::char_traits<char>, NAlloc<char>>;
-using RtString = std::basic_string<char, std::char_traits<char>, NAlloc<char>>;
+//     bool operator!=(const NAlloc<T>& other) const
+//     {
+//         return !(*this == other);
+//     }
+//     bool operator==(const NAlloc<T>& other) const
+//     {
+//         return alloc == other.alloc;
+//     }
+
+//     my_allocator<char> alloc;
+//     std::size_t m_alloc_size {};
+// };
 
 
-} //namespace
+// using OstringStream = std::basic_ostringstream<char, std::char_traits<char>, NAlloc<char>>;
+// using IstringStream = std::basic_istringstream<char, std::char_traits<char>, NAlloc<char>>;
+// using RtString = std::basic_string<char, std::char_traits<char>, NAlloc<char>>;
+
+
+// } //namespace
 
 TEST_CASE("controlled bad_alloc_rt_string")
 {
+    using RtString = std::basic_string<char, std::char_traits<char>, my_allocator<char>>;
     // create JSON type using the throwing allocator
     using my_json = nlohmann::basic_json<std::map,
           std::vector,

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -288,7 +288,7 @@ struct NAlloc
 
     }
 
-    virtual ~NAlloc() { }
+    virtual ~NAlloc() = default;
 
     pointer allocate(std::size_t n)
     {
@@ -312,16 +312,16 @@ struct NAlloc
     }
 
     my_allocator<char> alloc;
-    std::size_t m_alloc_size;
+    std::size_t m_alloc_size {};
 };
 
 
 using OstringStream = std::basic_ostringstream<char, std::char_traits<char>, NAlloc<char>>;
 using IstringStream = std::basic_istringstream<char, std::char_traits<char>, NAlloc<char>>;
-typedef std::basic_string<char, std::char_traits<char>, NAlloc<char>> RtString;
+using RtString = std::basic_string<char, std::char_traits<char>, NAlloc<char>>;
 
 
-}
+} //namespace
 
 TEST_CASE("controlled bad_alloc_rt_string")
 {

--- a/tests/src/unit-allocator.cpp
+++ b/tests/src/unit-allocator.cpp
@@ -286,7 +286,7 @@ struct NAlloc
         alloc()
     {
 
-    };
+    }
 
     virtual ~NAlloc() { }
 


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

we need some json functionality completely  without any memory allocations. That means passing allocators als template parameter to different classes: parser,binary_reader,inputadapter,sax_dom_parser,lexer.
json functions that need to use custom memory allocator: to_bson;from_bson;parse.
Some std containers in lib are not allocator aware:
-std::vector<char_type> token_string - lexer
-std::vector<BasicJsonType*> ref_stack - json_sax.hpp
we need 2 types of allocator as template parameter : basic_json* and char_type(char)
there are also  make_shared ptr in output adapter which should be replaced with allocate_shared.
some other minor conversions functions which allocate.

usage from our client code will be as follows:
namespace rtjson {
using json = nlohmann::basic_json<std::map,
                                  std::vector,
                                  sqp::core::rtutils::RtString,       //use rtstring
                                  bool,
                                  long long,
                                  unsigned long long,
                                  double,
                                  sqp::core::memory::PolymorphicAllocator,  //use polymorpic allocator

                                  nlohmann::adl_serializer>;


}  // namespace ext

using json = rtjson::json;

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
