### PR TITLE
Remove deprecated windows-2019 image

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   mingw:
-    runs-on: windows-2019
+    runs-on: windows-2025
     strategy:
       matrix:
         architecture: [x64, x86]
@@ -81,7 +81,7 @@ jobs:
         run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
 
   clang:
-    runs-on: windows-2019
+    runs-on: windows-2025
     strategy:
       matrix:
         version: [11, 12, 13, 14, 15]
@@ -98,7 +98,7 @@ jobs:
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure
 
   clang-cl-12:
-    runs-on: windows-2019
+    runs-on: windows-2025
     strategy:
       matrix:
         architecture: [Win32, x64]


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/12045