### PR TITLE
Add missing header

### DIFF
--- a/docs/mkdocs/docs/community/quality_assurance.md
+++ b/docs/mkdocs/docs/community/quality_assurance.md
@@ -76,6 +76,7 @@ violations will result in a failed build.
         | GNU 13.3.0                                   | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | GNU 14.2.0                                   | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | GNU 14.2.0                                   | arm64        | Linux 6.1.100            | Cirrus CI |
+        | GNU 15.1.0                                   | x86_64       | Ubuntu 22.04.1 LTS       | GitHub    |
         | icpc (ICC) 2021.5.0 20211109                 | x86_64       | Ubuntu 20.04.3 LTS       | GitHub    |
         | MSVC 19.0.24241.7                            | x86          | Windows 8.1              | AppVeyor  |
         | MSVC 19.16.27035.0                           | x86          | Windows-10 (Build 14393) | AppVeyor  |

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -34,6 +34,10 @@
     #include <optional> // optional
 #endif
 
+#if JSON_HAS_FILESYSTEM || JSON_HAS_EXPERIMENTAL_FILESYSTEM
+    #include <string_view> // u8string_view
+#endif
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4819,6 +4819,10 @@ NLOHMANN_JSON_NAMESPACE_END
     #include <optional> // optional
 #endif
 
+#if JSON_HAS_FILESYSTEM || JSON_HAS_EXPERIMENTAL_FILESYSTEM
+    #include <string_view> // u8string_view
+#endif
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 namespace detail
 {

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -396,7 +396,7 @@ struct Example_3810
     Example_3810() = default;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Example_3810, bla); // NOLINT(misc-use-internal-linkage)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Example_3810, bla) // NOLINT(misc-use-internal-linkage)
 
 /////////////////////////////////////////////////////////////////////
 // for #4740

--- a/tests/src/unit-user_defined_input.cpp
+++ b/tests/src/unit-user_defined_input.cpp
@@ -60,12 +60,12 @@ TEST_CASE("Custom container member begin/end")
     {
         const char* data;
 
-        const char* begin() const
+        const char* begin() const noexcept
         {
             return data;
         }
 
-        const char* end() const
+        const char* end() const noexcept
         {
             return data + strlen(data); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         }


### PR DESCRIPTION
#4631 forgot to include `<string_view>`. This PR adds this include.

Closes #4761

Furthermore, fixes two warnings in the tests that made the latest GCC build fail.