### PR TITLE
Adjust warnings flags

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 # TODO: The first three checks are only removed to get the CI going. They have to be addressed at some point.
+# TODO: portability-avoid-pragma-once: should be fixed eventually
 
 Checks: '*,
 
@@ -59,6 +60,7 @@ Checks: '*,
          -modernize-use-std-numbers,
          -modernize-use-trailing-return-type,
          -performance-enum-size,
+         -portability-avoid-pragma-once,
          -readability-function-cognitive-complexity,
          -readability-function-size,
          -readability-identifier-length,

--- a/cmake/clang_flags.cmake
+++ b/cmake/clang_flags.cmake
@@ -3,6 +3,7 @@
 # -Wno-c++98-compat-pedantic      The library targets C++11.
 # -Wno-deprecated-declarations    The library contains annotations for deprecated functions.
 # -Wno-extra-semi-stmt            The library uses assert which triggers this warning.
+# -Wno-nrvo                       Doctest triggers this warning.
 # -Wno-padded                     We do not care about padding warnings.
 # -Wno-covered-switch-default     All switches list all cases and a default case.
 # -Wno-unsafe-buffer-usage        Otherwise Doctest would not compile.
@@ -14,6 +15,7 @@ set(CLANG_CXXFLAGS
     -Wno-c++98-compat-pedantic
     -Wno-deprecated-declarations
     -Wno-extra-semi-stmt
+    -Wno-nrvo
     -Wno-padded
     -Wno-covered-switch-default
     -Wno-unsafe-buffer-usage

--- a/cmake/clang_flags.cmake
+++ b/cmake/clang_flags.cmake
@@ -3,7 +3,6 @@
 # -Wno-c++98-compat-pedantic      The library targets C++11.
 # -Wno-deprecated-declarations    The library contains annotations for deprecated functions.
 # -Wno-extra-semi-stmt            The library uses assert which triggers this warning.
-# -Wno-nrvo                       Doctest triggers this warning.
 # -Wno-padded                     We do not care about padding warnings.
 # -Wno-covered-switch-default     All switches list all cases and a default case.
 # -Wno-unsafe-buffer-usage        Otherwise Doctest would not compile.
@@ -15,7 +14,6 @@ set(CLANG_CXXFLAGS
     -Wno-c++98-compat-pedantic
     -Wno-deprecated-declarations
     -Wno-extra-semi-stmt
-    -Wno-nrvo
     -Wno-padded
     -Wno-covered-switch-default
     -Wno-unsafe-buffer-usage

--- a/tests/thirdparty/doctest/doctest.h
+++ b/tests/thirdparty/doctest/doctest.h
@@ -4501,7 +4501,7 @@ namespace {
         auto&  translators = getExceptionTranslators();
         for(auto& curr : translators)
             if(curr->translate(res))
-              DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")
+              DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnrvo")
                 return res;
               DOCTEST_CLANG_SUPPRESS_WARNING_POP
         // clang-format off

--- a/tests/thirdparty/doctest/doctest.h
+++ b/tests/thirdparty/doctest/doctest.h
@@ -4497,11 +4497,12 @@ namespace {
 
     String translateActiveException() {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        String res;
         auto&  translators = getExceptionTranslators();
-        for(auto& curr : translators)
-            if(curr->translate(res))
-                return std::move(res);
+        for(auto& curr : translators) {
+            String res;
+            if (curr->translate(res))
+                return res;
+        }
         // clang-format off
         DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
         try {

--- a/tests/thirdparty/doctest/doctest.h
+++ b/tests/thirdparty/doctest/doctest.h
@@ -4501,7 +4501,9 @@ namespace {
         auto&  translators = getExceptionTranslators();
         for(auto& curr : translators)
             if(curr->translate(res))
+              DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")
                 return res;
+              DOCTEST_CLANG_SUPPRESS_WARNING_POP
         // clang-format off
         DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
         try {

--- a/tests/thirdparty/doctest/doctest.h
+++ b/tests/thirdparty/doctest/doctest.h
@@ -4501,9 +4501,7 @@ namespace {
         auto&  translators = getExceptionTranslators();
         for(auto& curr : translators)
             if(curr->translate(res))
-              DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnrvo")
-                return res;
-              DOCTEST_CLANG_SUPPRESS_WARNING_POP
+                return std::move(res);
         // clang-format off
         DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
         try {


### PR DESCRIPTION
A recent Clang update introduced a new Clang Tidy flag `portability-avoid-pragma-once` and found a `Wnrvo` warning in doctest. This PR suppresses/fixes these.

In a follow-up ticket, we may want to fix `portability-avoid-pragma-once`.