### PR TITLE
Use ubuntu-latest image to run Valgrind

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -84,7 +84,7 @@ jobs:
           egress-policy: audit
 
       - name: Install Valgrind
-        run: apt-get update ; apt-get install -y valgrind
+        run: sudo apt-get update ; sudo apt-get install -y valgrind
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -76,13 +76,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ci_cppcheck, ci_cpplint, ci_reproducible_tests, ci_non_git_tests, ci_offline_testdata, ci_reuse_compliance]
+        target: [ci_cppcheck, ci_cpplint, ci_reproducible_tests, ci_non_git_tests, ci_offline_testdata, ci_reuse_compliance, ci_test_valgrind]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
 
+      - name: Install Valgrind
+        run: apt-get update ; apt-get install -y valgrind
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2
@@ -96,7 +98,7 @@ jobs:
     container: silkeh/clang:dev
     strategy:
       matrix:
-        target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze, ci_test_valgrind]
+        target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze]
     steps:
       - name: Install git, clang-tools, and unzip
         run: apt-get update ; apt-get install -y git clang-tools unzip valgrind

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,6 @@ jobs:
     strategy:
       matrix:
         target: [
-          ci_test_valgrind,     # needs Valgrind
           ci_test_amalgamation, # needs AStyle
           ci_infer,             # needs Infer
           ci_single_binaries    # needs iwyu
@@ -97,10 +96,10 @@ jobs:
     container: silkeh/clang:dev
     strategy:
       matrix:
-        target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze]
+        target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze, ci_test_valgrind]
     steps:
       - name: Install git, clang-tools, and unzip
-        run: apt-get update ; apt-get install -y git clang-tools unzip
+        run: apt-get update ; apt-get install -y git clang-tools unzip valgrind
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -101,7 +101,7 @@ jobs:
         target: [ci_clang_tidy, ci_test_clang_sanitizer, ci_clang_analyze]
     steps:
       - name: Install git, clang-tools, and unzip
-        run: apt-get update ; apt-get install -y git clang-tools unzip valgrind
+        run: apt-get update ; apt-get install -y git clang-tools unzip
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2


### PR DESCRIPTION
Install Valgrind on the ubuntu-latest image to use a more version (3.18.1 vs. 3.15.0).