### PR TITLE
Add test for libstdc++

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -206,6 +206,7 @@ jobs:
     strategy:
       matrix:
         standard: [11, 14, 17, 20, 23]
+        stdlib: [libcxx, libstdcxx]
     steps:
       - name: Install git and unzip
         run: apt-get update ; apt-get install -y git unzip
@@ -214,8 +215,12 @@ jobs:
         uses: lukka/get-cmake@v3.27.7
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
-      - name: Build
+      - name: Build with libc++
+        run: cmake --build build --target ci_test_clang_libcxx_cxx${{ matrix.standard }}
+        if: ${{ matrix.stdlib == 'libcxx' }}
+      - name: Build with libstdc++
         run: cmake --build build --target ci_test_clang_cxx${{ matrix.standard }}
+        if: ${{ matrix.stdlib == 'libstdcxx' }}
 
   ci_cuda_example:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -249,6 +249,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install REUSE tool
         run:  python -m pip install reuse
       - name: Run REUSE lint

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
         run: apt-get update ; apt-get install -y git unzip
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
@@ -79,7 +79,7 @@ jobs:
         run: apt-get update ; apt-get install -y git clang-tools unzip
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
@@ -96,7 +96,7 @@ jobs:
         run: apt-get update ; apt-get install -y build-essential unzip wget git
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
@@ -165,7 +165,7 @@ jobs:
         run: apt-get update ; apt-get install -y unzip git
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Set env FORCE_STDCPPFS_FLAG for clang 7 / 8 / 9 / 10
         run: echo "JSON_FORCED_GLOBAL_COMPILE_OPTIONS=-DJSON_HAS_FILESYSTEM=0;-DJSON_HAS_EXPERIMENTAL_FILESYSTEM=0" >> "$GITHUB_ENV"
         if: ${{ matrix.compiler == '7' || matrix.compiler == '8' || matrix.compiler == '9' || matrix.compiler == '10' }}
@@ -212,7 +212,7 @@ jobs:
         run: apt-get update ; apt-get install -y git unzip
       - uses: actions/checkout@v4
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@v3.27.7
+        uses: lukka/get-cmake@v3.31.0
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build with libc++

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/nlohmann/json-ci:v2.2.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
       - name: Install REUSE tool
         run:  python -m pip install reuse
       - name: Run REUSE lint

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -468,7 +468,7 @@ foreach(CXX_STANDARD 11 14 17 20 23)
             -DJSON_BuildTests=ON -DJSON_FastTests=ON
             -DJSON_TestStandards=${CXX_STANDARD}
             -DCMAKE_CXX_FLAGS="-stdlib=libc++"
-            -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi"
+            -DCMAKE_EXE_LINKER_FLAGS="-lc++abi"
             -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD}
         COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD}
         COMMAND cd ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -13,7 +13,7 @@ execute_process(COMMAND ${ASTYLE_TOOL} --version OUTPUT_VARIABLE ASTYLE_TOOL_VER
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" ASTYLE_TOOL_VERSION "${ASTYLE_TOOL_VERSION}")
 message(STATUS "🔖 Artistic Style ${ASTYLE_TOOL_VERSION} (${ASTYLE_TOOL})")
 
-find_program(CLANG_TOOL NAMES clang++-HEAD clang++ clang++-17 clang++-16 clang++-15 clang++-14 clang++-13 clang++-12 clang++-11 clang++)
+find_program(CLANG_TOOL NAMES clang++-HEAD clang++ clang++-20 clang++-19 clang++-18 clang++-17 clang++-16 clang++-15 clang++-14 clang++-13 clang++-12 clang++-11 clang++)
 execute_process(COMMAND ${CLANG_TOOL} --version OUTPUT_VARIABLE CLANG_TOOL_VERSION ERROR_VARIABLE CLANG_TOOL_VERSION)
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" CLANG_TOOL_VERSION "${CLANG_TOOL_VERSION}")
 message(STATUS "🔖 Clang ${CLANG_TOOL_VERSION} (${CLANG_TOOL})")
@@ -461,6 +461,19 @@ foreach(CXX_STANDARD 11 14 17 20 23)
         COMMAND cd ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
         COMMENT "Compile and test with Clang for C++${CXX_STANDARD}"
     )
+
+    add_custom_target(ci_test_clang_libcxx_cxx${CXX_STANDARD}
+        COMMAND CXX=${CLANG_TOOL} CXXFLAGS="${CLANG_CXXFLAGS}" ${CMAKE_COMMAND}
+            -DCMAKE_BUILD_TYPE=Debug -GNinja
+            -DJSON_BuildTests=ON -DJSON_FastTests=ON
+            -DJSON_TestStandards=${CXX_STANDARD}
+            -DCMAKE_CXX_FLAGS="-stdlib=libc++"
+            -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi"
+            -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD}
+        COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD}
+        COMMAND cd ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
+        COMMENT "Compile and test with Clang for C++${CXX_STANDARD} (libc++++)"
+    )
 endforeach()
 
 ###############################################################################
