### PR TITLE
Add step to build the documentation

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ci_test_examples, ci_test_api_documentation]
+        target: [ci_test_examples, ci_test_api_documentation, ci_test_build_documentation]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ci_test_examples, ci_test_api_documentation, ci_test_build_documentation]
+        target: [ci_test_examples, ci_test_build_documentation]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -1029,6 +1029,14 @@ add_custom_target(ci_test_api_documentation
     COMMENT "Lint the API documentation"
 )
 
+add_custom_target(ci_test_build_documentation
+    COMMAND ${Python3_EXECUTABLE} -mvenv venv
+    COMMAND venv/bin/pip3 install -r requirements.txt
+    COMMAND venv/bin/mkdocs build
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs/mkdocs
+    COMMENT "Build the documentation"
+)
+
 ###############################################################################
 # Clean up all generated files.
 ###############################################################################

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -1023,16 +1023,10 @@ add_custom_target(ci_test_examples
     COMMENT "Check that all examples compile and create the desired output"
 )
 
-add_custom_target(ci_test_api_documentation
-    COMMAND ${Python3_EXECUTABLE} ../scripts/check_structure.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs/mkdocs/docs
-    COMMENT "Lint the API documentation"
-)
-
 add_custom_target(ci_test_build_documentation
     COMMAND ${Python3_EXECUTABLE} -mvenv venv
     COMMAND venv/bin/pip3 install -r requirements.txt
-    COMMAND venv/bin/mkdocs build
+    COMMAND make build
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs/mkdocs
     COMMENT "Build the documentation"
 )


### PR DESCRIPTION
For updates like #4548, it is important to have a CI step that actually builds the documentation.