### PR TITLE
Make escape/unescape functions linear and not memory-storming.

### DIFF
--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -46,7 +46,7 @@ inline StringType escape(StringType const& s)
             if (ch == CharT('~'))
             {
                 res.push_back(CharT('~'));
-		res.push_back(CharT{'0'});
+                res.push_back(CharT{'0'});
             }
             else if (ch == CharT('/'))
             {

--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -15,7 +15,7 @@ namespace detail
 {
 
 /*!
- * @brief Out Of Place string escaping as described in RFC 6901 (Sect. 4)
+ * @brief Returns a copy of a string escaped as described in RFC 6901 (Sect. 4)
  * @param[in] s string to escape
  * @return    escaped string
  *
@@ -45,11 +45,13 @@ inline StringType escape(StringType const& s)
         {
             if (ch == CharT('~'))
             {
-                res.append(StringType{"~0"});
+                res.push_back(CharT('~'));
+		res.push_back(CharT{'0'});
             }
             else if (ch == CharT('/'))
             {
-                res.append(StringType{"~1"});
+                res.push_back(CharT{'~'});
+                res.push_back(CharT{'1'});
             }
             else
             {
@@ -61,7 +63,7 @@ inline StringType escape(StringType const& s)
 }
 
 /*!
- * @brief In Place string unescaping as described in RFC 6901 (Sect. 4)
+ * @brief Unescapes a string as described in RFC 6901 (Sect. 4), in-place
  * @param[in] s string to unescape
  *
  */

--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -15,58 +15,79 @@ namespace detail
 {
 
 /*!
-@brief replace all occurrences of a substring by another string
-
-@param[in,out] s  the string to manipulate; changed so that all
-               occurrences of @a f are replaced with @a t
-@param[in]     f  the substring to replace with @a t
-@param[in]     t  the string to replace @a f
-
-@pre The search string @a f must not be empty. **This precondition is
-enforced with an assertion.**
-
-@since version 2.0.0
-*/
-template<typename StringType>
-inline void replace_substring(StringType& s, const StringType& f,
-                              const StringType& t)
-{
-    JSON_ASSERT(!f.empty());
-    for (auto pos = s.find(f);                // find the first occurrence of f
-            pos != StringType::npos;          // make sure f was found
-            s.replace(pos, f.size(), t),      // replace with t, and
-            pos = s.find(f, pos + t.size()))  // find the next occurrence of f
-    {}
-}
-
-/*!
- * @brief string escaping as described in RFC 6901 (Sect. 4)
+ * @brief Out Of Place string escaping as described in RFC 6901 (Sect. 4)
  * @param[in] s string to escape
  * @return    escaped string
  *
- * Note the order of escaping "~" to "~0" and "/" to "~1" is important.
  */
-template<typename StringType>
-inline StringType escape(StringType s)
-{
-    replace_substring(s, StringType{"~"}, StringType{"~0"});
-    replace_substring(s, StringType{"/"}, StringType{"~1"});
-    return s;
-}
+template<typename StringType> // [[nodiscard]]
+inline StringType escape(StringType const & s)
+    {
+        using CharT = typename StringType::value_type;
+        StringType res;
+
+        int esz=s.size();
+        for (auto const ch : s)
+            if(ch == CharT('~') || ch == CharT('/'))
+                ++esz;
+        if(esz == s.size())
+            res = s;
+        else {
+            res.reserve(esz);
+            for (auto const ch : s) // Yes, this is UTF8-safe
+                if(ch == CharT('~'))
+                    res.append(StringType{"~0"});
+                else if (ch == CharT('/'))
+                    res.append(StringType{"~1"});
+                else
+                    res.push_back(ch);
+        }
+        return res;
+    }
 
 /*!
- * @brief string unescaping as described in RFC 6901 (Sect. 4)
+ * @brief In Place string unescaping as described in RFC 6901 (Sect. 4)
  * @param[in] s string to unescape
- * @return    unescaped string
  *
- * Note the order of escaping "~1" to "/" and "~0" to "~" is important.
  */
-template<typename StringType>
-inline void unescape(StringType& s)
-{
-    replace_substring(s, StringType{"~1"}, StringType{"/"});
-    replace_substring(s, StringType{"~0"}, StringType{"~"});
-}
+    template<typename StringType>
+    inline void unescape(StringType& s)
+    {
+        using CharT = typename StringType::value_type;
+        auto j = s.begin();
+        while(j != s.end() && *j != CharT('~'))
+            ++j;
+        auto i = j;
+        while(i != s.end()) {
+            if (*i == CharT('~') && (i + 1) != s.end()) {
+                if (*(i + 1) == CharT('0')) {
+                    *j++ = CharT('~');
+                    ++i;
+                } else if (*(i + 1) == CharT('1')) {
+                    *j++ = CharT('/');
+                    ++i;
+                } // ... else shouldn't we throw parse_error.108 here?
+            } else {
+                *j++ = *i;
+                }
+            ++i;
+        }
+        s.resize(j-s.begin());
+        s.shrink_to_fit();
+    }
+
+/*!
+ * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
+ * @param[in] s string to unescape
+ *
+ */
+    template<typename StringType> // [[nodiscard]]
+    inline StringType unescape(StringType const& s)
+    {
+        StringType res = s;
+        unescape(res);
+        return res;
+    }
 
 }  // namespace detail
 NLOHMANN_JSON_NAMESPACE_END

--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -21,73 +21,89 @@ namespace detail
  *
  */
 template<typename StringType> // [[nodiscard]]
-inline StringType escape(StringType const & s)
-    {
-        using CharT = typename StringType::value_type;
-        StringType res;
+inline StringType escape(StringType const& s)
+{
+    using CharT = typename StringType::value_type;
+    StringType res;
 
-        int esz=s.size();
-        for (auto const ch : s)
-            if(ch == CharT('~') || ch == CharT('/'))
-                ++esz;
-        if(esz == s.size())
-            res = s;
-        else {
-            res.reserve(esz);
-            for (auto const ch : s) // Yes, this is UTF8-safe
-                if(ch == CharT('~'))
-                    res.append(StringType{"~0"});
-                else if (ch == CharT('/'))
-                    res.append(StringType{"~1"});
-                else
-                    res.push_back(ch);
+    int esz = s.size();
+    for (auto const ch : s)
+        if (ch == CharT('~') || ch == CharT('/'))
+        {
+            ++esz;
         }
-        return res;
+    if (esz == s.size())
+    {
+        res = s;
     }
+    else
+    {
+        res.reserve(esz);
+        for (auto const ch : s) // Yes, this is UTF8-safe
+            if (ch == CharT('~'))
+                res.append(StringType{"~0"});
+            else if (ch == CharT('/'))
+                res.append(StringType{"~1"});
+            else
+            {
+                res.push_back(ch);
+            }
+    }
+    return res;
+}
 
 /*!
  * @brief In Place string unescaping as described in RFC 6901 (Sect. 4)
  * @param[in] s string to unescape
  *
  */
-    template<typename StringType>
-    inline void unescape(StringType& s)
+template<typename StringType>
+inline void unescape(StringType& s)
+{
+    using CharT = typename StringType::value_type;
+    auto j = s.begin();
+    while (j != s.end() && *j != CharT('~'))
     {
-        using CharT = typename StringType::value_type;
-        auto j = s.begin();
-        while(j != s.end() && *j != CharT('~'))
-            ++j;
-        auto i = j;
-        while(i != s.end()) {
-            if (*i == CharT('~') && (i + 1) != s.end()) {
-                if (*(i + 1) == CharT('0')) {
-                    *j++ = CharT('~');
-                    ++i;
-                } else if (*(i + 1) == CharT('1')) {
-                    *j++ = CharT('/');
-                    ++i;
-                } // ... else shouldn't we throw parse_error.108 here?
-            } else {
-                *j++ = *i;
-                }
-            ++i;
-        }
-        s.resize(j-s.begin());
-        s.shrink_to_fit();
+        ++j;
     }
+    auto i = j;
+    while (i != s.end())
+    {
+        if (*i == CharT('~') && (i + 1) != s.end())
+        {
+            if (*(i + 1) == CharT('0'))
+            {
+                *j++ = CharT('~');
+                ++i;
+            }
+            else if (*(i + 1) == CharT('1'))
+            {
+                *j++ = CharT('/');
+                ++i;
+            } // ... else shouldn't we throw parse_error.108 here?
+        }
+        else
+        {
+            *j++ = *i;
+        }
+        ++i;
+    }
+    s.resize(j - s.begin());
+    s.shrink_to_fit();
+}
 
 /*!
  * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
  * @param[in] s string to unescape
  *
  */
-    template<typename StringType> // [[nodiscard]]
-    inline StringType unescape(StringType const& s)
-    {
-        StringType res = s;
-        unescape(res);
-        return res;
-    }
+template<typename StringType> // [[nodiscard]]
+inline StringType unescape(StringType const& s)
+{
+    StringType res = s;
+    unescape(res);
+    return res;
+}
 
 }  // namespace detail
 NLOHMANN_JSON_NAMESPACE_END

--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -28,10 +28,12 @@ inline StringType escape(StringType const& s)
 
     int esz = s.size();
     for (auto const ch : s)
+    {
         if (ch == CharT('~') || ch == CharT('/'))
         {
             ++esz;
         }
+    }
     if (esz == s.size())
     {
         res = s;
@@ -39,15 +41,21 @@ inline StringType escape(StringType const& s)
     else
     {
         res.reserve(esz);
-        for (auto const ch : s) // Yes, this is UTF8-safe
+        for (auto const ch : s)   // Yes, this is UTF8-safe
+        {
             if (ch == CharT('~'))
+            {
                 res.append(StringType{"~0"});
+            }
             else if (ch == CharT('/'))
+            {
                 res.append(StringType{"~1"});
+            }
             else
             {
                 res.push_back(ch);
             }
+        }
     }
     return res;
 }
@@ -92,18 +100,19 @@ inline void unescape(StringType& s)
     s.shrink_to_fit();
 }
 
-/*!
- * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
- * @param[in] s string to unescape
- *
- */
-template<typename StringType> // [[nodiscard]]
-inline StringType unescape(StringType const& s)
-{
-    StringType res = s;
-    unescape(res);
-    return res;
-}
+// Left out, so far we don't use it, so it just lowers test coverage
+// /*!
+// * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
+// * @param[in] s string to unescape
+// *
+// */
+// template<typename StringType> // [[nodiscard]]
+// inline StringType unescape(StringType const& s)
+// {
+//    StringType res = s;
+//    unescape(res);
+//    return res;
+// }
 
 }  // namespace detail
 NLOHMANN_JSON_NAMESPACE_END

--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -26,7 +26,7 @@ inline StringType escape(StringType const& s)
     using CharT = typename StringType::value_type;
     StringType res;
 
-    int esz = s.size();
+    auto esz = s.size();
     for (auto const ch : s)
     {
         if (ch == CharT('~') || ch == CharT('/'))

--- a/include/nlohmann/detail/string_escape.hpp
+++ b/include/nlohmann/detail/string_escape.hpp
@@ -88,7 +88,7 @@ inline void unescape(StringType& s)
         }
         ++i;
     }
