### PR TITLE
Add comment regarding #4767

### DIFF
--- a/tests/src/unit-locale-cpp.cpp
+++ b/tests/src/unit-locale-cpp.cpp
@@ -139,7 +139,12 @@ TEST_CASE("locale-dependent test (LC_NUMERIC=de_DE)")
         {
             std::array<char, 6> buffer = {};
             CHECK(std::snprintf(buffer.data(), buffer.size(), "%.2f", 12.34) == 5); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-            CHECK(std::string(buffer.data()) == "12,34");
+            const auto snprintf_result = std::string(buffer.data());
+            if (snprintf_result != "12,34")
+            {
+                CAPTURE(snprintf_result)
+                MESSAGE("To test if number parsing is locale-independent, we set the locale to de_DE. However, on this system, the decimal separator doesn't change `,` due to a known musl issue (https://github.com/nlohmann/json/issues/4767).");
+            }
         }
 
         SECTION("parsing")

--- a/tests/src/unit-locale-cpp.cpp
+++ b/tests/src/unit-locale-cpp.cpp
@@ -143,7 +143,7 @@ TEST_CASE("locale-dependent test (LC_NUMERIC=de_DE)")
             if (snprintf_result != "12,34")
             {
                 CAPTURE(snprintf_result)
-                MESSAGE("To test if number parsing is locale-independent, we set the locale to de_DE. However, on this system, the decimal separator doesn't change `,` potentially due to a known musl issue (https://github.com/nlohmann/json/issues/4767).");
+                MESSAGE("To test if number parsing is locale-independent, we set the locale to de_DE. However, on this system, the decimal separator doesn't change to `,` potentially due to a known musl issue (https://github.com/nlohmann/json/issues/4767).");
             }
         }
 

--- a/tests/src/unit-locale-cpp.cpp
+++ b/tests/src/unit-locale-cpp.cpp
@@ -143,7 +143,7 @@ TEST_CASE("locale-dependent test (LC_NUMERIC=de_DE)")
             if (snprintf_result != "12,34")
             {
                 CAPTURE(snprintf_result)
-                MESSAGE("To test if number parsing is locale-independent, we set the locale to de_DE. However, on this system, the decimal separator doesn't change `,` due to a known musl issue (https://github.com/nlohmann/json/issues/4767).");
+                MESSAGE("To test if number parsing is locale-independent, we set the locale to de_DE. However, on this system, the decimal separator doesn't change `,` potentially due to a known musl issue (https://github.com/nlohmann/json/issues/4767).");
             }
         }
 


### PR DESCRIPTION
In the decimal separator is not set to `,` in de_DE, we add a warning message instead of making the test fail.

Closes #4767