### PR TITLE
Docs: fix typos of 'whether' in `operator_{gt,le,lt}.md`

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/operator_gt.md
+++ b/docs/mkdocs/docs/api/basic_json/operator_gt.md
@@ -17,7 +17,7 @@ bool operator>(ScalarType lhs, const const_reference rhs) noexcept;  // (2)
       operand is `NaN` and the other operand is either `NaN` or any other number.
     - Otherwise, returns the result of `#!cpp !(lhs <= rhs)` (see [**operator<=**](operator_le.md)).
 
-2. Compares wether a JSON value is greater than a scalar or a scalar is greater than a JSON value by
+2. Compares whether a JSON value is greater than a scalar or a scalar is greater than a JSON value by
    converting the scalar to a JSON value and comparing both JSON values according to 1.
 
 ## Template parameters

--- a/docs/mkdocs/docs/api/basic_json/operator_le.md
+++ b/docs/mkdocs/docs/api/basic_json/operator_le.md
@@ -17,7 +17,7 @@ bool operator<=(ScalarType lhs, const const_reference rhs) noexcept;  // (2)
       operand is `NaN` and the other operand is either `NaN` or any other number.
     - Otherwise, returns the result of `#!cpp !(rhs < lhs)` (see [**operator<**](operator_lt.md)).
 
-1. Compares wether a JSON value is less than or equal to a scalar or a scalar is less than or equal
+1. Compares whether a JSON value is less than or equal to a scalar or a scalar is less than or equal
    to a JSON value by converting the scalar to a JSON value and comparing both JSON values according
    to 1.
 

--- a/docs/mkdocs/docs/api/basic_json/operator_lt.md
+++ b/docs/mkdocs/docs/api/basic_json/operator_lt.md
@@ -27,7 +27,7 @@ bool operator<(ScalarType lhs, const const_reference rhs) noexcept;  // (2)
         7. binary
       For instance, any boolean value is considered less than any string.
 
-2. Compares wether a JSON value is less than a scalar or a scalar is less than a JSON value by converting
+2. Compares whether a JSON value is less than a scalar or a scalar is less than a JSON value by converting
    the scalar to a JSON value and comparing both JSON values according to 1.
 
 ## Template parameters


### PR DESCRIPTION
Fixed some typos in the documentation that I noticed while browsing the docs on `operator<`. 

The word "whether" was typo-ed as "wether." I fixed this typo and all others I could find in the repo using simple text-search after confirming each one.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).