### PR TITLE
Update to Doctest 2.4.12

### DIFF
--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -235,7 +235,7 @@ TEST_CASE("alternative string type")
         {
             alt_json doc;
             doc["answer"]["everything"] = 42;
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"answer":{"everything":42}})");
         }
 

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -207,28 +207,28 @@ TEST_CASE("alternative string type")
         {
             alt_json doc;
             doc["pi"] = 3.141;
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"pi":3.141})");
         }
 
         {
             alt_json doc;
             doc["happy"] = true;
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"happy":true})");
         }
 
         {
             alt_json doc;
             doc["name"] = "I'm Batman";
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"name":"I'm Batman"})");
         }
 
         {
             alt_json doc;
             doc["nothing"] = nullptr;
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"nothing":null})");
         }
 
@@ -242,14 +242,14 @@ TEST_CASE("alternative string type")
         {
             alt_json doc;
             doc["list"] = { 1, 0, 2 };
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"list":[1,0,2]})");
         }
 
         {
             alt_json doc;
             doc["object"] = { {"currency", "USD"}, {"value", 42.99} };
-            alt_string dump = doc.dump();
+            const alt_string dump = doc.dump();
             CHECK(dump == R"({"object":{"currency":"USD","value":42.99}})");
         }
     }
@@ -257,7 +257,7 @@ TEST_CASE("alternative string type")
     SECTION("parse")
     {
         auto doc = alt_json::parse(R"({"foo": "bar"})");
-        alt_string dump = doc.dump();
+        const alt_string dump = doc.dump();
         CHECK(dump == R"({"foo":"bar"})");
     }
 

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -1226,21 +1226,21 @@ TEST_CASE("BJData")
                     SECTION("0 (0 00000 0000000000)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == 0.0);
                     }
 
                     SECTION("-0 (1 00000 0000000000)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0x80}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == -0.0);
                     }
 
                     SECTION("2**-24 (0 00000 0000000001)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x01, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == std::pow(2.0, -24.0));
                     }
                 }
@@ -1250,7 +1250,7 @@ TEST_CASE("BJData")
                     SECTION("infinity (0 11111 0000000000)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0x7c}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == std::numeric_limits<json::number_float_t>::infinity());
                         CHECK(j.dump() == "null");
                     }
@@ -1258,7 +1258,7 @@ TEST_CASE("BJData")
                     SECTION("-infinity (1 11111 0000000000)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0xfc}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == -std::numeric_limits<json::number_float_t>::infinity());
                         CHECK(j.dump() == "null");
                     }
@@ -1269,21 +1269,21 @@ TEST_CASE("BJData")
                     SECTION("1 (0 01111 0000000000)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0x3c}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == 1);
                     }
 
                     SECTION("-2 (1 10000 0000000000)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0x00, 0xc0}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == -2);
                     }
 
                     SECTION("65504 (0 11110 1111111111)")
                     {
                         json const j = json::from_bjdata(std::vector<uint8_t>({'h', 0xff, 0x7b}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == 65504);
                     }
                 }
@@ -3789,7 +3789,7 @@ TEST_CASE("BJData roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse BJData file
                 auto packed = utils::read_binary_file(filename + ".bjdata");
@@ -3804,7 +3804,7 @@ TEST_CASE("BJData roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::ifstream");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse BJData file
                 std::ifstream f_bjdata(filename + ".bjdata", std::ios::binary);

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -1242,7 +1242,7 @@ TEST_CASE("BSON roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::ifstream");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse BSON file
                 std::ifstream f_bson(filename + ".bson", std::ios::binary);

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -596,7 +596,7 @@ TEST_CASE("BSON input/output_adapters")
         {"object", {{ "string", "value" }}}
     };
 
-    const std::vector<std::uint8_t> const bson_representation =
+    const std::vector<std::uint8_t> bson_representation =
     {
         /*size */ 0x4f, 0x00, 0x00, 0x00,
         /*entry*/ 0x01, 'd',  'o',  'u',  'b',  'l',  'e',  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x45, 0x40,

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -565,10 +565,10 @@ TEST_CASE("BSON")
         SECTION("Example 1")
         {
             std::vector<std::uint8_t> input = {0x16, 0x00, 0x00, 0x00, 0x02, 'h', 'e', 'l', 'l', 'o', 0x00, 0x06, 0x00, 0x00, 0x00, 'w', 'o', 'r', 'l', 'd', 0x00, 0x00};
-            json parsed = json::from_bson(input);
-            json expected = {{"hello", "world"}};
+            const json parsed = json::from_bson(input);
+            const json expected = {{"hello", "world"}};
             CHECK(parsed == expected);
-            auto dumped = json::to_bson(parsed);
+            const auto dumped = json::to_bson(parsed);
             CHECK(dumped == input);
             CHECK(json::from_bson(dumped) == expected);
         }
@@ -576,10 +576,10 @@ TEST_CASE("BSON")
         SECTION("Example 2")
         {
             std::vector<std::uint8_t> input = {0x31, 0x00, 0x00, 0x00, 0x04, 'B', 'S', 'O', 'N', 0x00, 0x26, 0x00, 0x00, 0x00, 0x02, 0x30, 0x00, 0x08, 0x00, 0x00, 0x00, 'a', 'w', 'e', 's', 'o', 'm', 'e', 0x00, 0x01, 0x31, 0x00, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x14, 0x40, 0x10, 0x32, 0x00, 0xc2, 0x07, 0x00, 0x00, 0x00, 0x00};
-            json parsed = json::from_bson(input);
-            json expected = {{"BSON", {"awesome", 5.05, 1986}}};
+            const json parsed = json::from_bson(input);
+            const json expected = {{"BSON", {"awesome", 5.05, 1986}}};
             CHECK(parsed == expected);
-            auto dumped = json::to_bson(parsed);
+            const auto dumped = json::to_bson(parsed);
             CHECK(dumped == input);
             CHECK(json::from_bson(dumped) == expected);
         }
@@ -588,7 +588,7 @@ TEST_CASE("BSON")
 
 TEST_CASE("BSON input/output_adapters")
 {
-    json json_representation =
+    const json json_representation =
     {
         {"double", 42.5},
         {"entry", 4.2},
@@ -596,7 +596,7 @@ TEST_CASE("BSON input/output_adapters")
         {"object", {{ "string", "value" }}}
     };
 
-    std::vector<std::uint8_t> const bson_representation =
+    const std::vector<std::uint8_t> const bson_representation =
     {
         /*size */ 0x4f, 0x00, 0x00, 0x00,
         /*entry*/ 0x01, 'd',  'o',  'u',  'b',  'l',  'e',  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x45, 0x40,
@@ -621,7 +621,7 @@ TEST_CASE("BSON input/output_adapters")
         {
             std::basic_ostringstream<char> ss;
             json::to_bson(json_representation, ss);
-            json j3 = json::from_bson(ss.str());
+            const json j3 = json::from_bson(ss.str());
             CHECK(json_representation == j3);
         }
 
@@ -629,7 +629,7 @@ TEST_CASE("BSON input/output_adapters")
         {
             std::string s;
             json::to_bson(json_representation, s);
-            json j3 = json::from_bson(s);
+            const json j3 = json::from_bson(s);
             CHECK(json_representation == j3);
         }
 
@@ -637,7 +637,7 @@ TEST_CASE("BSON input/output_adapters")
         {
             std::vector<std::uint8_t> v;
             json::to_bson(json_representation, v);
-            json j3 = json::from_bson(v);
+            const json j3 = json::from_bson(v);
             CHECK(json_representation == j3);
         }
     }
@@ -1227,7 +1227,7 @@ TEST_CASE("BSON roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::vector<std::uint8_t>");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse BSON file
                 auto packed = utils::read_binary_file(filename + ".bson");
@@ -1257,7 +1257,7 @@ TEST_CASE("BSON roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse BSON file
                 auto packed = utils::read_binary_file(filename + ".bson");

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -1022,21 +1022,21 @@ TEST_CASE("CBOR")
                     SECTION("0 (0 00000 0000000000)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0x00, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == 0.0);
                     }
 
                     SECTION("-0 (1 00000 0000000000)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0x80, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == -0.0);
                     }
 
                     SECTION("2**-24 (0 00000 0000000001)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0x00, 0x01}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == std::pow(2.0, -24.0));
                     }
                 }
@@ -1046,7 +1046,7 @@ TEST_CASE("CBOR")
                     SECTION("infinity (0 11111 0000000000)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0x7c, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == std::numeric_limits<json::number_float_t>::infinity());
                         CHECK(j.dump() == "null");
                     }
@@ -1054,7 +1054,7 @@ TEST_CASE("CBOR")
                     SECTION("-infinity (1 11111 0000000000)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0xfc, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == -std::numeric_limits<json::number_float_t>::infinity());
                         CHECK(j.dump() == "null");
                     }
@@ -1065,21 +1065,21 @@ TEST_CASE("CBOR")
                     SECTION("1 (0 01111 0000000000)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0x3c, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == 1);
                     }
 
                     SECTION("-2 (1 10000 0000000000)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0xc0, 0x00}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == -2);
                     }
 
                     SECTION("65504 (0 11110 1111111111)")
                     {
                         json const j = json::from_cbor(std::vector<uint8_t>({0xf9, 0x7b, 0xff}));
-                        json::number_float_t d{j};
+                        const json::number_float_t d{j};
                         CHECK(d == 65504);
                     }
                 }
@@ -1942,7 +1942,7 @@ TEST_CASE("CBOR regressions")
             {
                 // parse CBOR file
                 auto vec1 = utils::read_binary_file(filename);
-                json j1 = json::from_cbor(vec1);
+                const json j1 = json::from_cbor(vec1);
 
                 try
                 {
@@ -2143,7 +2143,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse CBOR file
                 const auto packed = utils::read_binary_file(filename + ".cbor");
@@ -2158,7 +2158,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::ifstream");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
@@ -2173,7 +2173,7 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse CBOR file
                 const auto packed = utils::read_binary_file(filename + ".cbor");

--- a/tests/src/unit-class_parser.cpp
+++ b/tests/src/unit-class_parser.cpp
@@ -1366,7 +1366,7 @@ TEST_CASE("parser class")
                 return event != json::parse_event_t::key;
             };
 
-            json x = json::parse("{\"key\": false}", cb);
+            const json x = json::parse("{\"key\": false}", cb);
             CHECK(x == json::object());
         }
     }
