### PR TITLE
Make iterator_proxy_value a forward_iterator (#4371)

### DIFF
--- a/include/nlohmann/detail/iterators/iteration_proxy.hpp
+++ b/include/nlohmann/detail/iterators/iteration_proxy.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <cstddef> // size_t
-#include <iterator> // input_iterator_tag
+#include <iterator> // forward_iterator_tag
 #include <string> // string, to_string
 #include <tuple> // tuple_size, get, tuple_element
 #include <utility> // move
@@ -40,7 +40,7 @@ template<typename IteratorType> class iteration_proxy_value
     using value_type = iteration_proxy_value;
     using pointer = value_type *;
     using reference = value_type &;
-    using iterator_category = std::input_iterator_tag;
+    using iterator_category = std::forward_iterator_tag;
     using string_type = typename std::remove_cv< typename std::remove_reference<decltype( std::declval<IteratorType>().key() ) >::type >::type;
 
   private:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5181,7 +5181,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 #include <cstddef> // size_t
-#include <iterator> // input_iterator_tag
+#include <iterator> // forward_iterator_tag
 #include <string> // string, to_string
 #include <tuple> // tuple_size, get, tuple_element
 #include <utility> // move
@@ -5215,7 +5215,7 @@ template<typename IteratorType> class iteration_proxy_value
     using value_type = iteration_proxy_value;
     using pointer = value_type *;
     using reference = value_type &;
-    using iterator_category = std::input_iterator_tag;
+    using iterator_category = std::forward_iterator_tag;
     using string_type = typename std::remove_cv< typename std::remove_reference<decltype( std::declval<IteratorType>().key() ) >::type >::type;
 
   private:

--- a/tests/src/unit-readme.cpp
+++ b/tests/src/unit-readme.cpp
@@ -171,7 +171,7 @@ TEST_CASE("README" * doctest::skip())
 
             // find an entry
             CHECK(o.find("foo") != o.end());
-            if (o.find("foo") != o.end())
+            if (o.find("foo") != o.end()) // NOLINT(readability-container-contains)
             {
                 // there is an entry with key "foo"
             }


### PR DESCRIPTION
See #4371 for all the details - but long story short, there seems to be no reason not to expose `iterator_proxy_value` as a `forward_iterator` instead of just an `input_iterator`.  This allows more use cases when `items()` is fed into C++20 `std::views`.

If there _is_ a reason not to do so, please let me know - but the `iterator_category` on this type currently seems to [long predate](https://github.com/nlohmann/json/commit/8d8f8907715798dcca106509e4d9056a2b9f784e) the [more recent change](https://github.com/nlohmann/json/pull/3446) to fix it for C++20 ranges initially.  As well, the actual json iterator which the proxy wraps is also a forward iterator, so this keeps them on par with each other in terms of capabilities.

Another option is to remove this `iterator_category` typedef entirely, and let [`iterator_traits`](https://en.cppreference.com/w/cpp/iterator/iterator_traits) deduce it - since the type otherwise satisfies `ForwardIterator`, it should (and does, in my motivating case) do the right thing.  But since the other required typedefs are here, might as well keep it but change it IMO.

I'm not sure what, if any, tests can/should be updated/added in this case - I'm open to suggestions, though it seems like all the relevant `static_assert`s and such should still apply.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [X]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues). (#4371)
- [X]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [X]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

Note on amalgamation:  I did run `make amalgamate`, and that touched a bunch of lines unrelated to my change.  The actual change I've made is to `iterator_proxy.hpp`, and hopefully hiding whitespace in the diff will narrow that down.  If you'd rather I revert the other amalgamate changes to keep this diff confined to the 2 (well, 4, including generated code) lines I changed, I'm more than happy to do so - but I figured I'd err on the side of caution w.r.t. any checks that run in CI.