### PR TITLE
Check we don't overflow when casting down integers during parsing

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -43,6 +43,24 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
     n = nullptr;
 }
 
+template <typename BasicJsonType, typename ArithmeticTypeTarget, typename ArithmeticTypeSource>
+ArithmeticTypeTarget static_cast_check_range(const BasicJsonType& j)
+{
+    const auto val = *j.template get_ptr<ArithmeticTypeSource*>();
+    const auto min = std::numeric_limits<ArithmeticTypeTarget>::min();
+    const auto max = std::numeric_limits<ArithmeticTypeTarget>::max();
+    if (val < min && val > max)
+    {
+        JSON_THROW(
+            out_of_range::create(
+                406,
+                "value " + std::to_string(val) + " is out of target integer range [" + std::to_string(min) + ", " +
+                    std::to_string(max) + "]", &j));
+    }
+    return static_cast<ArithmeticTypeTarget>(val);
+}
+
+
 // overloads for basic_json template parameters
 template < typename BasicJsonType, typename ArithmeticType,
            enable_if_t < std::is_arithmetic<ArithmeticType>::value&&
@@ -54,17 +72,17 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
     {
         case value_t::number_unsigned:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            val = static_cast_check_range<BasicJsonType, ArithmeticType, const typename BasicJsonType::number_unsigned_t>(j);
             break;
         }
         case value_t::number_integer:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            val = static_cast_check_range<BasicJsonType, ArithmeticType, const typename BasicJsonType::number_integer_t>(j);
             break;
         }
         case value_t::number_float:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            val = static_cast_check_range<BasicJsonType, ArithmeticType, const typename BasicJsonType::number_float_t>(j);
             break;
         }
 
@@ -343,17 +361,17 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
     {
         case value_t::number_unsigned:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            val = static_cast_check_range<BasicJsonType, ArithmeticType, const typename BasicJsonType::number_unsigned_t>(j);
             break;
         }
         case value_t::number_integer:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            val = static_cast_check_range<BasicJsonType, ArithmeticType, const typename BasicJsonType::number_integer_t>(j);
             break;
         }
         case value_t::number_float:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            val = static_cast_check_range<BasicJsonType, ArithmeticType, const typename BasicJsonType::number_float_t>(j);
             break;
         }
         case value_t::boolean:

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -55,7 +55,7 @@ ArithmeticTypeTarget static_cast_check_range(const BasicJsonType& j)
         bool valIsInf = false;
         if constexpr (std::is_floating_point<ArithmeticTypeSource>::value)
         {
-            valIsInf = isinf(val);
+            valIsInf = std::isinf(val);
         }
         if ((val < min || val > max) && !valIsInf)
         {

--- a/tests/src/unit-class_parser.cpp
+++ b/tests/src/unit-class_parser.cpp
@@ -589,6 +589,9 @@ TEST_CASE("parser class")
             {
                 // overflows during parsing with casting yield an exception
                 CHECK_THROWS_WITH_AS(parser_helper("123456").get<int16_t>(), "[json.exception.out_of_range.406] value 123456 is out of target integer range [-32768, 32767]", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(parser_helper("65536").get<int16_t>(), "[json.exception.out_of_range.406] value 65536 is out of target integer range [-32768, 32767]", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(parser_helper("-32769").get<int16_t>(), "[json.exception.out_of_range.406] value -32769 is out of target integer range [-32768, 32767]", json::out_of_range&);
+                CHECK_THROWS_WITH_AS(parser_helper("18446744073709559808").get<uint64_t>(), "[json.exception.out_of_range.406] value 18446744073709559808.000000 is out of target integer range [0, 18446744073709551615]", json::out_of_range&);
             }
 
             SECTION("invalid numbers")

--- a/tests/src/unit-class_parser.cpp
+++ b/tests/src/unit-class_parser.cpp
@@ -585,6 +585,12 @@ TEST_CASE("parser class")
                 CHECK_THROWS_WITH_AS(parser_helper("1.18973e+4932").empty(), "[json.exception.out_of_range.406] number overflow parsing '1.18973e+4932'", json::out_of_range&);
             }
 
+            SECTION("out-of-range-conversion")
+            {
+                // overflows during parsing with casting yield an exception
+                CHECK_THROWS_WITH_AS(parser_helper("123456").get<int16_t>(), "[json.exception.out_of_range.406] value 123456 is out of target integer range [-32768, 32767]", json::out_of_range&);
+            }
+
             SECTION("invalid numbers")
             {
                 // numbers must not begin with "+"


### PR DESCRIPTION
Hi,

I've faced the following issue when using this library: I stored some numbers in small integers (because I expect to use values in a small interval in practice) but the `static_cast` made during parsing lead to invalid values because of the overflow.

I believe it would be nice to have this runtime check to notice possible overflows at runtime.