@@ -900,7 +913,7 @@ add_custom_target(ci_cmake_flags
 # Use more installed compilers.
 ###############################################################################
 
-foreach(COMPILER g++-4.8 g++-4.9 g++-5 g++-6 g++-7 g++-8 g++-9 g++-10 g++-11 clang++-3.5 clang++-3.6 clang++-3.7 clang++-3.8 clang++-3.9 clang++-4.0 clang++-5.0 clang++-6.0 clang++-7 clang++-8 clang++-9 clang++-10 clang++-11 clang++-12 clang++-13 clang++-14 clang++-15 clang++-16 clang++-17)
+foreach(COMPILER g++-4.8 g++-4.9 g++-5 g++-6 g++-7 g++-8 g++-9 g++-10 g++-11 clang++-3.5 clang++-3.6 clang++-3.7 clang++-3.8 clang++-3.9 clang++-4.0 clang++-5.0 clang++-6.0 clang++-7 clang++-8 clang++-9 clang++-10 clang++-11 clang++-12 clang++-13 clang++-14 clang++-15 clang++-16 clang++-17 clang++-18 clang++-19 clang++-20)
     find_program(COMPILER_TOOL NAMES ${COMPILER})
     if (COMPILER_TOOL)
         unset(ADDITIONAL_FLAGS)

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -472,7 +472,7 @@ foreach(CXX_STANDARD 11 14 17 20 23)
             -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD}
         COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD}
         COMMAND cd ${PROJECT_BINARY_DIR}/build_clang_cxx${CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
-        COMMENT "Compile and test with Clang for C++${CXX_STANDARD} (libc++++)"
+        COMMENT "Compile and test with Clang for C++${CXX_STANDARD} (libc++)"
     )
 endforeach()
 

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -621,7 +621,7 @@ TEST_CASE("BSON input/output_adapters")
     {
         SECTION("std::ostringstream")
         {
-            std::basic_ostringstream<std::uint8_t> ss;
+            std::basic_ostringstream<char> ss;
             json::to_bson(json_representation, ss);
             json j3 = json::from_bson(ss.str());
             CHECK(json_representation == j3);

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -1880,7 +1880,7 @@ TEST_CASE("single CBOR roundtrip")
         {
             SECTION("std::ostringstream")
             {
-                std::basic_ostringstream<std::uint8_t> ss;
+                std::basic_ostringstream<char> ss;
                 json::to_cbor(j1, ss);
                 json j3 = json::from_cbor(ss.str());
                 CHECK(j1 == j3);

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -20,6 +20,7 @@ using nlohmann::json;
 #include <sstream>
 #include <valarray>
 
+
 namespace
 {
 struct SaxEventLogger : public nlohmann::json_sax<json>
@@ -1131,18 +1132,15 @@ TEST_CASE("deserialization")
     }
 }
 
-TEST_CASE_TEMPLATE("deserialization of different character types (ASCII)", T, // NOLINT(readability-math-missing-parentheses)
+// select the types to test - char8_t is only available in C++20
+#define TYPE_LIST(...) __VA_ARGS__
 #ifdef JSON_HAS_CPP_20
-    char8_t,
+    #define ASCII_TYPES TYPE_LIST(char, wchar_t, char16_t, char32_t, char8_t)
+#else
+    #define ASCII_TYPES TYPE_LIST(char, wchar_t, char16_t, char32_t)
 #endif
-#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
-    unsigned char, signed char,
-    std::uint8_t, std::int8_t,
-    std::int16_t, std::uint16_t,
-    std::int32_t, std::uint32_t,
-#endif
-                   char, wchar_t, char16_t, char32_t
-                  )
+
+TEST_CASE_TEMPLATE("deserialization of different character types (ASCII)", T, ASCII_TYPES) // NOLINT(readability-math-missing-parentheses)
 {
     std::vector<T> const v = {'t', 'r', 'u', 'e'};
     CHECK(json::parse(v) == json(true));
@@ -1154,8 +1152,7 @@ TEST_CASE_TEMPLATE("deserialization of different character types (ASCII)", T, //
     CHECK(l.events == std::vector<std::string>({"boolean(true)"}));
 }
 
-TEST_CASE_TEMPLATE("deserialization of different character types (UTF-8)", T, // NOLINT(readability-math-missing-parentheses)
-                   char, unsigned char, std::uint8_t)
+TEST_CASE_TEMPLATE("deserialization of different character types (UTF-8)", T, char, unsigned char, std::uint8_t) // NOLINT(readability-math-missing-parentheses)
 {
     // a star emoji
     std::vector<T> const v = {'"', static_cast<T>(0xe2u), static_cast<T>(0xadu), static_cast<T>(0x90u), static_cast<T>(0xefu), static_cast<T>(0xb8u), static_cast<T>(0x8fu), '"'};
@@ -1167,12 +1164,7 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-8)", T, //
     CHECK(l.events.size() == 1);
 }
 
-TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T, // NOLINT(readability-math-missing-parentheses)
-#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
-    std::uint16_t,
-#endif
-                   char16_t
-                  )
+TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T, char16_t) // NOLINT(readability-math-missing-parentheses)
 {
     // a star emoji
     std::vector<T> const v = {static_cast<T>('"'), static_cast<T>(0x2b50), static_cast<T>(0xfe0f), static_cast<T>('"')};
@@ -1184,12 +1176,7 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T, /
     CHECK(l.events.size() == 1);
 }
 
-TEST_CASE_TEMPLATE("deserialization of different character types (UTF-32)", T, // NOLINT(readability-math-missing-parentheses)
-#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
-    std::uint32_t,
-#endif
-                   char32_t
-                  )
+TEST_CASE_TEMPLATE("deserialization of different character types (UTF-32)", T, char32_t) // NOLINT(readability-math-missing-parentheses)
 {
     // a star emoji
     std::vector<T> const v = {static_cast<T>('"'), static_cast<T>(0x2b50), static_cast<T>(0xfe0f), static_cast<T>('"')};

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -1132,12 +1132,17 @@ TEST_CASE("deserialization")
 }
 
 TEST_CASE_TEMPLATE("deserialization of different character types (ASCII)", T, // NOLINT(readability-math-missing-parentheses)
-                   char, unsigned char, signed char,
-                   wchar_t,
-                   char16_t, char32_t,
-                   std::uint8_t, std::int8_t,
-                   std::int16_t, std::uint16_t,
-                   std::int32_t, std::uint32_t)
+#ifdef JSON_HAS_CPP_20
+    char8_t,
+#endif
+#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
+    unsigned char, signed char,
+    std::uint8_t, std::int8_t,
+    std::int16_t, std::uint16_t,
+    std::int32_t, std::uint32_t,
+#endif
+                   char, wchar_t, char16_t, char32_t
+                  )
 {
     std::vector<T> const v = {'t', 'r', 'u', 'e'};
     CHECK(json::parse(v) == json(true));
@@ -1163,7 +1168,11 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-8)", T, //
 }
 
 TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T, // NOLINT(readability-math-missing-parentheses)
