### PR TITLE
Fix typo in FuzzerMerge.cpp

### DIFF
--- a/tests/thirdparty/Fuzzer/FuzzerMerge.cpp
+++ b/tests/thirdparty/Fuzzer/FuzzerMerge.cpp
@@ -231,7 +231,7 @@ void Fuzzer::CrashResistantMerge(const std::vector<std::string> &Args,
     ControlFile << Path << "\n";
   ControlFile.close();
 
-  // Execute the inner process untill it passes.
+  // Execute the inner process until it passes.
   // Every inner process should execute at least one input.
   std::string BaseCmd = CloneArgsWithoutX(Args, "keep-all-flags");
   for (size_t i = 1; i <= AllFiles.size(); i++) {


### PR DESCRIPTION


Fixed typo.
```
untill -> until
```

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
