### PR TITLE
Fix warning and add emscripten CI step

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1
       - name: Run CMake
-        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMROOT/cmake/Modules/Platform/Emscripten.cmake
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/usr/libexec/cmake/Modules/Platform/Emscripten.cmake
       - name: Build
         run: cmake --build build
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1
       - name: Run CMake
-        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/cmake/Modules/Platform/Emscripten.cmake -GNinja
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/emscripten/cmake/Modules/Platform/Emscripten.cmake -GNinja
       - name: Build
         run: cmake --build build
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -233,6 +233,24 @@ jobs:
           . /opt/intel/oneapi/setvars.sh
           cmake --build build --target ci_icpc
 
+  ci_emscripten:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - name: Install emscripten
+        run: sudo apt-get update ; sudo apt-get install -y emscripten
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Get latest CMake and ninja
+        uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1
+      - name: Run CMake
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMROOT/cmake/Modules/Platform/Emscripten.cmake
+      - name: Build
+        run: cmake --build build
+
   ci_test_documentation:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1
       - name: Run CMake
-        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/cmake/Modules/Platform/Emscripten.cmake
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/cmake/Modules/Platform/Emscripten.cmake -GNinja
       - name: Build
         run: cmake --build build
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -243,6 +243,12 @@ jobs:
 
       - name: Install emscripten
         uses: mymindstorm/setup-emsdk@v14
+      - name: Search files
+        run:
+          - echo $EMSDK
+          - ls $EMSDK
+          - ls $EMSDK/emscripten
+          - find $EMSDK -name '*.cmake'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -242,12 +242,12 @@ jobs:
           egress-policy: audit
 
       - name: Install emscripten
-        run: sudo apt-get update ; sudo apt-get install -y emscripten
+        uses: mymindstorm/setup-emsdk@v14
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1
       - name: Run CMake
-        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/usr/libexec/cmake/Modules/Platform/Emscripten.cmake
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/cmake/Modules/Platform/Emscripten.cmake
       - name: Build
         run: cmake --build build
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -244,11 +244,11 @@ jobs:
       - name: Install emscripten
         uses: mymindstorm/setup-emsdk@v14
       - name: Search files
-        run:
-          - echo $EMSDK
-          - ls $EMSDK
-          - ls $EMSDK/emscripten
-          - find $EMSDK -name '*.cmake'
+        run: |
+          echo $EMSDK
+          ls $EMSDK
+          ls $EMSDK/emscripten
+          find $EMSDK -name '*.cmake'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -243,15 +243,11 @@ jobs:
 
       - name: Install emscripten
         uses: mymindstorm/setup-emsdk@v14
-      - name: Search files
-        run: |
-          echo $EMSDK
-          find $EMSDK -name '*.cmake'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@57c20a23a6cac5b90f31864439996e5b206df9dc # v4.0.1
       - name: Run CMake
-        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/emscripten/cmake/Modules/Platform/Emscripten.cmake -GNinja
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -GNinja
       - name: Build
         run: cmake --build build
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -246,8 +246,6 @@ jobs:
       - name: Search files
         run: |
           echo $EMSDK
-          ls $EMSDK
-          ls $EMSDK/emscripten
           find $EMSDK -name '*.cmake'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get latest CMake and ninja

--- a/docs/mkdocs/docs/community/quality_assurance.md
+++ b/docs/mkdocs/docs/community/quality_assurance.md
@@ -57,6 +57,7 @@ violations will result in a failed build.
         | Clang 19.1.7                                 | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | Clang 20.1.1                                 | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | Clang 21.0.0                                 | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
+        | Emscripten 4.0.6                             | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | GNU 4.8.5                                    | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | GNU 4.9.3                                    | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | GNU 5.5.0                                    | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -762,7 +762,7 @@ class serializer
 
         // jump to the end to generate the string from backward,
         // so we later avoid reversing the result
-        buffer_ptr += n_chars;
+        buffer_ptr += static_cast<typename decltype(number_buffer)::difference_type>(n_chars);
 
         // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
         // See: https://www.youtube.com/watch?v=o4-CwDo2zpg

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19483,7 +19483,7 @@ class serializer
 
         // jump to the end to generate the string from backward,
         // so we later avoid reversing the result
-        buffer_ptr += n_chars;
+        buffer_ptr += static_cast<typename decltype(number_buffer)::difference_type>(n_chars);
 
         // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
         // See: https://www.youtube.com/watch?v=o4-CwDo2zpg


### PR DESCRIPTION
- Fixes a `-Wsign-conversion` compiler warning that occurred when compiling the library with Emscripten em++.
- Add a CI step that compiles the library with Emscripten em++. We don't yet enable maximal warning flags here, but will probably do so in the future.

Closes #4662 