### PR TITLE
Extend type_name() to invalid type

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -563,7 +563,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 (t == value_t::binary && binary == nullptr)
             )
             {
-                //not initialized (e.g., due to exception in the ctor)
+                // not initialized (e.g., due to exception in the ctor)
                 return;
             }
             if (t == value_t::array || t == value_t::object)
@@ -4206,8 +4206,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             case value_t::number_integer:
             case value_t::number_unsigned:
             case value_t::number_float:
-            default:
                 return "number";
+            default:
+                return "invalid";
         }
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20629,7 +20629,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 (t == value_t::binary && binary == nullptr)
             )
             {
-                //not initialized (e.g., due to exception in the ctor)
+                // not initialized (e.g., due to exception in the ctor)
                 return;
             }
             if (t == value_t::array || t == value_t::object)
@@ -24272,8 +24272,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             case value_t::number_integer:
             case value_t::number_unsigned:
             case value_t::number_float:
-            default:
                 return "number";
+            default:
+                return "invalid";
         }
     }
 

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1082,6 +1082,8 @@ TEST_CASE("regression tests 2")
 #endif
 
 #if !defined(_MSVC_LANG)
+    // MSVC returns garbage on invalid enum values, so this test is excluded
+    // there.
     SECTION("issue #4762 - json exception 302 with unhelpful explanation : type must be number, but is number")
     {
         // In #4762, the main issue was that a json object with an invalid type

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1081,15 +1081,17 @@ TEST_CASE("regression tests 2")
     }
 #endif
 
+#if !defined(_MSVC_LANG)
     SECTION("issue #4762 - json exception 302 with unhelpful explanation : type must be number, but is number")
     {
         // In #4762, the main issue was that a json object with an invalid type
         // returned "number" as type_name(), because this was the default case.
         // This test makes sure we now return "invalid" instead.
         json j;
-        j.m_data.m_type = static_cast<json::value_t>(100);
+        j.m_data.m_type = static_cast<json::value_t>(100); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
         CHECK(j.type_name() == "invalid");
     }
+#endif
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1080,6 +1080,16 @@ TEST_CASE("regression tests 2")
         CHECK(t4.port.has_value());
     }
 #endif
+
+    SECTION("issue #4762 - json exception 302 with unhelpful explanation : type must be number, but is number")
+    {
+        // In #4762, the main issue was that a json object with an invalid type
+        // returned "number" as type_name(), because this was the default case.
+        // This test makes sure we now return "invalid" instead.
+        json j;
+        j.m_data.m_type = static_cast<json::value_t>(100);
+        CHECK(j.type_name() == "invalid");
+    }
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
Change the default return value for `type_name()` to "invalid" to detect data corruption in `basic_json` values.

Closes #4762 