### PR TITLE
Allowing std::map object with serialized Enum key type to be converted to a JSON object and vice versa - #4378

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -325,9 +325,9 @@ inline void from_json(const BasicJsonType& j, typename BasicJsonType::binary_t& 
     bin = *j.template get_ptr<const typename BasicJsonType::binary_t*>();
 }
 
-template<typename BasicJsonType, typename ConstructibleObjectType,
-         enable_if_t<is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value&&
-         !std::is_enum<typename ConstructibleObjectType::key_type>::value, int> = 0>
+template < typename BasicJsonType, typename ConstructibleObjectType,
+           enable_if_t < is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value&&
+                         !std::is_enum<typename ConstructibleObjectType::key_type>::value, int > = 0 >
 inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
@@ -348,10 +348,10 @@ inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
     obj = std::move(ret);
 }
 
-template <typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
-          enable_if_t<is_constructible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
-          is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
-          std::is_enum<Key>::value, int> = 0>
+template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
+           enable_if_t < is_constructible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
+                         is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
+                         std::is_enum<Key>::value, int > = 0 >
 inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
@@ -361,7 +361,7 @@ inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allo
     m.clear();
     for (const auto& p : j.items())
     {
-        m.emplace(string_to_enum(json(p.key()),Key()), p.value().template get<Value>());
+        m.emplace(string_to_enum(json(p.key()), Key()), p.value().template get<Value>());
     }
 }
 
@@ -459,7 +459,7 @@ auto from_json(BasicJsonType&& j, TupleRelated&& t)
 template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
            typename = enable_if_t < !std::is_constructible <
                                         typename BasicJsonType::string_t, Key >::value &&
-                                    !is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value>>
+                                    !is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value >>
 inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_array()))

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -325,9 +325,9 @@ inline void from_json(const BasicJsonType& j, typename BasicJsonType::binary_t& 
     bin = *j.template get_ptr<const typename BasicJsonType::binary_t*>();
 }
 
-template < typename BasicJsonType, typename ConstructibleObjectType,
-           enable_if_t < is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value&&
-                         !std::is_enum<typename ConstructibleObjectType::key_type>::value, int > = 0 >
+template<typename BasicJsonType, typename ConstructibleObjectType,
+         enable_if_t<is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value&&
+         !std::is_enum<typename ConstructibleObjectType::key_type>::value, int> = 0>
 inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
@@ -348,10 +348,10 @@ inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
     obj = std::move(ret);
 }
 
-template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
-           enable_if_t < is_constructible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
-                         is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
-                         std::is_enum<Key>::value, int > = 0 >
+template <typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
+          enable_if_t<is_constructible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
+          is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
+          std::is_enum<Key>::value, int> = 0>
 inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
@@ -361,7 +361,7 @@ inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allo
     m.clear();
     for (const auto& p : j.items())
     {
-        m.emplace(string_to_enum(json(p.key()), Key()), p.value().template get<Value>());
+        m.emplace(string_to_enum(json(p.key()),Key()), p.value().template get<Value>());
     }
 }
 
@@ -459,7 +459,7 @@ auto from_json(BasicJsonType&& j, TupleRelated&& t)
 template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
            typename = enable_if_t < !std::is_constructible <
                                         typename BasicJsonType::string_t, Key >::value &&
-                                    !is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value >>
+                                    !is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value>>
 inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_array()))

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -270,7 +270,8 @@ struct external_constructor<value_t::object>
 
     template < typename BasicJsonType, typename CompatibleObjectType,
                enable_if_t < !std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value&&
-                             is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value&&
+                             is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&&
+                             !is_basic_json<CompatibleObjectType>::value&&
                              !std::is_enum<typename  CompatibleObjectType::key_type>::value, int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleObjectType& obj)
     {
@@ -409,7 +410,8 @@ inline void to_json(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
 }
 
 template < typename BasicJsonType, typename CompatibleObjectType,
-           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value&&
+           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&&
+                         !is_basic_json<CompatibleObjectType>::value&&
                          !std::is_enum<typename  CompatibleObjectType::key_type>::value, int > = 0 >
 inline void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
 {
@@ -417,8 +419,8 @@ inline void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
 }
 
 template < typename BasicJsonType, typename Key, typename Value,
-           enable_if_t < (is_compatible_object_type<BasicJsonType, std::map<Key, Value>>::value)&&
-                         (!is_basic_json<std::map<Key, Value>>::value)&&
+           enable_if_t < is_compatible_object_type<BasicJsonType, std::map<Key, Value>>::value&&
+                         !is_basic_json<std::map<Key, Value>>::value&&
                          std::is_enum<Key>::value, int > = 0 >
 inline void to_json(BasicJsonType& j, const std::map<Key, Value>& obj)
 {

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -240,7 +240,47 @@
             return ej_pair.second == j;                                                         \
         });                                                                                     \
         e = ((it != std::end(m)) ? it : std::begin(m))->first;                                  \
