### PR TITLE
exclude some parts of the tests from the build

### DIFF
--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3366,71 +3366,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -19437,7 +19437,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3366,71 +3366,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-#include <cstdint> // int64_t, uint64_t
-#include <map> // map
-#include <memory> // allocator
-#include <string> // string
-#include <vector> // vector
+    #include <cstdint> // int64_t, uint64_t
+    #include <map> // map
+    #include <memory> // allocator
+    #include <string> // string
+    #include <vector> // vector
 
-// #include <nlohmann/detail/abi_macros.hpp>
+    // #include <nlohmann/detail/abi_macros.hpp>
 
 
-/*!
-@brief namespace for Niels Lohmann
-@see https://github.com/nlohmann
-@since version 1.0.0
-*/
-NLOHMANN_JSON_NAMESPACE_BEGIN
+    /*!
+    @brief namespace for Niels Lohmann
+    @see https://github.com/nlohmann
+    @since version 1.0.0
+    */
+    NLOHMANN_JSON_NAMESPACE_BEGIN
 
-/*!
-@brief default JSONSerializer template argument
+    /*!
+    @brief default JSONSerializer template argument
 
-This serializer ignores the template arguments and uses ADL
-([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-for serialization.
-*/
-template<typename T = void, typename SFINAE = void>
-struct adl_serializer;
+    This serializer ignores the template arguments and uses ADL
+    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+    for serialization.
+    */
+    template<typename T = void, typename SFINAE = void>
+    struct adl_serializer;
 
-/// a class to store JSON values
-/// @sa https://json.nlohmann.me/api/basic_json/
-template<template<typename U, typename V, typename... Args> class ObjectType =
-         std::map,
-         template<typename U, typename... Args> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
-         class NumberIntegerType = std::int64_t,
-         class NumberUnsignedType = std::uint64_t,
-         class NumberFloatType = double,
-         template<typename U> class AllocatorType = std::allocator,
-         template<typename T, typename SFINAE = void> class JSONSerializer =
-         adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-         class CustomBaseClass = void>
-class basic_json;
+    /// a class to store JSON values
+    /// @sa https://json.nlohmann.me/api/basic_json/
+    template<template<typename U, typename V, typename... Args> class ObjectType =
+    std::map,
+    template<typename U, typename... Args> class ArrayType = std::vector,
+    class StringType = std::string, class BooleanType = bool,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
+    class NumberFloatType = double,
+    template<typename U> class AllocatorType = std::allocator,
+    template<typename T, typename SFINAE = void> class JSONSerializer =
+    adl_serializer,
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
+    class basic_json;
 
-/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-/// @sa https://json.nlohmann.me/api/json_pointer/
-template<typename RefStringType>
-class json_pointer;
+    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+    /// @sa https://json.nlohmann.me/api/json_pointer/
+    template<typename RefStringType>
+    class json_pointer;
 
-/*!
-@brief default specialization
-@sa https://json.nlohmann.me/api/json/
-*/
-using json = basic_json<>;
+    /*!
+    @brief default specialization
+    @sa https://json.nlohmann.me/api/json/
+    */
+    using json = basic_json<>;
 
-/// @brief a minimal map-like container that preserves insertion order
-/// @sa https://json.nlohmann.me/api/ordered_map/
-template<class Key, class T, class IgnoredLess, class Allocator>
-struct ordered_map;
+    /// @brief a minimal map-like container that preserves insertion order
+    /// @sa https://json.nlohmann.me/api/ordered_map/
+    template<class Key, class T, class IgnoredLess, class Allocator>
+    struct ordered_map;
 
-/// @brief specialization that maintains the insertion order of object keys
-/// @sa https://json.nlohmann.me/api/ordered_json/
-using ordered_json = basic_json<nlohmann::ordered_map>;
+    /// @brief specialization that maintains the insertion order of object keys
+    /// @sa https://json.nlohmann.me/api/ordered_json/
+    using ordered_json = basic_json<nlohmann::ordered_map>;
 
-NLOHMANN_JSON_NAMESPACE_END
+    NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -19437,7 +19437,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         detail::parser_callback_t<basic_json>cb = nullptr,
         const bool allow_exceptions = true,
         const bool ignore_comments = false