-    s.resize(j - s.begin());
+    s.erase(j, s.end());
     s.shrink_to_fit();
 }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3085,57 +3085,94 @@ namespace detail
 {
 
 /*!
-@brief replace all occurrences of a substring by another string
-
-@param[in,out] s  the string to manipulate; changed so that all
-               occurrences of @a f are replaced with @a t
-@param[in]     f  the substring to replace with @a t
-@param[in]     t  the string to replace @a f
-
-@pre The search string @a f must not be empty. **This precondition is
-enforced with an assertion.**
-
-@since version 2.0.0
-*/
-template<typename StringType>
-inline void replace_substring(StringType& s, const StringType& f,
-                              const StringType& t)
-{
-    JSON_ASSERT(!f.empty());
-    for (auto pos = s.find(f);                // find the first occurrence of f
-            pos != StringType::npos;          // make sure f was found
-            s.replace(pos, f.size(), t),      // replace with t, and
-            pos = s.find(f, pos + t.size()))  // find the next occurrence of f
-    {}
-}
-
-/*!
- * @brief string escaping as described in RFC 6901 (Sect. 4)
+ * @brief Out Of Place string escaping as described in RFC 6901 (Sect. 4)
  * @param[in] s string to escape
  * @return    escaped string
  *
- * Note the order of escaping "~" to "~0" and "/" to "~1" is important.
  */
-template<typename StringType>
-inline StringType escape(StringType s)
+template<typename StringType> // [[nodiscard]]
+inline StringType escape(StringType const& s)
 {
-    replace_substring(s, StringType{"~"}, StringType{"~0"});
-    replace_substring(s, StringType{"/"}, StringType{"~1"});
-    return s;
+    using CharT = typename StringType::value_type;
+    StringType res;
+
+    int esz = s.size();
+    for (auto const ch : s)
+        if (ch == CharT('~') || ch == CharT('/'))
+        {
+            ++esz;
+        }
+    if (esz == s.size())
+    {
+        res = s;
+    }
+    else
+    {
+        res.reserve(esz);
+        for (auto const ch : s) // Yes, this is UTF8-safe
+            if (ch == CharT('~'))
+                res.append(StringType{"~0"});
+            else if (ch == CharT('/'))
+                res.append(StringType{"~1"});
+            else
+            {
+                res.push_back(ch);
+            }
+    }
+    return res;
 }
 
 /*!
- * @brief string unescaping as described in RFC 6901 (Sect. 4)
+ * @brief In Place string unescaping as described in RFC 6901 (Sect. 4)
  * @param[in] s string to unescape
- * @return    unescaped string
  *
- * Note the order of escaping "~1" to "/" and "~0" to "~" is important.
  */
 template<typename StringType>
 inline void unescape(StringType& s)
 {
-    replace_substring(s, StringType{"~1"}, StringType{"/"});
-    replace_substring(s, StringType{"~0"}, StringType{"~"});
+    using CharT = typename StringType::value_type;
+    auto j = s.begin();
+    while (j != s.end() && *j != CharT('~'))
+    {
+        ++j;
+    }
+    auto i = j;
+    while (i != s.end())
+    {
+        if (*i == CharT('~') && (i + 1) != s.end())
+        {
+            if (*(i + 1) == CharT('0'))
+            {
+                *j++ = CharT('~');
+                ++i;
+            }
+            else if (*(i + 1) == CharT('1'))
+            {
+                *j++ = CharT('/');
+                ++i;
+            } // ... else shouldn't we throw parse_error.108 here?
+        }
+        else
+        {
+            *j++ = *i;
+        }
+        ++i;
+    }
+    s.resize(j - s.begin());
+    s.shrink_to_fit();
+}
+
+/*!
+ * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
+ * @param[in] s string to unescape
+ *
+ */
+template<typename StringType> // [[nodiscard]]
+inline StringType unescape(StringType const& s)
+{
+    StringType res = s;
+    unescape(res);
+    return res;
 }
 
 }  // namespace detail

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3085,7 +3085,7 @@ namespace detail
 {
 
 /*!
- * @brief Out Of Place string escaping as described in RFC 6901 (Sect. 4)
+ * @brief Returns a copy of a string escaped as described in RFC 6901 (Sect. 4)
  * @param[in] s string to escape
  * @return    escaped string
  *
@@ -3115,11 +3115,13 @@ inline StringType escape(StringType const& s)
         {
             if (ch == CharT('~'))
             {
-                res.append(StringType{"~0"});
+                res.push_back(CharT('~'));
+                res.push_back(CharT{'0'});
             }
             else if (ch == CharT('/'))
             {
-                res.append(StringType{"~1"});
+                res.push_back(CharT{'~'});
+                res.push_back(CharT{'1'});
             }
             else
             {
@@ -3131,7 +3133,7 @@ inline StringType escape(StringType const& s)
 }
 
 /*!
- * @brief In Place string unescaping as described in RFC 6901 (Sect. 4)
+ * @brief Unescapes a string as described in RFC 6901 (Sect. 4), in-place
  * @param[in] s string to unescape
  *
  */

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3098,10 +3098,12 @@ inline StringType escape(StringType const& s)
 
     int esz = s.size();
     for (auto const ch : s)
+    {
         if (ch == CharT('~') || ch == CharT('/'))
         {
             ++esz;
         }
+    }
     if (esz == s.size())
     {
         res = s;
@@ -3109,15 +3111,21 @@ inline StringType escape(StringType const& s)
     else
     {
         res.reserve(esz);
-        for (auto const ch : s) // Yes, this is UTF8-safe
+        for (auto const ch : s)   // Yes, this is UTF8-safe
+        {
             if (ch == CharT('~'))
+            {
                 res.append(StringType{"~0"});
+            }
             else if (ch == CharT('/'))
+            {
                 res.append(StringType{"~1"});
+            }
             else
             {
                 res.push_back(ch);
             }
+        }
     }
     return res;
 }
@@ -3162,18 +3170,19 @@ inline void unescape(StringType& s)
     s.shrink_to_fit();
 }
 
