### PR TITLE
docs: remove unnecessary template before get in README & docs (fixes #4825)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Note the difference between serialization and assignment:
 json j_string = "this is a string";
 
 // retrieve the string value
-auto cpp_string = j_string.template get<std::string>();
+auto cpp_string = j_string.get<std::string>();
 // retrieve the string value (alternative when a variable already exists)
 std::string cpp_string2;
 j_string.get_to(cpp_string2);
@@ -354,7 +354,7 @@ j_string.get_to(cpp_string2);
 std::string serialized_string = j_string.dump();
 
 // output of original string
-std::cout << cpp_string << " == " << cpp_string2 << " == " << j_string.template get<std::string>() << '\n';
+std::cout << cpp_string << " == " << cpp_string2 << " == " << j_string.get<std::string>() << '\n';
 // output of serialized value
 std::cout << j_string << " == " << serialized_string << std::endl;
 ```
@@ -527,7 +527,7 @@ for (auto& element : j) {
 }
 
 // getter/setter
-const auto tmp = j[0].template get<std::string>();
+const auto tmp = j[0].get<std::string>();
 j[1] = 42;
 bool foo = j.at(2);
 
@@ -734,7 +734,7 @@ You can switch off implicit conversions by defining `JSON_USE_IMPLICIT_CONVERSIO
 // strings
 std::string s1 = "Hello, world!";
 json js = s1;
-auto s2 = js.template get<std::string>();
+auto s2 = js.get<std::string>();
 // NOT RECOMMENDED
 std::string s3 = js;
 std::string s4;
@@ -743,7 +743,7 @@ s4 = js;
 // Booleans
 bool b1 = true;
 json jb = b1;
-auto b2 = jb.template get<bool>();
+auto b2 = jb.get<bool>();
 // NOT RECOMMENDED
 bool b3 = jb;
 bool b4;
@@ -752,7 +752,7 @@ b4 = jb;
 // numbers
 int i = 42;
 json jn = i;
-auto f = jn.template get<double>();
+auto f = jn.get<double>();
 // NOT RECOMMENDED
 double f2 = jb;
 double f3;
@@ -795,9 +795,9 @@ j["age"] = p.age;
 
 // convert from JSON: copy each value from the JSON object
 ns::person p {
-    j["name"].template get<std::string>(),
-    j["address"].template get<std::string>(),
-    j["age"].template get<int>()
+     j["name"].get<std::string>(),
+     j["address"].get<std::string>(),
+     j["age"].get<int>()
 };
 ```
 
@@ -814,7 +814,7 @@ std::cout << j << std::endl;
 // {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}
 
 // conversion: json -> person
-auto p2 = j.template get<ns::person>();
+auto p2 = j.get<ns::person>();
 
 // that's it
 assert(p == p2);
@@ -927,7 +927,7 @@ namespace nlohmann {
             if (j.is_null()) {
                 opt = boost::none;
             } else {
-                opt = j.template get<T>(); // same as above, but with
+                opt = j.get<T>(); // same as above, but with
                                            // adl_serializer<T>::from_json
             }
         }
@@ -955,7 +955,7 @@ namespace nlohmann {
         // note: the return type is no longer 'void', and the method only takes
         // one argument
         static move_only_type from_json(const json& j) {
-            return {j.template get<int>()};
+           return {j.get<int>()};
         }
 
         // Here's the catch! You must provide a to_json method! Otherwise, you
@@ -1059,11 +1059,11 @@ assert(j == "stopped");
 
 // json string to enum
 json j3 = "running";
-assert(j3.template get<TaskState>() == TS_RUNNING);
+assert(j3.get<TaskState>() == TS_RUNNING);
 
 // undefined json value to enum (where the first map entry above is the default)
 json jPi = 3.14;
-assert(jPi.template get<TaskState>() == TS_INVALID);
+assert(jPi.get<TaskState>() == TS_INVALID);
 ```
 
 Just as in [Arbitrary Type Conversions](#arbitrary-types-conversions) above,

--- a/docs/mkdocs/docs/api/macros/json_disable_enum_serialization.md
+++ b/docs/mkdocs/docs/api/macros/json_disable_enum_serialization.md
@@ -53,7 +53,7 @@ The default value is `0`.
         const json j = Choice::first; 
 
         // normally invokes from_json parse function but with JSON_DISABLE_ENUM_SERIALIZATION defined, it does not
-        Choice ch = j.template get<Choice>();
+        Choice ch = j.get<Choice>();
     }
     ```
 
@@ -86,7 +86,7 @@ The default value is `0`.
         const json j = Choice::first; 
 
         // uses user-defined from_json function defined by macro
-        Choice ch = j.template get<Choice>();
+        Choice ch = j.get<Choice>();
     }
     ```
 
@@ -109,7 +109,7 @@ The default value is `0`.
 
     void from_json(const json& j, Choice& ch)
     {
-        auto value = j.template get<std::string>();
+        auto value = j.get<std::string>();
         if (value == "first")
         {
             ch = Choice::first;
@@ -122,7 +122,7 @@ The default value is `0`.
 
     void to_json(json& j, const Choice& ch)
     {
-        auto value = j.template get<std::string>();
+        auto value = j.get<std::string>();
         if (value == "first")
         {
             ch = Choice::first;
@@ -139,7 +139,7 @@ The default value is `0`.
         const json j = Choice::first; 
 
         // uses user-defined from_json function
-        Choice ch = j.template get<Choice>();
+        auto value = j.get<std::string>();
     }
     ```
 

--- a/docs/mkdocs/docs/api/macros/json_use_implicit_conversions.md
+++ b/docs/mkdocs/docs/api/macros/json_use_implicit_conversions.md
@@ -46,7 +46,7 @@ By default, implicit conversions are enabled.
 
     ```cpp
     json j = "Hello, world!";
-    auto s = j.template get<std::string>();
+    auto s = j.get<std::string>();
     ```
 
 ## See also

--- a/docs/mkdocs/docs/examples/from_json__default_constructible.cpp
+++ b/docs/mkdocs/docs/examples/from_json__default_constructible.cpp
@@ -31,7 +31,7 @@ int main()
     j["address"] = "744 Evergreen Terrace";
     j["age"] = 60;
 
-    auto p = j.template get<ns::person>();
+    auto p = j.get<ns::person>();
 
     std::cout << p.name << " (" << p.age << ") lives in " << p.address << std::endl;
 }

--- a/docs/mkdocs/docs/examples/from_json__non_default_constructible.cpp
+++ b/docs/mkdocs/docs/examples/from_json__non_default_constructible.cpp
@@ -47,7 +47,7 @@ int main()
     j["address"] = "744 Evergreen Terrace";
     j["age"] = 60;
 
-    auto p = j.template get<ns::person>();
+    auto p = j.get<ns::person>();
 
     std::cout << p.name << " (" << p.age << ") lives in " << p.address << std::endl;
 }

--- a/docs/mkdocs/docs/examples/get__PointerType.cpp
+++ b/docs/mkdocs/docs/examples/get__PointerType.cpp
@@ -9,11 +9,11 @@ int main()
     json value = 17;
 
     // explicitly getting pointers
-    auto p1 = value.template get<const json::number_integer_t*>();
-    auto p2 = value.template get<json::number_integer_t*>();
-    auto p3 = value.template get<json::number_integer_t* const>();
-    auto p4 = value.template get<const json::number_integer_t* const>();
-    auto p5 = value.template get<json::number_float_t*>();
+    auto p1 = value.get<const json::number_integer_t*>();
+    auto p2 = value.get<json::number_integer_t*>();
+    auto p3 = value.get<json::number_integer_t* const>();
+    auto p4 = value.get<const json::number_integer_t* const>();
+    auto p5 = value.get<json::number_float_t*>();
 
     // print the pointees
     std::cout << *p1 << ' ' << *p2 << ' ' << *p3 << ' ' << *p4 << '\n';

--- a/docs/mkdocs/docs/examples/get__ValueType_const.cpp
+++ b/docs/mkdocs/docs/examples/get__ValueType_const.cpp
@@ -22,14 +22,14 @@ int main()
     };
 
     // use explicit conversions
-    auto v1 = json_types["boolean"].template get<bool>();
-    auto v2 = json_types["number"]["integer"].template get<int>();
-    auto v3 = json_types["number"]["integer"].template get<short>();
-    auto v4 = json_types["number"]["floating-point"].template get<float>();
-    auto v5 = json_types["number"]["floating-point"].template get<int>();
-    auto v6 = json_types["string"].template get<std::string>();
-    auto v7 = json_types["array"].template get<std::vector<short>>();
-    auto v8 = json_types.template get<std::unordered_map<std::string, json>>();
+    auto v1 = json_types["boolean"].get<bool>();
+    auto v2 = json_types["number"]["integer"].get<int>();
+    auto v3 = json_types["number"]["integer"].get<short>();
+    auto v4 = json_types["number"]["floating-point"].get<float>();
+    auto v5 = json_types["number"]["floating-point"].get<int>();
+    auto v6 = json_types["string"].get<std::string>();
+    auto v7 = json_types["array"].get<std::vector<short>>();
+    auto v8 = json_types.get<std::unordered_map<std::string, json>>();
 
     // print the conversion results
     std::cout << v1 << '\n';

--- a/docs/mkdocs/docs/examples/nlohmann_define_type_intrusive_with_default_explicit.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_define_type_intrusive_with_default_explicit.cpp
@@ -48,10 +48,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.template get<ns::person>();
+    auto p2 = j2.get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.template get<ns::person>();
+    auto p3 = j3.get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/mkdocs/docs/examples/nlohmann_define_type_intrusive_with_default_macro.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_define_type_intrusive_with_default_macro.cpp
@@ -33,10 +33,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.template get<ns::person>();
+    auto p2 = j2.get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.template get<ns::person>();
+    auto p3 = j3.get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_explicit.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_explicit.cpp
@@ -40,13 +40,13 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.template get<ns::person>();
+    auto p2 = j2.get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
     try
     {
-        auto p3 = j3.template get<ns::person>();
+        auto p3 = j3.get<ns::person>();
     }
     catch (const json::exception& e)
     {

--- a/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_macro.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_macro.cpp
@@ -26,13 +26,13 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.template get<ns::person>();
+    auto p2 = j2.get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
     try
     {
-        auto p3 = j3.template get<ns::person>();
+        auto p3 = j3.get<ns::person>();
     }
     catch (const json::exception& e)
     {

--- a/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_with_default_explicit.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_with_default_explicit.cpp
@@ -46,10 +46,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.template get<ns::person>();
+    auto p2 = j2.get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.template get<ns::person>();
+    auto p3 = j3.get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_with_default_macro.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_define_type_non_intrusive_with_default_macro.cpp
@@ -31,10 +31,10 @@ int main()
 
     // deserialization: json -> person
     json j2 = R"({"address": "742 Evergreen Terrace", "age": 40, "name": "Homer Simpson"})"_json;
-    auto p2 = j2.template get<ns::person>();
+    auto p2 = j2.get<ns::person>();
 
     // incomplete deserialization:
     json j3 = R"({"address": "742 Evergreen Terrace", "name": "Maggie Simpson"})"_json;
-    auto p3 = j3.template get<ns::person>();
+    auto p3 = j3.get<ns::person>();
     std::cout << "roundtrip: " << json(p3) << std::endl;
 }

--- a/docs/mkdocs/docs/examples/nlohmann_json_serialize_enum.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_json_serialize_enum.cpp
@@ -44,16 +44,16 @@ int main()
     // deserialization
     json j_running = "running";
     json j_blue = "blue";
-    auto running = j_running.template get<ns::TaskState>();
-    auto blue = j_blue.template get<ns::Color>();
+    auto running = j_running.get<ns::TaskState>();
+    auto blue = j_blue.get<ns::Color>();
     std::cout << j_running << " -> " << running
               << ", " << j_blue << " -> " << static_cast<int>(blue) << std::endl;
 
     // deserializing undefined JSON value to enum
     // (where the first map entry above is the default)
     json j_pi = 3.14;
-    auto invalid = j_pi.template get<ns::TaskState>();
-    auto unknown = j_pi.template get<ns::Color>();
+    auto invalid = j_pi.get<ns::TaskState>();
+    auto unknown = j_pi.get<ns::Color>();
     std::cout << j_pi << " -> " << invalid << ", "
               << j_pi << " -> " << static_cast<int>(unknown) << std::endl;
 }

--- a/docs/mkdocs/docs/examples/nlohmann_json_serialize_enum_2.cpp
+++ b/docs/mkdocs/docs/examples/nlohmann_json_serialize_enum_2.cpp
@@ -26,8 +26,8 @@ int main()
 
     // deserialization
     json j_rot = "rot";
-    auto rot = j_rot.template get<ns::Color>();
-    auto red = j_red.template get<ns::Color>();
+    auto rot = j_rot.get<ns::Color>();
+    auto red = j_red.get<ns::Color>();
     std::cout << j_rot << " -> " << static_cast<int>(rot) << std::endl;
     std::cout << j_red << " -> " << static_cast<int>(red) << std::endl;
 }

--- a/docs/mkdocs/docs/features/arbitrary_types.md
+++ b/docs/mkdocs/docs/features/arbitrary_types.md
@@ -24,9 +24,9 @@ j["age"] = p.age;
 
 // convert from JSON: copy each value from the JSON object
 ns::person p {
-    j["name"].template get<std::string>(),
-    j["address"].template get<std::string>(),
-    j["age"].template get<int>()
+    j["name"].get<std::string>(),
+    j["address"].get<std::string>(),
+    j["age"].get<int>()
 };
 ```
 
@@ -43,7 +43,7 @@ std::cout << j << std::endl;
 // {"address":"744 Evergreen Terrace","age":60,"name":"Ned Flanders"}
 
 // conversion: json -> person
-auto p2 = j.template get<ns::person>();
+auto p2 = j.get<ns::person>();
 
 // that's it
 assert(p == p2);
@@ -191,7 +191,7 @@ struct adl_serializer<boost::optional<T>> {
         if (j.is_null()) {
             opt = boost::none;
         } else {
-            opt = j.template get<T>(); // same as above, but with
+            opt = j.get<T>(); // same as above, but with
                               // adl_serializer<T>::from_json
         }
     }
@@ -224,7 +224,7 @@ namespace nlohmann {
         // note: the return type is no longer 'void', and the method only takes
         // one argument
         static move_only_type from_json(const json& j) {
-            return {j.template get<int>()};
+            return {j.get<int>()};
         }
 
         // Here's the catch! You must provide a to_json method! Otherwise, you

--- a/docs/mkdocs/docs/features/enum_conversion.md
+++ b/docs/mkdocs/docs/features/enum_conversion.md
@@ -36,11 +36,11 @@ assert(j == "stopped");
 
 // json string to enum
 json j3 = "running";
-assert(j3.template get<TaskState>() == TS_RUNNING);
+assert(j3.get<TaskState>() == TS_RUNNING);
 
 // undefined json value to enum (where the first map entry above is the default)
 json jPi = 3.14;
-assert(jPi.template get<TaskState>() == TS_INVALID );
+assert(jPi.get<TaskState>() == TS_INVALID );
 ```
 
 ## Notes

--- a/docs/mkdocs/docs/features/types/number_handling.md
+++ b/docs/mkdocs/docs/features/types/number_handling.md
@@ -237,7 +237,7 @@ integers, and between integers and floating-point values to integers. This behav
     ```cpp hl_lines="3"
     double d = 42.3;                                   // non-integer double value 42.3
     json jd = d;                                       // stores double value 42.3
-    std::int64_t i = jd.template get<std::int64_t>();  // now i==42; no warning or error is produced
+    std::int64_t i = jd.get<std::int64_t>();  // now i==42; no warning or error is produced
     ```
 
     Note the last line with throw a [`json.exception.type_error.302`](../../home/exceptions.md#jsonexceptiontype_error302)
@@ -259,7 +259,7 @@ The rationale is twofold:
     if (jd.is_number_integer())
     {
         // if so, do the conversion and use i
-        std::int64_t i = jd.template get<std::int64_t>();
+        std::int64_t i = jd.get<std::int64_t>();
         // ...
     }
     else

--- a/docs/mkdocs/docs/integration/migration_guide.md
+++ b/docs/mkdocs/docs/integration/migration_guide.md
@@ -187,7 +187,7 @@ conversions with calls to [`get`](../api/basic_json/get.md), [`get_to`](../api/b
 
       ```cpp
       nlohmann::json j = "Hello, world!";
-      auto s = j.template get<std::string>();
+      auto s = j.get<std::string>();
       ```
 
 === "Future-proof (alternative)"


### PR DESCRIPTION
Description
This pull request resolves issue #4825 by removing the unnecessary template keyword from get() calls in non-dependent contexts throughout the README and MkDocs documentation.

What
Replaced .template get<...>() with .get<...>() in documentation examples where it was not required.
No library code was changed.

Why
Improves the clarity and correctness of the code examples for users.
The .template keyword is only necessary for dependent names in C++ templates and can be confusing when used outside of that context.

How Tested
Successfully built and previewed the documentation locally using mkdocs.
Ran the full CTest suite as a courtesy check to ensure no regressions were introduced.
