### PR TITLE
Use Clang image to run iwyu

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -51,8 +51,7 @@ jobs:
         target: [
           ci_test_valgrind,     # needs Valgrind
           ci_test_amalgamation, # needs AStyle
-          ci_infer,             # needs Infer
-          ci_single_binaries    # needs iwyu
+          ci_infer              # needs Infer
         ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -97,10 +96,10 @@ jobs:
     container: silkeh/clang:dev
     strategy:
       matrix:
-        target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze]
+        target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze, ci_single_binaries]
     steps:
       - name: Install git, clang-tools, and unzip
-        run: apt-get update ; apt-get install -y git clang-tools unzip
+        run: apt-get update ; apt-get install -y git clang-tools iwyu unzip
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -8,11 +8,13 @@
 
 #pragma once
 
-#include <algorithm> // copy
-#include <iterator> // begin, end
+#include <nlohmann/detail/macro_scope.hpp> // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
+
+#include <algorithm> // copy
+#include <iterator> // begin, end
 #include <string> // string
 #include <tuple> // tuple, get
 #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type
@@ -21,7 +23,6 @@
 #include <vector> // vector
 
 #include <nlohmann/detail/iterators/iteration_proxy.hpp>
-#include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
 #include <nlohmann/detail/meta/std_fs.hpp>
 #include <nlohmann/detail/meta/type_traits.hpp>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5267,11 +5267,14 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 
-#include <algorithm> // copy
-#include <iterator> // begin, end
+// #include <nlohmann/detail/macro_scope.hpp>
+// JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
+
+#include <algorithm> // copy
+#include <iterator> // begin, end
 #include <string> // string
 #include <tuple> // tuple, get
 #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type
@@ -5557,8 +5560,6 @@ class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
     template <typename IteratorType>
     inline constexpr bool ::std::ranges::enable_borrowed_range<::nlohmann::detail::iteration_proxy<IteratorType>> = true;
 #endif
-
-// #include <nlohmann/detail/macro_scope.hpp>
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 


### PR DESCRIPTION
Install iwyu on the Clang Docker image to use a more recent version (0.18 vs. 0.12).