### PR TITLE
Change member variable from 'is' to 'is_' to avoid possible (macro) name collision

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -90,14 +90,14 @@ class input_stream_adapter
     {
         // clear stream flags; we use underlying streambuf I/O, do not
         // maintain ifstream flags, except eof
-        if (is != nullptr)
+        if (is_ != nullptr)
         {
-            is->clear(is->rdstate() & std::ios::eofbit);
+            is_->clear(is_->rdstate() & std::ios::eofbit);
         }
     }
 
     explicit input_stream_adapter(std::istream& i)
-        : is(&i), sb(i.rdbuf())
+        : is_(&i), sb_(i.rdbuf())
     {}
 
     // delete because of pointer members
@@ -106,10 +106,10 @@ class input_stream_adapter
     input_stream_adapter& operator=(input_stream_adapter&&) = delete;
 
     input_stream_adapter(input_stream_adapter&& rhs) noexcept
-        : is(rhs.is), sb(rhs.sb)
+        : is_(rhs.is_), sb_(rhs.sb_)
     {
-        rhs.is = nullptr;
-        rhs.sb = nullptr;
+        rhs.is_ = nullptr;
+        rhs.sb_ = nullptr;
     }
 
     // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
@@ -117,19 +117,19 @@ class input_stream_adapter
     // end up as the same value, e.g. 0xFFFFFFFF.
     std::char_traits<char>::int_type get_character()
     {
-        auto res = sb->sbumpc();
+        auto res = sb_->sbumpc();
         // set eof manually, as we don't use the istream interface.
         if (JSON_HEDLEY_UNLIKELY(res == std::char_traits<char>::eof()))
         {
-            is->clear(is->rdstate() | std::ios::eofbit);
+            is_->clear(is_->rdstate() | std::ios::eofbit);
         }
         return res;
     }
 
   private:
     /// the associated input stream
-    std::istream* is = nullptr;
-    std::streambuf* sb = nullptr;
+    std::istream* is_ = nullptr;
+    std::streambuf* sb_ = nullptr;
 };
 #endif  // JSON_NO_IO
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6232,14 +6232,14 @@ class input_stream_adapter
     {
         // clear stream flags; we use underlying streambuf I/O, do not
         // maintain ifstream flags, except eof
-        if (is != nullptr)
+        if (is_ != nullptr)
         {
-            is->clear(is->rdstate() & std::ios::eofbit);
+            is_->clear(is_->rdstate() & std::ios::eofbit);
         }
     }
 
     explicit input_stream_adapter(std::istream& i)
-        : is(&i), sb(i.rdbuf())
+        : is_(&i), sb_(i.rdbuf())
     {}
 
     // delete because of pointer members
@@ -6248,10 +6248,10 @@ class input_stream_adapter
     input_stream_adapter& operator=(input_stream_adapter&&) = delete;
 
     input_stream_adapter(input_stream_adapter&& rhs) noexcept
-        : is(rhs.is), sb(rhs.sb)
+        : is_(rhs.is_), sb_(rhs.sb_)
     {
-        rhs.is = nullptr;
-        rhs.sb = nullptr;
+        rhs.is_ = nullptr;
+        rhs.sb_ = nullptr;
     }
 
     // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
@@ -6259,19 +6259,19 @@ class input_stream_adapter
     // end up as the same value, e.g. 0xFFFFFFFF.
     std::char_traits<char>::int_type get_character()
     {
-        auto res = sb->sbumpc();
+        auto res = sb_->sbumpc();
         // set eof manually, as we don't use the istream interface.
         if (JSON_HEDLEY_UNLIKELY(res == std::char_traits<char>::eof()))
         {
-            is->clear(is->rdstate() | std::ios::eofbit);
+            is_->clear(is_->rdstate() | std::ios::eofbit);
         }
         return res;
     }
 
   private:
     /// the associated input stream
-    std::istream* is = nullptr;
-    std::streambuf* sb = nullptr;
+    std::istream* is_ = nullptr;
+    std::streambuf* sb_ = nullptr;
 };
 #endif  // JSON_NO_IO
 

--- a/tests/abi/include/nlohmann/json_v3_10_5.hpp
+++ b/tests/abi/include/nlohmann/json_v3_10_5.hpp
@@ -5287,14 +5287,14 @@ class input_stream_adapter
     {
         // clear stream flags; we use underlying streambuf I/O, do not
         // maintain ifstream flags, except eof
-        if (is != nullptr)
+        if (is_ != nullptr)
         {
-            is->clear(is->rdstate() & std::ios::eofbit);
+            is_->clear(is_->rdstate() & std::ios::eofbit);
         }
     }
 
     explicit input_stream_adapter(std::istream& i)
