### PR TITLE
 Simplify module API

### DIFF
--- a/docs/mkdocs/docs/features/modules.md
+++ b/docs/mkdocs/docs/features/modules.md
@@ -25,6 +25,7 @@ json data = json::parse(f);
 
 ## Modules do not export macros
 It should be noted that as modules do not export macros, the `nlohmann.json` module will not export any macros, but rather only the following symbols:
+
 - `nlohmann::adl_serializer`
 - `nlohmann::basic_json`
 - `nlohmann::json`

--- a/src/modules/json.cppm
+++ b/src/modules/json.cppm
@@ -5,18 +5,10 @@ module;
 export module nlohmann.json;
 
 export namespace nlohmann {
-    template <typename T = void, typename SFINAE = void>
-    using adl_serializer = ::nlohmann::adl_serializer<T, SFINAE>;
-
-    using basic_json = ::nlohmann::basic_json<>;
-
-    using json = ::nlohmann::json;
-
-    template <typename RefStringType>
-    using json_pointer = ::nlohmann::json_pointer<RefStringType>;
-
+    using ::nlohmann::adl_serializer;
+    using ::nlohmann::basic_json;
+    using ::nlohmann::json;
+    using ::nlohmann::json_pointer;
     using ::nlohmann::ordered_json;
-
-    template <class Key, class T, class IgnoredLess, class Allocator>
-    using ordered_map = ::nlohmann::ordered_map<Key, T, IgnoredLess, Allocator>;
+    using ::nlohmann::ordered_map;
 }  // namespace nlohmann


### PR DESCRIPTION
- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [ ] The source code is amalgamated by running `make amalgamate`.

This pull request follows up with and addresses a previous pull request, #4799. Here we reduce the `using` statements to non-templated `using` statements as it is simpler and does not interfere with the original header API.