### PR TITLE
Optimize binary `get_number` implementation by reading multiple bytes at once

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -20,6 +20,9 @@
 #include <string> // char_traits, string
 #include <utility> // make_pair, move
 #include <vector> // vector
+#ifdef __cpp_lib_byteswap
+    #include <bit>  //byteswap
+#endif
 
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/input/input_adapters.hpp>
@@ -2755,6 +2758,29 @@ class binary_reader
     }
 
     /*!
+    @brief get_to read into a primitive type
+
+    This function provides the interface to the used input adapter. It does
+    not throw in case the input reached EOF, but returns false instead
+
+    @return bool, whether the read was successful
+    */
+    template<class T>
+    bool get_to(T& dest, const input_format_t format, const char* context)
+    {
+        auto new_chars_read = ia.get_elements(&dest);
+        chars_read += new_chars_read;
+        if (JSON_HEDLEY_UNLIKELY(new_chars_read < sizeof(T)))
+        {
+            // in case of failure, advance position by 1 to report failing location
+            ++chars_read;
+            sax->parse_error(chars_read, "<end of file>", parse_error::create(110, chars_read, exception_message(format, "unexpected end of input", context), nullptr));
+            return false;
+        }
+        return true;
+    }
+
+    /*!
     @return character read from the input after ignoring all 'N' entries
     */
     char_int_type get_ignore_noop()
@@ -2766,6 +2792,28 @@ class binary_reader
         while (current == 'N');
 
         return current;
+    }
+
+    template<class NumberType>
+    static void byte_swap(NumberType& number)
+    {
+        constexpr std::size_t sz = sizeof(number);
+#ifdef __cpp_lib_byteswap
+        if constexpr (sz == 1)
+        {
+            return;
+        }
+        // convert float types to int types of the same size
+        using swap_t = std::conditional<sz == 2, std::uint16_t, typename std::conditional<sz == 4, std::uint32_t, std::uint64_t>::type>::type;
+        swap_t& number_ref = reinterpret_cast<swap_t&>(number);
+        number_ref = std::byteswap(number_ref);
+#else
+        auto ptr = reinterpret_cast<std::uint8_t*>(&number);
+        for (std::size_t i = 0; i < sz / 2; ++i)
+        {
+            std::swap(ptr[i], ptr[sz - i - 1]);
+        }
+#endif
     }
 
     /*
@@ -2786,29 +2834,16 @@ class binary_reader
     template<typename NumberType, bool InputIsLittleEndian = false>
     bool get_number(const input_format_t format, NumberType& result)
     {
-        // step 1: read input into array with system's byte order
-        std::array<std::uint8_t, sizeof(NumberType)> vec{};
-        for (std::size_t i = 0; i < sizeof(NumberType); ++i)
+        // read in the original format
+
+        if (JSON_HEDLEY_UNLIKELY(!get_to(result, format, "number")))
         {
-            get();
-            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "number")))
-            {
-                return false;
-            }
-
-            // reverse byte order prior to conversion if necessary
-            if (is_little_endian != (InputIsLittleEndian || format == input_format_t::bjdata))
-            {
-                vec[sizeof(NumberType) - i - 1] = static_cast<std::uint8_t>(current);
-            }
-            else
-            {
-                vec[i] = static_cast<std::uint8_t>(current); // LCOV_EXCL_LINE
-            }
+            return false;
         }
-
-        // step 2: convert array into number of type T and return
-        std::memcpy(&result, vec.data(), sizeof(NumberType));
+        if (is_little_endian != (InputIsLittleEndian || format == input_format_t::bjdata))
+        {
+            byte_swap(result);
+        }
         return true;
     }
 

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2803,17 +2803,17 @@ class binary_reader
         {
             return;
         }
-        // convert float types to int types of the same size
-        using swap_t = std::conditional<sz == 2, std::uint16_t, typename std::conditional<sz == 4, std::uint32_t, std::uint64_t>::type>::type;
-        swap_t& number_ref = reinterpret_cast<swap_t&>(number);
-        number_ref = std::byteswap(number_ref);
-#else
+        if constexpr(std::is_integral_v<NumberType>)
+        {
+            number = std::byteswap(number);
+            return;
+        }
+#endif
         auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
         for (std::size_t i = 0; i < sz / 2; ++i)
         {
             std::swap(ptr[i], ptr[sz - i - 1]);
         }
-#endif
     }
 
     /*

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2808,7 +2808,7 @@ class binary_reader
         swap_t& number_ref = reinterpret_cast<swap_t&>(number);
         number_ref = std::byteswap(number_ref);
 #else
-        auto ptr = reinterpret_cast<std::uint8_t*>(&number);
+        auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
         for (std::size_t i = 0; i < sz / 2; ++i)
         {
             std::swap(ptr[i], ptr[sz - i - 1]);

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -180,12 +180,12 @@ class iterator_input_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto* ptr = reinterpret_cast<unsigned char*>(dest);
+        auto* ptr = reinterpret_cast<char*>(dest);
         for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
         {
             if (JSON_HEDLEY_LIKELY(current != end))
             {
-                ptr[read_index] = *current;
+                ptr[read_index] = static_cast<char>(*current);
                 std::advance(current, 1);
             }
             else
@@ -359,15 +359,11 @@ class wide_string_input_adapter
         return utf8_bytes[utf8_bytes_index++];
     }
 
+    // parsing binary with wchar doesn't make sense, but since the parsing mode can be runtime, we need something here
     template<class T>
-    std::size_t get_elements(T* dest, std::size_t count = 1)
+    std::size_t get_elements(T* /*dest*/, std::size_t /*count*/ = 1)
     {
-        auto* ptr = reinterpret_cast<char*>(dest);
-        for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
-        {
-            ptr[read_index] = static_cast<char>(get_character());
-        }
-        return count * sizeof(T);
+        JSON_THROW(parse_error::create(112, 1, "wide string type cannot be interpreted as binary data", nullptr));
     }
 
   private:

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -68,6 +68,13 @@ class file_input_adapter
         return std::fgetc(m_file);
     }
 
