### PR TITLE
Bring Meson build definition more in line with CMake

### DIFF
--- a/FILES.md
+++ b/FILES.md
@@ -232,7 +232,22 @@ The file can be updated by calling
 make BUILD.bazel
 ```
 
-### `meson.build`
+### `meson.build` and `meson_options.txt`
+
+Meson build definitions suitable for use as a subproject ("wrap" in Meson terminology).
+
+Projects wishing to use the wrap can execute:
+```sh
+meson wrap install nlohmann_json
+```
+
+Which allows Meson to build from source when a system provided dependency isn't available.
+
+To build directly:
+```sh
+meson setup builddir
+ninja -C builddir
+```
 
 ### `Package.swift`
 

--- a/meson.build
+++ b/meson.build
@@ -16,8 +16,11 @@ nlohmann_json_multiple_headers = declare_dependency(
 meson.override_dependency('nlohmann_json_multiple_headers', nlohmann_json_multiple_headers)
 
 if not meson.is_subproject()
-    install_headers('single_include/nlohmann/json.hpp', subdir: 'nlohmann')
-    install_headers('single_include/nlohmann/json_fwd.hpp', subdir: 'nlohmann')
+    install_subdir(
+        'single_include/nlohmann',
+        install_dir: get_option('includedir'),
+        install_tag: 'devel',
+    )
 
     pkgc = import('pkgconfig')
     pkgc.generate(name: 'nlohmann_json',

--- a/meson.build
+++ b/meson.build
@@ -13,12 +13,12 @@ nlohmann_json_multiple_headers = declare_dependency(
 )
 
 if not meson.is_subproject()
-install_headers('single_include/nlohmann/json.hpp', subdir: 'nlohmann')
-install_headers('single_include/nlohmann/json_fwd.hpp', subdir: 'nlohmann')
+    install_headers('single_include/nlohmann/json.hpp', subdir: 'nlohmann')
+    install_headers('single_include/nlohmann/json_fwd.hpp', subdir: 'nlohmann')
 
-pkgc = import('pkgconfig')
-pkgc.generate(name: 'nlohmann_json',
-    version: meson.project_version(),
-    description: 'JSON for Modern C++'
-)
+    pkgc = import('pkgconfig')
+    pkgc.generate(name: 'nlohmann_json',
+        version: meson.project_version(),
+        description: 'JSON for Modern C++'
+    )
 endif

--- a/meson.build
+++ b/meson.build
@@ -8,10 +8,12 @@ project('nlohmann_json',
 nlohmann_json_dep = declare_dependency(
     include_directories: include_directories('single_include')
 )
+meson.override_dependency('nlohmann_json', nlohmann_json_dep)
 
 nlohmann_json_multiple_headers = declare_dependency(
     include_directories: include_directories('include')
 )
+meson.override_dependency('nlohmann_json_multiple_headers', nlohmann_json_multiple_headers)
 
 if not meson.is_subproject()
     install_headers('single_include/nlohmann/json.hpp', subdir: 'nlohmann')

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,13 @@ else
     incdir = 'single_include'
 endif
 
+cpp_args = [
+    '-DJSON_USE_GLOBAL_UDLS=@0@'.format(
+        (not get_option('GlobalUDLs')).to_int()),
+]
+
 nlohmann_json_dep = declare_dependency(
+    compile_args: cpp_args,
     include_directories: include_directories(incdir)
 )
 meson.override_dependency('nlohmann_json', nlohmann_json_dep)

--- a/meson.build
+++ b/meson.build
@@ -6,19 +6,20 @@ project('nlohmann_json',
     default_options: ['cpp_std=c++11'],
 )
 
+if get_option('MultipleHeaders')
+    incdir = 'include'
+else
+    incdir = 'single_include'
+endif
+
 nlohmann_json_dep = declare_dependency(
-    include_directories: include_directories('single_include')
+    include_directories: include_directories(incdir)
 )
 meson.override_dependency('nlohmann_json', nlohmann_json_dep)
 
-nlohmann_json_multiple_headers = declare_dependency(
-    include_directories: include_directories('include')
-)
-meson.override_dependency('nlohmann_json_multiple_headers', nlohmann_json_multiple_headers)
-
 if not meson.is_subproject()
     install_subdir(
-        'single_include/nlohmann',
+        incdir / 'nlohmann',
         install_dir: get_option('includedir'),
         install_tag: 'devel',
     )

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ endif
 cpp_args = [
     '-DJSON_USE_GLOBAL_UDLS=@0@'.format(
         (not get_option('GlobalUDLs')).to_int()),
+    '-DJSON_USE_IMPLICIT_CONVERSIONS=@0@'.format(
+        (not get_option('ImplicitConversions')).to_int()),
 ]
 
 nlohmann_json_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('nlohmann_json',
     'cpp',
     version : '3.12.0',
     license : 'MIT',
+    meson_version : '>= 0.64',
 )
 
 nlohmann_json_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('nlohmann_json',
     version : '3.12.0',
     license : 'MIT',
     meson_version : '>= 0.64',
+    default_options: ['cpp_std=c++11'],
 )
 
 nlohmann_json_dep = declare_dependency(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,9 @@ option(
     value: true,
     description: 'Place user-defined string literals in the global namespace',
 )
+option(
+    'ImplicitConversions',
+    type: 'boolean',
+    value: true,
+    description: 'Enable implicit conversions',
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,9 @@ option(
     value: true,
     description: 'Use non-amalgamated version of the library',
 )
+option(
+    'GlobalUDLs',
+    type: 'boolean',
+    value: true,
+    description: 'Place user-defined string literals in the global namespace',
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+    'MultipleHeaders',
+    type: 'boolean',
+    value: true,
+    description: 'Use non-amalgamated version of the library',
+)


### PR DESCRIPTION
Update the Meson build definition to use Meson best practices, and bring into alignment with the CMake build files.

Particularly, This changes the meson build to only expose a single target, like the CMake does, controlled by an option with the same name. It additionally exposes the `GlobalUDLs` and `ImplicitConversions` options, which have behavioral implementations a consumer may wish to control. I have not exposed other options as they don't seem to be important for behavior.

The options names do not have the `JSON_` prefix, and Meson already has (sub)project option namespaces, so adding `JSON_` would worse (`-Dnlohmann_json:ImplicitConversions` vs `-Dnlohmann_json:JSON_ImplicitConversions`). 

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).