### PR TITLE
Specialize char_traits for std::byte to fix from_msgpack (fixes #4756)

### DIFF
--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -13,7 +13,7 @@
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
-#include <cstddef>
+#include <cstddef> // byte
 
 #include <nlohmann/detail/iterators/iterator_traits.hpp>
 #include <nlohmann/detail/macro_scope.hpp>

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -13,8 +13,9 @@
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
-#include <cstddef> // byte
-
+#if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
+    #include <cstddef> // byte
+#endif
 #include <nlohmann/detail/iterators/iterator_traits.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/call_std/begin.hpp>

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -13,6 +13,7 @@
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
+#include <cstddef>
 
 #include <nlohmann/detail/iterators/iterator_traits.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
@@ -238,6 +239,30 @@ struct char_traits<signed char> : std::char_traits<char>
         return static_cast<int_type>(std::char_traits<char>::eof());
     }
 };
+
+#if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
+template<>
+struct char_traits<std::byte> : std::char_traits<char>
+{
+    using char_type = std::byte;
+    using int_type = uint64_t;
+
+    static int_type to_int_type(char_type c) noexcept
+    {
+        return static_cast<int_type>(std::to_integer<unsigned char>(c));
+    }
+
+    static char_type to_char_type(int_type i) noexcept
+    {
+        return std::byte(static_cast<unsigned char>(i));
+    }
+
+    static constexpr int_type eof() noexcept
+    {
+        return static_cast<int_type>(std::char_traits<char>::eof());
+    }
+};
+#endif
 
 ///////////////////
 // is_ functions //

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3367,8 +3367,9 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
-#include <cstddef> // byte
-
+#if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
+    #include <cstddef> // byte
+#endif
 // #include <nlohmann/detail/iterators/iterator_traits.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3367,6 +3367,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
+#include <cstddef> // byte
 
 // #include <nlohmann/detail/iterators/iterator_traits.hpp>
 //     __ _____ _____ _____
@@ -3775,6 +3776,30 @@ struct char_traits<signed char> : std::char_traits<char>
         return static_cast<int_type>(std::char_traits<char>::eof());
     }
 };
+
+#if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
+template<>
+struct char_traits<std::byte> : std::char_traits<char>
+{
+    using char_type = std::byte;
+    using int_type = uint64_t;
+
+    static int_type to_int_type(char_type c) noexcept
+    {
+        return static_cast<int_type>(std::to_integer<unsigned char>(c));
+    }
+
+    static char_type to_char_type(int_type i) noexcept
+    {
+        return std::byte(static_cast<unsigned char>(i));
+    }
+
+    static constexpr int_type eof() noexcept
+    {
+        return static_cast<int_type>(std::char_traits<char>::eof());
+    }
+};
+#endif
 
 ///////////////////
 // is_ functions //

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1914,9 +1914,12 @@ TEST_CASE("MessagePack with std::byte")
         SECTION("empty vector")
         {
             const std::vector<std::byte> empty_data;
-            CHECK_THROWS_WITH_AS(json::from_msgpack(empty_data),
-                                 "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input",
-                                 json::parse_error&);
+            CHECK_THROWS_WITH_AS([&]() { 
+                [[maybe_unused]] auto result = json::from_msgpack(empty_data); 
+                return true; 
+            }(),
+            "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input",
+            json::parse_error&);
         }
 
         SECTION("comparison with workaround")

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1880,3 +1880,70 @@ TEST_CASE("MessagePack roundtrips" * doctest::skip())
         }
     }
 }
+
+#ifdef JSON_HAS_CPP_17
+TEST_CASE("MessagePack with std::byte")
+{
+    SECTION("std::byte compatibility")
+    {
+        SECTION("vector roundtrip")
+        {
+            json original = {
+                {"name", "test"},
+                {"value", 42},
+                {"array", {1, 2, 3}}
+            };
+            
+            std::vector<uint8_t> temp = json::to_msgpack(original);
+            std::vector<std::byte> msgpack_data(temp.size());
+            for (size_t i = 0; i < temp.size(); ++i) {
+                msgpack_data[i] = std::byte(temp[i]);
+            }
+            
+            json from_bytes;
+            CHECK_NOTHROW(from_bytes = json::from_msgpack(msgpack_data));
+            
+            CHECK(from_bytes == original);
+        }
+
+        SECTION("empty vector")
+        {
+            std::vector<std::byte> empty_data;
+            CHECK_THROWS_WITH_AS(json::from_msgpack(empty_data), 
+                                 "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input", 
+                                 json::parse_error&);
+        }
+
+        SECTION("comparison with workaround")
+        {
+            json original = {
+                {"string", "hello"},
+                {"integer", 42},
+                {"float", 3.14},
+                {"boolean", true},
+                {"null", nullptr},
+                {"array", {1, 2, 3}},
+                {"object", {{"key", "value"}}}
+            };
+            
+            std::vector<uint8_t> temp = json::to_msgpack(original);
+            
+            std::vector<std::byte> msgpack_data(temp.size());
+            for (size_t i = 0; i < temp.size(); ++i) {
+                msgpack_data[i] = std::byte(temp[i]);
+            }
+            
+            json direct_result = json::from_msgpack(msgpack_data);
+            
+            // 测试PR中的临时解决方案作为对比
+            auto const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
+            auto const char_end = char_start + msgpack_data.size();
+            json workaround_result = json::from_msgpack(char_start, char_end);
+            
+            // 验证两种方法产生相同的结果
+            CHECK(direct_result == workaround_result);
+            CHECK(direct_result == original);
+        }
+    }
+}
+#endif

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1882,41 +1882,47 @@ TEST_CASE("MessagePack roundtrips" * doctest::skip())
 }
 
 #ifdef JSON_HAS_CPP_17
