### PR TITLE
Docs: Fix wrong code usage in the Value access section of `json_pointer.md`

### DIFF
--- a/docs/mkdocs/docs/features/json_pointer.md
+++ b/docs/mkdocs/docs/features/json_pointer.md
@@ -71,10 +71,10 @@ auto j = json::parse(R"({
 })");
 
 // access values
-auto val = j["/"_json_pointer];                             // {"array":["A","B","C"],...}
+auto val = j[""_json_pointer];                              // {"array":["A","B","C"],...}
 auto val1 = j["/nested/one"_json_pointer];                  // 1
-auto val2 = j.at[json::json_pointer("/nested/three/1")];    // false
-auto val3 = j.value[json::json_pointer("/nested/four", 0)]; // 0
+auto val2 = j.at(json::json_pointer("/nested/three/1"));    // false
+auto val3 = j.value(json::json_pointer("/nested/four"), 0); // 0
 ```
 
 ## Flatten / unflatten


### PR DESCRIPTION
The code usage demo in the Value access section of the JSON Pointer document does not work correctly

https://json.nlohmann.me/features/json_pointer/#value-access

https://github.com/nlohmann/json/blob/a259ecc51e1951e12f757ce17db958e9881e9c6c/docs/mkdocs/docs/features/json_pointer.md?plain=1#L62-L78

There are 3 mistakes in the code above:

1. (line 74) The json pointer `"/"` does not point to the root object. Instead, it points to the value with an empty string as the key at the root object. It should be replaced with json pointer `""`

    https://github.com/nlohmann/json/blob/a259ecc51e1951e12f757ce17db958e9881e9c6c/tests/src/unit-json_pointer.cpp#L91-L92

    https://github.com/nlohmann/json/blob/a259ecc51e1951e12f757ce17db958e9881e9c6c/tests/src/unit-json_pointer.cpp#L68-L70

2. (line 76) Incorrect usage of `nlohmann::basic_json::at`. It's a function and does not support the `[]` operator
3. (line 77) Incorrect usage of `nlohmann::basic_json::value`. It's a function and does not support the `[]` operator. Additionally, the argument `0` as the default value for the `value` function is incorrectly placed

This PR resolves these 3 mistakes and makes the demo code work correctly

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