@@ -1400,14 +1400,14 @@ TEST_CASE("parser class")
 
         SECTION("filter nothing")
         {
-            json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
+            const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
             {
                 return true;
             });
 
             CHECK (j_object == json({{"foo", 2}, {"bar", {{"baz", 1}}}}));
 
-            json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
+            const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
             {
                 return true;
             });
@@ -1436,7 +1436,7 @@ TEST_CASE("parser class")
 
         SECTION("filter specific element")
         {
-            json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
+            const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
             {
                 // filter all number(2) elements
                 return event != json::parse_event_t::value || j != json(2);
@@ -1444,7 +1444,7 @@ TEST_CASE("parser class")
 
             CHECK (j_object == json({{"bar", {{"baz", 1}}}}));
 
-            json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
+            const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
             {
                 return event != json::parse_event_t::value || j != json(2);
             });
@@ -1454,7 +1454,7 @@ TEST_CASE("parser class")
 
         SECTION("filter object in array")
         {
-            json j_filtered1 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json & parsed)
+            const json j_filtered1 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json & parsed)
             {
                 return !(e == json::parse_event_t::object_end && parsed.contains("foo"));
             });
@@ -1463,7 +1463,7 @@ TEST_CASE("parser class")
             CHECK (j_filtered1.size() == 2);
             CHECK (j_filtered1 == json({1, {{"qux", "baz"}}}));
 
-            json j_filtered2 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json& /*parsed*/) noexcept
+            const json j_filtered2 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json& /*parsed*/) noexcept
             {
                 return e != json::parse_event_t::object_end;
             });
@@ -1478,7 +1478,7 @@ TEST_CASE("parser class")
             SECTION("first closing event")
             {
                 {
-                    json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+                    const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
                     {
                         static bool first = true;
                         if (e == json::parse_event_t::object_end && first)
@@ -1495,7 +1495,7 @@ TEST_CASE("parser class")
                 }
 
                 {
-                    json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+                    const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
                     {
                         static bool first = true;
                         if (e == json::parse_event_t::array_end && first)
@@ -1519,13 +1519,13 @@ TEST_CASE("parser class")
             // object and array is discarded only after the closing character
             // has been read
 
-            json j_empty_object = json::parse("{}", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+            const json j_empty_object = json::parse("{}", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
             {
                 return e != json::parse_event_t::object_end;
             });
             CHECK(j_empty_object == json());
 
-            json j_empty_array = json::parse("[]", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+            const json j_empty_array = json::parse("[]", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
             {
                 return e != json::parse_event_t::array_end;
             });

--- a/tests/src/unit-class_parser_diagnostic_positions.cpp
+++ b/tests/src/unit-class_parser_diagnostic_positions.cpp
@@ -1413,7 +1413,7 @@ TEST_CASE("parser class")
                 return event != json::parse_event_t::key;
             };
 
-            json x = json::parse("{\"key\": false}", cb);
+            const json x = json::parse("{\"key\": false}", cb);
             CHECK(x == json::object());
         }
     }
@@ -1447,14 +1447,14 @@ TEST_CASE("parser class")
 
         SECTION("filter nothing")
         {
-            json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
+            const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
             {
                 return true;
             });
 
             CHECK (j_object == json({{"foo", 2}, {"bar", {{"baz", 1}}}}));
 
-            json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
+            const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t /*unused*/, const json& /*unused*/) noexcept
             {
                 return true;
             });
@@ -1483,7 +1483,7 @@ TEST_CASE("parser class")
 
         SECTION("filter specific element")
         {
-            json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
+            const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
             {
                 // filter all number(2) elements
                 return event != json::parse_event_t::value || j != json(2);
@@ -1491,7 +1491,7 @@ TEST_CASE("parser class")
 
             CHECK (j_object == json({{"bar", {{"baz", 1}}}}));
 
-            json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
+            const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t event, const json & j) noexcept
             {
                 return event != json::parse_event_t::value || j != json(2);
             });
@@ -1501,7 +1501,7 @@ TEST_CASE("parser class")
 
         SECTION("filter object in array")
         {
-            json j_filtered1 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json & parsed)
+            const json j_filtered1 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json & parsed)
             {
                 return !(e == json::parse_event_t::object_end && parsed.contains("foo"));
             });
@@ -1510,7 +1510,7 @@ TEST_CASE("parser class")
             CHECK (j_filtered1.size() == 2);
             CHECK (j_filtered1 == json({1, {{"qux", "baz"}}}));
 
-            json j_filtered2 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json& /*parsed*/) noexcept
+            const json j_filtered2 = json::parse(structured_array, [](int /*unused*/, json::parse_event_t e, const json& /*parsed*/) noexcept
             {
                 return e != json::parse_event_t::object_end;
             });
