### PR TITLE
fixing the compilation issue with use of overloaded operator '<=>' is ambiguous #4197 and 3 test suites.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,8 +15,11 @@ cxx_standard = $(lastword c++11 $(filter c++%, $(subst ., ,$1)))
 %.output: %.cpp
 	@echo "standard $(call cxx_standard $(<:.cpp=))"
 	$(MAKE) $(<:.cpp=) \
-		CPPFLAGS="-I $(SRCDIR) -DJSON_USE_GLOBAL_UDLS=0" \
-		CXXFLAGS="-std=$(call cxx_standard,$(<:.cpp=)) -Wno-deprecated-declarations"
+		
+		CPPFLAGS="-I ../single_include -DJSON_USE_GLOBAL_UDLS=0" \
+		CXXFLAGS="-std=c++2a -Wno-deprecated-declarations"
+		CPPFLAGS += -include <compare>
+		examples/operator_spaceship__const_reference.c++20: examples/operator_spaceship__const_reference.c++20.cpp $(CXX) $(CXXFLAGS) $(CPPFLAGS) $< -o $@
 	./$(<:.cpp=) > $@
 	rm $(<:.cpp=)
 
@@ -41,5 +44,6 @@ check_output_portable: $(filter-out examples/meta.test examples/max_size.test ex
 
 clean:
 	rm -fr $(EXAMPLES:.cpp=)
+	rm -f examples/operator_spaceship__const_reference.c++20
 	$(MAKE) clean -C docset
 	$(MAKE) clean -C mkdocs

--- a/tests/src/unit-make1.cpp
+++ b/tests/src/unit-make1.cpp
@@ -1,0 +1,83 @@
+// test_json_suite_extended.cpp
+#include "doctest_compatibility.h"
+#include <nlohmann/json.hpp>
+using nlohmann::json;
+
+TEST_SUITE("nlohmann/json test suite - Extended")
+{
+    TEST_CASE("Nested Structures")
+    {
+        SECTION("Nested Objects")
+        {
+            json nested_object = {
+                {"person", {
+                    {"name", "Bob"},
+                    {"age", 40},
+                    {"address", {
+                        {"city", "Example City"},
+                        {"zip", "12345"}
+                    }}
+                }}
+            };
+
+            CHECK(nested_object["person"]["name"] == "Bob");
+            CHECK(nested_object["person"]["address"]["city"] == "Example City");
+        }
+
+        SECTION("Nested Arrays")
+        {
+            json nested_array = {
+                {"numbers", {1, 2, {3, 4}, 5}}
+            };
+
+            CHECK(nested_array["numbers"][2][1] == 4);
+        }
+    }
+
+    TEST_CASE("Exception Handling")
+    {
+        SECTION("Parsing Invalid JSON")
+        {
+            // Expecting a parse error for invalid JSON
+            CHECK_THROWS_AS(json::parse("invalid_json_string"), json::parse_error);
+        }
+
+        SECTION("Accessing Nonexistent Key")
+        {
+            json object = {{"name", "Alice"}, {"age", 25}};
+
+            // Expecting an exception when accessing a nonexistent key
+            CHECK_THROWS_AS(object.at("nonexistent_key"), json::out_of_range);
+        }
+    }
+
+    TEST_CASE("Additional Serialization and Deserialization")
+    {
+        SECTION("Serialize and Deserialize with Custom Format")
+        {
+            json data = {{"key1", 42}, {"key2", "value"}};
+
+            // Serialize with indentation for human-readable format
+            std::string serialized = data.dump(2);
+
+            // Deserialize the serialized string
+            json parsed = json::parse(serialized);
+
+            CHECK(parsed == data);
+        }
+
+        SECTION("Deserialize from Stream")
+        {
+            std::istringstream stream(R"({"name": "Charlie", "age": 35})");
+
+            // Deserialize from the input stream
+            json parsed;
+            stream >> parsed;
+
+            CHECK(parsed["name"] == "Charlie");
+            CHECK(parsed["age"] == 35);
+        }
+    }
+
+    // Add more test cases and sections as needed to cover other functionalities.
+}

--- a/tests/src/unit-make2.cpp
+++ b/tests/src/unit-make2.cpp
@@ -1,0 +1,49 @@
+// test_json_suite.cpp
+#include "doctest_compatibility.h"
+#include <nlohmann/json.hpp>
+using nlohmann::json;
+
+TEST_SUITE("nlohmann/json test suite")
+{
+    TEST_CASE("Basic JSON Operations")
+    {
+        SECTION("Construction and Type Checks")
+        {
+            json number = 42;
+            json text = "Hello, JSON!";
+            json array = {1, 2, 3};
+            json object = {{"key", "value"}};
+
+            CHECK(number.is_number());
+            CHECK(text.is_string());
+            CHECK(array.is_array());
+            CHECK(object.is_object());
+        }
+
+        SECTION("Serialization and Deserialization")
+        {
+            json original = {{"name", "John"}, {"age", 30}};
+            std::string serialized = original.dump();
+            json parsed = json::parse(serialized);
+
+            CHECK(parsed == original);
+        }
+
+        SECTION("Array and Object Operations")
+        {
+            json array = {1, 2, 3};
+            array.push_back(4);
+            array.insert(array.begin() + 1, 10);
+
+            CHECK(array.size() == 5);
+            CHECK(array[1] == 10);
+
+            json object = {{"name", "Alice"}, {"age", 25}};
+            object["city"] = "Wonderland";
+
+            CHECK(object["city"] == "Wonderland");
+        }
+    }
+
+    // Add more test cases and sections as needed to cover other functionalities.
+}

--- a/tests/src/unit-make3.cpp
+++ b/tests/src/unit-make3.cpp
@@ -1,0 +1,48 @@
+// test_json_suite_more.cpp
+#include "doctest_compatibility.h"
+#include <nlohmann/json.hpp>
+using nlohmann::json;
+
+TEST_SUITE("nlohmann/json test suite - More")
+{
+    TEST_CASE("Comparing JSON Objects")
+    {
+        SECTION("Ordering of Object Keys Matters")
+        {
+            json object1 = {
+                {"name", "Alice"},
+                {"age", 25},
+                {"city", "Wonderland"}
+            };
+
+            json object2 = {
+                {"name", "Alice"},
+                {"city", "Wonderland"},
+                {"age", 25}
+            };
+
+            // Expecting the objects to be different due to key order
+            CHECK(object1 != object2);
+        }
+
+        SECTION("Ordering of Object Keys Doesn't Matter")
+        {
+            json object1 = {
+                {"name", "Bob"},
+                {"age", 30},
+                {"city", "Example City"}
+            };
+
+            json object2 = {
+                {"age", 30},
+                {"name", "Bob"},
+                {"city", "Example City"}
+            };
+
+            // Expecting the objects to be considered equal
+            CHECK(object1 == object2);
+        }
+    }
+
+    // Add more test cases and sections as needed to cover other functionalities.
+}


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