+    // returns the number of characters successfully read
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        return fread(dest, 1, sizeof(T) * count, m_file);
+    }
+
   private:
     /// the file pointer to read from
     std::FILE* m_file;
@@ -127,6 +134,17 @@ class input_stream_adapter
         return res;
     }
 
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        auto res = sb->sgetn(reinterpret_cast<char*>(dest), count * sizeof(T));
+        if (JSON_HEDLEY_UNLIKELY(res < count * sizeof(T)))
+        {
+            is->clear(is->rdstate() | std::ios::eofbit);
+        }
+        return static_cast<std::size_t>(res);
+    }
+
   private:
     /// the associated input stream
     std::istream* is = nullptr;
@@ -156,6 +174,26 @@ class iterator_input_adapter
         }
 
         return char_traits<char_type>::eof();
+    }
+
+    // for general iterators, we cannot really do something better than falling back to processing the range one-by-one
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        auto ptr = reinterpret_cast<char*>(dest);
+        for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
+        {
+            if (JSON_HEDLEY_LIKELY(current != end))
+            {
+                ptr[read_index] = *current;
+                std::advance(current, 1);
+            }
+            else
+            {
+                return read_index;
+            }
+        }
+        return count * sizeof(T);
     }
 
   private:
@@ -319,6 +357,13 @@ class wide_string_input_adapter
         JSON_ASSERT(utf8_bytes_filled > 0);
         JSON_ASSERT(utf8_bytes_index < utf8_bytes_filled);
         return utf8_bytes[utf8_bytes_index++];
+    }
+
+    template<class T>
+    std::size_t get_elements(T*, std::size_t = 1)
+    {
+        JSON_THROW(other_error::create(500, "Unexpected get_elements call to wchar input adapter", nullptr));
+        return 0;
     }
 
   private:

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -137,7 +137,7 @@ class input_stream_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto res = sb->sgetn(reinterpret_cast<char*>(dest), count * sizeof(T));
+        auto res = sb->sgetn(reinterpret_cast<char*>(dest), static_cast<std::streamsize>(count * sizeof(T)));
         if (JSON_HEDLEY_UNLIKELY(res < count * sizeof(T)))
         {
             is->clear(is->rdstate() | std::ios::eofbit);
@@ -360,10 +360,14 @@ class wide_string_input_adapter
     }
 
     template<class T>
