### PR TITLE
Add note to Jetbrains support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ You can sponsor this library at [GitHub Sponsors](https://github.com/sponsors/nl
 - [Steve Wagner](https://github.com/ciroque)
 - [Lion Yang](https://github.com/LionNatsu)
 
+### Further support
+
+The development of the library is further supported by JetBrains by providing free access to their IDE tools.
+
+[![JetBrains logo.](https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg)](https://jb.gg/OpenSourceSupport)
+
 Thanks everyone!
 
 


### PR DESCRIPTION
Jetbrains provides @nlohmann with their IDE tools free of charge. Therefore, they are added as sponsors in the README.

See https://www.jetbrains.com/community/opensource/ for more information.