### PR TITLE
Fix C4702 warning and extend MSVC CI job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,15 +75,27 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         architecture: [Win32, x64]
+        std_version: [default, latest]
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set extra CXX_FLAGS for latest std_version
+      id: cxxflags
+      run: |
+        if [ "${{ matrix.std_version }}" = "latest" ]; then
+          echo "flags=/permissive- /std:c++latest /utf-8 /W4 /WX" >> $GITHUB_ENV
+        else
+          echo "flags=/W4 /WX" >> $GITHUB_ENV
+        fi
+      shell: bash
     - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
+      run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="$env:flags"
       if: matrix.build_type == 'Release'
+      shell: pwsh
     - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
+      run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="$env:flags"
       if: matrix.build_type == 'Debug'
+      shell: pwsh
     - name: Build
       run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
     - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,81 +37,43 @@ jobs:
       - name: Test
         run: cd build ; ctest -j 10 -C Debug --output-on-failure
 
-  msvc2019:
-    runs-on: windows-2019
+  msvc:
     strategy:
       matrix:
-        build_type: [Debug, Release]
-        architecture: [Win32, x64]
-
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/W4 /WX"
-      if: matrix.build_type == 'Release'
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="/W4 /WX"
-      if: matrix.build_type == 'Debug'
-    - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
-    - name: Test
-      run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
-
-  msvc2019_latest:
-    runs-on: windows-2019
-
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
-    - name: Build
-      run: cmake --build build --config Release --parallel 10
-    - name: Test
-      run: cd build ; ctest -j 10 -C Release --output-on-failure
-
-  msvc2022:
-    runs-on: windows-2022
-    strategy:
-      matrix:
+        include:
+          - generator: "Visual Studio 16 2019"
+            runs_on: windows-2019
+          - generator: "Visual Studio 17 2022"
+            runs_on: windows-2022
         build_type: [Debug, Release]
         architecture: [Win32, x64]
         std_version: [default, latest]
 
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set extra CXX_FLAGS for latest std_version
-      id: cxxflags
-      run: |
-        if [ "${{ matrix.std_version }}" = "latest" ]; then
-          echo "flags=/permissive- /std:c++latest /utf-8 /W4 /WX" >> $GITHUB_ENV
-        else
-          echo "flags=/W4 /WX" >> $GITHUB_ENV
-        fi
-      shell: bash
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="$env:flags"
-      if: matrix.build_type == 'Release'
-      shell: pwsh
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="$env:flags"
-      if: matrix.build_type == 'Debug'
-      shell: pwsh
-    - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
-    - name: Test
-      run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
-
-  msvc2022_latest:
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runs_on }}
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 17 2022" -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="/permissive- /std:c++latest /utf-8 /W4 /WX"
-    - name: Build
-      run: cmake --build build --config Release --parallel 10
-    - name: Test
-      run: cd build ; ctest -j 10 -C Release --output-on-failure
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set extra CXX_FLAGS for latest std_version
+        id: cxxflags
+        run: |
+          if [ "${{ matrix.std_version }}" = "latest" ]; then
+            echo "flags=/permissive- /std:c++latest /utf-8 /W4 /WX" >> $GITHUB_ENV
+          else
+            echo "flags=/W4 /WX" >> $GITHUB_ENV
+          fi
+        shell: bash
+      - name: Run CMake (Release)
+        run: cmake -S . -B build -G "${{ matrix.generator }}" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="$env:flags"
+        if: matrix.build_type == 'Release'
+        shell: pwsh
+      - name: Run CMake (Debug)
+        run: cmake -S . -B build -G "${{ matrix.generator }}" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="$env:flags"
+        if: matrix.build_type == 'Debug'
+        shell: pwsh
+      - name: Build
+        run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
+      - name: Test
+        run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
 
   clang:
     runs-on: windows-2019

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,11 +40,7 @@ jobs:
   msvc:
     strategy:
       matrix:
