### PR TITLE
Remove alwayslink=True Bazel flag

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,5 +49,4 @@ cc_library(
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],
-    alwayslink = True,
 )


### PR DESCRIPTION
Remove the `alwayslink=True` flag from `BUILD.bazel`.

This should have no effect for header only libraries as mentioned in https://github.com/googleapis/google-cloud-cpp/pull/14310#issuecomment-2154986153.