@@ -1525,7 +1525,7 @@ TEST_CASE("parser class")
             SECTION("first closing event")
             {
                 {
-                    json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+                    const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
                     {
                         static bool first = true;
                         if (e == json::parse_event_t::object_end && first)
@@ -1542,7 +1542,7 @@ TEST_CASE("parser class")
                 }
 
                 {
-                    json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+                    const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
                     {
                         static bool first = true;
                         if (e == json::parse_event_t::array_end && first)
@@ -1566,13 +1566,13 @@ TEST_CASE("parser class")
             // object and array is discarded only after the closing character
             // has been read
 
-            json j_empty_object = json::parse("{}", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+            const json j_empty_object = json::parse("{}", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
             {
                 return e != json::parse_event_t::object_end;
             });
             CHECK(j_empty_object == json());
 
-            json j_empty_array = json::parse("[]", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
+            const json j_empty_array = json::parse("[]", [](int /*unused*/, json::parse_event_t e, const json& /*unused*/) noexcept
             {
                 return e != json::parse_event_t::array_end;
             });

--- a/tests/src/unit-comparison.cpp
+++ b/tests/src/unit-comparison.cpp
@@ -576,7 +576,7 @@ TEST_CASE("lexicographical comparison operators")
                 [1,2,[3,4,5],4,5]
             )";
 
-            json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t /*unused*/, const json & j) noexcept
+            const json j_object = json::parse(s_object, [](int /*unused*/, json::parse_event_t /*unused*/, const json & j) noexcept
             {
                 // filter all number(2) elements
                 return j != json(2);
@@ -584,7 +584,7 @@ TEST_CASE("lexicographical comparison operators")
 
             CHECK (j_object == json({{"bar", {{"baz", 1}}}}));
 
-            json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t /*unused*/, const json & j) noexcept
+            const json j_array = json::parse(s_array, [](int /*unused*/, json::parse_event_t /*unused*/, const json & j) noexcept
             {
                 return j != json(2);
             });

--- a/tests/src/unit-constructor1.cpp
+++ b/tests/src/unit-constructor1.cpp
@@ -779,7 +779,7 @@ TEST_CASE("constructors")
 
         SECTION("integer literal with u suffix")
         {
-            json j(42u);
+            const json j(42u);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -793,7 +793,7 @@ TEST_CASE("constructors")
 
         SECTION("integer literal with ul suffix")
         {
-            json j(42ul);
+            const json j(42ul);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -807,7 +807,7 @@ TEST_CASE("constructors")
 
         SECTION("integer literal with ull suffix")
         {
-            json j(42ull);
+            const json j(42ull);
             CHECK(j.type() == json::value_t::number_unsigned);
             CHECK(j == j_unsigned_reference);
         }
@@ -1362,7 +1362,7 @@ TEST_CASE("constructors")
             {
                 {
                     json jarray = {1, 2, 3, 4, 5};
-                    json j_new(jarray.begin(), jarray.begin());
+                    const json j_new(jarray.begin(), jarray.begin());
                     CHECK(j_new == json::array());
                 }
                 {

--- a/tests/src/unit-constructor2.cpp
+++ b/tests/src/unit-constructor2.cpp
@@ -17,63 +17,63 @@ TEST_CASE("other constructors and destructor")
     {
         SECTION("object")
         {
-            json j {{"foo", 1}, {"bar", false}};
+            const json j {{"foo", 1}, {"bar", false}};
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("array")
         {
-            json j {"foo", 1, 42.23, false};
+            const json j {"foo", 1, 42.23, false};
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("null")
         {
-            json j(nullptr);
+            const json j(nullptr);
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("boolean")
         {
-            json j(true);
+            const json j(true);
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("string")
         {
-            json j("Hello world");
+            const json j("Hello world");
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("number (integer)")
         {
-            json j(42);
+            const json j(42);
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("number (unsigned)")
         {
-            json j(42u);
+            const  json j(42u);
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("number (floating-point)")
         {
-            json j(42.23);
+            const json j(42.23);
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
 
         SECTION("binary")
         {
-            json j = json::binary({1, 2, 3});
+            const json j = json::binary({1, 2, 3});
             json k(j); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(j == k);
         }
@@ -92,7 +92,7 @@ TEST_CASE("other constructors and destructor")
     {
         SECTION("object")
         {
-            json j {{"foo", 1}, {"bar", false}};
+            const json j {{"foo", 1}, {"bar", false}};
             json k;
             k = j;
             CHECK(j == k);
@@ -100,7 +100,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("array")
         {
-            json j {"foo", 1, 42.23, false};
+            const json j {"foo", 1, 42.23, false};
             json k;
             k = j;
             CHECK(j == k);
@@ -108,7 +108,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("null")
         {
-            json j(nullptr);
+            const json j(nullptr);
             json k;
             k = j;
             CHECK(j == k);
@@ -116,7 +116,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("boolean")
         {
-            json j(true);
+            const json j(true);
             json k;
             k = j;
             CHECK(j == k);
@@ -124,7 +124,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("string")
         {
-            json j("Hello world");
+            const json j("Hello world");
             json k;
             k = j;
             CHECK(j == k);
@@ -132,7 +132,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("number (integer)")
         {
-            json j(42);
+            const json j(42);
             json k;
             k = j;
             CHECK(j == k);
@@ -140,7 +140,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("number (unsigned)")
         {
-            json j(42u);
+            const json j(42u);
             json k;
             k = j;
             CHECK(j == k);
@@ -148,7 +148,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("number (floating-point)")
         {
-            json j(42.23);
+            const json j(42.23);
             json k;
             k = j;
             CHECK(j == k);
@@ -156,7 +156,7 @@ TEST_CASE("other constructors and destructor")
 
         SECTION("binary")
         {
-            json j = json::binary({1, 2, 3});
+            const json j = json::binary({1, 2, 3});
             json k;
             k = j;
             CHECK(j == k);

--- a/tests/src/unit-convenience.cpp
+++ b/tests/src/unit-convenience.cpp
@@ -179,9 +179,9 @@ TEST_CASE("convenience functions")
 
         SECTION("std::string")
         {
-            std::string str1 = concat(hello_iter, world, '!');
-            std::string str2 = concat(hello_data, world, '!');
-            std::string str3 = concat("Hello, ", world, '!');
+            const std::string str1 = concat(hello_iter, world, '!');
+            const std::string str2 = concat(hello_data, world, '!');
+            const std::string str3 = concat("Hello, ", world, '!');
 
             CHECK(str1 == expected);
             CHECK(str2 == expected);
@@ -190,14 +190,14 @@ TEST_CASE("convenience functions")
 
         SECTION("alt_string_iter")
         {
-            alt_string_iter str = concat<alt_string_iter>(hello_iter, world, '!');
+            const alt_string_iter str = concat<alt_string_iter>(hello_iter, world, '!');
 
             CHECK(str.impl == expected);
         }
 
         SECTION("alt_string_data")
         {
-            alt_string_data str = concat<alt_string_data>(hello_data, world, '!');
+            const alt_string_data str = concat<alt_string_data>(hello_data, world, '!');
 
             CHECK(str.impl == expected);
         }

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1514,7 +1514,7 @@ TEST_CASE("value conversion")
 
             SECTION("std::map (array of pairs)")
             {
-                std::map<int, int> m{{0, 1}, {1, 2}, {2, 3}};
+                const std::map<int, int> m{{0, 1}, {1, 2}, {2, 3}};
                 json const j6 = m;
 
                 auto m2 = j6.get<std::map<int, int>>();
@@ -1539,7 +1539,7 @@ TEST_CASE("value conversion")
 
             SECTION("std::unordered_map (array of pairs)")
             {
-                std::unordered_map<int, int> m{{0, 1}, {1, 2}, {2, 3}};
+                const std::unordered_map<int, int> m{{0, 1}, {1, 2}, {2, 3}};
                 json const j6 = m;
 
                 auto m2 = j6.get<std::unordered_map<int, int>>();

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -227,7 +227,7 @@ TEST_CASE("deserialization")
             ss1 << R"(["foo",1,2,3,false,{"one":1}])";
             ss2 << R"(["foo",1,2,3,false,{"one":1}])";
             ss3 << R"(["foo",1,2,3,false,{"one":1}])";
-            json j = json::parse(ss1);
+            const json j = json::parse(ss1);
             CHECK(json::accept(ss2));
             CHECK(j == json({"foo", 1, 2, 3, false, {{"one", 1}}}));
 
@@ -246,7 +246,7 @@ TEST_CASE("deserialization")
         SECTION("string literal")
         {
             const auto* s = R"(["foo",1,2,3,false,{"one":1}])";
-            json j = json::parse(s);
+            const json j = json::parse(s);
             CHECK(json::accept(s));
             CHECK(j == json({"foo", 1, 2, 3, false, {{"one", 1}}}));
 
@@ -265,7 +265,7 @@ TEST_CASE("deserialization")
         SECTION("string_t")
         {
             json::string_t const s = R"(["foo",1,2,3,false,{"one":1}])";
-            json j = json::parse(s);
+            const json j = json::parse(s);
             CHECK(json::accept(s));
             CHECK(j == json({"foo", 1, 2, 3, false, {{"one", 1}}}));
 

--- a/tests/src/unit-element_access1.cpp
+++ b/tests/src/unit-element_access1.cpp
@@ -16,7 +16,7 @@ TEST_CASE("element access 1")
     SECTION("array")
     {
         json j = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
-        const json j_const = j;
+        const json j_const = j; // NOLINT(performance-unnecessary-copy-initialization)
 
         SECTION("access specified element with bounds checking")
         {
@@ -289,13 +289,13 @@ TEST_CASE("element access 1")
                 {
                     {
                         json jarray = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
-                        json::iterator it2 = jarray.erase(jarray.begin(), jarray.end());
+                        const json::iterator it2 = jarray.erase(jarray.begin(), jarray.end());
                         CHECK(jarray == json::array());
                         CHECK(it2 == jarray.end());
                     }
                     {
                         json jarray = {1, 1u, true, nullptr, "string", 42.23, json::object(), {1, 2, 3}};
-                        json::const_iterator it2 = jarray.erase(jarray.cbegin(), jarray.cend());
+                        const json::const_iterator it2 = jarray.erase(jarray.cbegin(), jarray.cend());
                         CHECK(jarray == json::array());
                         CHECK(it2 == jarray.cend());
                     }
@@ -537,13 +537,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = "foo";
-                    json::iterator it = j.erase(j.begin());
+                    const json::iterator it = j.erase(j.begin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = "bar";
-                    json::const_iterator it = j.erase(j.cbegin());
+                    const json::const_iterator it = j.erase(j.cbegin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -553,13 +553,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = false;
-                    json::iterator it = j.erase(j.begin());
+                    const json::iterator it = j.erase(j.begin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = true;
-                    json::const_iterator it = j.erase(j.cbegin());
+                    const json::const_iterator it = j.erase(j.cbegin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -569,13 +569,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17;
-                    json::iterator it = j.erase(j.begin());
+                    const json::iterator it = j.erase(j.begin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = 17;
-                    json::const_iterator it = j.erase(j.cbegin());
+                    const json::const_iterator it = j.erase(j.cbegin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -585,13 +585,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17u;
-                    json::iterator it = j.erase(j.begin());
+                    const json::iterator it = j.erase(j.begin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = 17u;
-                    json::const_iterator it = j.erase(j.cbegin());
+                    const json::const_iterator it = j.erase(j.cbegin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -601,13 +601,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 23.42;
-                    json::iterator it = j.erase(j.begin());
+                    const json::iterator it = j.erase(j.begin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = 23.42;
-                    json::const_iterator it = j.erase(j.cbegin());
+                    const json::const_iterator it = j.erase(j.cbegin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -617,13 +617,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = json::binary({1, 2, 3});
-                    json::iterator it = j.erase(j.begin());
+                    const json::iterator it = j.erase(j.begin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = json::binary({1, 2, 3});
-                    json::const_iterator it = j.erase(j.cbegin());
+                    const json::const_iterator it = j.erase(j.cbegin());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -711,13 +711,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = "foo";
-                    json::iterator it = j.erase(j.begin(), j.end());
+                    const json::iterator it = j.erase(j.begin(), j.end());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = "bar";
-                    json::const_iterator it = j.erase(j.cbegin(), j.cend());
+                    const json::const_iterator it = j.erase(j.cbegin(), j.cend());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -727,13 +727,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = false;
-                    json::iterator it = j.erase(j.begin(), j.end());
+                    const json::iterator it = j.erase(j.begin(), j.end());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = true;
-                    json::const_iterator it = j.erase(j.cbegin(), j.cend());
+                    const json::const_iterator it = j.erase(j.cbegin(), j.cend());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -743,13 +743,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17;
-                    json::iterator it = j.erase(j.begin(), j.end());
+                    const json::iterator it = j.erase(j.begin(), j.end());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = 17;
-                    json::const_iterator it = j.erase(j.cbegin(), j.cend());
+                    const json::const_iterator it = j.erase(j.cbegin(), j.cend());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -759,13 +759,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 17u;
-                    json::iterator it = j.erase(j.begin(), j.end());
+                    const json::iterator it = j.erase(j.begin(), j.end());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = 17u;
-                    json::const_iterator it = j.erase(j.cbegin(), j.cend());
+                    const json::const_iterator it = j.erase(j.cbegin(), j.cend());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -775,13 +775,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = 23.42;
-                    json::iterator it = j.erase(j.begin(), j.end());
+                    const json::iterator it = j.erase(j.begin(), j.end());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = 23.42;
-                    json::const_iterator it = j.erase(j.cbegin(), j.cend());
+                    const json::const_iterator it = j.erase(j.cbegin(), j.cend());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
@@ -791,13 +791,13 @@ TEST_CASE("element access 1")
             {
                 {
                     json j = json::binary({1, 2, 3});
-                    json::iterator it = j.erase(j.begin(), j.end());
+                    const json::iterator it = j.erase(j.begin(), j.end());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }
                 {
                     json j = json::binary({1, 2, 3});
-                    json::const_iterator it = j.erase(j.cbegin(), j.cend());
+                    const json::const_iterator it = j.erase(j.cbegin(), j.cend());
                     CHECK(j.type() == json::value_t::null);
                     CHECK(it == j.end());
                 }

--- a/tests/src/unit-element_access2.cpp
+++ b/tests/src/unit-element_access2.cpp
@@ -847,13 +847,13 @@ TEST_CASE_TEMPLATE("element access 2", Json, nlohmann::json, nlohmann::ordered_j
                 {
                     {
                         Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        typename Json::iterator it2 = jobject.erase(jobject.begin(), jobject.end());
+                        const typename Json::iterator it2 = jobject.erase(jobject.begin(), jobject.end());
                         CHECK(jobject == Json::object());
                         CHECK(it2 == jobject.end());
                     }
                     {
                         Json jobject = {{"a", "a"}, {"b", 1}, {"c", 17u}};
-                        typename Json::const_iterator it2 = jobject.erase(jobject.cbegin(), jobject.cend());
+                        const typename Json::const_iterator it2 = jobject.erase(jobject.cbegin(), jobject.cend());
                         CHECK(jobject == Json::object());
                         CHECK(it2 == jobject.cend());
                     }

--- a/tests/src/unit-inspection.cpp
+++ b/tests/src/unit-inspection.cpp
@@ -278,8 +278,8 @@ TEST_CASE("object inspection")
                 std::ifstream f_escaped(TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode_ascii.json");
                 std::ifstream f_unescaped(TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json");
 
-                json j1 = json::parse(f_escaped);
-                json j2 = json::parse(f_unescaped);
+                const json j1 = json::parse(f_escaped);
+                const json j2 = json::parse(f_unescaped);
                 CHECK(j1 == j2);
             }
 
@@ -289,10 +289,10 @@ TEST_CASE("object inspection")
                 std::ifstream f_unescaped(TEST_DATA_DIRECTORY "/json_nlohmann_tests/all_unicode.json");
 
                 json const value = json::parse(f_unescaped);
-                std::string text = value.dump(4, ' ', true);
+                const std::string text = value.dump(4, ' ', true);
 
-                std::string expected((std::istreambuf_iterator<char>(f_escaped)),
-                                     std::istreambuf_iterator<char>());
+                const std::string expected((std::istreambuf_iterator<char>(f_escaped)),
+                                           std::istreambuf_iterator<char>());
                 CHECK(text == expected);
             }
         }
@@ -333,7 +333,7 @@ TEST_CASE("object inspection")
                 })
         {
             json const j1 = json::parse(s);
-            std::string s1 = j1.dump();
+            const std::string s1 = j1.dump();
             json const j2 = json::parse(s1);
             std::string s2 = j2.dump();
             CHECK(s1 == s2);
@@ -396,63 +396,63 @@ TEST_CASE("object inspection")
         SECTION("null")
         {
             json const j = nullptr;
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("object")
         {
             json const j = {{"foo", "bar"}};
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("array")
         {
             json const j = {1, 2, 3, 4};
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("boolean")
         {
             json const j = true;
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("string")
         {
             json const j = "Hello world";
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("number (integer)")
         {
             json const j = 23;
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("number (unsigned)")
         {
             json const j = 23u;
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("number (floating-point)")
         {
             json const j = 42.23;
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
 
         SECTION("binary")
         {
             json const j = json::binary({});
-            json::value_t t = j;
+            const json::value_t t = j;
             CHECK(t == j.type());
         }
     }

--- a/tests/src/unit-iterators1.cpp
+++ b/tests/src/unit-iterators1.cpp
@@ -18,10 +18,10 @@ TEST_CASE("iterators 1")
     {
         SECTION("uninitialized")
         {
-            json::iterator it;
+            const json::iterator it;
             CHECK(it.m_object == nullptr);
 
-            json::const_iterator cit;
+            const json::const_iterator cit;
             CHECK(cit.m_object == nullptr);
         }
 
@@ -1498,46 +1498,46 @@ TEST_CASE("iterators 1")
 
             SECTION("json + begin/end")
             {
-                json::iterator it = j.begin();
+                const json::iterator it = j.begin();
                 CHECK(it == j.end());
             }
 
             SECTION("const json + begin/end")
             {
-                json::const_iterator it_begin = j_const.begin();
+                const json::const_iterator it_begin = j_const.begin();
                 json::const_iterator it_end = j_const.end();
                 CHECK(it_begin == it_end);
             }
 
             SECTION("json + cbegin/cend")
             {
-                json::const_iterator it_begin = j.cbegin();
+                const json::const_iterator it_begin = j.cbegin();
                 json::const_iterator it_end = j.cend();
                 CHECK(it_begin == it_end);
             }
 
             SECTION("const json + cbegin/cend")
             {
-                json::const_iterator it_begin = j_const.cbegin();
+                const json::const_iterator it_begin = j_const.cbegin();
                 json::const_iterator it_end = j_const.cend();
                 CHECK(it_begin == it_end);
             }
 
             SECTION("json + rbegin/rend")
             {
-                json::reverse_iterator it = j.rbegin();
+                const json::reverse_iterator it = j.rbegin();
                 CHECK(it == j.rend());
             }
 
             SECTION("json + crbegin/crend")
             {
-                json::const_reverse_iterator it = j.crbegin();
+                const json::const_reverse_iterator it = j.crbegin();
                 CHECK(it == j.crend());
             }
 
             SECTION("const json + crbegin/crend")
             {
-                json::const_reverse_iterator it = j_const.crbegin();
+                const json::const_reverse_iterator it = j_const.crbegin();
                 CHECK(it == j_const.crend());
             }
 

--- a/tests/src/unit-iterators1.cpp
+++ b/tests/src/unit-iterators1.cpp
@@ -18,10 +18,10 @@ TEST_CASE("iterators 1")
     {
         SECTION("uninitialized")
         {
-            const json::iterator it;
+            json::iterator it; // NOLINT(misc-const-correctness)
             CHECK(it.m_object == nullptr);
 
-            const json::const_iterator cit;
+            json::const_iterator cit; // NOLINT(misc-const-correctness)
             CHECK(cit.m_object == nullptr);
         }
 

--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -24,9 +24,9 @@ TEST_CASE("JSON patch")
         SECTION("4. Operations")
         {
             // the ordering of members in JSON objects is not significant:
-            json op1 = R"({ "op": "add", "path": "/a/b/c", "value": "foo" })"_json;
-            json op2 = R"({ "path": "/a/b/c", "op": "add", "value": "foo" })"_json;
-            json op3 = R"({ "value": "foo", "path": "/a/b/c", "op": "add" })"_json;
+            const json op1 = R"({ "op": "add", "path": "/a/b/c", "value": "foo" })"_json;
+            const json op2 = R"({ "path": "/a/b/c", "op": "add", "value": "foo" })"_json;
+            const json op3 = R"({ "value": "foo", "path": "/a/b/c", "op": "add" })"_json;
 
             // check if the operation objects are equivalent
             CHECK(op1 == op2);
@@ -642,12 +642,12 @@ TEST_CASE("JSON patch")
                     )"_json;
 
                 // apply the patch
-                json target = source.patch(p1);
+                const json target = source.patch(p1);
                 // target = { "D": "Berlin", "F": "Paris", "GB": "London" }
                 CHECK(target == R"({ "D": "Berlin", "F": "Paris", "GB": "London" })"_json);
 
                 // create a diff from two JSONs
-                json p2 = json::diff(target, source); // NOLINT(readability-suspicious-call-argument)
+                const json p2 = json::diff(target, source); // NOLINT(readability-suspicious-call-argument)
                 // p2 = [{"op": "delete", "path": "/GB"}]
                 CHECK(p2 == R"([{"op":"remove","path":"/GB"}])"_json);
             }
@@ -666,7 +666,7 @@ TEST_CASE("JSON patch")
                 j["/2/en"_json_pointer] = "ugly";
                 CHECK(j == R"(["good","bad",{"en":"ugly","it":"cattivo"}])"_json);
 
-                json flat = j.flatten();
+                const json flat = j.flatten();
                 CHECK(flat == R"({"/0":"good","/1":"bad","/2/en":"ugly","/2/it":"cattivo"})"_json);
             }
         }

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1606,7 +1606,7 @@ TEST_CASE("single MessagePack roundtrip")
 
         // parse JSON file
         std::ifstream f_json(filename);
-        json j1 = json::parse(f_json);
+        const json j1 = json::parse(f_json);
 
         // parse MessagePack file
         auto packed = utils::read_binary_file(filename + ".msgpack");
@@ -1817,7 +1817,7 @@ TEST_CASE("MessagePack roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse MessagePack file
                 auto packed = utils::read_binary_file(filename + ".msgpack");
@@ -1832,7 +1832,7 @@ TEST_CASE("MessagePack roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": std::ifstream");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
@@ -1847,7 +1847,7 @@ TEST_CASE("MessagePack roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse MessagePack file
                 auto packed = utils::read_binary_file(filename + ".msgpack");

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1945,7 +1945,7 @@ TEST_CASE("MessagePack with std::byte")
                 msgpack_data[i] = std::byte(temp[i]);
             }
             // Attempt direct deserialization using std::byte input
-            json direct_result = json::from_msgpack(msgpack_data);
+            const json direct_result = json::from_msgpack(msgpack_data);
 
             // Test the workaround approach: reinterpret as unsigned char* and use iterator range
             const auto* const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1914,10 +1914,12 @@ TEST_CASE("MessagePack with std::byte")
         SECTION("empty vector")
         {
             const std::vector<std::byte> empty_data;
-            CHECK_THROWS_WITH_AS([&]() { 
-                [[maybe_unused]] auto result = json::from_msgpack(empty_data); 
-                return true; 
-            }(),
+            CHECK_THROWS_WITH_AS([&]()
+            {
+                [[maybe_unused]] auto result = json::from_msgpack(empty_data);
+                return true;
+            }
+            (),
             "[json.exception.parse_error.110] parse error at byte 1: syntax error while parsing MessagePack value: unexpected end of input",
             json::parse_error&);
         }
@@ -1946,8 +1948,8 @@ TEST_CASE("MessagePack with std::byte")
             json direct_result = json::from_msgpack(msgpack_data);
 
             // Test the workaround approach: reinterpret as unsigned char* and use iterator range
-            const auto *const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
-            const auto *const char_end = char_start + msgpack_data.size();
+            const auto* const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
+            const auto* const char_end = char_start + msgpack_data.size();
             json workaround_result = json::from_msgpack(char_start, char_end);
 
             // Verify that the final deserialized JSON matches the original JSON

--- a/tests/src/unit-ordered_map.cpp
+++ b/tests/src/unit-ordered_map.cpp
@@ -36,7 +36,7 @@ TEST_CASE("ordered_map")
     {
         std::map<std::string, std::string> m {{"eins", "one"}, {"zwei", "two"}, {"drei", "three"}};
         ordered_map<std::string, std::string> om(m.begin(), m.end());
-        const auto com = om;
+        const auto com = om; // NOLINT(performance-unnecessary-copy-initialization)
 
         SECTION("with Key&&")
         {
@@ -68,7 +68,7 @@ TEST_CASE("ordered_map")
     SECTION("operator[]")
     {
         std::map<std::string, std::string> m {{"eins", "one"}, {"zwei", "two"}, {"drei", "three"}};
-        ordered_map<std::string, std::string> om(m.begin(), m.end());
+        ordered_map<std::string, std::string> om(m.begin(), m.end()); // NOLINT(performance-unnecessary-copy-initialization)
         const auto com = om;
 
         SECTION("with Key&&")

--- a/tests/src/unit-ordered_map.cpp
+++ b/tests/src/unit-ordered_map.cpp
@@ -68,8 +68,8 @@ TEST_CASE("ordered_map")
     SECTION("operator[]")
     {
         std::map<std::string, std::string> m {{"eins", "one"}, {"zwei", "two"}, {"drei", "three"}};
-        ordered_map<std::string, std::string> om(m.begin(), m.end()); // NOLINT(performance-unnecessary-copy-initialization)
-        const auto com = om;
+        ordered_map<std::string, std::string> om(m.begin(), m.end());
+        const auto com = om; // NOLINT(performance-unnecessary-copy-initialization)
 
         SECTION("with Key&&")
         {

--- a/tests/src/unit-pointer_access.cpp
+++ b/tests/src/unit-pointer_access.cpp
@@ -19,7 +19,7 @@ TEST_CASE("pointer access")
         json value = {{"one", 1}, {"two", 2}};
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == value.get<test_type>());
 
@@ -77,7 +77,7 @@ TEST_CASE("pointer access")
         json value = {1, 2, 3, 4};
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == value.get<test_type>());
 
@@ -135,7 +135,7 @@ TEST_CASE("pointer access")
         json value = "hello";
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == value.get<test_type>());
 
@@ -193,7 +193,7 @@ TEST_CASE("pointer access")
         json value = false;
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == value.get<test_type>());
 
@@ -251,7 +251,7 @@ TEST_CASE("pointer access")
         json value = 23;
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == value.get<test_type>());
 
@@ -309,7 +309,7 @@ TEST_CASE("pointer access")
         json value = 23u;
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == value.get<test_type>());
 
@@ -367,7 +367,7 @@ TEST_CASE("pointer access")
         json value = 42.23;
 
         // check if pointers are returned correctly
-        test_type* p1 = value.get_ptr<test_type*>();
+        const test_type* p1 = value.get_ptr<test_type*>();
         CHECK(p1 == value.get_ptr<test_type*>());
         CHECK(*p1 == Approx(value.get<test_type>()));
 

--- a/tests/src/unit-readme.cpp
+++ b/tests/src/unit-readme.cpp
@@ -136,7 +136,7 @@ TEST_CASE("README" * doctest::skip())
             j.push_back(true);
 
             // comparison
-            bool x = (j == R"(["foo", 1, true])"_json);  // true
+            const bool x = (j == R"(["foo", 1, true])"_json);  // true
             CHECK(x == true);
 
             // iterate the array
@@ -154,7 +154,7 @@ TEST_CASE("README" * doctest::skip())
             // getter/setter
             const auto tmp = j[0].get<std::string>(); // NOLINT(bugprone-unused-local-non-trivial-variable)
             j[1] = 42;
-            bool foo{j.at(2)};
+            const bool foo{j.at(2)};
             CHECK(foo == true);
 
             // other stuff
@@ -242,21 +242,21 @@ TEST_CASE("README" * doctest::skip())
             // Booleans
             bool const b1 = true;
             json const jb = b1;
-            bool b2{jb};
+            const bool b2{jb};
             CHECK(b2 == true);
 
             // numbers
             int const i = 42;
             json const jn = i;
-            double f{jn};
+            const double f{jn};
             CHECK(f == 42);
 
             // etc.
 
             std::string const vs = js.get<std::string>(); // NOLINT(bugprone-unused-local-non-trivial-variable)
-            bool vb = jb.get<bool>();
+            const bool vb = jb.get<bool>();
             CHECK(vb == true);
-            int vi = jn.get<int>();
+            const int vi = jn.get<int>();
             CHECK(vi == 42);
 
             // etc.

--- a/tests/src/unit-regression1.cpp
+++ b/tests/src/unit-regression1.cpp
@@ -122,7 +122,7 @@ TEST_CASE("regression tests 1")
         SECTION("escape_doublequote")
         {
             const auto* s = R"(["\"foo\""])";
-            json j = json::parse(s);
+            const json j = json::parse(s);
             auto expected = R"(["\"foo\""])"_json;
             CHECK(j == expected);
         }
@@ -182,7 +182,7 @@ TEST_CASE("regression tests 1")
         j.push_back(t);
 
         // maybe this is not the place to test this?
-        json j2 = u;
+        const json j2 = u;
 
         auto anon_enum_value = j2.get<decltype(u)>();
         CHECK(u == anon_enum_value);
@@ -247,9 +247,9 @@ TEST_CASE("regression tests 1")
 
         auto test = j["Test"].get<std::string>();
         CHECK(test == "Test1");
-        int number{j["Number"]};
+        const int number{j["Number"]};
         CHECK(number == 100);
-        float foo{j["Foo"]};
+        const float foo{j["Foo"]};
         CHECK(static_cast<double>(foo) == Approx(42.42));
     }
 
@@ -371,7 +371,7 @@ TEST_CASE("regression tests 1")
     {
         json o = {{"name", "value"}};
 
-        std::string s1 = o["name"];
+        const std::string s1 = o["name"];
         CHECK(s1 == "value");
 
         std::string s2;
@@ -607,8 +607,8 @@ TEST_CASE("regression tests 1")
             {"object", {{"key1", 1}, {"key2", 2}}},
         };
 
-        int at_integer{j.at("/object/key2"_json_pointer)};
-        int val_integer = j.value("/object/key2"_json_pointer, 0);
+        const int at_integer{j.at("/object/key2"_json_pointer)};
+        const int val_integer = j.value("/object/key2"_json_pointer, 0);
 
         CHECK(at_integer == val_integer);
     }
@@ -1099,7 +1099,7 @@ TEST_CASE("regression tests 1")
 #if JSON_USE_IMPLICIT_CONVERSIONS
     SECTION("issue #464 - VS2017 implicit to std::string conversion fix")
     {
-        json v = "test";
+        const json v = "test";
         std::string test;
         test = v;
         CHECK(v == "test");
@@ -1109,9 +1109,9 @@ TEST_CASE("regression tests 1")
     SECTION("issue #465 - roundtrip error while parsing 1000000000000000010E5")
     {
         json const j1 = json::parse("1000000000000000010E5");
-        std::string s1 = j1.dump();
+        const std::string s1 = j1.dump();
         json const j2 = json::parse(s1);
-        std::string s2 = j2.dump();
+        const std::string s2 = j2.dump();
         CHECK(s1 == s2);
     }
 
@@ -1243,7 +1243,7 @@ TEST_CASE("regression tests 1")
         SECTION("example 1")
         {
             // create a map
-            std::map<std::string, int> m1 {{"key", 1}};
+            const std::map<std::string, int> m1 {{"key", 1}};
 
             // create and print a JSON from the map
             json const j = m1;
@@ -1258,7 +1258,7 @@ TEST_CASE("regression tests 1")
         SECTION("example 2")
         {
             // create a map
-            std::map<std::string, std::string> m1 {{"key", "val"}};
+            const std::map<std::string, std::string> m1 {{"key", "val"}};
 
             // create and print a JSON from the map
             json const j = m1;
@@ -1322,7 +1322,7 @@ TEST_CASE("regression tests 1")
 
             auto m1 = j1.get<std::map<std::string, std::string>>();
             auto m2 = j2.get<std::map<std::string, std::string>>();
-            int i3{j3};
+            const int i3{j3};
 
             CHECK( m1 == ( std::map<std::string, std::string> {{ "first",  "one" }} ));
             CHECK( m2 == ( std::map<std::string, std::string> {{ "second", "two" }} ));
@@ -1431,7 +1431,7 @@ TEST_CASE("regression tests 1")
             '1', '2', '3',
             0xFF
         };
-        json j = json::from_cbor(v_cbor);
+        const json j = json::from_cbor(v_cbor);
         CHECK(j == "abcd123");
     }
 
@@ -1477,7 +1477,7 @@ TEST_CASE("regression tests 1")
         };
 
         // parse (with callback) and serialize JSON
-        json j_filtered = json::parse(text, cb);
+        const json j_filtered = json::parse(text, cb);
 
         CHECK(j_filtered == R"({"Image":{"Animated":false,"Height":600,"IDs":[116,943,234,38793], "Title":"View from 15th Floor","Width":800}})"_json);
     }
@@ -1490,7 +1490,7 @@ TEST_CASE("regression tests 1")
     SECTION("issue #977 - Assigning between different json types")
     {
         foo_json lj = ns::foo{3};
-        ns::foo ff(lj);
+        const ns::foo ff(lj);
         CHECK(lj.is_object());
         CHECK(lj.size() == 1);
         CHECK(lj["x"] == 3);

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -549,7 +549,7 @@ TEST_CASE("regression tests 2")
             {"3", {{"a", "testa_3"}, {"b", "testb_3"}}},
         };
 
-        std::map<std::string, Data> expected
+        const std::map<std::string, Data> expected
         {
             {"1", {"testa_1", "testb_1"}},
             {"2", {"testa_2", "testb_2"}},
@@ -642,7 +642,7 @@ TEST_CASE("regression tests 2")
 #if !(defined(__INTEL_COMPILER) && __cplusplus >= 202000)
         {
             const json j;
-            NonDefaultFromJsonStruct x(j);
+            const NonDefaultFromJsonStruct x(j);
             NonDefaultFromJsonStruct y;
             CHECK(x == y);
         }
@@ -919,7 +919,7 @@ TEST_CASE("regression tests 2")
 
     SECTION("issue #2982 - to_{binary format} does not provide a mechanism for specifying a custom allocator for the returned type")
     {
-        std::vector<std::uint8_t, my_allocator<std::uint8_t>> my_vector;
+        const std::vector<std::uint8_t, my_allocator<std::uint8_t>> my_vector;
         json j = {1, 2, 3, 4};
         json::to_cbor(j, my_vector);
         json k = json::from_cbor(my_vector);
@@ -1019,8 +1019,8 @@ TEST_CASE("regression tests 2")
 
     SECTION("issue #3204 - ambiguous regression")
     {
-        for_3204_bar bar_from_foo([](for_3204_foo) noexcept {}); // NOLINT(performance-unnecessary-value-param)
-        for_3204_bar bar_from_json([](json) noexcept {}); // NOLINT(performance-unnecessary-value-param)
+        const for_3204_bar bar_from_foo([](for_3204_foo) noexcept {}); // NOLINT(performance-unnecessary-value-param)
+        const for_3204_bar bar_from_json([](json) noexcept {}); // NOLINT(performance-unnecessary-value-param)
 
         CHECK(bar_from_foo.constructed_from == for_3204_bar::constructed_from_foo);
         CHECK(bar_from_json.constructed_from == for_3204_bar::constructed_from_json);
@@ -1033,7 +1033,7 @@ TEST_CASE("regression tests 2")
             {"x", 1},
             {"y", 2}
         };
-        for_3333 p = j;
+        const for_3333 p = j;
 
         CHECK(p.x == 1);
         CHECK(p.y == 2);

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -919,7 +919,7 @@ TEST_CASE("regression tests 2")
 
     SECTION("issue #2982 - to_{binary format} does not provide a mechanism for specifying a custom allocator for the returned type")
     {
-        const std::vector<std::uint8_t, my_allocator<std::uint8_t>> my_vector;
+        std::vector<std::uint8_t, my_allocator<std::uint8_t>> my_vector;
         json j = {1, 2, 3, 4};
         json::to_cbor(j, my_vector);
         json k = json::from_cbor(my_vector);

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -920,7 +920,7 @@ TEST_CASE("regression tests 2")
     SECTION("issue #2982 - to_{binary format} does not provide a mechanism for specifying a custom allocator for the returned type")
     {
         std::vector<std::uint8_t, my_allocator<std::uint8_t>> my_vector;
-        json j = {1, 2, 3, 4};
+        const json j = {1, 2, 3, 4};
         json::to_cbor(j, my_vector);
         json k = json::from_cbor(my_vector);
         CHECK(j == k);

--- a/tests/src/unit-to_chars.cpp
+++ b/tests/src/unit-to_chars.cpp
@@ -340,7 +340,7 @@ TEST_CASE("formatting")
         {
             std::array<char, 33> buf{};
             char* end = nlohmann::detail::to_chars(buf.data(), buf.data() + 32, number); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-            std::string actual(buf.data(), end);
+            const std::string actual(buf.data(), end);
 
             CHECK(actual == expected);
         };
@@ -400,7 +400,7 @@ TEST_CASE("formatting")
         {
             std::array<char, 33> buf{};
             char* end = nlohmann::detail::to_chars(buf.data(), buf.data() + 32, number); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-            std::string actual(buf.data(), end);
+            const std::string actual(buf.data(), end);
 
             CHECK(actual == expected);
         };

--- a/tests/src/unit-ubjson.cpp
+++ b/tests/src/unit-ubjson.cpp
@@ -2515,7 +2515,7 @@ TEST_CASE("UBJSON roundtrips" * doctest::skip())
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
                 // parse JSON file
                 std::ifstream f_json(filename);
-                json j1 = json::parse(f_json);
+                const json j1 = json::parse(f_json);
 
                 // parse UBJSON file
                 auto const packed = utils::read_binary_file(filename + ".ubjson");

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -735,14 +735,14 @@ TEST_CASE("different basic_json types conversions")
     SECTION("null")
     {
         json const j;
-        custom_json cj = j;
+        const custom_json cj = j;
         CHECK(cj == nullptr);
     }
 
     SECTION("boolean")
     {
         json const j = true;
-        custom_json cj = j;
+        const custom_json cj = j;
         CHECK(cj == true);
     }
 
@@ -764,28 +764,28 @@ TEST_CASE("different basic_json types conversions")
     SECTION("integer")
     {
         json const j = 42;
-        custom_json cj = j;
+        const custom_json cj = j;
         CHECK(cj == 42);
     }
 
     SECTION("float")
     {
         json const j = 42.0;
-        custom_json cj = j;
+        const custom_json cj = j;
         CHECK(cj == 42.0);
     }
 
     SECTION("unsigned")
     {
         json const j = 42u;
-        custom_json cj = j;
+        const custom_json cj = j;
         CHECK(cj == 42u);
     }
 
     SECTION("string")
     {
         json const j = "forty-two";
-        custom_json cj = j;
+        const custom_json cj = j;
         CHECK(cj == "forty-two");
     }
 
@@ -794,7 +794,7 @@ TEST_CASE("different basic_json types conversions")
         json j = json::binary({1, 2, 3}, 42);
         custom_json cj = j;
         CHECK(cj.get_binary().subtype() == 42);
-        std::vector<std::uint8_t> cv = cj.get_binary();
+        const std::vector<std::uint8_t> cv = cj.get_binary();
         std::vector<std::uint8_t> v = j.get_binary();
         CHECK(cv == v);
     }
@@ -802,7 +802,7 @@ TEST_CASE("different basic_json types conversions")
     SECTION("object")
     {
         json const j = {{"forty", "two"}};
-        custom_json cj = j;
+        const custom_json cj = j;
         auto m = j.get<std::map<std::string, std::string>>();
         CHECK(cj == m);
     }
@@ -810,7 +810,7 @@ TEST_CASE("different basic_json types conversions")
     SECTION("get<custom_json>")
     {
         json const j = 42;
-        custom_json cj = j.get<custom_json>();
+        const custom_json cj = j.get<custom_json>();
         CHECK(cj == 42);
     }
 }
@@ -861,11 +861,11 @@ TEST_CASE("Issue #924")
     CHECK_NOTHROW(j.get<std::vector<Evil>>());
 
     // silence Wunused-template warnings
-    Evil e(1);
+    const Evil e(1);
     CHECK(e.m_i >= 0);
 
     // suppress warning: function "<unnamed>::Evil::Evil(T) [with T=std::string]" was declared but never referenced [declared_but_not_referenced]
-    Evil e2(std::string("foo"));
+    const Evil e2(std::string("foo"));
     CHECK(e2.m_i >= 0);
 }
 

--- a/tests/src/unit-udt.cpp
+++ b/tests/src/unit-udt.cpp
@@ -794,7 +794,7 @@ TEST_CASE("different basic_json types conversions")
         json j = json::binary({1, 2, 3}, 42);
         custom_json cj = j;
         CHECK(cj.get_binary().subtype() == 42);
-        const std::vector<std::uint8_t> cv = cj.get_binary();
+        const std::vector<std::uint8_t>& cv = cj.get_binary();
         std::vector<std::uint8_t> v = j.get_binary();
         CHECK(cv == v);
     }

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -640,7 +640,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
     SECTION("alphabet")
     {
-        const T obj1;
+        T obj1; // NOLINT(misc-const-correctness)
         Json const j = obj1;
         T obj2;
         j.get_to(obj2);

--- a/tests/src/unit-udt_macro.cpp
+++ b/tests/src/unit-udt_macro.cpp
@@ -640,7 +640,7 @@ TEST_CASE_TEMPLATE("Serialization/deserialization of classes with 26 public/priv
 
     SECTION("alphabet")
     {
-        T obj1;
+        const T obj1;
         Json const j = obj1;
         T obj2;
         j.get_to(obj2);

--- a/tests/thirdparty/doctest/doctest.h
+++ b/tests/thirdparty/doctest/doctest.h
@@ -48,7 +48,7 @@
 
 #define DOCTEST_VERSION_MAJOR 2
 #define DOCTEST_VERSION_MINOR 4
-#define DOCTEST_VERSION_PATCH 11
+#define DOCTEST_VERSION_PATCH 12
 
 // util we need here
 #define DOCTEST_TOSTR_IMPL(x) #x
@@ -925,6 +925,7 @@ struct ContextOptions //!OCLINT too many fields
     bool no_skip;              // don't skip test cases which are marked to be skipped
     bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
     bool no_path_in_filenames; // if the path to files should be removed from the output
+    String strip_file_prefixes;// remove the longest matching one of these prefixes from any file paths in the output
     bool no_line_numbers;      // if source code line numbers should be omitted from the output
     bool no_debug_output;      // no output in the debug console when a debugger is attached
     bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
@@ -1578,8 +1579,8 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
         // https://github.com/catchorg/Catch2/issues/870
         // https://github.com/catchorg/Catch2/issues/565
         template <typename L>
-        Expression_lhs<L> operator<<(L&& operand) {
-            return Expression_lhs<L>(static_cast<L&&>(operand), m_at);
+        Expression_lhs<const L&&> operator<<(const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
+            return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
         }
 
         template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
@@ -3243,6 +3244,10 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define DOCTEST_CONFIG_OPTIONS_PREFIX "dt-"
 #endif
 
+#ifndef DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR
+#define DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR ':'
+#endif
+
 #ifndef DOCTEST_THREAD_LOCAL
 #if defined(DOCTEST_CONFIG_NO_MULTITHREADING) || DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
 #define DOCTEST_THREAD_LOCAL
@@ -3751,7 +3756,7 @@ String::size_type String::capacity() const {
 }
 
 String String::substr(size_type pos, size_type cnt) && {
-    cnt = std::min(cnt, size() - 1 - pos);
+    cnt = std::min(cnt, size() - pos);
     char* cptr = c_str();
     memmove(cptr, cptr + pos, cnt);
     setSize(cnt);
@@ -3759,7 +3764,7 @@ String String::substr(size_type pos, size_type cnt) && {
 }
 
 String String::substr(size_type pos, size_type cnt) const & {
-    cnt = std::min(cnt, size() - 1 - pos);
+    cnt = std::min(cnt, size() - pos);
     return String{ c_str() + pos, cnt };
 }
 
@@ -3891,6 +3896,26 @@ const char* skipPathFromFilename(const char* file) {
                 forward = back;
             return forward + 1;
         }
+    } else {
+        const auto prefixes = getContextOptions()->strip_file_prefixes;
+        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
+        String::size_type longest_match = 0U;
+        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
+        {
+            const auto prefix_start = pos;
+            pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
+            
+            const auto prefix_size = pos - prefix_start;
+            if(prefix_size > longest_match)
+            {
+                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
+                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
+                {
+                    longest_match = prefix_size;
+                }
+            }
+        }
+        return &file[longest_match];
     }
 #endif // DOCTEST_CONFIG_DISABLE
     return file;
@@ -6181,6 +6206,8 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << ":n: vs (n): for line numbers in output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
               << Whitespace(sizePrefixDisplay*1) << "only filenames and no paths in output\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "spp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "skip-path-prefixes=<p1:p2>    "
+              << Whitespace(sizePrefixDisplay*1) << "whenever file paths start with this prefix, remove it from the output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
               << Whitespace(sizePrefixDisplay*1) << "0 instead of real line numbers in output\n";
             // ================================================================================== << 79
@@ -6685,6 +6712,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skip", "ns", no_skip, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
+    DOCTEST_PARSE_STR_OPTION("strip-file-prefixes", "sfp", strip_file_prefixes, "");
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);


### PR DESCRIPTION
Update to https://github.com/doctest/doctest/releases/tag/v2.4.12.

The PR also fixes Clang-Tidy warnings that were detected after the update.