-        include:
-          - generator: "Visual Studio 16 2019"
-            runs_on: windows-2019
-          - generator: "Visual Studio 17 2022"
-            runs_on: windows-2022
+        runs_on: [windows-2019, windows-2022]
         build_type: [Debug, Release]
         architecture: [Win32, x64]
         std_version: [default, latest]
@@ -53,6 +49,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set generator
+        id: generator
+        run: |
+          if [ "${{ matrix.runs_on }}" = "windows-2019" ]; then
+            echo "generator=Visual Studio 16 2019" >> $GITHUB_ENV
+          else
+            echo "generator=Visual Studio 17 2022" >> $GITHUB_ENV
+          fi
+        shell: bash
       - name: Set extra CXX_FLAGS for latest std_version
         id: cxxflags
         run: |
@@ -63,11 +68,11 @@ jobs:
           fi
         shell: bash
       - name: Run CMake (Release)
-        run: cmake -S . -B build -G "${{ matrix.generator }}" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="$env:flags"
+        run: cmake -S . -B build -G "$env:generator" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DCMAKE_CXX_FLAGS="$env:flags"
         if: matrix.build_type == 'Release'
         shell: pwsh
       - name: Run CMake (Debug)
-        run: cmake -S . -B build -G "${{ matrix.generator }}" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="$env:flags"
+        run: cmake -S . -B build -G "$env:generator" -A ${{ matrix.architecture }} -DJSON_BuildTests=On -DJSON_FastTests=ON -DCMAKE_CXX_FLAGS="$env:flags"
         if: matrix.build_type == 'Debug'
         shell: pwsh
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Test
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure
 
-  clang-cl-11:
+  clang-cl-12:
     runs-on: windows-2019
     strategy:
       matrix:

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2826,16 +2826,19 @@ class binary_reader
         {
             return;
         }
-        if constexpr(std::is_integral_v<NumberType>)
+        else if constexpr(std::is_integral_v<NumberType>)
         {
             number = std::byteswap(number);
             return;
         }
+        else
 #endif
-        auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
-        for (std::size_t i = 0; i < sz / 2; ++i)
         {
-            std::swap(ptr[i], ptr[sz - i - 1]);
+            auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
+            for (std::size_t i = 0; i < sz / 2; ++i)
+            {
+                std::swap(ptr[i], ptr[sz - i - 1]);
+            }
         }
     }
 

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -2832,14 +2832,16 @@ class binary_reader
             return;
         }
         else
-#endif
         {
+#endif
             auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
             for (std::size_t i = 0; i < sz / 2; ++i)
             {
                 std::swap(ptr[i], ptr[sz - i - 1]);
             }
+#ifdef __cpp_lib_byteswap
         }
+#endif
     }
 
     /*

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12601,16 +12601,19 @@ class binary_reader
         {
             return;
         }
-        if constexpr(std::is_integral_v<NumberType>)
+        else if constexpr(std::is_integral_v<NumberType>)
         {
             number = std::byteswap(number);
             return;
         }
+        else
 #endif
-        auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
-        for (std::size_t i = 0; i < sz / 2; ++i)
         {
-            std::swap(ptr[i], ptr[sz - i - 1]);
+            auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
+            for (std::size_t i = 0; i < sz / 2; ++i)
+            {
+                std::swap(ptr[i], ptr[sz - i - 1]);
+            }
         }
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12607,14 +12607,16 @@ class binary_reader
             return;
         }
         else
-#endif
         {
+#endif
             auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
             for (std::size_t i = 0; i < sz / 2; ++i)
             {
                 std::swap(ptr[i], ptr[sz - i - 1]);
             }
+#ifdef __cpp_lib_byteswap
         }
+#endif
     }
 
     /*


### PR DESCRIPTION
- Add release/debug matrix step to MSVC job to detect warnings as reported in #4745
- Simplified MSVC 2019/2022 job.
- Fixes C4702 warning in binary reader code (thanks @gregmarr).

Closes #4745