### PR TITLE
Modernizing integer comparison (#4559)

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -172,7 +172,7 @@ class binary_reader
         std::int32_t document_size{};
         get_number<std::int32_t, true>(input_format_t::bson, document_size);
 
-        if (JSON_HEDLEY_UNLIKELY(!sax->start_object(static_cast<std::size_t>(-1))))
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_object(std::numeric_limits<std::size_t>::max())))
         {
             return false;
         }
@@ -394,7 +394,7 @@ class binary_reader
         std::int32_t document_size{};
         get_number<std::int32_t, true>(input_format_t::bson, document_size);
 
-        if (JSON_HEDLEY_UNLIKELY(!sax->start_array(static_cast<std::size_t>(-1))))
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_array(std::numeric_limits<std::size_t>::max())))
         {
             return false;
         }
@@ -654,7 +654,7 @@ class binary_reader
             }
 
             case 0x9F: // array (indefinite length)
-                return get_cbor_array(static_cast<std::size_t>(-1), tag_handler);
+                return get_cbor_array(std::numeric_limits<std::size_t>::max(), tag_handler);
 
             // map (0x00..0x17 pairs of data items follow)
             case 0xA0:
@@ -708,7 +708,7 @@ class binary_reader
             }
 
             case 0xBF: // map (indefinite length)
-                return get_cbor_object(static_cast<std::size_t>(-1), tag_handler);
+                return get_cbor_object(std::numeric_limits<std::size_t>::max(), tag_handler);
 
             case 0xC6: // tagged item
             case 0xC7:
@@ -1096,9 +1096,9 @@ class binary_reader
     }
 
     /*!
-    @param[in] len  the length of the array or static_cast<std::size_t>(-1) for an
+    @param[in] len  the length of the array or std::numeric_limits<std::size_t>::max() for an
                     array of indefinite size
-    @param[in] tag_handler how CBOR tags should be treated
+    @param[in] tag_handler how CBOR tags should be treated 	
     @return whether array creation completed
     */
     bool get_cbor_array(const std::size_t len,
@@ -1109,7 +1109,7 @@ class binary_reader
             return false;
         }
 
-        if (len != static_cast<std::size_t>(-1))
+        if (len != std::numeric_limits<std::size_t>::max())
         {
             for (std::size_t i = 0; i < len; ++i)
             {
@@ -1134,7 +1134,7 @@ class binary_reader
     }
 
     /*!
-    @param[in] len  the length of the object or static_cast<std::size_t>(-1) for an
+    @param[in] len  the length of the object or std::numeric_limits<std::size_t>::max() for an
                     object of indefinite size
     @param[in] tag_handler how CBOR tags should be treated
     @return whether object creation completed
@@ -1150,7 +1150,7 @@ class binary_reader
         if (len != 0)
         {
             string_t key;
-            if (len != static_cast<std::size_t>(-1))
+            if (len != std::numeric_limits<std::size_t>::max())
             {
                 for (std::size_t i = 0; i < len; ++i)
                 {
@@ -2568,7 +2568,7 @@ class binary_reader
         }
         else
         {
-            if (JSON_HEDLEY_UNLIKELY(!sax->start_array(static_cast<std::size_t>(-1))))
+            if (JSON_HEDLEY_UNLIKELY(!sax->start_array(std::numeric_limits<std::size_t>::max())))
             {
                 return false;
             }
@@ -2646,7 +2646,7 @@ class binary_reader
         }
         else
         {
-            if (JSON_HEDLEY_UNLIKELY(!sax->start_object(static_cast<std::size_t>(-1))))
+            if (JSON_HEDLEY_UNLIKELY(!sax->start_object(std::numeric_limits<std::size_t>::max())))
             {
                 return false;
             }
@@ -2982,7 +2982,7 @@ class binary_reader
     }
 
   private:
-    static JSON_INLINE_VARIABLE constexpr std::size_t npos = static_cast<std::size_t>(-1);
+    static JSON_INLINE_VARIABLE constexpr std::size_t npos = std::numeric_limits<std::size_t>::max();
 
     /// input adapter
     InputAdapterType ia;

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -242,7 +242,7 @@ class json_sax_dom_parser
         }
 #endif
 
-        if (JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+        if (JSON_HEDLEY_UNLIKELY(len != std::numeric_limits<std::size_t>::max() && len > ref_stack.back()->max_size()))
         {
             JSON_THROW(out_of_range::create(408, concat("excessive object size: ", std::to_string(len)), ref_stack.back()));
         }
@@ -291,7 +291,7 @@ class json_sax_dom_parser
         }
 #endif
 
-        if (JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+        if (JSON_HEDLEY_UNLIKELY(len != std::numeric_limits<std::size_t>::max() && len > ref_stack.back()->max_size()))
         {
             JSON_THROW(out_of_range::create(408, concat("excessive array size: ", std::to_string(len)), ref_stack.back()));
         }
@@ -559,7 +559,7 @@ class json_sax_dom_callback_parser
 #endif
 
             // check object limit
-            if (JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+            if (JSON_HEDLEY_UNLIKELY(len != std::numeric_limits<std::size_t>::max() && len > ref_stack.back()->max_size()))
             {
                 JSON_THROW(out_of_range::create(408, concat("excessive object size: ", std::to_string(len)), ref_stack.back()));
             }
@@ -657,7 +657,7 @@ class json_sax_dom_callback_parser
 #endif
 
             // check array limit
-            if (JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+            if (JSON_HEDLEY_UNLIKELY(len != std::numeric_limits<std::size_t>::max() && len > ref_stack.back()->max_size()))
             {
                 JSON_THROW(out_of_range::create(408, concat("excessive array size: ", std::to_string(len)), ref_stack.back()));
             }
@@ -946,7 +946,7 @@ class json_sax_acceptor
         return true;
     }
 
-    bool start_object(std::size_t /*unused*/ = static_cast<std::size_t>(-1))
+    bool start_object(std::size_t /*unused*/ = std::numeric_limits<std::size_t>::max())
     {
         return true;
     }
@@ -961,7 +961,7 @@ class json_sax_acceptor
         return true;
     }
 
-    bool start_array(std::size_t /*unused*/ = static_cast<std::size_t>(-1))
+    bool start_array(std::size_t /*unused*/ = std::numeric_limits<std::size_t>::max())
     {
         return true;
     }


### PR DESCRIPTION
Replaced `static_cast<size_t>(-1)` with `std::numeric_limits<std::size_t>::max()` for better clarity and compliance with modern C++ best practices. 