### PR TITLE
Use the provided allocator in destroy() (#4842)

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -570,7 +570,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             if (t == value_t::array || t == value_t::object)
             {
                 // flatten the current json_value to a heap-allocated stack
-                std::vector<basic_json> stack;
+                std::vector<basic_json, allocator_type> stack;
 
                 // move the top-level items to stack
                 if (t == value_t::array)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20673,7 +20673,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             if (t == value_t::array || t == value_t::object)
             {
                 // flatten the current json_value to a heap-allocated stack
-                std::vector<basic_json> stack;
+                std::vector<basic_json, allocator_type> stack;
 
                 // move the top-level items to stack
                 if (t == value_t::array)


### PR DESCRIPTION
Uses the provided allocator to allocate the stack used to avoid recursion in the destroy() implementation used by ~basic_json.

This addresses issue #4842, by changing the std::vector to use the user-provided allocatorl