### PR TITLE
Update natvis to reflect 3.11.3 and the current structure of basic_json

### DIFF
--- a/nlohmann_json.natvis
+++ b/nlohmann_json.natvis
@@ -7,21 +7,21 @@
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
     <!-- Namespace nlohmann -->
     <Type Name="nlohmann::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::detail::value_t::discarded">discarded</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
@@ -37,21 +37,21 @@
 
     <!-- Namespace nlohmann::json_abi -->
     <Type Name="nlohmann::json_abi::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi::detail::value_t::discarded">discarded</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
@@ -65,30 +65,30 @@
         </Expand>
     </Type>
 
-    <!-- Namespace nlohmann::json_abi_v3_11_2 -->
-    <Type Name="nlohmann::json_abi_v3_11_2::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::discarded">discarded</DisplayString>
+    <!-- Namespace nlohmann::json_abi_v3_11_3 -->
+    <Type Name="nlohmann::json_abi_v3_11_3::basic_json&lt;*&gt;">
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_v3_11_2::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_v3_11_3::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
 
     <!-- Skip the pair first/second members in the treeview while traversing a map.
          Only works in VS 2015 Update 2 and beyond using the new visualization -->
-    <Type Name="std::pair&lt;*, nlohmann::json_abi_v3_11_2::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
+    <Type Name="std::pair&lt;*, nlohmann::json_abi_v3_11_3::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
         <DisplayString>{second}</DisplayString>
         <Expand>
             <ExpandedItem>second</ExpandedItem>
@@ -97,21 +97,21 @@
 
     <!-- Namespace nlohmann::json_abi_diag -->
     <Type Name="nlohmann::json_abi_diag::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag::detail::value_t::discarded">discarded</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
@@ -125,30 +125,30 @@
         </Expand>
     </Type>
 
-    <!-- Namespace nlohmann::json_abi_diag_v3_11_2 -->
-    <Type Name="nlohmann::json_abi_diag_v3_11_2::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::discarded">discarded</DisplayString>
+    <!-- Namespace nlohmann::json_abi_diag_v3_11_3 -->
+    <Type Name="nlohmann::json_abi_diag_v3_11_3::basic_json&lt;*&gt;">
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag_v3_11_2::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag_v3_11_3::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
 
     <!-- Skip the pair first/second members in the treeview while traversing a map.
          Only works in VS 2015 Update 2 and beyond using the new visualization -->
-    <Type Name="std::pair&lt;*, nlohmann::json_abi_diag_v3_11_2::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
+    <Type Name="std::pair&lt;*, nlohmann::json_abi_diag_v3_11_3::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
         <DisplayString>{second}</DisplayString>
         <Expand>
             <ExpandedItem>second</ExpandedItem>
@@ -157,21 +157,21 @@
 
     <!-- Namespace nlohmann::json_abi_ldvcmp -->
     <Type Name="nlohmann::json_abi_ldvcmp::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::discarded">discarded</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_ldvcmp::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_ldvcmp::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
@@ -185,30 +185,30 @@
         </Expand>
     </Type>
 
-    <!-- Namespace nlohmann::json_abi_ldvcmp_v3_11_2 -->
-    <Type Name="nlohmann::json_abi_ldvcmp_v3_11_2::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::discarded">discarded</DisplayString>
+    <!-- Namespace nlohmann::json_abi_ldvcmp_v3_11_3 -->
+    <Type Name="nlohmann::json_abi_ldvcmp_v3_11_3::basic_json&lt;*&gt;">
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_ldvcmp_v3_11_2::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_ldvcmp_v3_11_3::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
 
     <!-- Skip the pair first/second members in the treeview while traversing a map.
          Only works in VS 2015 Update 2 and beyond using the new visualization -->
-    <Type Name="std::pair&lt;*, nlohmann::json_abi_ldvcmp_v3_11_2::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
+    <Type Name="std::pair&lt;*, nlohmann::json_abi_ldvcmp_v3_11_3::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
         <DisplayString>{second}</DisplayString>
         <Expand>
             <ExpandedItem>second</ExpandedItem>
@@ -217,21 +217,21 @@
 
     <!-- Namespace nlohmann::json_abi_diag_ldvcmp -->
     <Type Name="nlohmann::json_abi_diag_ldvcmp::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::discarded">discarded</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
@@ -245,30 +245,30 @@
         </Expand>
     </Type>
 
-    <!-- Namespace nlohmann::json_abi_diag_ldvcmp_v3_11_2 -->
-    <Type Name="nlohmann::json_abi_diag_ldvcmp_v3_11_2::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::discarded">discarded</DisplayString>
+    <!-- Namespace nlohmann::json_abi_diag_ldvcmp_v3_11_3 -->
+    <Type Name="nlohmann::json_abi_diag_ldvcmp_v3_11_3::basic_json&lt;*&gt;">
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_2::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == nlohmann::json_abi_diag_ldvcmp_v3_11_3::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>
 
     <!-- Skip the pair first/second members in the treeview while traversing a map.
          Only works in VS 2015 Update 2 and beyond using the new visualization -->
-    <Type Name="std::pair&lt;*, nlohmann::json_abi_diag_ldvcmp_v3_11_2::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
+    <Type Name="std::pair&lt;*, nlohmann::json_abi_diag_ldvcmp_v3_11_3::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
         <DisplayString>{second}</DisplayString>
         <Expand>
             <ExpandedItem>second</ExpandedItem>

--- a/tools/generate_natvis/nlohmann_json.natvis.j2
+++ b/tools/generate_natvis/nlohmann_json.natvis.j2
@@ -8,21 +8,21 @@
 {% for ns in namespaces %}
     <!-- Namespace {{ ns }} -->
     <Type Name="{{ ns }}::basic_json&lt;*&gt;">
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::null">null</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::object">{*(m_value.object)}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::array">{*(m_value.array)}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::string">{*(m_value.string)}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::boolean">{m_value.boolean}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::number_float">{m_value.number_float}</DisplayString>
-        <DisplayString Condition="m_type == {{ ns }}::detail::value_t::discarded">discarded</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::object">{*(m_data.m_value.object)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::array">{*(m_data.m_value.array)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::string">{*(m_data.m_value.string)}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::boolean">{m_data.m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::number_integer">{m_data.m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::number_unsigned">{m_data.m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::number_float">{m_data.m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_data.m_type == {{ ns }}::detail::value_t::discarded">discarded</DisplayString>
         <Expand>
-            <ExpandedItem Condition="m_type == {{ ns }}::detail::value_t::object">
-                *(m_value.object),view(simple)
+            <ExpandedItem Condition="m_data.m_type == {{ ns }}::detail::value_t::object">
+                *(m_data.m_value.object),view(simple)
             </ExpandedItem>
-            <ExpandedItem Condition="m_type == {{ ns }}::detail::value_t::array">
-                *(m_value.array),view(simple)
+            <ExpandedItem Condition="m_data.m_type == {{ ns }}::detail::value_t::array">
+                *(m_data.m_value.array),view(simple)
             </ExpandedItem>
         </Expand>
     </Type>


### PR DESCRIPTION
In #3901 the underlying structure of `basic_json` was altered to move `m_type` and `m_value` under an `m_data` field. This updates the natvis Jinja template to be consistent with this change.  The template is rendered to produce `nlohmann_json.natvis` consistent with version 3.11.3.

fixes #4438
fixes #4340

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).