### PR TITLE
Fix example code for json::json_pointer initialization

### DIFF
--- a/docs/mkdocs/docs/features/json_pointer.md
+++ b/docs/mkdocs/docs/features/json_pointer.md
@@ -42,7 +42,7 @@ Note `/` does not identify the root (i.e., the whole document), but an object en
 JSON Pointers can be created from a string:
 
 ```cpp
-json::json_pointer p = "/nested/one";
+json::json_pointer p("/nested/one");
 ```
 
 Furthermore, a user-defined string literal can be used to achieve the same result:


### PR DESCRIPTION
## Description
In #4453, the compilation error of `json::json_pointer p = "/nested/one";` is due to the implicit conversion, as the constructor for `json_pointer` is marked `explicit` (see following source code).

https://github.com/nlohmann/json/blob/b36f4c477c40356a0ae1204b567cca3c2a57d201/include/nlohmann/detail/json_pointer.hpp#L62-L64

Removing the `explicit` can allows to compile and pass the test, but i think it it might violate the design intentions.


## Modification
Changed the example code in the documentation (https://json.nlohmann.me/features/json_pointer/#json-pointer-creation) from copy initialization to direct initialization.

### Before
```cpp
json::json_pointer p = "/nested/one";
```

### After
```cpp
json::json_pointer p("/nested/one");
```

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
