### PR TITLE
fix diagnostic positions related compilation errors

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -849,8 +849,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::is_basic_json<BasicJsonType>::value&& !std::is_same<basic_json, BasicJsonType>::value, int > = 0 >
     basic_json(const BasicJsonType& val)
 #if JSON_DIAGNOSTIC_POSITIONS
-        : start_position(val.start_position),
-          end_position(val.end_position)
+        : start_position(val.start_pos()),
+          end_position(val.end_pos())
 #endif
     {
         using other_boolean_t = typename BasicJsonType::boolean_t;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20704,8 +20704,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::is_basic_json<BasicJsonType>::value&& !std::is_same<basic_json, BasicJsonType>::value, int > = 0 >
     basic_json(const BasicJsonType& val)
 #if JSON_DIAGNOSTIC_POSITIONS
-        : start_position(val.start_position),
-          end_position(val.end_position)
+        : start_position(val.start_pos()),
+          end_position(val.end_pos())
 #endif
     {
         using other_boolean_t = typename BasicJsonType::boolean_t;


### PR DESCRIPTION
This change fixes the compilation issue #4569 by using the public member functions instead of private members to access the start and end positions 

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