-/*!
- * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
- * @param[in] s string to unescape
- *
- */
-template<typename StringType> // [[nodiscard]]
-inline StringType unescape(StringType const& s)
-{
-    StringType res = s;
-    unescape(res);
-    return res;
-}
+// Left out, so far we don't use it, so it just lowers test coverage
+// /*!
+// * @brief Out Of Place string unescaping as described in RFC 6901 (Sect. 4)
+// * @param[in] s string to unescape
+// *
+// */
+// template<typename StringType> // [[nodiscard]]
+// inline StringType unescape(StringType const& s)
+// {
+//    StringType res = s;
+//    unescape(res);
+//    return res;
+// }
 
 }  // namespace detail
 NLOHMANN_JSON_NAMESPACE_END

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3158,7 +3158,7 @@ inline void unescape(StringType& s)
         }
         ++i;
     }
-    s.resize(j - s.begin());
+    s.erase(j, s.end());
     s.shrink_to_fit();
 }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3096,7 +3096,7 @@ inline StringType escape(StringType const& s)
     using CharT = typename StringType::value_type;
     StringType res;
 
-    int esz = s.size();
+    auto esz = s.size();
     for (auto const ch : s)
     {
         if (ch == CharT('~') || ch == CharT('/'))

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -58,23 +58,28 @@ class alt_string
         str_impl.push_back(c);
     }
 