-    )
+                                 )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
                 std::move(cb), allow_exceptions, ignore_comments);

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1263,7 +1263,7 @@ TEST_CASE("value conversion")
     }
 #endif
 
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
     SECTION("get an enum")
     {
         enum c_enum { value_1, value_2 };
@@ -1272,7 +1272,7 @@ TEST_CASE("value conversion")
         CHECK(json(value_1).get<c_enum>() == value_1);
         CHECK(json(cpp_enum::value_1).get<cpp_enum>() == cpp_enum::value_1);
     }
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
 
     SECTION("more involved conversions")
     {

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1263,6 +1263,7 @@ TEST_CASE("value conversion")
     }
 #endif
 
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
     SECTION("get an enum")
     {
         enum c_enum { value_1, value_2 };
@@ -1271,6 +1272,7 @@ TEST_CASE("value conversion")
         CHECK(json(value_1).get<c_enum>() == value_1);
         CHECK(json(cpp_enum::value_1).get<cpp_enum>() == cpp_enum::value_1);
     }
+#endif
 
     SECTION("more involved conversions")
     {

--- a/tests/src/unit-noexcept.cpp
+++ b/tests/src/unit-noexcept.cpp
@@ -45,8 +45,8 @@ static_assert(!noexcept(std::declval<json>().get<pod_bis>()), "");
 static_assert(noexcept(json(pod{})), "");
 
 #if JSON_DISABLE_ENUM_SERIALIZATION
-    static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), test{})), "");
-    static_assert(noexcept(json(test{})), "");
+static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), test {})), "");
+static_assert(noexcept(json(test{})), "");
 #endif // JSON_DISABLE_ENUM_SERIALIZATION
 } // namespace
 

--- a/tests/src/unit-noexcept.cpp
+++ b/tests/src/unit-noexcept.cpp
@@ -44,10 +44,10 @@ static_assert(noexcept(std::declval<json>().get<pod>()), "");
 static_assert(!noexcept(std::declval<json>().get<pod_bis>()), "");
 static_assert(noexcept(json(pod{})), "");
 
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
     static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), test{})), "");
     static_assert(noexcept(json(test{})), "");
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
 } // namespace
 
 TEST_CASE("noexcept")

--- a/tests/src/unit-noexcept.cpp
+++ b/tests/src/unit-noexcept.cpp
@@ -36,15 +36,18 @@ static_assert(noexcept(json{}), "");
 static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), 2)), "");
 static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), 2.5)), "");
 static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), true)), "");
-static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), test{})), "");
 static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), pod{})), "");
 static_assert(!noexcept(nlohmann::to_json(std::declval<json&>(), pod_bis{})), "");
 static_assert(noexcept(json(2)), "");
-static_assert(noexcept(json(test{})), "");
 static_assert(noexcept(json(pod{})), "");
 static_assert(noexcept(std::declval<json>().get<pod>()), "");
 static_assert(!noexcept(std::declval<json>().get<pod_bis>()), "");
 static_assert(noexcept(json(pod{})), "");
+
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+    static_assert(noexcept(nlohmann::to_json(std::declval<json&>(), test{})), "");
+    static_assert(noexcept(json(test{})), "");
+#endif
 } // namespace
 
 TEST_CASE("noexcept")

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -169,7 +169,7 @@ TEST_CASE("regression tests 1")
         }
     }
 
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
     SECTION("pull request #71 - handle enum type")
     {
         enum { t = 0, u = 102};
@@ -192,7 +192,7 @@ TEST_CASE("regression tests 1")
             {"game_type", t}
         }));
     }
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
 
     SECTION("issue #76 - dump() / parse() not idempotent")
     {

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -169,6 +169,7 @@ TEST_CASE("regression tests 1")
         }
     }
 
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
     SECTION("pull request #71 - handle enum type")
     {
         enum { t = 0, u = 102};
@@ -191,6 +192,7 @@ TEST_CASE("regression tests 1")
             {"game_type", t}
         }));
     }
+#endif
 
     SECTION("issue #76 - dump() / parse() not idempotent")
     {

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -130,12 +130,12 @@ static void to_json(nlohmann::json& j, const contact& c)
     j = json{{"person", c.m_person}, {"address", c.m_address}};
 }
 
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
 static void to_json(nlohmann::json& j, const contact_book& cb)
 {
     j = json{{"name", cb.m_book_name}, {"id", cb.m_book_id}, {"contacts", cb.m_contacts}};
 }
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
 
 // operators
 static bool operator==(age lhs, age rhs)
@@ -221,14 +221,14 @@ static void from_json(const nlohmann::json& j, contact& c)
     c.m_address = j["address"].get<address>();
 }
 
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
 static void from_json(const nlohmann::json& j, contact_book& cb)
 {
     cb.m_book_name = j["name"].get<name>();
     cb.m_book_id = j["id"].get<book_id>();
     cb.m_contacts = j["contacts"].get<std::vector<contact>>();
 }
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
 } // namespace udt
 
 TEST_CASE("basic usage" * doctest::test_suite("udt"))
