### PR TITLE
Disable GCC False `array-bounds` Warning

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -840,7 +840,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                            std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
+        // in some optimization modes (-O3, or -O2 with NDEBUG), GCC gives false warning about out-of-bounds access, see
+        // https://github.com/nlohmann/json/issues/4657
+#ifdef JSON_HEDLEY_GNUC_VERSION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
         set_parents();
+#ifdef JSON_HEDLEY_GNUC_VERSION
+#pragma GCC diagnostic pop
+#endif
         assert_invariant();
     }
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -840,8 +840,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                            std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
-        // in some optimization modes (-O3, or -O2 with NDEBUG), GCC gives false warning about out-of-bounds access, see
-        // https://github.com/nlohmann/json/issues/4657
+        // in some optimization modes (-O2 or -O3, sometimes only with -DNDEBUG), GCC might give a false array-bounds warning,
+        // see https://github.com/nlohmann/json/issues/4657
 #ifdef JSON_HEDLEY_GNUC_VERSION
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20839,7 +20839,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                        std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
+        // in some optimization modes (-O3, or -O2 with NDEBUG), GCC gives false warning about out-of-bounds access, see
+        // https://github.com/nlohmann/json/issues/4657
+#ifdef JSON_HEDLEY_GNUC_VERSION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
         set_parents();
+#ifdef JSON_HEDLEY_GNUC_VERSION
+#pragma GCC diagnostic pop
+#endif
         assert_invariant();
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20839,8 +20839,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                        std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
-        // in some optimization modes (-O3, or -O2 with NDEBUG), GCC gives false warning about out-of-bounds access, see
-        // https://github.com/nlohmann/json/issues/4657
+        // in some optimization modes (-O2 or -O3, sometimes only with -DNDEBUG), GCC might give a false array-bounds warning,
+        // see https://github.com/nlohmann/json/issues/4657
 #ifdef JSON_HEDLEY_GNUC_VERSION
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"


### PR DESCRIPTION
When `JSON_DIAGNOSTICS` is set to 1, GCC might (depending on optimization level and the exact code) give an `array-bounds` warning about the `basic_json::basic_json(CompatibleType&&)` constructor, saying that `basic_json::set_parents()` might access a larger object than the storage allocated by `to_json`. That is not true, as the storage is only accessed according to the value type set in `m_data.m_type` by the constructing function, but GCC seems to not understand it.
This PR simply adds preprocessor directives around the call to `set_parents` to ignore the warning.

fixes #4657