+    }                                                                                           \
+    /* Function to check for serialized ENUM type */                                            \
+    template<typename BasicJsonType>                                                            \
+    inline constexpr bool serialized(BasicJsonType& j, ENUM_TYPE e)                             \
+    {                                                                                           \
+        return true;                                                                            \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    inline std::string enum_to_string(BasicJsonType j, ENUM_TYPE e)                             \
+    {                                                                                           \
+        /* NOLINTNEXTLINE(modernize-type-traits) we use C++11 */                                \
+        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");          \
+        /* NOLINTNEXTLINE(modernize-avoid-c-arrays) we don't want to depend on <array> */       \
+        static const std::pair<ENUM_TYPE,  BasicJsonType> m[] = __VA_ARGS__;                    \
+        auto it = std::find_if(std::begin(m), std::end(m),                                      \
+                               [e](const std::pair<ENUM_TYPE,  BasicJsonType>& ej_pair) -> bool \
+        {                                                                                       \
+            return ej_pair.first == e;                                                          \
+        });                                                                                     \
+        return ((it != std::end(m)) ? it : std::begin(m))->second;                              \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    inline ENUM_TYPE string_to_enum(BasicJsonType j, ENUM_TYPE e)                               \
+    {                                                                                           \
+        /* NOLINTNEXTLINE(modernize-type-traits) we use C++11 */                                \
+        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");          \
+        /* NOLINTNEXTLINE(modernize-avoid-c-arrays) we don't want to depend on <array> */       \
+        static const std::pair<ENUM_TYPE,  BasicJsonType> m[] = __VA_ARGS__;                    \
+        auto it = std::find_if(std::begin(m), std::end(m),                                      \
+                               [j](const std::pair<ENUM_TYPE,  BasicJsonType>& ej_pair) -> bool \
+        {                                                                                       \
+            return ej_pair.second == j;                                                         \
+        });                                                                                     \
+        return ((it != std::end(m)) ? it : std::begin(m))->first;                               \
     }
+// Function to check for non-serialized ENUM type
+template<typename BasicJsonType, typename EnumType>
+inline constexpr bool serialized(BasicJsonType& j, EnumType e)
+{
+    return false;
+}
 
 // Ugly macros to avoid uglier copy-paste when specializing basic_json. They
 // may be removed in the future once the class is split.

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -386,7 +386,7 @@ struct is_constructible_object_type_impl <
          (std::is_move_assignable<ConstructibleObjectType>::value ||
           std::is_copy_assignable<ConstructibleObjectType>::value) &&
          (is_constructible<typename ConstructibleObjectType::key_type,
-           typename object_t::key_type>::value &&
+          typename object_t::key_type>::value &&
           std::is_same <
           typename object_t::mapped_type,
           typename ConstructibleObjectType::mapped_type >::value)) ||

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -357,8 +357,10 @@ struct is_compatible_object_type_impl <
 
     // macOS's is_constructible does not play well with nonesuch...
     static constexpr bool value =
-        is_constructible<typename object_t::key_type,
-        typename CompatibleObjectType::key_type>::value &&
+        (is_constructible<typename object_t::key_type,
+         typename CompatibleObjectType::key_type>::value ||
+         (std::is_enum<typename CompatibleObjectType::key_type>::value &&
+          serialized("", typename CompatibleObjectType::key_type()))) &&
         is_constructible<typename object_t::mapped_type,
         typename CompatibleObjectType::mapped_type>::value;
 };
@@ -384,7 +386,7 @@ struct is_constructible_object_type_impl <
          (std::is_move_assignable<ConstructibleObjectType>::value ||
           std::is_copy_assignable<ConstructibleObjectType>::value) &&
          (is_constructible<typename ConstructibleObjectType::key_type,
-          typename object_t::key_type>::value &&
+           typename object_t::key_type>::value &&
           std::is_same <
           typename object_t::mapped_type,
           typename ConstructibleObjectType::mapped_type >::value)) ||

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5776,7 +5776,8 @@ struct external_constructor<value_t::object>
 
     template < typename BasicJsonType, typename CompatibleObjectType,
                enable_if_t < !std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value&&
