### PR TITLE
fix the abi tests for diagnostics positions feature

### DIFF
--- a/tests/abi/config/default.cpp
+++ b/tests/abi/config/default.cpp
@@ -24,6 +24,10 @@ TEST_CASE("default namespace")
         expected += "_diag";
 #endif
 
+#if JSON_DIAGNOSTIC_POSITIONS
+        expected += "_dp";
+#endif
+
 #if JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
         expected += "_ldvcmp";
 #endif

--- a/tests/abi/config/noversion.cpp
+++ b/tests/abi/config/noversion.cpp
@@ -25,6 +25,10 @@ TEST_CASE("default namespace without version component")
         expected += "_diag";
 #endif
 
+#if JSON_DIAGNOSTIC_POSITIONS
+        expected += "_dp";
+#endif
+
 #if JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
         expected += "_ldvcmp";
 #endif


### PR DESCRIPTION
This PR changes fix the issue #4571, when 'JSON_Diagnostic_Positions' cmake option is enabled, we need to cover JSON_DIAGNOSTIC_POSITIONS preprocessor directive as well.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).