-    std::size_t get_elements(T*, std::size_t = 1)
+    std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        JSON_THROW(other_error::create(500, "Unexpected get_elements call to wchar input adapter", nullptr));
-        return 0;
+        auto ptr = reinterpret_cast<char*>(dest);
+        for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
+        {
+            ptr[read_index] = static_cast<char>(get_character());
+        }
+        return count * sizeof(T);
     }
 
   private:

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -137,12 +137,12 @@ class input_stream_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto res = sb->sgetn(reinterpret_cast<char*>(dest), static_cast<std::streamsize>(count * sizeof(T)));
+        auto res = static_cast<std::size_t>(sb->sgetn(reinterpret_cast<char*>(dest), static_cast<std::streamsize>(count * sizeof(T))));
         if (JSON_HEDLEY_UNLIKELY(res < count * sizeof(T)))
         {
             is->clear(is->rdstate() | std::ios::eofbit);
         }
-        return static_cast<std::size_t>(res);
+        return res;
     }
 
   private:
@@ -180,7 +180,7 @@ class iterator_input_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto ptr = reinterpret_cast<char*>(dest);
+        auto* ptr = reinterpret_cast<unsigned char*>(dest);
         for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
         {
             if (JSON_HEDLEY_LIKELY(current != end))
@@ -362,7 +362,7 @@ class wide_string_input_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto ptr = reinterpret_cast<char*>(dest);
+        auto* ptr = reinterpret_cast<char*>(dest);
         for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
         {
             ptr[read_index] = static_cast<char>(get_character());

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6370,12 +6370,12 @@ class input_stream_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto res = sb->sgetn(reinterpret_cast<char*>(dest), static_cast<std::streamsize>(count * sizeof(T)));
+        auto res = static_cast<std::size_t>(sb->sgetn(reinterpret_cast<char*>(dest), static_cast<std::streamsize>(count * sizeof(T))));
         if (JSON_HEDLEY_UNLIKELY(res < count * sizeof(T)))
         {
             is->clear(is->rdstate() | std::ios::eofbit);
         }
-        return static_cast<std::size_t>(res);
+        return res;
     }
 
   private:
@@ -6413,7 +6413,7 @@ class iterator_input_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto ptr = reinterpret_cast<char*>(dest);
+        auto* ptr = reinterpret_cast<unsigned char*>(dest);
         for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
         {
             if (JSON_HEDLEY_LIKELY(current != end))
@@ -6595,7 +6595,7 @@ class wide_string_input_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto ptr = reinterpret_cast<char*>(dest);
+        auto* ptr = reinterpret_cast<char*>(dest);
         for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
         {
             ptr[read_index] = static_cast<char>(get_character());
@@ -12110,7 +12110,7 @@ class binary_reader
         swap_t& number_ref = reinterpret_cast<swap_t&>(number);
         number_ref = std::byteswap(number_ref);
 #else
-        auto ptr = reinterpret_cast<std::uint8_t*>(&number);
+        auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
         for (std::size_t i = 0; i < sz / 2; ++i)
         {
             std::swap(ptr[i], ptr[sz - i - 1]);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12101,17 +12101,17 @@ class binary_reader
         {
             return;
         }
-        // convert float types to int types of the same size
-        using swap_t = std::conditional<sz == 2, std::uint16_t, typename std::conditional<sz == 4, std::uint32_t, std::uint64_t>::type>::type;
-        swap_t& number_ref = reinterpret_cast<swap_t&>(number);
-        number_ref = std::byteswap(number_ref);
-#else
+        if constexpr(std::is_integral_v<NumberType>)
+        {
+            number = std::byteswap(number);
+            return;
+        }
+#endif
         auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
         for (std::size_t i = 0; i < sz / 2; ++i)
         {
             std::swap(ptr[i], ptr[sz - i - 1]);
         }
-#endif
     }
 
     /*

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6413,12 +6413,12 @@ class iterator_input_adapter
     template<class T>
     std::size_t get_elements(T* dest, std::size_t count = 1)
     {
-        auto* ptr = reinterpret_cast<unsigned char*>(dest);
+        auto* ptr = reinterpret_cast<char*>(dest);
         for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
         {
             if (JSON_HEDLEY_LIKELY(current != end))
             {
-                ptr[read_index] = *current;
+                ptr[read_index] = static_cast<char>(*current);
                 std::advance(current, 1);
             }
             else
@@ -6592,15 +6592,11 @@ class wide_string_input_adapter
         return utf8_bytes[utf8_bytes_index++];
     }
 
+    // parsing binary with wchar doesn't make sense, but since the parsing mode can be runtime, we need something here
     template<class T>
-    std::size_t get_elements(T* dest, std::size_t count = 1)
+    std::size_t get_elements(T* /*dest*/, std::size_t /*count*/ = 1)
     {
-        auto* ptr = reinterpret_cast<char*>(dest);
-        for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
-        {
-            ptr[read_index] = static_cast<char>(get_character());
-        }
-        return count * sizeof(T);
+        JSON_THROW(parse_error::create(112, 1, "wide string type cannot be interpreted as binary data", nullptr));
     }
 
   private:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6220,6 +6220,9 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <string> // char_traits, string
 #include <utility> // make_pair, move
 #include <vector> // vector
+#ifdef __cpp_lib_byteswap
+    #include <bit>  //byteswap
+#endif
 
 // #include <nlohmann/detail/exceptions.hpp>
 
@@ -6298,6 +6301,13 @@ class file_input_adapter
         return std::fgetc(m_file);
     }
 
+    // returns the number of characters successfully read
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        return fread(dest, 1, sizeof(T) * count, m_file);
+    }
+
   private:
     /// the file pointer to read from
     std::FILE* m_file;