-                             is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value&&
+                             is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&&
+                             !is_basic_json<CompatibleObjectType>::value&&
                              !std::is_enum<typename  CompatibleObjectType::key_type>::value, int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleObjectType& obj)
     {
@@ -5915,7 +5916,8 @@ inline void to_json(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
 }
 
 template < typename BasicJsonType, typename CompatibleObjectType,
-           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value&&
+           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&&
+                         !is_basic_json<CompatibleObjectType>::value&&
                          !std::is_enum<typename  CompatibleObjectType::key_type>::value, int > = 0 >
 inline void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
 {
@@ -5923,8 +5925,8 @@ inline void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
 }
 
 template < typename BasicJsonType, typename Key, typename Value,
-           enable_if_t < (is_compatible_object_type<BasicJsonType, std::map<Key, Value>>::value)&&
-                         (!is_basic_json<std::map<Key, Value>>::value)&&
+           enable_if_t < is_compatible_object_type<BasicJsonType, std::map<Key, Value>>::value&&
+                         !is_basic_json<std::map<Key, Value>>::value&&
                          std::is_enum<Key>::value, int > = 0 >
 inline void to_json(BasicJsonType& j, const std::map<Key, Value>& obj)
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2596,7 +2596,47 @@ JSON_HEDLEY_DIAGNOSTIC_POP
             return ej_pair.second == j;                                                         \
         });                                                                                     \
         e = ((it != std::end(m)) ? it : std::begin(m))->first;                                  \
+    }                                                                                           \
+    /* Function to check for serialized ENUM type */                                            \
+    template<typename BasicJsonType>                                                            \
+    inline constexpr bool serialized(BasicJsonType& j, ENUM_TYPE e)                             \
+    {                                                                                           \
+        return true;                                                                            \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    inline std::string enum_to_string(BasicJsonType j, ENUM_TYPE e)                             \
+    {                                                                                           \
+        /* NOLINTNEXTLINE(modernize-type-traits) we use C++11 */                                \
+        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");          \
+        /* NOLINTNEXTLINE(modernize-avoid-c-arrays) we don't want to depend on <array> */       \
+        static const std::pair<ENUM_TYPE,  BasicJsonType> m[] = __VA_ARGS__;                    \
+        auto it = std::find_if(std::begin(m), std::end(m),                                      \
+                               [e](const std::pair<ENUM_TYPE,  BasicJsonType>& ej_pair) -> bool \
+        {                                                                                       \
+            return ej_pair.first == e;                                                          \
+        });                                                                                     \
+        return ((it != std::end(m)) ? it : std::begin(m))->second;                              \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    inline ENUM_TYPE string_to_enum(BasicJsonType j, ENUM_TYPE e)                               \
+    {                                                                                           \
+        /* NOLINTNEXTLINE(modernize-type-traits) we use C++11 */                                \
+        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");          \
+        /* NOLINTNEXTLINE(modernize-avoid-c-arrays) we don't want to depend on <array> */       \
+        static const std::pair<ENUM_TYPE,  BasicJsonType> m[] = __VA_ARGS__;                    \
+        auto it = std::find_if(std::begin(m), std::end(m),                                      \
+                               [j](const std::pair<ENUM_TYPE,  BasicJsonType>& ej_pair) -> bool \
+        {                                                                                       \
+            return ej_pair.second == j;                                                         \
+        });                                                                                     \
+        return ((it != std::end(m)) ? it : std::begin(m))->first;                               \
     }
+// Function to check for non-serialized ENUM type
+template<typename BasicJsonType, typename EnumType>
+inline constexpr bool serialized(BasicJsonType& j, EnumType e)
+{
+    return false;
+}
 
 // Ugly macros to avoid uglier copy-paste when specializing basic_json. They
 // may be removed in the future once the class is split.
@@ -3804,8 +3844,10 @@ struct is_compatible_object_type_impl <
 
     // macOS's is_constructible does not play well with nonesuch...
     static constexpr bool value =
-        is_constructible<typename object_t::key_type,
-        typename CompatibleObjectType::key_type>::value &&
+        (is_constructible<typename object_t::key_type,
+         typename CompatibleObjectType::key_type>::value ||
+         (std::is_enum<typename CompatibleObjectType::key_type>::value &&
+          serialized("", typename CompatibleObjectType::key_type()))) &&
         is_constructible<typename object_t::mapped_type,
         typename CompatibleObjectType::mapped_type>::value;
 };
@@ -4998,8 +5040,9 @@ inline void from_json(const BasicJsonType& j, typename BasicJsonType::binary_t& 
     bin = *j.template get_ptr<const typename BasicJsonType::binary_t*>();
 }
 
