### PR TITLE
Fixed an error in the `Custom data source` example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ struct MyIterator {
     using iterator_category = std::input_iterator_tag;
 
     MyIterator& operator++() {
-        MyContainer.advance();
+        target->advance();
         return *this;
     }
 
@@ -394,7 +394,7 @@ struct MyIterator {
     }
 
     reference operator*() const {
-        return target.get_current();
+        return target->get_current();
     }
 
     MyContainer* target = nullptr;


### PR DESCRIPTION
The `target` member of the `MyIterator` class was used as if it was a reference, but it is a pointer.
Furthermore, the increment operator used `advance()` as a static function, which it is not.