### PR TITLE
add a ci step for Json_Diagnostic_Positions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -108,7 +108,7 @@ jobs:
     container: ubuntu:focal
     strategy:
       matrix:
-        target: [ci_cmake_flags, ci_test_diagnostics, ci_test_noexceptions, ci_test_noimplicitconversions, ci_test_legacycomparison, ci_test_noglobaludls]
+        target: [ci_cmake_flags, ci_test_diagnostics, ci_test_diagnostic_positions, ci_test_noexceptions, ci_test_noimplicitconversions, ci_test_legacycomparison, ci_test_noglobaludls]
     steps:
       - name: Install build-essential
         run: apt-get update ; apt-get install -y build-essential unzip wget git

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -562,7 +562,7 @@ add_custom_target(ci_test_diagnostic_positions
     -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_diagnostics_positions
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_diagnostics_positions
     COMMAND cd ${PROJECT_BINARY_DIR}/build_diagnostics_positions && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
-    COMMENT "Compile and test with improved diagnostics positions enabled"
+    COMMENT "Compile and test with diagnostics positions enabled"
 )
 
 ###############################################################################

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -562,7 +562,7 @@ add_custom_target(ci_test_diagnostic_positions
     -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_diagnostics_positions
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_diagnostics_positions
     COMMAND cd ${PROJECT_BINARY_DIR}/build_diagnostics_positions && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
-    COMMENT "Compile and test with diagnostics positions enabled"
+    COMMENT "Compile and test with diagnostic positions enabled"
 )
 
 ###############################################################################

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -552,10 +552,10 @@ add_custom_target(ci_test_diagnostics
 )
 
 ###############################################################################
-# Enable improved diagnostics with positions.
+# Enable diagnostic positions support.
 ###############################################################################
 
-add_custom_target(ci_test_diagnostics_positions
+add_custom_target(ci_test_diagnostic_positions
     COMMAND ${CMAKE_COMMAND}
     -DCMAKE_BUILD_TYPE=Debug -GNinja
     -DJSON_BuildTests=ON -DJSON_Diagnostics=ON -DJSON_Diagnostic_Positions=ON

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -552,6 +552,20 @@ add_custom_target(ci_test_diagnostics
 )
 
 ###############################################################################
+# Enable improved diagnostics with positions.
+###############################################################################
+
+add_custom_target(ci_test_diagnostics_positions
+    COMMAND ${CMAKE_COMMAND}
+    -DCMAKE_BUILD_TYPE=Debug -GNinja
+    -DJSON_BuildTests=ON -DJSON_Diagnostics=ON -DJSON_Diagnostic_Positions=ON
+    -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_diagnostics_positions
+    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_diagnostics_positions
+    COMMAND cd ${PROJECT_BINARY_DIR}/build_diagnostics_positions && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
+    COMMENT "Compile and test with improved diagnostics positions enabled"
+)
+
+###############################################################################
 # Enable legacy discarded value comparison.
 ###############################################################################
 
@@ -910,7 +924,7 @@ endfunction()
 ci_get_cmake(3.1.0 CMAKE_3_1_0_BINARY)
 ci_get_cmake(3.13.0 CMAKE_3_13_0_BINARY)
 
-set(JSON_CMAKE_FLAGS_3_1_0 JSON_Diagnostics JSON_GlobalUDLs JSON_ImplicitConversions JSON_DisableEnumSerialization
+set(JSON_CMAKE_FLAGS_3_1_0 JSON_Diagnostics JSON_Diagnostic_Positions JSON_GlobalUDLs JSON_ImplicitConversions JSON_DisableEnumSerialization
     JSON_LegacyDiscardedValueComparison JSON_Install JSON_MultipleHeaders JSON_SystemInclude JSON_Valgrind)
 set(JSON_CMAKE_FLAGS_3_13_0 JSON_BuildTests)
 

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -558,7 +558,7 @@ add_custom_target(ci_test_diagnostics
 add_custom_target(ci_test_diagnostic_positions
     COMMAND ${CMAKE_COMMAND}
     -DCMAKE_BUILD_TYPE=Debug -GNinja
-    -DJSON_BuildTests=ON -DJSON_Diagnostics=ON -DJSON_Diagnostic_Positions=ON
+    -DJSON_BuildTests=ON -DJSON_Diagnostic_Positions=ON
     -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_diagnostic_positions
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_diagnostic_positions
     COMMAND cd ${PROJECT_BINARY_DIR}/build_diagnostic_positions && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -559,9 +559,9 @@ add_custom_target(ci_test_diagnostic_positions
     COMMAND ${CMAKE_COMMAND}
     -DCMAKE_BUILD_TYPE=Debug -GNinja
     -DJSON_BuildTests=ON -DJSON_Diagnostics=ON -DJSON_Diagnostic_Positions=ON
-    -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_diagnostics_positions
-    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_diagnostics_positions
-    COMMAND cd ${PROJECT_BINARY_DIR}/build_diagnostics_positions && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
+    -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_diagnostic_positions
+    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_diagnostic_positions
+    COMMAND cd ${PROJECT_BINARY_DIR}/build_diagnostic_positions && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
     COMMENT "Compile and test with diagnostic positions enabled"
 )
 


### PR DESCRIPTION
This PR brings the change to add a CI step for the new feature Json_Diagnostic_Positions

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [x]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