-                   char16_t, std::uint16_t)
+#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
+    std::uint16_t,
+#endif
+                   char16_t
+                  )
 {
     // a star emoji
     std::vector<T> const v = {static_cast<T>('"'), static_cast<T>(0x2b50), static_cast<T>(0xfe0f), static_cast<T>('"')};
@@ -1176,7 +1185,11 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T, /
 }
 
 TEST_CASE_TEMPLATE("deserialization of different character types (UTF-32)", T, // NOLINT(readability-math-missing-parentheses)
-                   char32_t, std::uint32_t)
+#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
+    std::uint32_t,
+#endif
+                   char32_t
+                  )
 {
     // a star emoji
     std::vector<T> const v = {static_cast<T>('"'), static_cast<T>(0x2b50), static_cast<T>(0xfe0f), static_cast<T>('"')};

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1604,7 +1604,7 @@ TEST_CASE("single MessagePack roundtrip")
         {
             SECTION("std::ostringstream")
             {
-                std::basic_ostringstream<std::uint8_t> ss;
+                std::basic_ostringstream<char> ss;
                 json::to_msgpack(j1, ss);
                 json j3 = json::from_msgpack(ss.str());
                 CHECK(j1 == j3);

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -675,6 +675,7 @@ TEST_CASE("regression tests 2")
     }
 
 #ifdef JSON_HAS_CPP_20
+#ifndef _LIBCPP_VERSION // see https://github.com/nlohmann/json/issues/4490
 #if __has_include(<span>)
     SECTION("issue #2546 - parsing containers of std::byte")
     {
@@ -683,6 +684,7 @@ TEST_CASE("regression tests 2")
         const json j = json::parse(s);
         CHECK(j.dump() == "\"Hello, world!\"");
     }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
- add CI job to use libdc++ to detect errors like #4490
- remove unsupported char types (see #4490)
- update `lukka/get-cmake` to fix warning
- add `python-version` for `actions/setup-python@v5` to fix warning