-    void  shrink_to_fit() {
+    void  shrink_to_fit()
+    {
         str_impl.shrink_to_fit();
     }
 
-    std::string::iterator begin() {
+    std::string::iterator begin()
+    {
         return str_impl.begin();
     }
 
-    std::string::const_iterator begin() const {
+    std::string::const_iterator begin() const
+    {
         return str_impl.begin();
     }
 
-    std::string::iterator end() {
+    std::string::iterator end()
+    {
         return str_impl.end();
     }
 
-    std::string::const_iterator end() const {
+    std::string::const_iterator end() const
+    {
         return str_impl.end();
     }
 

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -73,12 +73,12 @@ class alt_string
         return str_impl.begin();
     }
 
-    std::string::iterator end()
+    std::string::iterator end() noexcept
     {
         return str_impl.end();
     }
 
-    std::string::const_iterator end() const
+    std::string::const_iterator end() const noexcept
     {
         return str_impl.end();
     }

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -58,6 +58,26 @@ class alt_string
         str_impl.push_back(c);
     }
 
+    void  shrink_to_fit() {
+        str_impl.shrink_to_fit();
+    }
+
+    std::string::iterator begin() {
+        return str_impl.begin();
+    }
+
+    std::string::const_iterator begin() const {
+        return str_impl.begin();
+    }
+
+    std::string::iterator end() {
+        return str_impl.end();
+    }
+
+    std::string::const_iterator end() const {
+        return str_impl.end();
+    }
+
     template <typename op_type>
     bool operator==(const op_type& op) const
     {

--- a/tests/src/unit-alt-string.cpp
+++ b/tests/src/unit-alt-string.cpp
@@ -83,6 +83,11 @@ class alt_string
         return str_impl.end();
     }
 
+    std::string::iterator erase(std::string::const_iterator first, std::string::const_iterator last )
+    {
+        return str_impl.erase(first, last);
+    }
+
     template <typename op_type>
     bool operator==(const op_type& op) const
     {


### PR DESCRIPTION
Hello,

I am working on a project which does heavy use of JSON pointers (see #4859 ); while digging into the code I saw that the escape/unescape of JSON pointers was not linear, in example escaping "~~~~~~~~~~" requires 10 reallocations and 200 byte copies, escaping ;  "~~~~~~~~~~~~~~~~~~~~" requires 20 reallocations and 800 byte copies.

I rewrote these two functions: one allocation and exactly two cycles on the key for escaping, no allocations and at most two loops for unescaping; I understand they are way less readable in this flavour but also way more efficient,

Existing tests already cover all the new code, I had to add iterators to the unit-alt-string "alt_string" class.

I tried to follow the CONTRIBUTING.md document throughly, but it's my first PR to this project, so forgive any mistake.

A.


