### PR TITLE
Give CMake message about the version of the code used only once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,14 @@ set(NLOHMANN_JSON_PKGCONFIG_INSTALL_DIR     "${CMAKE_INSTALL_DATADIR}/pkgconfig"
 
 if (JSON_MultipleHeaders)
     set(NLOHMANN_JSON_INCLUDE_BUILD_DIR "${PROJECT_SOURCE_DIR}/include/")
-    message(STATUS "Using the multi-header code from ${NLOHMANN_JSON_INCLUDE_BUILD_DIR}")
+    set(NLOHMANN_JSON_CODE_VERSION_NOW "multi-header")
 else()
     set(NLOHMANN_JSON_INCLUDE_BUILD_DIR "${PROJECT_SOURCE_DIR}/single_include/")
-    message(STATUS "Using the single-header code from ${NLOHMANN_JSON_INCLUDE_BUILD_DIR}")
+    set(NLOHMANN_JSON_CODE_VERSION_NOW "single-header")
+endif()
+if(NOT "${NLOHMANN_JSON_CODE_VERSION_NOW}" STREQUAL "${NLOHMANN_JSON_CODE_VERSION}")
+    set(NLOHMANN_JSON_CODE_VERSION "${NLOHMANN_JSON_CODE_VERSION_NOW}" CACHE INTERNAL "")
+    message(STATUS "Using the ${NLOHMANN_JSON_CODE_VERSION} code from ${NLOHMANN_JSON_INCLUDE_BUILD_DIR}")
 endif()
 
 if (NOT JSON_ImplicitConversions)


### PR DESCRIPTION
When consuming the library via `add_subdirectory()` using CMake, the
message about the version of the code being used was given every time
CMake was re-run, even if it happened due to the changes in the super
project completely unrelated to this library.

This was somewhat annoying, so avoid this by remembering the version of
the code used in the cache and not giving the message about it again if
it didn't change since the last run.

-----

Sorry, I don't follow the check list in your guidelines because this change doesn't affect the code, only the build system, so the items in it are mostly inapplicable.