@@ -257,7 +257,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
         CHECK(json("Paris") == json(addr));
         CHECK(json(cpp_programmer) ==
               R"({"person" : {"age":23, "name":"theo", "country":"France"}, "address":"Paris"})"_json);
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
         CHECK(json(large_id) == json(static_cast<std::uint64_t>(1) << 63));
         CHECK(json(large_id) > 0u);
         CHECK(to_string(json(large_id)) == "9223372036854775808");
@@ -266,7 +266,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
         CHECK(
             json(book) ==
             R"({"name":"C++", "id":42, "contacts" : [{"person" : {"age":23, "name":"theo", "country":"France"}, "address":"Paris"}, {"person" : {"age":42, "country":"中华人民共和国", "name":"王芳"}, "address":"Paris"}]})"_json);
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
     }
 
     SECTION("conversion from json via free-functions")
@@ -275,11 +275,11 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             R"({"name":"C++", "id":42, "contacts" : [{"person" : {"age":23, "name":"theo", "country":"France"}, "address":"Paris"}, {"person" : {"age":42, "country":"中华人民共和国", "name":"王芳"}, "address":"Paris"}]})"_json;
         SECTION("via explicit calls to get")
         {
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0
+#if JSON_DISABLE_ENUM_SERIALIZATION
             const auto parsed_book = big_json.get<udt::contact_book>();
             const auto book_name = big_json["name"].get<udt::name>();
             const auto book_id = big_json["id"].get<udt::book_id>();
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
             const auto contacts =
                 big_json["contacts"].get<std::vector<udt::contact>>();
             const auto contact_json = big_json["contacts"].at(0);
@@ -298,11 +298,11 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             CHECK(person == sfinae_addict);
             CHECK(contact == cpp_programmer);
             CHECK(contacts == book.m_contacts);
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0            
+#if JSON_DISABLE_ENUM_SERIALIZATION
             CHECK(book_name == udt::name{"C++"});
             CHECK(book_id == book.m_book_id);
             CHECK(book == parsed_book);
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
         }
 
         SECTION("via explicit calls to get_to")
@@ -317,7 +317,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             person_json["name"].get_to(name).m_val = "new name";
             CHECK(name.m_val == "new name");
         }
-#if JSON_DISABLE_ENUM_SERIALIZATION != 0                 
+#if JSON_DISABLE_ENUM_SERIALIZATION
 #if JSON_USE_IMPLICIT_CONVERSIONS
         SECTION("implicit conversions")
         {
@@ -347,7 +347,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             CHECK(book == parsed_book);
         }
 #endif
-#endif
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
     }
 }
 

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -163,12 +163,13 @@ static bool operator==(const contact& lhs, const contact& rhs)
     return std::tie(lhs.m_person, lhs.m_address) ==
            std::tie(rhs.m_person, rhs.m_address);
 }
-
+#if JSON_DISABLE_ENUM_SERIALIZATION
 static bool operator==(const contact_book& lhs, const contact_book& rhs)
 {
     return std::tie(lhs.m_book_name, lhs.m_book_id, lhs.m_contacts) ==
            std::tie(rhs.m_book_name, rhs.m_book_id, rhs.m_contacts);
 }
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
 } // namespace udt
 
 // from_json methods
@@ -245,7 +246,9 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
     const udt::person senior_programmer{{42}, {"王芳"}, udt::country::china};
     const udt::address addr{"Paris"};
     const udt::contact cpp_programmer{sfinae_addict, addr};
+#if JSON_DISABLE_ENUM_SERIALIZATION
     const udt::book_id large_id{static_cast<udt::book_id>(static_cast<std::uint64_t>(1) << 63)}; // verify large unsigned enums are handled correctly
+#endif // JSON_DISABLE_ENUM_SERIALIZATION
     const udt::contact_book book{{"C++"}, static_cast<udt::book_id>(42u), {cpp_programmer, {senior_programmer, addr}}};
 
     SECTION("conversion to json via free-functions")

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -130,10 +130,12 @@ static void to_json(nlohmann::json& j, const contact& c)
     j = json{{"person", c.m_person}, {"address", c.m_address}};
 }
 
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
 static void to_json(nlohmann::json& j, const contact_book& cb)
 {
     j = json{{"name", cb.m_book_name}, {"id", cb.m_book_id}, {"contacts", cb.m_contacts}};
 }
+#endif
 
 // operators
 static bool operator==(age lhs, age rhs)
@@ -219,12 +221,14 @@ static void from_json(const nlohmann::json& j, contact& c)
     c.m_address = j["address"].get<address>();
 }
 
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
 static void from_json(const nlohmann::json& j, contact_book& cb)
 {
     cb.m_book_name = j["name"].get<name>();
     cb.m_book_id = j["id"].get<book_id>();
     cb.m_contacts = j["contacts"].get<std::vector<contact>>();
 }
