### PR TITLE
docs: Fix broken package manager links in the integration tab.

### DIFF
--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -1,6 +1,6 @@
 # Package Managers
 
-<center>
+<p markdown style="text-align: center">
 ![Homebrew](../images/package_managers/homebrew.svg){: style="height:1em"}&nbsp;[**Homebrew**](#homebrew) `nlohmann-json` &emsp;
 ![Meson](../images/package_managers/meson.svg){: style="height:1em"}&nbsp;[**Meson**](#meson) `nlohmann_json` &emsp;
 ![Bazel](../images/package_managers/bazel.svg){: style="height:1em"}&nbsp;[**Bazel**](#bazel) `nlohmann_json`<br>
@@ -15,7 +15,7 @@
 ![MacPorts](../images/package_managers/macports.svg){: style="height:1em"}&nbsp;[**MacPorts**](#macports) `nlohmann-json`<br>
 ![cpm.cmake](../images/package_managers/CPM.png){: style="height:1em"}&nbsp;[**CPM.cmake**](#cpmcmake) `gh:nlohmann/json`
 ![xmake](../images/package_managers/xmake.svg){: style="height:1em"}&nbsp;[**xmake**](#xmake) `nlohmann_json`
-</center>
+</p>
 
 ## Running example
 

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -322,6 +322,7 @@ markdown_extensions:
       guess_lang: false
   - toc:
       permalink: true
+  - md_in_html
   - pymdownx.arithmatex
   - pymdownx.betterem:
       smart_enable: all


### PR DESCRIPTION
## Issue

`docs/mkdocs/docs/integration/package_managers.md` renders package manager links & icons as raw code.

This page is linked in the README so it's the first thing users see when looking for package manager docs.

## Cause

Links are wrapped in a `<center>` tag which prevents them from being parsed as markdown.

## Fix

Use `md_in_html` plugin as specified by the Material theme [documentation](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=markdown+ht+in#markdown-in-html).

HTML tags with internal md require explicit `markdown` attribute, so it shouldn't affect other pages.

## Additional notes

HTML tag `<center>` is considered [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/center) in favor of CSS like `<p style="text-align: center">`, so it was replaced.

## Before/after

<img width="1401" height="878" alt="before" src="https://github.com/user-attachments/assets/1144b525-7e8d-4930-bced-1f1c61dbe4f7" />

<img width="1396" height="903" alt="after" src="https://github.com/user-attachments/assets/5a10f173-cbec-4254-99b1-9d312987ba41" />