+// Test suite for verifying MessagePack handling with std::byte input
 TEST_CASE("MessagePack with std::byte")
 {
+
     SECTION("std::byte compatibility")
     {
         SECTION("vector roundtrip")
         {
-            json original = {
+            json original =
+            {
                 {"name", "test"},
                 {"value", 42},
                 {"array", {1, 2, 3}}
             };
-            
+
             std::vector<uint8_t> temp = json::to_msgpack(original);
+            // Convert the uint8_t vector to std::byte vector
             std::vector<std::byte> msgpack_data(temp.size());
-            for (size_t i = 0; i < temp.size(); ++i) {
+            for (size_t i = 0; i < temp.size(); ++i)
+            {
                 msgpack_data[i] = std::byte(temp[i]);
             }
-            
+            // Deserialize from std::byte vector back to JSON
             json from_bytes;
             CHECK_NOTHROW(from_bytes = json::from_msgpack(msgpack_data));
-            
+
             CHECK(from_bytes == original);
         }
 
         SECTION("empty vector")
         {
             std::vector<std::byte> empty_data;
-            CHECK_THROWS_WITH_AS(json::from_msgpack(empty_data), 
-                                 "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input", 
+            CHECK_THROWS_WITH_AS(json::from_msgpack(empty_data),
+                                 "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input",
                                  json::parse_error&);
         }
 
         SECTION("comparison with workaround")
         {
-            json original = {
+            json original =
+            {
                 {"string", "hello"},
                 {"integer", 42},
                 {"float", 3.14},
@@ -1925,22 +1931,23 @@ TEST_CASE("MessagePack with std::byte")
                 {"array", {1, 2, 3}},
                 {"object", {{"key", "value"}}}
             };
-            
+
             std::vector<uint8_t> temp = json::to_msgpack(original);
-            
+
             std::vector<std::byte> msgpack_data(temp.size());
-            for (size_t i = 0; i < temp.size(); ++i) {
+            for (size_t i = 0; i < temp.size(); ++i)
+            {
                 msgpack_data[i] = std::byte(temp[i]);
             }
-            
+            // Attempt direct deserialization using std::byte input
             json direct_result = json::from_msgpack(msgpack_data);
-            
-            // 测试PR中的临时解决方案作为对比
+
+            // Test the workaround approach: reinterpret as unsigned char* and use iterator range
             auto const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
             auto const char_end = char_start + msgpack_data.size();
             json workaround_result = json::from_msgpack(char_start, char_end);
-            
-            // 验证两种方法产生相同的结果
+
+            // Verify that the final deserialized JSON matches the original JSON
             CHECK(direct_result == workaround_result);
             CHECK(direct_result == original);
         }

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1913,7 +1913,7 @@ TEST_CASE("MessagePack with std::byte")
 
         SECTION("empty vector")
         {
-            std::vector<std::byte> empty_data;
+            const std::vector<std::byte> empty_data;
             CHECK_THROWS_WITH_AS(json::from_msgpack(empty_data),
                                  "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input",
                                  json::parse_error&);
@@ -1943,8 +1943,8 @@ TEST_CASE("MessagePack with std::byte")
             json direct_result = json::from_msgpack(msgpack_data);
 
             // Test the workaround approach: reinterpret as unsigned char* and use iterator range
-            auto const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
-            auto const char_end = char_start + msgpack_data.size();
+            const auto *const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
+            const auto *const char_end = char_start + msgpack_data.size();
             json workaround_result = json::from_msgpack(char_start, char_end);
 
             // Verify that the final deserialized JSON matches the original JSON


### PR DESCRIPTION
### Summary

Ensure `from_msgpack` properly handles containers of `std::byte` by mapping `std::byte` to `unsigned char`.

### Changes

- Specialize `char_traits<std::byte>` when `__cpp_lib_byte >= 201603L`.
- Implement `to_int_type`, `to_char_type`, and `eof()` for `std::byte` using `std::char_traits<char>` as a base.
- Guard specialization with `#if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L` to maintain compatibility with C++11.

### Reason

Without `char_traits<std::byte>`, using `from_msgpack` on `std::vector<std::byte>` leads to a appleclang compilation failure, because `char_traits<T>` is required by the input adapter.

Fixes #4756

### Testing Done

- Verified that existing tests pass (`ctest --test-dir build -j 10`).
- Added new test cases in `tests/src/unit-msgpack.cpp`

### Checklist

- [x] Changes are described in detail.
- [x] Linked to [[existing issue #4756](https://github.com/nlohmann/json/issues/4756)](https://github.com/nlohmann/json/issues/4756).
- [x] Code coverage remains 100%.
- [x] No breaking changes to the public API.
- [x] Source code is amalgamated with `make amalgamate`.
- [ ] Documentation update not required (behavioral fix, no API change).

### Additional Note on Test Behavior

The newly added unit test verifying `from_msgpack` with `std::byte` containers is only strictly required and triggered on stricter compilers such as:

- Apple Clang 17.0.0 (clang-1700.0.13.3)
- Target: arm64-apple-darwin24.2.0

On most GCC and older Clang versions, this specific issue does not manifest because of more relaxed type deduction and `char_traits` usage, so the corresponding test would pass without triggering a compilation error even without the fix.  
However, maintaining the specialization ensures consistent behavior and future-proof compatibility across all supported compilers.