@@ -6357,6 +6367,17 @@ class input_stream_adapter
         return res;
     }
 
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        auto res = sb->sgetn(reinterpret_cast<char*>(dest), static_cast<std::streamsize>(count * sizeof(T)));
+        if (JSON_HEDLEY_UNLIKELY(res < count * sizeof(T)))
+        {
+            is->clear(is->rdstate() | std::ios::eofbit);
+        }
+        return static_cast<std::size_t>(res);
+    }
+
   private:
     /// the associated input stream
     std::istream* is = nullptr;
@@ -6386,6 +6407,26 @@ class iterator_input_adapter
         }
 
         return char_traits<char_type>::eof();
+    }
+
+    // for general iterators, we cannot really do something better than falling back to processing the range one-by-one
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        auto ptr = reinterpret_cast<char*>(dest);
+        for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
+        {
+            if (JSON_HEDLEY_LIKELY(current != end))
+            {
+                ptr[read_index] = *current;
+                std::advance(current, 1);
+            }
+            else
+            {
+                return read_index;
+            }
+        }
+        return count * sizeof(T);
     }
 
   private:
@@ -6549,6 +6590,17 @@ class wide_string_input_adapter
         JSON_ASSERT(utf8_bytes_filled > 0);
         JSON_ASSERT(utf8_bytes_index < utf8_bytes_filled);
         return utf8_bytes[utf8_bytes_index++];
+    }
+
+    template<class T>
+    std::size_t get_elements(T* dest, std::size_t count = 1)
+    {
+        auto ptr = reinterpret_cast<char*>(dest);
+        for (std::size_t read_index = 0; read_index < count * sizeof(T); ++read_index)
+        {
+            ptr[read_index] = static_cast<char>(get_character());
+        }
+        return count * sizeof(T);
     }
 
   private:
@@ -12008,6 +12060,29 @@ class binary_reader
     }
 
     /*!
+    @brief get_to read into a primitive type
+
+    This function provides the interface to the used input adapter. It does
+    not throw in case the input reached EOF, but returns false instead
+
+    @return bool, whether the read was successful
+    */
+    template<class T>
+    bool get_to(T& dest, const input_format_t format, const char* context)
+    {
+        auto new_chars_read = ia.get_elements(&dest);
+        chars_read += new_chars_read;
+        if (JSON_HEDLEY_UNLIKELY(new_chars_read < sizeof(T)))
+        {
+            // in case of failure, advance position by 1 to report failing location
+            ++chars_read;
+            sax->parse_error(chars_read, "<end of file>", parse_error::create(110, chars_read, exception_message(format, "unexpected end of input", context), nullptr));
+            return false;
+        }
+        return true;
+    }
+
+    /*!
     @return character read from the input after ignoring all 'N' entries
     */
     char_int_type get_ignore_noop()
