### PR TITLE
Fix the -fstack-protector warning

### DIFF
--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1550,17 +1550,17 @@ scan_number_done:
             // literals
             case 't':
             {
-                std::array<char_type, 8> true_literal = {{static_cast<char_type>('t'), static_cast<char_type>('r'), static_cast<char_type>('u'), static_cast<char_type>('e'), 0, 0, 0, 0}};
+                std::array<char_type, 8> true_literal = {{static_cast<char_type>('t'), static_cast<char_type>('r'), static_cast<char_type>('u'), static_cast<char_type>('e')}};
                 return scan_literal(true_literal.data(), 4, token_type::literal_true);
             }
             case 'f':
             {
-                std::array<char_type, 8> false_literal = {{static_cast<char_type>('f'), static_cast<char_type>('a'), static_cast<char_type>('l'), static_cast<char_type>('s'), static_cast<char_type>('e'), 0, 0, 0}};
+                std::array<char_type, 8> false_literal = {{static_cast<char_type>('f'), static_cast<char_type>('a'), static_cast<char_type>('l'), static_cast<char_type>('s'), static_cast<char_type>('e')}};
                 return scan_literal(false_literal.data(), 5, token_type::literal_false);
             }
             case 'n':
             {
-                std::array<char_type, 8> null_literal = {{static_cast<char_type>('n'), static_cast<char_type>('u'), static_cast<char_type>('l'), static_cast<char_type>('l'), 0, 0, 0, 0}};
+                std::array<char_type, 8> null_literal = {{static_cast<char_type>('n'), static_cast<char_type>('u'), static_cast<char_type>('l'), static_cast<char_type>('l')}};
                 return scan_literal(null_literal.data(), 4, token_type::literal_null);
             }
 

--- a/include/nlohmann/detail/input/lexer.hpp
+++ b/include/nlohmann/detail/input/lexer.hpp
@@ -1550,18 +1550,18 @@ scan_number_done:
             // literals
             case 't':
             {
-                std::array<char_type, 4> true_literal = {{static_cast<char_type>('t'), static_cast<char_type>('r'), static_cast<char_type>('u'), static_cast<char_type>('e')}};
-                return scan_literal(true_literal.data(), true_literal.size(), token_type::literal_true);
+                std::array<char_type, 8> true_literal = {{static_cast<char_type>('t'), static_cast<char_type>('r'), static_cast<char_type>('u'), static_cast<char_type>('e'), 0, 0, 0, 0}};
+                return scan_literal(true_literal.data(), 4, token_type::literal_true);
             }
             case 'f':
             {
-                std::array<char_type, 5> false_literal = {{static_cast<char_type>('f'), static_cast<char_type>('a'), static_cast<char_type>('l'), static_cast<char_type>('s'), static_cast<char_type>('e')}};
-                return scan_literal(false_literal.data(), false_literal.size(), token_type::literal_false);
+                std::array<char_type, 8> false_literal = {{static_cast<char_type>('f'), static_cast<char_type>('a'), static_cast<char_type>('l'), static_cast<char_type>('s'), static_cast<char_type>('e'), 0, 0, 0}};
+                return scan_literal(false_literal.data(), 5, token_type::literal_false);
             }
             case 'n':
             {
-                std::array<char_type, 4> null_literal = {{static_cast<char_type>('n'), static_cast<char_type>('u'), static_cast<char_type>('l'), static_cast<char_type>('l')}};
-                return scan_literal(null_literal.data(), null_literal.size(), token_type::literal_null);
+                std::array<char_type, 8> null_literal = {{static_cast<char_type>('n'), static_cast<char_type>('u'), static_cast<char_type>('l'), static_cast<char_type>('l'), 0, 0, 0, 0}};
+                return scan_literal(null_literal.data(), 4, token_type::literal_null);
             }
 
             // string


### PR DESCRIPTION
There is a warning appeared when the json library is compiled with -fstack-protector flag using g++ 11th version in Linux Fedora 37.
In our case it turns into error since we use -Werror flag.
The commit aims to fix the issue by adjusting the array size to 8 bytes in `lexer.hpp` in lines `1553`, `1558` and `1563`.

Example:
main.cpp
```
#include <nlohmann/json.hpp>
using json = nlohmann::json;

int main()
{
    json ex1 = json::parse(R"(
    {
        "pi": 3.141,
        "happy": true
    })");
   return 0;
}
```
Build:
`g++ main.cpp -o out -fstack-protector -Wstack-protector -I nlohmann/include`

Output:
`In file included from nlohmann/include/nlohmann/detail/input/binary_reader.hpp:27,
                 from nlohmann/include/nlohmann/json.hpp:40,
                 from main.cpp:1:
nlohmann/include/nlohmann/detail/input/lexer.hpp: In member function 'nlohmann::json_abi_v3_11_3::detail::lexer<BasicJsonType, InputAdapterType>::token_type nlohmann::json_abi_v3_11_3::detail::lexer<BasicJsonType, InputAdapterType>::scan() [with BasicJsonType = nlohmann::json_abi_v3_11_3::basic_json<>; InputAdapterType = nlohmann::json_abi_v3_11_3::detail::iterator_input_adapter<const char*>]':
nlohmann/include/nlohmann/detail/input/lexer.hpp:1510:16: warning: stack protector not protecting function: all local arrays are less than 8 bytes long [-Wstack-protector]
     token_type scan()`
	 
The PR fixes the warning.
