### PR TITLE
Improve Bazel support: Switch to Bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 /.build
 
 /tools/astyle/venv/
+
+# Bazel-related
+MODULE.bazel.lock

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,20 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+exports_files([
+    "LICENSE.MIT",
+])
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE.MIT",
+)
+
 cc_library(
     name = "json",
     hdrs = [
@@ -40,6 +57,7 @@ cc_library(
         "include/nlohmann/detail/output/serializer.hpp",
         "include/nlohmann/detail/string_concat.hpp",
         "include/nlohmann/detail/string_escape.hpp",
+        "include/nlohmann/detail/string_utils.hpp",
         "include/nlohmann/detail/value_t.hpp",
         "include/nlohmann/json.hpp",
         "include/nlohmann/json_fwd.hpp",
@@ -48,5 +66,14 @@ cc_library(
         "include/nlohmann/thirdparty/hedley/hedley_undef.hpp",
     ],
     includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "singleheader-json",
+    hdrs = [
+        "single_include/nlohmann/json.hpp",
+    ],
+    includes = ["single_include"],
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "nlohmann_json",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,1 +1,0 @@
-workspace(name = "nlohmann_json")

--- a/docs/mkdocs/docs/integration/bazel/MODULE.bazel
+++ b/docs/mkdocs/docs/integration/bazel/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "nlohmann_json", version = "3.11.3.bcr.1")

--- a/docs/mkdocs/docs/integration/bazel/WORKSPACE
+++ b/docs/mkdocs/docs/integration/bazel/WORKSPACE
@@ -1,7 +1,0 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "nlohmann_json",
-    urls = ["https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz"],
-    strip_prefix = "json-3.11.3",
-)

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -139,12 +139,12 @@ using the subproject directly.
 
     use `bazel_dep`, `git_override`, or `local_path_override`
 
-    - :octicons-tag-24: Any version, that is availibe via [Bazel Central Registry](https://registry.bazel.build/modules/nlohmann_json)
+    - :octicons-tag-24: Any version, that is available via [Bazel Central Registry](https://registry.bazel.build/modules/nlohmann_json)
     - :octicons-file-24: File issues at the [library issue tracker](https://github.com/nlohmann/json/issues)
     - :octicons-question-24: [Bazel website](https://bazel.build)
 
 This repository provides a [Bazel](https://bazel.build/) `MODULE.bazel` and a corresponding `BUILD.bazel` file. Therefore, this
-repository can be referenced within a `MODULE.bazel` by rules such as `archive_override`, `git_override`, or `local_path_override`. To use the library you only need to depend on the target `@nlohmann_json//:json` (e.g., via `deps` attribute).
+repository can be referenced within a `MODULE.bazel` by rules such as `archive_override`, `git_override`, or `local_path_override`. To use the library you need to depend on the target `@nlohmann_json//:json` (i.e., via `deps` attribute).
 
 ??? example
 

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -137,16 +137,14 @@ using the subproject directly.
 
 !!! abstract "Summary"
 
-    use `http_archive`, `git_repository`, or `local_repository`
+    use `bazel_dep`, `git_override`, or `local_path_override`
 
-    - :octicons-tag-24: Any version, as version is specified in `WORKSPACE` file
+    - :octicons-tag-24: Any version, that is availibe via [Bazel Central Registry](https://registry.bazel.build/modules/nlohmann_json)
     - :octicons-file-24: File issues at the [library issue tracker](https://github.com/nlohmann/json/issues)
     - :octicons-question-24: [Bazel website](https://bazel.build)
 
-This repository provides a [Bazel](https://bazel.build/) `WORKSPACE.bazel` and a corresponding `BUILD.bazel` file. Therefore, this
-repository can be referenced by workspace rules such as `http_archive`, `git_repository`, or `local_repository` from
-other Bazel workspaces. To use the library you only need to depend on the target `@nlohmann_json//:json` (e.g., via
-`deps` attribute).
+This repository provides a [Bazel](https://bazel.build/) `MODULE.bazel` and a corresponding `BUILD.bazel` file. Therefore, this
+repository can be referenced within a `MODULE.bazel` by rules such as `archive_override`, `git_override`, or `local_path_override`. To use the library you only need to depend on the target `@nlohmann_json//:json` (e.g., via `deps` attribute).
 
 ??? example
 
@@ -157,7 +155,7 @@ other Bazel workspaces. To use the library you only need to depend on the target
         ```
 
         ```ini title="WORKSPACE"
-        --8<-- "integration/bazel/WORKSPACE"
+        --8<-- "integration/bazel/MODULE"
         ```
 
         ```cpp title="example.cpp"

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -155,7 +155,7 @@ repository can be referenced within a `MODULE.bazel` by rules such as `archive_o
         ```
 
         ```ini title="WORKSPACE"
-        --8<-- "integration/bazel/MODULE"
+        --8<-- "integration/bazel/MODULE.bazel"
         ```
 
         ```cpp title="example.cpp"


### PR DESCRIPTION
This PR only affects the Bazel build. Switched from traditional WORKSPACE approach to Bzlmod.

Background: Due to the [shortcomings of WORKSPACE](https://bazel.build/external/overview#workspace-shortcomings), Bzlmod is going to replace the legacy WORKSPACE system. The WORKSPACE file will be disabled by default in Bazel 8 (late 2024) and will be removed in Bazel 9 (late 2025). Therefore, this PR.