+#endif
 } // namespace udt
 
 TEST_CASE("basic usage" * doctest::test_suite("udt"))
@@ -253,6 +257,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
         CHECK(json("Paris") == json(addr));
         CHECK(json(cpp_programmer) ==
               R"({"person" : {"age":23, "name":"theo", "country":"France"}, "address":"Paris"})"_json);
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
         CHECK(json(large_id) == json(static_cast<std::uint64_t>(1) << 63));
         CHECK(json(large_id) > 0u);
         CHECK(to_string(json(large_id)) == "9223372036854775808");
@@ -261,7 +266,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
         CHECK(
             json(book) ==
             R"({"name":"C++", "id":42, "contacts" : [{"person" : {"age":23, "name":"theo", "country":"France"}, "address":"Paris"}, {"person" : {"age":42, "country":"中华人民共和国", "name":"王芳"}, "address":"Paris"}]})"_json);
-
+#endif
     }
 
     SECTION("conversion from json via free-functions")
@@ -270,9 +275,11 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             R"({"name":"C++", "id":42, "contacts" : [{"person" : {"age":23, "name":"theo", "country":"France"}, "address":"Paris"}, {"person" : {"age":42, "country":"中华人民共和国", "name":"王芳"}, "address":"Paris"}]})"_json;
         SECTION("via explicit calls to get")
         {
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0
             const auto parsed_book = big_json.get<udt::contact_book>();
             const auto book_name = big_json["name"].get<udt::name>();
             const auto book_id = big_json["id"].get<udt::book_id>();
+#endif
             const auto contacts =
                 big_json["contacts"].get<std::vector<udt::contact>>();
             const auto contact_json = big_json["contacts"].at(0);
@@ -291,9 +298,11 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             CHECK(person == sfinae_addict);
             CHECK(contact == cpp_programmer);
             CHECK(contacts == book.m_contacts);
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0            
             CHECK(book_name == udt::name{"C++"});
             CHECK(book_id == book.m_book_id);
             CHECK(book == parsed_book);
+#endif
         }
 
         SECTION("via explicit calls to get_to")
@@ -308,11 +317,13 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             person_json["name"].get_to(name).m_val = "new name";
             CHECK(name.m_val == "new name");
         }
-
+#if JSON_DISABLE_ENUM_SERIALIZATION != 0                 
 #if JSON_USE_IMPLICIT_CONVERSIONS
         SECTION("implicit conversions")
         {
+
             const udt::contact_book parsed_book = big_json;
+
             const udt::name book_name = big_json["name"];
             const udt::book_id book_id = big_json["id"];
             const std::vector<udt::contact> contacts = big_json["contacts"];
@@ -335,6 +346,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             CHECK(book_id == static_cast<udt::book_id>(42u));
             CHECK(book == parsed_book);
         }
+#endif
 #endif
     }
 }

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -247,9 +247,9 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
     const udt::address addr{"Paris"};
     const udt::contact cpp_programmer{sfinae_addict, addr};
 #if JSON_DISABLE_ENUM_SERIALIZATION
-    const udt::book_id large_id{static_cast<udt::book_id>(static_cast<std::uint64_t>(1) << 63)}; // verify large unsigned enums are handled correctly
+    const udt::book_id large_id {static_cast<udt::book_id>(static_cast<std::uint64_t>(1) << 63)}; // verify large unsigned enums are handled correctly
 #endif // JSON_DISABLE_ENUM_SERIALIZATION
-    const udt::contact_book book{{"C++"}, static_cast<udt::book_id>(42u), {cpp_programmer, {senior_programmer, addr}}};
+    const udt::contact_book book {{"C++"}, static_cast<udt::book_id>(42u), {cpp_programmer, {senior_programmer, addr}}};
 
     SECTION("conversion to json via free-functions")
     {
@@ -302,7 +302,7 @@ TEST_CASE("basic usage" * doctest::test_suite("udt"))
             CHECK(contact == cpp_programmer);
             CHECK(contacts == book.m_contacts);
 #if JSON_DISABLE_ENUM_SERIALIZATION
-            CHECK(book_name == udt::name{"C++"});
+            CHECK(book_name == udt::name {"C++"});
             CHECK(book_id == book.m_book_id);
             CHECK(book == parsed_book);
 #endif // JSON_DISABLE_ENUM_SERIALIZATION


### PR DESCRIPTION
I've excluded the test parts that only work if JSON_DisableEnumSerialization option is OFF. 

#4384  

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
