### PR TITLE
Add VisionOS support to Swift Package Manager Package.swift definition file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "nlohmann-json",
      platforms: [
-        .iOS(.v12), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v4)
+        .iOS(.v12), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v4), .visionOS(.v1)
     ],
     products: [
         .library(name: "json", targets: ["json"])


### PR DESCRIPTION
Since the release of Apple Vision Pro hardware, it's now possible to run C++ code when targeting Vision OS. This change enables support for VisionOS in this package, so that the C++-based products can now leverage this library when being built for the AVP hardware.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.