-        : is(&i), sb(i.rdbuf())
+        : is_(&i), sb_(i.rdbuf())
     {}
 
     // delete because of pointer members
@@ -5303,10 +5303,10 @@ class input_stream_adapter
     input_stream_adapter& operator=(input_stream_adapter&&) = delete;
 
     input_stream_adapter(input_stream_adapter&& rhs) noexcept
-        : is(rhs.is), sb(rhs.sb)
+        : is_(rhs.is_), sb_(rhs.sb_)
     {
-        rhs.is = nullptr;
-        rhs.sb = nullptr;
+        rhs.is_ = nullptr;
+        rhs.sb_ = nullptr;
     }
 
     // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
@@ -5314,19 +5314,19 @@ class input_stream_adapter
     // end up as the same value, e.g. 0xFFFFFFFF.
     std::char_traits<char>::int_type get_character()
     {
-        auto res = sb->sbumpc();
+        auto res = sb_->sbumpc();
         // set eof manually, as we don't use the istream interface.
         if (JSON_HEDLEY_UNLIKELY(res == std::char_traits<char>::eof()))
         {
-            is->clear(is->rdstate() | std::ios::eofbit);
+            is_->clear(is_->rdstate() | std::ios::eofbit);
         }
         return res;
     }
 
   private:
     /// the associated input stream
-    std::istream* is = nullptr;
-    std::streambuf* sb = nullptr;
+    std::istream* is_ = nullptr;
+    std::streambuf* sb_ = nullptr;
 };
 #endif  // JSON_NO_IO
 

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -1326,30 +1326,30 @@ TEST_CASE("regression tests 1")
     SECTION("issue #714 - throw std::ios_base::failure exception when failbit set to true")
     {
         {
-            std::ifstream is;
-            is.exceptions(
-                is.exceptions()
+            std::ifstream is_;
+            is_.exceptions(
+                is_.exceptions()
                 | std::ios_base::failbit
                 | std::ios_base::badbit
             ); // handle different exceptions as 'file not found', 'permission denied'
 
-            is.open(TEST_DATA_DIRECTORY "/regression/working_file.json");
+            is_.open(TEST_DATA_DIRECTORY "/regression/working_file.json");
             json _;
-            CHECK_NOTHROW(_ = nlohmann::json::parse(is));
+            CHECK_NOTHROW(_ = nlohmann::json::parse(is_));
         }
 
         {
-            std::ifstream is;
-            is.exceptions(
-                is.exceptions()
+            std::ifstream is_;
+            is_.exceptions(
+                is_.exceptions()
                 | std::ios_base::failbit
                 | std::ios_base::badbit
             ); // handle different exceptions as 'file not found', 'permission denied'
 
-            is.open(TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json.cbor",
+            is_.open(TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json.cbor",
                     std::ios_base::in | std::ios_base::binary);
             json _;
-            CHECK_NOTHROW(_ = nlohmann::json::from_cbor(is));
+            CHECK_NOTHROW(_ = nlohmann::json::from_cbor(is_));
         }
     }
 

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -1347,7 +1347,7 @@ TEST_CASE("regression tests 1")
             ); // handle different exceptions as 'file not found', 'permission denied'
 
             is_.open(TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json.cbor",
-                    std::ios_base::in | std::ios_base::binary);
+                     std::ios_base::in | std::ios_base::binary);
             json _;
             CHECK_NOTHROW(_ = nlohmann::json::from_cbor(is_));
         }


### PR DESCRIPTION
*TL; DR:*       This pull request was attempting to addresses potential naming collisions with macros defined by users of the library. Specifically, the member variable `is` in the `input_adapter` class has been renamed to `is_` and `sb` to `sb_`.
* * *
### Description

we encountered issues caused by some users who came from Java/C# and defined `is` as a macro in their code. This macro interfered with the library internal implementation, resulting in unexpected behavior and compilation errors due to the macro replacing variables named `is` in the library's internal implementation.

I admit defining `is` is very inappropriate and was a bad idea and inadvisable for them. It's the user's fault to do that and definitely out of control of this json library, however, I believe that issues caused by such `keyword-like` named variables are avoidable. To prevent potential naming collisions and improve compatibility with user-defined macros, in the `input_adapter` class, I
   - Renamed the member variable `is` to `is_`.
   - Renamed the member variable `sb` to `sb_` (naming consistency).

* * *

## Pull request checklist

- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).