@@ -12019,6 +12094,28 @@ class binary_reader
         while (current == 'N');
 
         return current;
+    }
+
+    template<class NumberType>
+    static void byte_swap(NumberType& number)
+    {
+        constexpr std::size_t sz = sizeof(number);
+#ifdef __cpp_lib_byteswap
+        if constexpr (sz == 1)
+        {
+            return;
+        }
+        // convert float types to int types of the same size
+        using swap_t = std::conditional<sz == 2, std::uint16_t, typename std::conditional<sz == 4, std::uint32_t, std::uint64_t>::type>::type;
+        swap_t& number_ref = reinterpret_cast<swap_t&>(number);
+        number_ref = std::byteswap(number_ref);
+#else
+        auto ptr = reinterpret_cast<std::uint8_t*>(&number);
+        for (std::size_t i = 0; i < sz / 2; ++i)
+        {
+            std::swap(ptr[i], ptr[sz - i - 1]);
+        }
+#endif
     }
 
     /*
@@ -12039,29 +12136,16 @@ class binary_reader
     template<typename NumberType, bool InputIsLittleEndian = false>
     bool get_number(const input_format_t format, NumberType& result)
     {
-        // step 1: read input into array with system's byte order
-        std::array<std::uint8_t, sizeof(NumberType)> vec{};
-        for (std::size_t i = 0; i < sizeof(NumberType); ++i)
+        // read in the original format
+
+        if (JSON_HEDLEY_UNLIKELY(!get_to(result, format, "number")))
         {
-            get();
-            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "number")))
-            {
-                return false;
-            }
-
-            // reverse byte order prior to conversion if necessary
-            if (is_little_endian != (InputIsLittleEndian || format == input_format_t::bjdata))
-            {
-                vec[sizeof(NumberType) - i - 1] = static_cast<std::uint8_t>(current);
-            }
-            else
-            {
-                vec[i] = static_cast<std::uint8_t>(current); // LCOV_EXCL_LINE
-            }
+            return false;
         }
-
-        // step 2: convert array into number of type T and return
-        std::memcpy(&result, vec.data(), sizeof(NumberType));
+        if (is_little_endian != (InputIsLittleEndian || format == input_format_t::bjdata))
+        {
+            byte_swap(result);
+        }
         return true;
     }
 

--- a/tests/benchmarks/src/benchmarks.cpp
+++ b/tests/benchmarks/src/benchmarks.cpp
@@ -141,6 +141,46 @@ BENCHMARK_CAPTURE(ToCbor, unsigned_ints,     TEST_DATA_DIRECTORY "/regression/un
 BENCHMARK_CAPTURE(ToCbor, small_signed_ints, TEST_DATA_DIRECTORY "/regression/small_signed_ints.json");
 
 //////////////////////////////////////////////////////////////////////////////
+// Parse Msgpack
+//////////////////////////////////////////////////////////////////////////////
+
+static void FromMsgpack(benchmark::State& state, const char* filename)
+{
+    std::ifstream f(filename);
+    std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    auto bytes = json::to_msgpack(json::parse(str));
+    std::ofstream o("test.msgpack");
+    o.write((char*)bytes.data(), bytes.size());
+    o.flush();
+    o.close();
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        auto* j = new json();
+        auto file = fopen("test.msgpack", "rb");
+        state.ResumeTiming();
+
+        *j = json::from_msgpack(file);
+
+        state.PauseTiming();
+        fclose(file);
+        delete j;
+        state.ResumeTiming();
+    }
+
+    state.SetBytesProcessed(state.iterations() * bytes.size());
+}
+
+BENCHMARK_CAPTURE(FromMsgpack, jeopardy, TEST_DATA_DIRECTORY "/jeopardy/jeopardy.json");
+BENCHMARK_CAPTURE(FromMsgpack, canada, TEST_DATA_DIRECTORY "/nativejson-benchmark/canada.json");
+BENCHMARK_CAPTURE(FromMsgpack, citm_catalog, TEST_DATA_DIRECTORY "/nativejson-benchmark/citm_catalog.json");
+BENCHMARK_CAPTURE(FromMsgpack, twitter, TEST_DATA_DIRECTORY "/nativejson-benchmark/twitter.json");
+BENCHMARK_CAPTURE(FromMsgpack, floats, TEST_DATA_DIRECTORY "/regression/floats.json");
+BENCHMARK_CAPTURE(FromMsgpack, signed_ints, TEST_DATA_DIRECTORY "/regression/signed_ints.json");
+BENCHMARK_CAPTURE(FromMsgpack, unsigned_ints, TEST_DATA_DIRECTORY "/regression/unsigned_ints.json");
+BENCHMARK_CAPTURE(FromMsgpack, small_signed_ints, TEST_DATA_DIRECTORY "/regression/small_signed_ints.json");
+
+//////////////////////////////////////////////////////////////////////////////
 // serialize binary CBOR
 //////////////////////////////////////////////////////////////////////////////
 static void BinaryToCbor(benchmark::State& state)

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1511,9 +1511,17 @@ TEST_CASE("MessagePack")
         SECTION("unexpected end inside int with stream")
         {
             json _;
-            std::string data = {static_cast<char>(0xd2), static_cast<char>(0x12), static_cast<char>(0x34), static_cast<char>(0x56)};
+            const std::string data = {static_cast<char>(0xd2u), static_cast<char>(0x12u), static_cast<char>(0x34u), static_cast<char>(0x56u)};
             CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::istringstream(data, std::ios::binary)),
                                  "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+        }
+        SECTION("misuse wchar for binary")
+        {
+            json _;
+            // creates 0xd2 after UTF-8 decoding, triggers get_elements in wide_string_input_adapter for code coverage
+            const std::u32string data = {static_cast<char32_t>(0x0280)};
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(data),
+                                 "[json.exception.parse_error.112] parse error at byte 1: wide string type cannot be interpreted as binary data", json::parse_error&);
         }
 
         SECTION("unsupported bytes")

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1508,6 +1508,14 @@ TEST_CASE("MessagePack")
             CHECK(json::from_msgpack(std::vector<uint8_t>({0xc4}), true, false).is_discarded());
         }
 
+        SECTION("unexpected end inside int with stream")
+        {
+            json _;
+            std::string data = {static_cast<char>(0xd2), static_cast<char>(0x12), static_cast<char>(0x34), static_cast<char>(0x56)};
+            CHECK_THROWS_WITH_AS(_ = json::from_msgpack(std::istringstream(data, std::ios::binary)),
+                                 "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing MessagePack number: unexpected end of input", json::parse_error&);
+        }
+
         SECTION("unsupported bytes")
         {
             SECTION("concrete examples")


### PR DESCRIPTION
This PR improves performance for `get_number` implementation by reading multiple bytes at once, which saves calling overhead especially when interacting with file I/O. It adds `get_elements` to input adapters and allow them to select more efficient underlying calls to read multiple bytes if available

Performance for reading msgpack from C style `FILE`

`develop`
```
FromMsgpack/floats             166717521 ns    163715750 ns            4 bytes_per_second=52.4267Mi/s
FromMsgpack/signed_ints        171707844 ns    167527000 ns            4 bytes_per_second=51.234Mi/s
FromMsgpack/unsigned_ints      167388344 ns    164910750 ns            4 bytes_per_second=52.0468Mi/s
FromMsgpack/small_signed_ints  102578387 ns    100799000 ns            7 bytes_per_second=46.3689Mi/s
```
branch:
```
FromMsgpack/floats              61241576 ns     60370091 ns           11 bytes_per_second=142.174Mi/s
FromMsgpack/signed_ints         67659257 ns     62698083 ns           12 bytes_per_second=136.895Mi/s
FromMsgpack/unsigned_ints       59830260 ns     57518000 ns           13 bytes_per_second=149.224Mi/s
FromMsgpack/small_signed_ints   63264757 ns     61850167 ns           12 bytes_per_second=75.5688Mi/s
```

Questions:

- for `get_elements` in `wide_string_input_adapter`, I encountered a compile error without it. If I don't implement it, tests are passing locally, which seems to make sense: if `wchar` is used, likely the content has non-ASCII text and we won't want to interpret it as binary numbers, where `get_elements` is currently used. After looking into more UTF-8 decoding rules I think parsing binary from wide string doesn't make sense, and is making it an error.
- adding msgpack parsing via C FILE which was used for benchmarking to the benchmark.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [X]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
