### PR TITLE
build2 integration doc update

### DIFF
--- a/docs/mkdocs/docs/integration/build2/README.md
+++ b/docs/mkdocs/docs/integration/build2/README.md
@@ -1,0 +1,2 @@
+The files in this directory are for documentation only. In the current file/directory configuration they cannot be used as a  `build2` project. Use `bdep new` to create a proper project and replace the files where necessary. See [../package_managers.md#build2] for details.
+

--- a/docs/mkdocs/docs/integration/build2/README.md
+++ b/docs/mkdocs/docs/integration/build2/README.md
@@ -1,2 +1,0 @@
-The files in this directory are for documentation only. In the current file/directory configuration they cannot be used as a  `build2` project. Use `bdep new` to create a proper project and replace the files where necessary. See [../package_managers.md#build2] for details.
-

--- a/docs/mkdocs/docs/integration/build2/buildfile
+++ b/docs/mkdocs/docs/integration/build2/buildfile
@@ -1,0 +1,6 @@
+libs =
+import libs = nlohmann-json%lib{json}
+
+exe{example}: {hxx ixx txx cxx}{**} $libs testscript
+
+cxx.poptions =+ "-I$out_root" "-I$src_root"

--- a/docs/mkdocs/docs/integration/build2/example.cpp
+++ b/docs/mkdocs/docs/integration/build2/example.cpp
@@ -1,0 +1,10 @@
+#include <nlohmann/json.hpp>
+#include <iostream>
+#include <iomanip>
+
+using json = nlohmann::json;
+
+int main()
+{
+    std::cout << std::setw(4) << json::meta() << std::endl;
+}

--- a/docs/mkdocs/docs/integration/build2/manifest
+++ b/docs/mkdocs/docs/integration/build2/manifest
@@ -11,4 +11,4 @@ depends: * build2 >= 0.16.0
 depends: * bpkg >= 0.16.0
 #depends: libhello ^1.0.0
 
-depends: nlohmann-json ^3.0.0
+depends: nlohmann-json

--- a/docs/mkdocs/docs/integration/build2/manifest
+++ b/docs/mkdocs/docs/integration/build2/manifest
@@ -1,0 +1,14 @@
+name: example
+version: 0.1.0-a.0.z
+language: c++
+summary: example C++ executable
+license: other: proprietary ; Not free/open source.
+description-file: README.md
+url: https://example.org/example
+email: your@emailprovider.com
+#build-error-email: your@emailprovider.com
+depends: * build2 >= 0.16.0
+depends: * bpkg >= 0.16.0
+#depends: libhello ^1.0.0
+
+depends: nlohmann-json ^3.0.0

--- a/docs/mkdocs/docs/integration/build2/repositories.manifest
+++ b/docs/mkdocs/docs/integration/build2/repositories.manifest
@@ -1,0 +1,11 @@
+: 1
+summary: example project repository
+
+:
+role: prerequisite
+location: https://pkg.cppget.org/1/stable
+#trust: ...
+
+#:
+#role: prerequisite
+#location: https://git.build2.org/hello/libhello.git

--- a/docs/mkdocs/docs/integration/build2/testscript
+++ b/docs/mkdocs/docs/integration/build2/testscript
@@ -1,0 +1,24 @@
+
+: json basics
+:
+$* >>~/EOO/
+{
+    "compiler": {
+/        "c\+\+": "\d+",/
+/        "family": "[\w\d]+",/
+/        "version": \d+/
+    },
+/    "copyright": "\(C\) 2013-\d+ Niels Lohmann",/
+    "name": "JSON for Modern C++",
+/    "platform": "[\w\d]+",/
+    "url": "https://github.com/nlohmann/json",
+    "version": {
+        "major": 3,
+/        "minor": \d+,/
+/        "patch": \d+,/
+/        "string": "3\.\d+\.\d+"/
+    }
+}
+EOO
+
+

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -464,7 +464,7 @@ dotnet add package nlohmann.json
 
 ??? example
 
-    Probably the easiest way to use NuGet packages is through Visual Studio graphical interface. Just right-click on a
+    Probably the easiest way to use NuGet packages is through Visual Studio graphical interface. Right-click on a
     project (any C++ project would do) in “Solution Explorer” and select “Manage NuGet Packages…”
 
     ![](nuget/nuget-search-package.png)
@@ -477,8 +477,8 @@ dotnet add package nlohmann.json
     recommends adding “native” and “nativepackage” tags to C++ NuGet packages to distinguish them, but even adding
     “native” to search query would still show many .NET-only packages in the list.
 
-    Nevertheless, after finding the package you want, just click on “Install” button and accept confirmation dialogs.
-    After the package is successfully added to the projects, you should be able to just build and execute the project
+    Nevertheless, after finding the package you want, click on “Install” button and accept confirmation dialogs.
+    After the package is successfully added to the projects, you should be able to build and execute the project
     without the need for making any more changes to build settings.
 
     !!! note

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -717,7 +717,7 @@ Note: [`build2`](https://build2.org) should not be considered as a standalone pa
 
 To use this package in an exising [`build2`](https://build2.org) project, the general steps are:
 
-  1. <details><summary>Make the package available to download from a package repository that provides it.</b></summary>
+  1. <details><summary>Make the package available to download from a package repository that provides it.</summary>
 
       Your project's `repositories.manifest` specifies where the package manager will try to acquire packages by default. Make sure one of the repositories specified in this file provides `nlhomann-json` package.
       The recommended open-source repository is [`cppget.org`](https://cppget.org/).
@@ -732,7 +732,7 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
 
   2. <details><summary>Add this package as dependency of your project.</summary>
 
-       In your project's `manifest` add the dependency to the package, like `depends: nlohmann-json`. You could also add some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps).
+       In your project's `manifest` add the dependency to the package using `depends: nlohmann-json`. You could also add some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps).
        For example, to depend on the latest version available:
        ```
        depends: nlohmann-json
@@ -747,7 +747,7 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
            ```
            import nljson = nlhomann-json%lib{json}
            ```
-        - add the library's target as requirement for your target using it, for example:
+        - then add the library's target as requirement for your target using it, for example:
            ```
            exe{example} : ... $nljson
            ```
@@ -757,7 +757,7 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
 
       At this point, assuming your project is initialized in a build-configuration, any `b` or `bdep update` command that will update/build the project will also acquire the missing dependency automatically, then build it and link it with your target.
 
-      If you just want to trigger the dependencies synchronization for all your configurations:
+      If you just want to synchronize dependencies for all your configurations to download the ones you just added:
         ```
         bdep sync -af
         ```
@@ -812,10 +812,10 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
         # create default C/C++ build configuration in ../example-myconfig/, initialize the project in it (downloads it's dependencies in it too)
         bdep init -C @myconfig cc
 
-        # build only
+        # build only,
         b
 
-        # build and test the executable's output, will only work if the `tescript` is correct
+        # or build and test the executable's output, will only work if the `tescript` is correct
         b test
 
         ```

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -703,19 +703,21 @@ to install the [nlohmann-json](https://ports.macports.org/port/nlohmann-json/) p
 !!! abstract "Summary"
 
     package: **`nlohmann-json`**
-    library target: **`nlohmann-json%`**
+    library target: **`nlohmann-json%lib{json}`**
     available in package repositories:
       - [`cppget.org` (recommended)](https://cppget.org/nlohmann-json)
       - [package's sources (for advanced users)](https://github.com/build2-packaging/nlohmann-json/)
 
     - :octicons-tag-24: Available versions: current version and older versions since `3.7.3` (see [cppget.org](https://cppget.org/nlohmann-json))
-    - :octicons-rocket-24: The package is maintained and published by the community in [this the repository][(https://github.com/conan-io/conan-center-index/tree/master/recipes/nlohmann_json](https://github.com/build2-packaging/nlohmann-json/)).
+    - :octicons-rocket-24: The package is maintained and published by the `build2` community in [this the repository][(https://github.com/conan-io/conan-center-index/tree/master/recipes/nlohmann_json](https://github.com/build2-packaging/nlohmann-json/)).
     - :octicons-file-24: File issues at the [package source repository](https://github.com/build2-packaging/nlohmann-json/issues/)
     - :octicons-question-24: [`build2` website](https://build2)
 
+Note: [`build2`](https://build2.org) should not be considered as a standalone package-manager. It is a build-system + package manager + project manager, a set of tools that work hand-in-hand. `build2`-based projects do not rely on existing `CMake` scripts and the build scripts defining the project's targets are specific to `build2`.
+
 To use this package in an exising [`build2`](https://build2.org) project, the general steps are:
 
-  0. <details><summary>Make the package available to download from a package repository that provides it.</b></summary>
+  1. <details><summary>Make the package available to download from a package repository that provides it.</b></summary>
 
       Your project's `repositories.manifest` specifies where the package manager will try to acquire packages by default. Make sure one of the repositories specified in this file provides `nlhomann-json` package.
       The recommended open-source repository is [`cppget.org`](https://cppget.org/).
@@ -728,7 +730,7 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
       ```
       </details>
 
-  1. <details><summary>Add this package as dependency of your project.</summary>
+  2. <details><summary>Add this package as dependency of your project.</summary>
 
        In your project's `manifest` add the dependency to the package, like `depends: nlohmann-json`, probably with some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps).
        For example, to depend on the latest `3.x` version available:
@@ -738,12 +740,12 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
        </details>
 
 
-  2. <details><summary>Add this library (from the package) as dependency of your target that uses it.</summary>
+  2. <details><summary>Add this library as dependency of your target that uses it.</summary>
 
       In the `buildfile` defining the target that will use this library:
-        - import the target from the `nlhomann-json` package, for example:
+        - import the target `lib{json}` from the `nlhomann-json` package, for example:
            ```
-           import nljson = nlhomann-json%json
+           import nljson = nlhomann-json%lib{json}
            ```
         - add the library's target as requirement for your target using it, for example:
            ```
@@ -753,7 +755,7 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
 
   3. <details><summary>Use the library in your project's code and build it.</summary>
 
-      At this point, any `b` or `bdep update` command that will update/build the project will also acquire the missing dependency automatically, then build it and link it with your target.
+      At this point, assuming your project is initialized in a build-configuration, any `b` or `bdep update` command that will update/build the project will also acquire the missing dependency automatically, then build it and link it with your target.
 
       If you just want to trigger the dependencies synchronization for all your configurations:
         ```
@@ -762,15 +764,90 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
       </details>
 
 ??? example "Example: from scratch, using `build2`'s [`bdep new` command](https://build2.org/bdep/doc/bdep-new.xhtml)"
-```
-# create a simple executable project from scratch, with a simplfied directory layout, using `.hpp/.cpp` file extensions:
-bdep new example -exe,no-subdirs,no-tests -l c++,cpp
 
-```
+    1. Create a new executable project "example" (see [`bdep new` command details](https://build2.org/bdep/doc/bdep-new.xhtml) for the various options to create a new project):
 
-```shell
-bdep new -t exe -l c++
-```
+        ```shell
+        bdep new example
+        ```
+
+    2. Enable acquiring packages from https://cppget.org by uncommenting these lines in `example/repositories.manifest`:
+
+        ```make
+        :
+        role: prerequisite
+        location: https://pkg.cppget.org/1/stable
+        ```
+
+        Your `example/manifest` should now look like this:
+
+        ```make title="project's `repositories.manifest`"
+        --8<-- "integration/build2/repositories.manifest"
+        ```
+
+    3. Add any available `3.x` version of the `nlohmann-json` package as dependency to the project by adding this line to `example/manifest`:
+
+        ```make
+        depends: nlohmann-json ^3.0.0
+        ```
+
+        Your `example/manifest` should now look like this:
+
+        ```make title="project's `manifest`"
+        --8<-- "integration/build2/manifest"
+        ```
+
+    4. In `example/example/buildfile`, import the library's target to be used as requirement for building the executable target `exe{example}` by replacing the top lines of that file by:
+
+        ```make
+        libs =
+        import libs = nlhomann-json%lib{json}
+
+        exe{example}: {hxx ixx txx cxx}{**} $libs testscript
+        ```
+
+        Your `example/example/buildfile` should now look like this:
+
+        ```make title="project's `buildfile`"
+        --8<-- "integration/build2/buildfile"
+        ```
+
+    5. Initialize the project in a C/C++ build configuration directory that we will create in the same command, with the default C++ build toolchain for simplicity:
+
+        ```shell
+        cd example/
+        bdep init -C @myconfig cc
+        ```
+
+        Note that this will also download the project's dependencies, here the package `nlhomann-json` into the newly created build configuration directory `example-myconfig/`.
+
+    6. Replace the C++ source code in `example/example/example.cxx` by this code:
+
+        ```cpp title="example.cxx"
+        --8<-- "integration/build2/example.cpp"
+        ```
+
+    7. Build the project by using [`b`](https://build2.org/build2/doc/b.xhtml) or [`bdep update`](https://build2.org/bdep/doc/bdep.xhtml):
+
+        ```shell
+        # in example/
+        b
+        ```
+
+        This should generate the executable in `example-myconfig/example/example/` and add a symbolic link to it in `example/example/`.
+
+        - If you want to be able to test that executable's output is correct, you can use build2's executable testing tooling `tescript` by changing the content of `example/example/testscript` to this code:
+
+            ```cpp title="`testscript` checking the output of the program"
+            --8<-- "integration/build2/testscript"
+            ```
+
+            Then run [`b test`](https://build2.org/build2/doc/b.xhtml) or [`bdep test`](https://build2.org/bdep/doc/bdep.xhtml) to automatically check the program's output. Assuming that the c++ code above didnt change, it should not fail as long as the library outputs the expected json format.
+
+            ```shell
+            # in example/
+            b test
+            ```
 
 ## CPM.cmake
 

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -732,10 +732,10 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
 
   2. <details><summary>Add this package as dependency of your project.</summary>
 
-       In your project's `manifest` add the dependency to the package, like `depends: nlohmann-json`, probably with some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps).
-       For example, to depend on the latest `3.x` version available:
+       In your project's `manifest` add the dependency to the package, like `depends: nlohmann-json`. You could also add some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps).
+       For example, to depend on the latest version available:
        ```
-       depends: nlohmann-json ^3.0.0
+       depends: nlohmann-json
        ```
        </details>
 
@@ -771,83 +771,54 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
         bdep new example
         ```
 
-    2. Enable acquiring packages from https://cppget.org by uncommenting these lines in `example/repositories.manifest`:
+    2. Edit these files by replacing their content:
 
-        ```make
-        :
-        role: prerequisite
-        location: https://pkg.cppget.org/1/stable
-        ```
+        - `example/repositories.manifest`: Enable acquiring packages from https://cppget.org by uncommenting the related lines:
 
-        Your `example/manifest` should now look like this:
+            ```make title="project's `repositories.manifest`"
+            --8<-- "integration/build2/repositories.manifest"
+            ```
 
-        ```make title="project's `repositories.manifest`"
-        --8<-- "integration/build2/repositories.manifest"
-        ```
+       - `example/manifest`: Add the latest version of the `nlohmann-json` package as dependency to the project:
 
-    3. Add any available `3.x` version of the `nlohmann-json` package as dependency to the project by adding this line to `example/manifest`:
+            ```make title="project's `manifest`"
+            --8<-- "integration/build2/manifest"
+            ```
 
-        ```make
-        depends: nlohmann-json ^3.0.0
-        ```
+       - `example/example/buildfile`: import the library's target to be used as requirement for building the executable target `exe{example}`:
 
-        Your `example/manifest` should now look like this:
+            ```make title="project's `buildfile`"
+            --8<-- "integration/build2/buildfile"
+            ```
 
-        ```make title="project's `manifest`"
-        --8<-- "integration/build2/manifest"
-        ```
+        - `example/example/example.cxx`: `bdep new` generates a "hello world" by default, replace it by this:
 
-    4. In `example/example/buildfile`, import the library's target to be used as requirement for building the executable target `exe{example}` by replacing the top lines of that file by:
+            ```cpp title="example.cxx"
+            --8<-- "integration/build2/example.cpp"
+            ```
 
-        ```make
-        libs =
-        import libs = nlhomann-json%lib{json}
-
-        exe{example}: {hxx ixx txx cxx}{**} $libs testscript
-        ```
-
-        Your `example/example/buildfile` should now look like this:
-
-        ```make title="project's `buildfile`"
-        --8<-- "integration/build2/buildfile"
-        ```
-
-    5. Initialize the project in a C/C++ build configuration directory that we will create in the same command, with the default C++ build toolchain for simplicity:
-
-        ```shell
-        cd example/
-        bdep init -C @myconfig cc
-        ```
-
-        Note that this will also download the project's dependencies, here the package `nlhomann-json` into the newly created build configuration directory `example-myconfig/`.
-
-    6. Replace the C++ source code in `example/example/example.cxx` by this code:
-
-        ```cpp title="example.cxx"
-        --8<-- "integration/build2/example.cpp"
-        ```
-
-    7. Build the project by using [`b`](https://build2.org/build2/doc/b.xhtml) or [`bdep update`](https://build2.org/bdep/doc/bdep.xhtml):
-
-        ```shell
-        # in example/
-        b
-        ```
-
-        This should generate the executable in `example-myconfig/example/example/` and add a symbolic link to it in `example/example/`.
-
-        - If you want to be able to test that executable's output is correct, you can use build2's executable testing tooling `tescript` by changing the content of `example/example/testscript` to this code:
+        - `example/example/testscript`: (optional) if you want to be able to test that executable's output is correct using `b test`:
 
             ```cpp title="`testscript` checking the output of the program"
             --8<-- "integration/build2/testscript"
             ```
 
-            Then run [`b test`](https://build2.org/build2/doc/b.xhtml) or [`bdep test`](https://build2.org/bdep/doc/bdep.xhtml) to automatically check the program's output. Assuming that the c++ code above didnt change, it should not fail as long as the library outputs the expected json format.
 
-            ```shell
-            # in example/
-            b test
-            ```
+    3. Initialize the project in a default C/C++ build configuration directory, then build and test:
+
+        ```shell
+        cd example/
+
+        # create default C/C++ build configuration in ../example-myconfig/, initialize the project in it (downloads it's dependencies in it too)
+        bdep init -C @myconfig cc
+
+        # build only
+        b
+
+        # build and test the executable's output, will only work if the `tescript` is correct
+        b test
+
+        ```
 
 ## CPM.cmake
 

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -363,7 +363,7 @@ and follow the then displayed descriptions. Please see the vcpkg project for any
         ```cmake title="CMakeLists.txt"
         --8<-- "integration/vcpkg/CMakeLists.txt"
         ```
-    
+
         ```cpp title="example.cpp"
         --8<-- "integration/vcpkg/example.cpp"
         ```
@@ -408,7 +408,7 @@ installed by adding the `-DJSON_MultipleHeaders=ON` flag (i.e., `cget install nl
         ```cmake title="CMakeLists.txt"
         --8<-- "integration/vcpkg/CMakeLists.txt"
         ```
-    
+
         ```cpp title="example.cpp"
         --8<-- "integration/vcpkg/example.cpp"
         ```
@@ -418,7 +418,7 @@ installed by adding the `-DJSON_MultipleHeaders=ON` flag (i.e., `cget install nl
         ```shell
         cget init
         ```
- 
+
     3. Install the library
 
         ```shell
@@ -476,15 +476,15 @@ dotnet add package nlohmann.json
     Most of the packages in NuGet gallery are .NET packages and would not be useful in a C++ project. Microsoft
     recommends adding “native” and “nativepackage” tags to C++ NuGet packages to distinguish them, but even adding
     “native” to search query would still show many .NET-only packages in the list.
-    
-    Nevertheless, after finding the package you want, click on “Install” button and accept confirmation dialogs.
-    After the package is successfully added to the projects, you should be able to build and execute the project
+
+    Nevertheless, after finding the package you want, just click on “Install” button and accept confirmation dialogs.
+    After the package is successfully added to the projects, you should be able to just build and execute the project
     without the need for making any more changes to build settings.
 
     !!! note
 
         A few notes:
-    
+
         - NuGet packages are installed per project and not system-wide. The header and binaries for the package are only
           available to the project it is added to, and not other projects (obviously unless we add the package to those
           projects as well)
@@ -502,9 +502,9 @@ dotnet add package nlohmann.json
 
     After you add a NuGet package, three changes occur in the project source directory. Of course, we could make these
     changes manually instead of using GUI:
-    
+
     ![](nuget/nuget-project-changes.png)
-    
+
     1. A `packages.config` file will be created (or updated to include the package name if one such file already
        exists). This file contains a list of the packages required by this project (name and minimum version) and must
        be added to the project source code repository, so if you move the source code to a new machine, MSBuild/NuGet
@@ -519,29 +519,29 @@ dotnet add package nlohmann.json
 
     2. A `packages` folder which contains actual files in the packages (these are header and binary files required for
        a successful build, plus a few metadata files). In case of this library for example, it contains `json.hpp`:
-    
+
         ![](nuget/nuget-package-content.png)
-    
+
         !!! note
 
             This directory should not be added to the project source code repository, as it will be restored before each
             build by MSBuild/NuGet. If you go ahead and delete this folder, then build the project again, it will
             magically re-appear!
-    
+
     3. Project MSBuild makefile (which for Visual C++ projects has a .vcxproj extension) will be updated to include
        settings from the package.
-    
+
         ![](nuget/nuget-project-makefile.png)
-    
+
         The important bit for us here is line 170, which tells MSBuild to import settings from
         `packages\nlohmann.json.3.5.0\build\native\nlohmann.json.targets` file. This is a file the package creator
         created and added to the package (you can see it is one of the two files I created in this repository, the other
         just contains package attributes like name and version number). What does it contain?
-    
+
         For our header-only repository, the only setting we need is to add our include directory to the list of
         `AdditionalIncludeDirectories`:
 
-        ```xml    
+        ```xml
         <?xml version="1.0" encoding="utf-8"?>
         <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
             <ItemDefinitionGroup>
@@ -554,21 +554,21 @@ dotnet add package nlohmann.json
 
         For libraries with binary files, we will need to add `.lib` files to linker inputs and add settings to copy
         `.dll` and other redistributable files to output directory, if needed.
-    
+
         There are other changes to the makefile as well:
-    
+
         - Lines 165-167 add the `packages.config` as one of project files (so it is shown in Solution Explorer tree
           view). It is added as None (no build action) and removing it wouldn’t affect build.
-    
+
         - Lines 172-177 check to ensure the required packages are present. This will display a build error if package
           directory is empty (for example when NuGet cannot restore packages because Internet connection is down).
           Again, if you omit this section, the only change in build would be a more cryptic error message if build
           fails.
-    
+
         !!! note
 
             Changes to .vcxproj makefile should also be added to project source code repository.
-    
+
     As you can see, the mechanism NuGet uses to modify project settings is through MSBuild makefiles, so using NuGet
     with other build systems and compilers (like CMake) as a dependency manager is either impossible or more problematic
     than useful.
@@ -645,7 +645,7 @@ If you are using [MSYS2](http://www.msys2.org/), you can use the [mingw-w64-nloh
     - :octicons-file-24: File issues at the [MacPorts issue tracker](https://trac.macports.org/newticket?port=nlohmann-json)
     - :octicons-question-24: [MacPorts website](https://www.macports.org)
 
-If you are using [MacPorts](https://ports.macports.org), execute 
+If you are using [MacPorts](https://ports.macports.org), execute
 
 ```shell
 sudo port install nlohmann-json
@@ -700,13 +700,73 @@ to install the [nlohmann-json](https://ports.macports.org/port/nlohmann-json/) p
 
 ## build2
 
-If you are using [`build2`](https://build2.org), you can use the [`nlohmann-json`](https://cppget.org/nlohmann-json)
-package from the public repository <http://cppget.org> or directly from the
-[package's sources repository](https://github.com/build2-packaging/nlohmann-json). In your project's `manifest` file,
-add `depends: nlohmann-json` (probably with some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps)). If you are not familiar with using dependencies in `build2`, [please read this introduction](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml).
-Please file issues [here](https://github.com/build2-packaging/nlohmann-json) if you experience problems with the packages.
+!!! abstract "Summary"
 
-:material-update: The [package](https://cppget.org/nlohmann-json) is updated automatically.
+    package: **`nlohmann-json`**
+    library target: **`nlohmann-json%`**
+    available in package repositories:
+      - [`cppget.org` (recommended)](https://cppget.org/nlohmann-json)
+      - [package's sources (for advanced users)](https://github.com/build2-packaging/nlohmann-json/)
+
+    - :octicons-tag-24: Available versions: current version and older versions since `3.7.3` (see [cppget.org](https://cppget.org/nlohmann-json))
+    - :octicons-rocket-24: The package is maintained and published by the community in [this the repository][(https://github.com/conan-io/conan-center-index/tree/master/recipes/nlohmann_json](https://github.com/build2-packaging/nlohmann-json/)).
+    - :octicons-file-24: File issues at the [package source repository](https://github.com/build2-packaging/nlohmann-json/issues/)
+    - :octicons-question-24: [`build2` website](https://build2)
+
+To use this package in an exising [`build2`](https://build2.org) project, the general steps are:
+
+  0. <details><summary>Make the package available to download from a package repository that provides it.</b></summary>
+
+      Your project's `repositories.manifest` specifies where the package manager will try to acquire packages by default. Make sure one of the repositories specified in this file provides `nlhomann-json` package.
+      The recommended open-source repository is [`cppget.org`](https://cppget.org/).
+
+      If the project has been created using [`bdep new`](https://build2.org/bdep/doc/bdep-new.xhtml), `cppget.org` is already specified in `repositories.manifest` but commented, just uncomment these lines:
+      ```
+      :
+      role: prerequisite
+      location: https://pkg.cppget.org/1/stable
+      ```
+      </details>
+
+  1. <details><summary>Add this package as dependency of your project.</summary>
+
+       In your project's `manifest` add the dependency to the package, like `depends: nlohmann-json`, probably with some [version constraints](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml#guide-add-remove-deps).
+       For example, to depend on the latest `3.x` version available:
+       ```
+       depends: nlohmann-json ^3.0.0
+       ```
+       </details>
+
+
+  2. <details><summary>Add this library (from the package) as dependency of your target that uses it.</summary>
+
+      In the `buildfile` defining the target that will use this library:
+        - import the target from the `nlhomann-json` package, for example:
+           ```
+           import nljson = nlhomann-json%json
+           ```
+        - add the library's target as requirement for your target using it, for example:
+           ```
+           exe{example} : ... $nljson
+           ```
+      </details>
+
+  3. <details><summary>Use the library in your project's code and build it.</summary>
+
+      At this point, any `b` or `bdep update` command that will update/build the project will also acquire the missing dependency automatically, then build it and link it with your target.
+
+      If you just want to trigger the dependencies synchronization for all your configurations:
+        ```
+        bdep sync -af
+        ```
+      </details>
+
+??? example "Example: from scratch, using `build2`'s [`bdep new` command](https://build2.org/bdep/doc/bdep-new.xhtml)"
+```
+# create a simple executable project from scratch, with a simplfied directory layout, using `.hpp/.cpp` file extensions:
+bdep new example -exe,no-subdirs,no-tests -l c++,cpp
+
+```
 
 ```shell
 bdep new -t exe -l c++
@@ -784,7 +844,7 @@ CPMAddPackage("gh:nlohmann/json@3.12.0")
         ```shell
         xmake
         ```
-    
+
     3. Run
 
         ```shell

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -363,7 +363,7 @@ and follow the then displayed descriptions. Please see the vcpkg project for any
         ```cmake title="CMakeLists.txt"
         --8<-- "integration/vcpkg/CMakeLists.txt"
         ```
-
+    
         ```cpp title="example.cpp"
         --8<-- "integration/vcpkg/example.cpp"
         ```
@@ -408,7 +408,7 @@ installed by adding the `-DJSON_MultipleHeaders=ON` flag (i.e., `cget install nl
         ```cmake title="CMakeLists.txt"
         --8<-- "integration/vcpkg/CMakeLists.txt"
         ```
-
+    
         ```cpp title="example.cpp"
         --8<-- "integration/vcpkg/example.cpp"
         ```
@@ -418,7 +418,7 @@ installed by adding the `-DJSON_MultipleHeaders=ON` flag (i.e., `cget install nl
         ```shell
         cget init
         ```
-
+ 
     3. Install the library
 
         ```shell
@@ -476,7 +476,7 @@ dotnet add package nlohmann.json
     Most of the packages in NuGet gallery are .NET packages and would not be useful in a C++ project. Microsoft
     recommends adding “native” and “nativepackage” tags to C++ NuGet packages to distinguish them, but even adding
     “native” to search query would still show many .NET-only packages in the list.
-
+    
     Nevertheless, after finding the package you want, click on “Install” button and accept confirmation dialogs.
     After the package is successfully added to the projects, you should be able to build and execute the project
     without the need for making any more changes to build settings.
@@ -484,7 +484,7 @@ dotnet add package nlohmann.json
     !!! note
 
         A few notes:
-
+    
         - NuGet packages are installed per project and not system-wide. The header and binaries for the package are only
           available to the project it is added to, and not other projects (obviously unless we add the package to those
           projects as well)
@@ -502,9 +502,9 @@ dotnet add package nlohmann.json
 
     After you add a NuGet package, three changes occur in the project source directory. Of course, we could make these
     changes manually instead of using GUI:
-
+    
     ![](nuget/nuget-project-changes.png)
-
+    
     1. A `packages.config` file will be created (or updated to include the package name if one such file already
        exists). This file contains a list of the packages required by this project (name and minimum version) and must
        be added to the project source code repository, so if you move the source code to a new machine, MSBuild/NuGet
@@ -519,29 +519,29 @@ dotnet add package nlohmann.json
 
     2. A `packages` folder which contains actual files in the packages (these are header and binary files required for
        a successful build, plus a few metadata files). In case of this library for example, it contains `json.hpp`:
-
+    
         ![](nuget/nuget-package-content.png)
-
+    
         !!! note
 
             This directory should not be added to the project source code repository, as it will be restored before each
             build by MSBuild/NuGet. If you go ahead and delete this folder, then build the project again, it will
             magically re-appear!
-
+    
     3. Project MSBuild makefile (which for Visual C++ projects has a .vcxproj extension) will be updated to include
        settings from the package.
-
+    
         ![](nuget/nuget-project-makefile.png)
-
+    
         The important bit for us here is line 170, which tells MSBuild to import settings from
         `packages\nlohmann.json.3.5.0\build\native\nlohmann.json.targets` file. This is a file the package creator
         created and added to the package (you can see it is one of the two files I created in this repository, the other
         just contains package attributes like name and version number). What does it contain?
-
+    
         For our header-only repository, the only setting we need is to add our include directory to the list of
         `AdditionalIncludeDirectories`:
 
-        ```xml
+        ```xml    
         <?xml version="1.0" encoding="utf-8"?>
         <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
             <ItemDefinitionGroup>
@@ -554,21 +554,21 @@ dotnet add package nlohmann.json
 
         For libraries with binary files, we will need to add `.lib` files to linker inputs and add settings to copy
         `.dll` and other redistributable files to output directory, if needed.
-
+    
         There are other changes to the makefile as well:
-
+    
         - Lines 165-167 add the `packages.config` as one of project files (so it is shown in Solution Explorer tree
           view). It is added as None (no build action) and removing it wouldn’t affect build.
-
+    
         - Lines 172-177 check to ensure the required packages are present. This will display a build error if package
           directory is empty (for example when NuGet cannot restore packages because Internet connection is down).
           Again, if you omit this section, the only change in build would be a more cryptic error message if build
           fails.
-
+    
         !!! note
 
             Changes to .vcxproj makefile should also be added to project source code repository.
-
+    
     As you can see, the mechanism NuGet uses to modify project settings is through MSBuild makefiles, so using NuGet
     with other build systems and compilers (like CMake) as a dependency manager is either impossible or more problematic
     than useful.
@@ -645,7 +645,7 @@ If you are using [MSYS2](http://www.msys2.org/), you can use the [mingw-w64-nloh
     - :octicons-file-24: File issues at the [MacPorts issue tracker](https://trac.macports.org/newticket?port=nlohmann-json)
     - :octicons-question-24: [MacPorts website](https://www.macports.org)
 
-If you are using [MacPorts](https://ports.macports.org), execute
+If you are using [MacPorts](https://ports.macports.org), execute 
 
 ```shell
 sudo port install nlohmann-json
@@ -892,7 +892,7 @@ CPMAddPackage("gh:nlohmann/json@3.12.0")
         ```shell
         xmake
         ```
-
+    
     3. Run
 
         ```shell

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -709,7 +709,7 @@ to install the [nlohmann-json](https://ports.macports.org/port/nlohmann-json/) p
       - [package's sources (for advanced users)](https://github.com/build2-packaging/nlohmann-json/)
 
     - :octicons-tag-24: Available versions: current version and older versions since `3.7.3` (see [cppget.org](https://cppget.org/nlohmann-json))
-    - :octicons-rocket-24: The package is maintained and published by the `build2` community in [this the repository][(https://github.com/conan-io/conan-center-index/tree/master/recipes/nlohmann_json](https://github.com/build2-packaging/nlohmann-json/)).
+    - :octicons-rocket-24: The package is maintained and published by the `build2` community in [this repository][(https://github.com/build2-packaging/nlohmann-json/](https://github.com/build2-packaging/nlohmann-json/)).
     - :octicons-file-24: File issues at the [package source repository](https://github.com/build2-packaging/nlohmann-json/issues/)
     - :octicons-question-24: [`build2` website](https://build2)
 
@@ -743,14 +743,17 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
   2. <details><summary>Add this library as dependency of your target that uses it.</summary>
 
       In the `buildfile` defining the target that will use this library:
+      
         - import the target `lib{json}` from the `nlhomann-json` package, for example:
-           ```
-           import nljson = nlhomann-json%lib{json}
-           ```
+            ```
+            import nljson = nlhomann-json%lib{json}
+            ```
+           
         - then add the library's target as requirement for your target using it, for example:
-           ```
-           exe{example} : ... $nljson
-           ```
+            ```
+            exe{example} : ... $nljson
+            ```
+           
       </details>
 
   3. <details><summary>Use the library in your project's code and build it.</summary>
@@ -779,13 +782,13 @@ To use this package in an exising [`build2`](https://build2.org) project, the ge
             --8<-- "integration/build2/repositories.manifest"
             ```
 
-       - `example/manifest`: Add the latest version of the `nlohmann-json` package as dependency to the project:
+        - `example/manifest`: Add the latest version of the `nlohmann-json` package as dependency to the project:
 
             ```make title="project's `manifest`"
             --8<-- "integration/build2/manifest"
             ```
 
-       - `example/example/buildfile`: import the library's target to be used as requirement for building the executable target `exe{example}`:
+        - `example/example/buildfile`: import the library's target to be used as requirement for building the executable target `exe{example}`:
 
             ```make title="project's `buildfile`"
             --8<-- "integration/build2/buildfile"


### PR DESCRIPTION
This PR adds a more complete description of how to use the [`build2`'](https://build2.org/)s package of `nlhomann-json` to consume the library in `build2` projects.

Note that `build2` is not only a package-manager but also a build-system and both tools are designed to work together, this impacts the verbosity of this documentation. I might have been too detailed or beginner-friendly in some parts, feel free to point if I should shortcut some of the explanations. In doubt, for the case of exising `build2` projects, I opted to use the "detail/summary" markdown/html tags so that people who already know about these steps (experimented `build2` users) dont have to read the whole paragraph. The details are for less experimented `build2` users.

The provided source files do not constitute as provided a valide `build2` project, that involves a specific organisation in particular for projects that use the package-manager. So instead of adding a whole project, I put there the files that will be modified from a `bdep new`-created project (that command creates a ready-to-work project). The example "from scratch" uses that approach.

Because `build2` projects with executables usually use `testscript` , the executable I/O testing tooling provided by `build2`, I also provided a `testscript` for testing the output from the classic output of the example source code.

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [x]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [x]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [x]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
