### PR TITLE
Disallowing implicit conversion from boolean type to some integers type (#4358)

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -203,7 +203,7 @@ inline void from_json(const BasicJsonType& j, std::valarray<T>& l)
 }
 
 template<typename BasicJsonType, typename T, std::size_t N>
-auto from_json(const BasicJsonType& j, T (&arr)[N])  // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+auto from_json(const BasicJsonType& j, T(&arr)[N])  // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 -> decltype(j.template get<T>(), void())
 {
     for (std::size_t i = 0; i < N; ++i)
@@ -378,8 +378,19 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
             break;
         }
-
         case value_t::boolean:
+        {
+            if ((sizeof(ArithmeticType) == 1) && std::is_unsigned<ArithmeticType>::value)
+            {
+                val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+            }
+            else
+            {
+                get_arithmetic_value(j, val);
+            }
+            break;
+        }
+
         case value_t::null:
         case value_t::object:
         case value_t::array:
@@ -400,8 +411,8 @@ std::tuple<Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<
 template < typename BasicJsonType, class A1, class A2 >
 std::pair<A1, A2> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::pair<A1, A2>> /*unused*/, priority_tag<0> /*unused*/)
 {
-    return {std::forward<BasicJsonType>(j).at(0).template get<A1>(),
-            std::forward<BasicJsonType>(j).at(1).template get<A2>()};
+    return { std::forward<BasicJsonType>(j).at(0).template get<A1>(),
+             std::forward<BasicJsonType>(j).at(1).template get<A2>() };
 }
 
 template<typename BasicJsonType, typename A1, typename A2>

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -378,12 +378,8 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
             break;
         }
-        case value_t::boolean:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
-            break;
-        }
 
+        case value_t::boolean:
         case value_t::null:
         case value_t::object:
         case value_t::array:

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -90,11 +90,12 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
             break;
         }
 
+
+        case value_t::boolean:
         case value_t::null:
         case value_t::object:
         case value_t::array:
         case value_t::string:
-        case value_t::boolean:
         case value_t::binary:
         case value_t::discarded:
         default:
@@ -380,15 +381,11 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::boolean:
         {
-            if ((sizeof(ArithmeticType) == 1) && std::is_unsigned<ArithmeticType>::value)
+            if (std::is_same<ArithmeticType, bool>::value || std::is_same<ArithmeticType, uint8_t>::value)
             {
                 val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+                break;
             }
-            else
-            {
-                get_arithmetic_value(j, val);
-            }
-            break;
         }
 
         case value_t::null:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4876,7 +4876,7 @@ inline void from_json(const BasicJsonType& j, std::valarray<T>& l)
 }
 
 template<typename BasicJsonType, typename T, std::size_t N>
-auto from_json(const BasicJsonType& j, T (&arr)[N])  // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+auto from_json(const BasicJsonType& j, T(&arr)[N])  // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 -> decltype(j.template get<T>(), void())
 {
     for (std::size_t i = 0; i < N; ++i)
@@ -5051,8 +5051,19 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
             break;
         }
-
         case value_t::boolean:
+        {
+            if ((sizeof(ArithmeticType) == 1) && std::is_unsigned<ArithmeticType>::value)
+            {
+                val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+            }
+            else
+            {
+                get_arithmetic_value(j, val);
+            }
+            break;
+        }
+
         case value_t::null:
         case value_t::object:
         case value_t::array:
@@ -5073,8 +5084,8 @@ std::tuple<Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<
 template < typename BasicJsonType, class A1, class A2 >
 std::pair<A1, A2> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::pair<A1, A2>> /*unused*/, priority_tag<0> /*unused*/)
 {
-    return {std::forward<BasicJsonType>(j).at(0).template get<A1>(),
-            std::forward<BasicJsonType>(j).at(1).template get<A2>()};
+    return { std::forward<BasicJsonType>(j).at(0).template get<A1>(),
+             std::forward<BasicJsonType>(j).at(1).template get<A2>() };
 }
 
 template<typename BasicJsonType, typename A1, typename A2>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4763,11 +4763,12 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
             break;
         }
 
+
+        case value_t::boolean:
         case value_t::null:
         case value_t::object:
         case value_t::array:
         case value_t::string:
-        case value_t::boolean:
         case value_t::binary:
         case value_t::discarded:
         default:
@@ -5053,15 +5054,11 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::boolean:
         {
-            if ((sizeof(ArithmeticType) == 1) && std::is_unsigned<ArithmeticType>::value)
+            if (std::is_same<ArithmeticType, bool>::value || std::is_same<ArithmeticType, uint8_t>::value)
             {
                 val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+                break;
             }
-            else
-            {
-                get_arithmetic_value(j, val);
-            }
-            break;
         }
 
         case value_t::null:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5051,12 +5051,8 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
             val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
             break;
         }
-        case value_t::boolean:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
-            break;
-        }
 
+        case value_t::boolean:
         case value_t::null:
         case value_t::object:
         case value_t::array:


### PR DESCRIPTION
## Abstract
Referring to issue #4358 , this pull request make some changes that causes implicit conversions from various integer types (listed here - https://godbolt.org/z/7Wrh6EanW) to boolean to fail. Now, instead of inconsistence behavior for different integer types, all implicit conversion from boolean to different integer types will throw a type error.

## Changes Proposed
Remove explicit overload for boolean_t from the from_json function (line 343 from_json.hpp). This will allow all implicit conversions from boolean to integers to fail.

## Possible Issues
This removal will causes two unit tests in unit-conversions.cpp to fail, but both unit tests involve implicit conversion from boolean to uint8_t (line 556-560). Based on issue #4358 , the failure of these two unit tests are expected. Removal of these tests allow the changes to pass all the remaining test cases.

## Validation
Unit test will be added if the propose change is accepted.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
