### PR TITLE
#4271: Use OS independent utf8 string representation of std_fs::path at to_j…

### DIFF
--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -435,7 +435,7 @@ inline void to_json(BasicJsonType& j, const T& t)
 template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, const std_fs::path& p)
 {
-    j = p.string();
+    j = p.u8string();
 }
 #endif
 

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -440,7 +440,6 @@ inline void to_json(BasicJsonType& j, const std_fs::path& p)
 #else
     j = p.u8string();
 #endif
-
 }
 #endif
 

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -435,7 +435,12 @@ inline void to_json(BasicJsonType& j, const T& t)
 template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, const std_fs::path& p)
 {
+#if defined __cpp_lib_char8_t
+    j = reinterpret_cast<char const*>(p.u8string().data());
+#else
     j = p.u8string();
+#endif
+
 }
 #endif
 


### PR DESCRIPTION
#

According to [#4271](https://github.com/nlohmann/json/issues/4271).

`std::filesystem::path::string` method uses system-dependent native format. `String` type is always `UTF8` format, by the json docs. So we force encoding to be `UTF8`.