-template<typename BasicJsonType, typename ConstructibleObjectType,
-         enable_if_t<is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value, int> = 0>
+template < typename BasicJsonType, typename ConstructibleObjectType,
+           enable_if_t < is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value&&
+                         !std::is_enum<typename ConstructibleObjectType::key_type>::value, int > = 0 >
 inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
@@ -5018,6 +5061,23 @@ inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
         return value_type(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
     });
     obj = std::move(ret);
+}
+
+template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
+           enable_if_t < is_constructible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
+                         is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value&&
+                         std::is_enum<Key>::value, int > = 0 >
+inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be object, but is ", j.type_name()), &j));
+    }
+    m.clear();
+    for (const auto& p : j.items())
+    {
+        m.emplace(string_to_enum(json(p.key()), Key()), p.value().template get<Value>());
+    }
 }
 
 // overload for arithmetic types, not chosen for basic_json template arguments
@@ -5113,7 +5173,8 @@ auto from_json(BasicJsonType&& j, TupleRelated&& t)
 
 template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
            typename = enable_if_t < !std::is_constructible <
-                                        typename BasicJsonType::string_t, Key >::value >>
+                                        typename BasicJsonType::string_t, Key >::value &&
+                                    !is_compatible_object_type<BasicJsonType, std::map<Key, Value, Compare, Allocator>>::value >>
 inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
 {
     if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
@@ -5213,6 +5274,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <utility> // move, forward, declval, pair
 #include <valarray> // valarray
 #include <vector> // vector
+#include <map> // map
 
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 //     __ _____ _____ _____
@@ -5689,8 +5751,33 @@ struct external_constructor<value_t::object>
         j.assert_invariant();
     }
 
+    template < typename BasicJsonType, typename Key, typename Value,
+               enable_if_t < is_compatible_object_type<BasicJsonType, std::map<Key, Value>>::value&&
+                             !is_basic_json<std::map<Key, Value>>::value&&
+                             std::is_enum<Key>::value, int > = 0 >
+    static void construct(BasicJsonType& j, const std::map<Key, Value>& obj)
+    {
+        using std::begin;
+        using std::end;
+        std::map<std::string, Value> temp;
+        for (auto& i : obj)
+        {
+            Key first = i.first;
+            Value second = i.second;
+            temp.insert({ enum_to_string(j, first), second });
+        }
+
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value.object = j.template create<typename BasicJsonType::object_t>(begin(temp), end(temp));
+        j.set_parents();
+        j.assert_invariant();
+    }
+
     template < typename BasicJsonType, typename CompatibleObjectType,
-               enable_if_t < !std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value, int > = 0 >
+               enable_if_t < !std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value&&
+                             is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value&&
+                             !std::is_enum<typename  CompatibleObjectType::key_type>::value, int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleObjectType& obj)
     {
         using std::begin;
@@ -5828,8 +5915,18 @@ inline void to_json(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
 }
 
 template < typename BasicJsonType, typename CompatibleObjectType,
-           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value, int > = 0 >
+           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value&&
+                         !std::is_enum<typename  CompatibleObjectType::key_type>::value, int > = 0 >
 inline void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
+{
+    external_constructor<value_t::object>::construct(j, obj);
+}
+
+template < typename BasicJsonType, typename Key, typename Value,
+           enable_if_t < (is_compatible_object_type<BasicJsonType, std::map<Key, Value>>::value)&&
+                         (!is_basic_json<std::map<Key, Value>>::value)&&
+                         std::is_enum<Key>::value, int > = 0 >
+inline void to_json(BasicJsonType& j, const std::map<Key, Value>& obj)
 {
     external_constructor<value_t::object>::construct(j, obj);
 }


### PR DESCRIPTION
## Abstract
This PR allows an std::map object with serialized Enum key type to be converted to a JSON object and vice versa (instead of the original JSON array). Now, a map object defined as `std::map<TaskState, std::string> t1 = {{TS_STOPPED, "aa"}, {TS_COMPLETED, "bb"}}` will be translated to `{"stopped":"aa","completed":"bb"}` instead of the original `[["stopped","aa"],["completed","bb"]]`. This constructed JSON object can also be translated back to the respective map object. fixes #4378.

## Changes Proposed
Create new templated `to_json` and  `from_json` functions and some helper functions to allow for this conversion, and also functions that can detect whether an Enum type have been serialized or not.

## Possible Issues
This changes will make changing the map object to JSON object (when the key type is a serialized Enum type) as the default behavior, though this might be the expected and desired behavior.
 
## Validation
The respective unit test will be added if the proposed change is accepted.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [X]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [X]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [X]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
