### PR TITLE
Fix conversion to std::optional

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -13,9 +13,6 @@
 #include <forward_list> // forward_list
 #include <iterator> // inserter, front_inserter, end
 #include <map> // map
-#ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
-#endif
 #include <string> // string
 #include <tuple> // tuple, make_tuple
 #include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
@@ -31,6 +28,11 @@
 #include <nlohmann/detail/meta/type_traits.hpp>
 #include <nlohmann/detail/string_concat.hpp>
 #include <nlohmann/detail/value_t.hpp>
+
+// include after macro_scope.hpp
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -47,7 +47,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 }
 
 #ifdef JSON_HAS_CPP_17
-#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+//#if JSON_USE_IMPLICIT_CONVERSIONS == 1
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
@@ -61,7 +61,7 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
     }
 }
 
-#endif // JSON_USE_IMPLICIT_CONVERSIONS
+//#endif // JSON_USE_IMPLICIT_CONVERSIONS
 #endif // JSON_HAS_CPP_17
 
 // overloads for basic_json template parameters

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -49,7 +49,6 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 }
 
 #ifdef JSON_HAS_CPP_17
-//#if JSON_USE_IMPLICIT_CONVERSIONS == 1
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
@@ -62,8 +61,6 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
         opt.emplace(j.template get<T>());
     }
 }
-
-//#endif // JSON_USE_IMPLICIT_CONVERSIONS
 #endif // JSON_HAS_CPP_17
 
 // overloads for basic_json template parameters

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -50,7 +50,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T>
-inline void from_json(const BasicJsonType& j, std::optional<T>& opt)
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
     if (j.is_null())
     {

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -50,7 +50,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T>
-void from_json(const BasicJsonType& j, std::optional<T>& opt)
+inline void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
     if (j.is_null())
     {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -267,7 +267,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::optional<T>& opt)
+void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -267,7 +267,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-inline void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
+void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -267,7 +267,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
+inline void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4834,7 +4834,6 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 }
 
 #ifdef JSON_HAS_CPP_17
-//#if JSON_USE_IMPLICIT_CONVERSIONS == 1
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
@@ -4847,8 +4846,6 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
         opt.emplace(j.template get<T>());
     }
 }
-
-//#endif // JSON_USE_IMPLICIT_CONVERSIONS
 #endif // JSON_HAS_CPP_17
 
 // overloads for basic_json template parameters

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4835,7 +4835,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T>
-inline void from_json(const BasicJsonType& j, std::optional<T>& opt)
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
     if (j.is_null())
     {
@@ -5913,7 +5913,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-inline void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
+void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4832,7 +4832,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 }
 
 #ifdef JSON_HAS_CPP_17
-#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+//#if JSON_USE_IMPLICIT_CONVERSIONS == 1
 template<typename BasicJsonType, typename T>
 void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
@@ -4846,7 +4846,7 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
     }
 }
 
-#endif // JSON_USE_IMPLICIT_CONVERSIONS
+//#endif // JSON_USE_IMPLICIT_CONVERSIONS
 #endif // JSON_HAS_CPP_17
 
 // overloads for basic_json template parameters

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -173,9 +173,6 @@
 #include <forward_list> // forward_list
 #include <iterator> // inserter, front_inserter, end
 #include <map> // map
-#ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
-#endif
 #include <string> // string
 #include <tuple> // tuple, make_tuple
 #include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
@@ -4816,6 +4813,11 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/value_t.hpp>
 
+
+// include after macro_scope.hpp
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4835,7 +4835,7 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
 
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T>
-void from_json(const BasicJsonType& j, std::optional<T>& opt)
+inline void from_json(const BasicJsonType& j, std::optional<T>& opt)
 {
     if (j.is_null())
     {
@@ -5913,7 +5913,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
+inline void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5916,7 +5916,7 @@ struct external_constructor<value_t::object>
 #ifdef JSON_HAS_CPP_17
 template<typename BasicJsonType, typename T,
          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::optional<T>& opt)
+void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
 {
     if (opt.has_value())
     {

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1062,12 +1062,22 @@ TEST_CASE("regression tests 2")
 #ifdef JSON_HAS_CPP_17
     SECTION("issue #4740 - build issue with std::optional")
     {
-        const auto t0 = Example_4740();
-        const auto j = nlohmann::json(t0);
-        CHECK(j.dump() == "{\"host\":null,\"port\":null}");
-        auto t1 = j.get<Example_4740>();
-        CHECK(!t1.host.has_value());
-        CHECK(!t1.port.has_value());
+        const auto t1 = Example_4740();
+        const auto j1 = nlohmann::json(t1);
+        CHECK(j1.dump() == "{\"host\":null,\"port\":null}");
+        const auto t2 = j1.get<Example_4740>();
+        CHECK(!t2.host.has_value());
+        CHECK(!t2.port.has_value());
+
+        // improve coverage
+        auto t3 = Example_4740();
+        t3.port = 80;
+        t3.host = "example.com";
+        const auto j2 = nlohmann::json(t3);
+        CHECK(j2.dump() == "{\"host\":\"example.com\",\"port\":80}");
+        const auto t4 = j2.get<Example_4740>();
+        CHECK(t4.host.has_value());
+        CHECK(t4.port.has_value());
     }
 #endif
 }

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -407,7 +407,7 @@ struct Example_4740
 {
     std::optional<std::string> host;
     std::optional<int> port;
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_4740, host, port);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_4740, host, port)
 };
 #endif
 

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -36,6 +36,14 @@ using ordered_json = nlohmann::ordered_json;
     #include <variant>
 #endif
 
+#ifdef JSON_HAS_CPP_17
+    #if __has_include(<optional>)
+        #include <optional>
+    #elif __has_include(<experimental/optional>)
+        #include <experimental/optional>
+    #endif
+#endif
+
 #ifdef JSON_HAS_CPP_20
     #if __has_include(<span>)
         #include <span>
@@ -389,6 +397,19 @@ struct Example_3810
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Example_3810, bla); // NOLINT(misc-use-internal-linkage)
+
+/////////////////////////////////////////////////////////////////////
+// for #4740
+/////////////////////////////////////////////////////////////////////
+
+#ifdef JSON_HAS_CPP_17
+struct Example_4740
+{
+    std::optional<std::string> host;
+    std::optional<int> port;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_4740, host, port);
+};
+#endif
 
 TEST_CASE("regression tests 2")
 {
@@ -1037,6 +1058,18 @@ TEST_CASE("regression tests 2")
         oj["test"] = states;
         CHECK(oj["test"].dump() == expected);
     }
+
+#ifdef JSON_HAS_CPP_17
+    SECTION("issue #4740 - build issue with std::optional")
+    {
+        const auto t0 = Example_4740();
+        const auto j = nlohmann::json(t0);
+        CHECK(j.dump() == "{\"host\":null,\"port\":null}");
+        auto t1 = j.get<Example_4740>();
+        CHECK(!t1.host.has_value());
+        CHECK(!t1.port.has_value());
+    }
+#endif
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -405,8 +405,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Example_3810, bla); // NOLINT(misc-use-intern
 #ifdef JSON_HAS_CPP_17
 struct Example_4740
 {
-    std::optional<std::string> host;
-    std::optional<int> port;
+    std::optional<std::string> host = std::nullopt;
+    std::optional<int> port = std::nullopt;
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_4740, host, port)
 };
 #endif


### PR DESCRIPTION
This MR fixes the conversion from JSON to `std::optional` by making it independent of `JSON_USE_IMPLICIT_CONVERSIONS`.

Fixes #4740