### PR TITLE
add fail-on-error:false for Coveralls

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -124,6 +124,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ${{ github.workspace }}/build/json.info.filtered.noexcept
+          fail-on-error: false
 
   ci_test_compilers_gcc_old:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR resolves https://github.com/nlohmann/json/issues/4890

The change includes the input option `fail-on-error: false` in the "Publish report to Coveralls" step. This ensures that temporary failures with the Coveralls service, such as internal server errors (HTTP 500) or downtime, do not block the entire workflow or cause unrelated jobs to fail.

**What**

- Added `fail-on-error: false` to the "Publish report to Coveralls" step in the Ubuntu.yml workflow file.

- This change allows the workflow to continue executing even when the Coveralls service experiences temporary issues.

**Why**

- Issues with Coveralls, such as its recent service outage (documented in their [postmortem](https://status.coveralls.io/incidents/v5mcbrsbhgt4)), can disrupt CI workflows unnecessarily.

- Adopting this change ensures resilience and allows unrelated steps to complete successfully, even when the Coveralls service is temporarily unavailable.