### PR TITLE
Feature/ordered map O(1)

### DIFF
--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -8,87 +8,413 @@
 
 #pragma once
 
-#include <functional> // equal_to, less
-#include <initializer_list> // initializer_list
-#include <iterator> // input_iterator_tag, iterator_traits
-#include <memory> // allocator
-#include <stdexcept> // for out_of_range
-#include <type_traits> // enable_if, is_convertible
-#include <utility> // pair
-#include <vector> // vector
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/type_traits.hpp>
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief Insertion-order-preserving map with O(1) average lookup
 
-/// ordered_map: a minimal map-like container that preserves insertion order
-/// for use within nlohmann::basic_json<ordered_map>
-template <class Key, class T, class IgnoredLess = std::less<Key>,
-          class Allocator = std::allocator<std::pair<const Key, T>>>
-              struct ordered_map : std::vector<std::pair<const Key, T>, Allocator>
+Internally uses a std::list to contain the <key,value> pairs, plus
+an index (effectively keyed by a pointer-to-key) for O(1) lookups.
+
+This implements all the methods of std::map except:
+- Ordering-dependent operations (lower_bound, upper_bound, equal_range,
+  key_comp and value_comp, etc.); these simply make no sense without
+  lexicographic ordering.
+- Extensions added after C++11 (try_emplace, insert_or_assign, contains,
+  erase_if, etc.).
+
+It also has iterator arithmetic (it+n), which is not used by the library
+but needed by some unit tests of the original implementation.
+
+Stable iterators guarantee: insertion and value updates do not invalidate
+iterators (except for the iterator to an element that is erased).
+
+Size complexity is linear to the size of contained data; time complexity
+is on average O(1) for all access methods and all methods that change a
+single element, O(N) when N elements are affected.
+*/
+template<class Key,
+         class T,
+         class IgnoredCompare = std::less<Key>, // Unused
+         class Allocator = std::allocator<std::pair<const Key, T>>>
+struct ordered_map
 {
-    using key_type = Key;
-    using mapped_type = T;
-    using Container = std::vector<std::pair<const Key, T>, Allocator>;
-    using iterator = typename Container::iterator;
-    using const_iterator = typename Container::const_iterator;
-    using size_type = typename Container::size_type;
-    using value_type = typename Container::value_type;
-#ifdef JSON_HAS_CPP_14
-    using key_compare = std::equal_to<>;
+private:
+    using value_pair    = std::pair<const Key, T>;
+    using list_type     = std::list<value_pair, Allocator>;
+    using list_iterator = typename list_type::iterator;
+    using list_const_iterator = typename list_type::const_iterator;
+
+    // --- pointer-to-key index machinery ---
+    struct key_ref
+    {
+        const Key* p;
+        key_ref() : p(nullptr) {}
+        explicit key_ref(const Key& k) : p(std::addressof(k)) {}
+        explicit key_ref(const Key* pk) : p(pk) {}
+    };
+    struct key_ref_hash
+    {
+        std::size_t operator()(const key_ref& kr) const noexcept
+        {
+            return std::hash<Key> {}(*kr.p);
+        }
+    };
+    struct key_ref_equal
+    {
+        bool operator()(const key_ref& a, const key_ref& b) const noexcept
+        {
+            return std::equal_to<Key> {}(*a.p, *b.p);
+        }
+    };
+
+    using index_type = std::unordered_map<key_ref, list_iterator, key_ref_hash, key_ref_equal>;
+
+    list_type  m_list;
+    index_type m_index;
+
+    // iterator wrapper that supports it+n for tests which do om.begin()+k
+    template <typename ListIter, typename Self, typename Ref, typename Ptr>
+    struct iter_base
+    {
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type        = value_pair;
+        using difference_type   = typename list_type::difference_type;
+        using reference         = Ref;
+        using pointer           = Ptr;
+
+        iter_base() : it_() {}
+        explicit iter_base(ListIter it) : it_(it) {}
+
+        reference operator*()  const
+        {
+            return *it_;
+        }
+        pointer   operator->() const
+        {
+            return std::addressof(*it_);
+        }
+
+        Self& operator++()
+        {
+            ++it_;
+            return self();
+        }
+        Self  operator++(int)
+        {
+            Self tmp = self();
+            ++(*this);
+            return tmp;
+        }
+        Self& operator--()
+        {
+            --it_;
+            return self();
+        }
+        Self  operator--(int)
+        {
+            Self tmp = self();
+            --(*this);
+            return tmp;
+        }
+
+        // This is O(n), but used only by unit tests
+        Self operator+(difference_type n) const
+        {
+            Self tmp = self();
+            if (n >= 0)    // NOLINT(*-braces-around-statements)
+                while (n--)
+                {
+                    ++tmp.it_;
+                }
+            else            // NOLINT(*-braces-around-statements)
+                while (n++)
+                {
+                    --tmp.it_;
+                }
+            return tmp;
+        }
+        Self& operator+=(difference_type n)
+        {
+            *this = *this + n;
+            return self();
+        }
+
+        bool operator==(const Self& o) const
+        {
+            return it_ == o.it_;
+        }
+        bool operator!=(const Self& o) const
+        {
+            return it_ != o.it_;
+        }
+
+        ListIter base() const
+        {
+            return it_;
+        }
+
+    private:
+        ListIter it_;
+        Self& self()
+        {
+            return static_cast<Self&>(*this);
+        }
+        const Self& self() const
+        {
+            return static_cast<const Self&>(*this);
+        }
+    };
+
+    // Strong-safety rebuild: build a temporary index, then swap.
+    void rebuild_index()
+    {
+#ifndef JSON_NOEXCEPTION
+        index_type tmp;
+        tmp.reserve(m_index.size());
+        for (list_iterator it = m_list.begin(); it != m_list.end(); ++it)
+        {
+            tmp.emplace(key_ref(std::addressof(it->first)), it);
+        }
+        m_index.swap(tmp);
 #else
-    using key_compare = std::equal_to<Key>;
+        m_index.clear();
+        for (list_iterator it = m_list.begin(); it != m_list.end(); ++it)
+        {
+            m_index.emplace(key_ref(std::addressof(it->first)), it);
+        }
+#endif
+    }
+
+    // ---- C++11-safe helper: reserve index only when the iterator is at least forward ----
+    template<typename It>
+    static void reserve_index_for_range(index_type& idx, It first, It last)
+    {
+        using cat_t = typename std::iterator_traits<It>::iterator_category;
+        reserve_index_for_range_impl(idx, first, last, cat_t{});
+    }
+
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::input_iterator_tag tag)
+    {
+        // single-pass; no pre-reserve possible
+    }
+
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::forward_iterator_tag tag)
+    {
+        (void)tag;
+        using size_type2 = typename index_type::size_type;
+        const auto add = static_cast<size_type2>(std::distance(first, last));
+        idx.reserve(idx.size() + add);
+    }
+
+    // Also reserve for bidirectional iterators
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::bidirectional_iterator_tag tag)
+    {
+        (void)tag;
+        using size_type2 = typename index_type::size_type;
+        const auto add = static_cast<size_type2>(std::distance(first, last));
+        idx.reserve(idx.size() + add);
+    }
+
+    // And for random-access iterators
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::random_access_iterator_tag tag)
+    {
+        (void) tag;
+        using size_type2 = typename index_type::size_type;
+        const auto add = static_cast<size_type2>(std::distance(first, last));
+        idx.reserve(idx.size() + add);
+    }
+
+public:
+    // types (match original)
+    using key_type             = Key;
+    using mapped_type          = T;
+    using value_type           = value_pair;
+    using allocator_type       = Allocator;
+    using size_type            = typename list_type::size_type;
+    using difference_type      = typename list_type::difference_type;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using pointer              = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename std::allocator_traits<Allocator>::const_pointer;
+
+#if defined(JSON_HAS_CPP_14)
+    using key_compare          = std::equal_to<>;
+#else
+    using key_compare          = std::equal_to<Key>;
 #endif
 
-    // Explicit constructors instead of `using Container::Container`
-    // otherwise older compilers choke on it (GCC <= 5.5, xcode <= 9.4)
-    ordered_map() noexcept(noexcept(Container())) : Container{} {}
-    explicit ordered_map(const Allocator& alloc) noexcept(noexcept(Container(alloc))) : Container{alloc} {}
-    template <class It>
-    ordered_map(It first, It last, const Allocator& alloc = Allocator())
-        : Container{first, last, alloc} {}
-    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
-        : Container{init, alloc} {}
+    // compatibility alias (original inherited std::vector<value_type>)
+    using Container            = std::vector<value_type, Allocator>;
 
-    std::pair<iterator, bool> emplace(const key_type& key, T&& t)
+    struct iterator : iter_base<list_iterator, iterator, value_type&, value_type*>
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return {it, false};
-            }
-        }
-        Container::emplace_back(key, std::forward<T>(t));
-        return {std::prev(this->end()), true};
+        iterator() : iter_base<list_iterator, iterator, value_type &, value_type*>() {}
+        explicit iterator(list_iterator it) : iter_base<list_iterator, iterator, value_type &, value_type*>(it) {}
+    };
+
+    struct const_iterator : iter_base<list_const_iterator, const_iterator, const value_type&, const value_type*>
+    {
+        const_iterator() : iter_base<list_const_iterator, const_iterator, const value_type &, const value_type*>() {}
+        explicit const_iterator(list_const_iterator it) : iter_base<list_const_iterator, const_iterator, const value_type &, const value_type*>(it) {}
+        const_iterator(iterator it) : iter_base<list_const_iterator, const_iterator, const value_type &, const value_type*>(it.base()) {}
+    };
+
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    // constructors
+    ordered_map() noexcept
+        : m_list(), m_index() {}
+
+    explicit ordered_map(const Allocator& alloc) noexcept
+        : m_list(alloc), m_index() {}
+
+    template<class InputIt>
+    ordered_map(InputIt first, InputIt last, const Allocator& alloc = Allocator())
+        : m_list(alloc), m_index()
+    {
+        insert(first, last);
     }
 
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator())
+        : m_list(alloc), m_index()
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return {it, false};
-            }
-        }
-        Container::emplace_back(std::forward<KeyType>(key), std::forward<T>(t));
-        return {std::prev(this->end()), true};
+        insert(init.begin(), init.end());
     }
 
-    T& operator[](const key_type& key)
+    ordered_map(const ordered_map& other)
+        : m_list(other.m_list), m_index()
     {
-        return emplace(key, T{}).first->second;
+        rebuild_index();
+    }
+
+    ordered_map(ordered_map&& other) noexcept
+        : m_list(std::move(other.m_list)), m_index()
+    {
+        rebuild_index();
+    }
+
+    ordered_map& operator=(const ordered_map& other)
+    {
+        if (this != &other)
+        {
+            m_list = other.m_list;
+            rebuild_index();
+        }
+        return *this;
+    }
+
+    ordered_map& operator=(ordered_map&& other) noexcept
+    {
+        if (this != &other)
+        {
+            m_list = std::move(other.m_list);
+            rebuild_index();
+        }
+        return *this;
+    }
+
+    ~ordered_map() noexcept = default;
+
+    allocator_type get_allocator() const noexcept
+    {
+        return m_list.get_allocator();
+    }
+
+    // element access
+    T& at(const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it == m_index.end())
+        {
+            JSON_THROW(std::out_of_range("key not found"));
+        }
+        return it->second->second;
+    }
+
+    const T& at(const Key& key) const
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it == m_index.end())
+        {
+            JSON_THROW(std::out_of_range("key not found"));
+        }
+        return it->second->second;
+    }
+
+    T& operator[](const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it != m_index.end())
+        {
+            return it->second->second;
+        }
+        m_list.emplace_back(key, T{});
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return lit->second;
     }
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     T & operator[](KeyType && key)
     {
-        return emplace(std::forward<KeyType>(key), T{}).first->second;
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        if (it != m_index.end())
+        {
+            return it->second->second;
+        }
+        m_list.emplace_back(k, T{});
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return lit->second;
     }
 
     const T& operator[](const key_type& key) const
@@ -100,260 +426,400 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     const T & operator[](KeyType && key) const
     {
-        return at(std::forward<KeyType>(key));
+        return at(key_type(std::forward<KeyType>(key)));
     }
 
-    T& at(const key_type& key)
+    // iterators
+    iterator       begin()        noexcept
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        return iterator(m_list.begin());
+    }
+    iterator       end()          noexcept
+    {
+        return iterator(m_list.end());
+    }
+    const_iterator begin()  const noexcept
+    {
+        return const_iterator(m_list.begin());
+    }
+    const_iterator end()    const noexcept
+    {
+        return const_iterator(m_list.end());
+    }
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(m_list.begin());
+    }
+    const_iterator cend()   const noexcept
+    {
+        return const_iterator(m_list.end());
+    }
+
+    reverse_iterator       rbegin()        noexcept
+    {
+        return reverse_iterator(end());
+    }
+    reverse_iterator       rend()          noexcept
+    {
+        return reverse_iterator(begin());
+    }
+    const_reverse_iterator rbegin()  const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    const_reverse_iterator rend()    const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(cend());
+    }
+    const_reverse_iterator crend()   const noexcept
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+    // capacity
+    bool empty() const noexcept
+    {
+        return m_list.empty();
+    }
+    size_type size() const noexcept
+    {
+        return m_index.size();
+    }
+    size_type max_size() const noexcept
+    {
+        return m_list.max_size();
+    }
+
+    // modifiers
+    void clear() noexcept
+    {
+        m_list.clear();
+        m_index.clear();
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        auto it = m_index.find(key_ref(value.first));
+        if (it != m_index.end())
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            return std::make_pair(iterator(it->second), false);
         }
+        m_list.push_back(value);
+        list_iterator lit = --m_list.end();
 
-        JSON_THROW(std::out_of_range("key not found"));
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    T & at(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
         }
-
-        JSON_THROW(std::out_of_range("key not found"));
-    }
-
-    const T& at(const key_type& key) const
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        JSON_CATCH(...)
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
         }
-
-        JSON_THROW(std::out_of_range("key not found"));
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
     }
 
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    const T & at(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
+    std::pair<iterator, bool> insert(value_type&& value)
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        auto it = m_index.find(key_ref(value.first));
+        if (it != m_index.end())
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            return std::make_pair(iterator(it->second), false);
         }
+        m_list.push_back(std::move(value));
+        list_iterator lit = --m_list.end();
 
-        JSON_THROW(std::out_of_range("key not found"));
-    }
-
-    size_type erase(const key_type& key)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
         {
-            if (m_compare(it->first, key))
-            {
-                // Since we cannot move const Keys, re-construct them in place
-                for (auto next = it; ++next != this->end(); ++it)
-                {
-                    it->~value_type(); // Destroy but keep allocation
-                    new (&*it) value_type{std::move(*next)};
-                }
-                Container::pop_back();
-                return 1;
-            }
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
         }
-        return 0;
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    size_type erase(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        JSON_CATCH(...)
         {
-            if (m_compare(it->first, key))
-            {
-                // Since we cannot move const Keys, re-construct them in place
-                for (auto next = it; ++next != this->end(); ++it)
-                {
-                    it->~value_type(); // Destroy but keep allocation
-                    new (&*it) value_type{std::move(*next)};
-                }
-                Container::pop_back();
-                return 1;
-            }
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
         }
-        return 0;
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
     }
 
-    iterator erase(iterator pos)
+    // hint overloads (the hint is ignored)
+    iterator insert(const_iterator /*hint*/, const value_type& value)
     {
-        return erase(pos, std::next(pos));
+        return insert(value).first;
     }
-
-    iterator erase(iterator first, iterator last)
+    iterator insert(const_iterator /*hint*/, value_type&& value)
     {
-        if (first == last)
-        {
-            return first;
-        }
-
-        const auto elements_affected = std::distance(first, last);
-        const auto offset = std::distance(Container::begin(), first);
-
-        // This is the start situation. We need to delete elements_affected
-        // elements (3 in this example: e, f, g), and need to return an
-        // iterator past the last deleted element (h in this example).
-        // Note that offset is the distance from the start of the vector
-        // to first. We will need this later.
-
-        // [ a, b, c, d, e, f, g, h, i, j ]
-        //               ^        ^
-        //             first    last
-
-        // Since we cannot move const Keys, we re-construct them in place.
-        // We start at first and re-construct (viz. copy) the elements from
-        // the back of the vector. Example for the first iteration:
-
-        //               ,--------.
-        //               v        |   destroy e and re-construct with h
-        // [ a, b, c, d, e, f, g, h, i, j ]
-        //               ^        ^
-        //               it       it + elements_affected
-
-        for (auto it = first; std::next(it, elements_affected) != Container::end(); ++it)
-        {
-            it->~value_type(); // destroy but keep allocation
-            new (&*it) value_type{std::move(*std::next(it, elements_affected))}; // "move" next element to it
-        }
-
-        // [ a, b, c, d, h, i, j, h, i, j ]
-        //               ^        ^
-        //             first    last
-
-        // remove the unneeded elements at the end of the vector
-        Container::resize(this->size() - static_cast<size_type>(elements_affected));
-
-        // [ a, b, c, d, h, i, j ]
-        //               ^        ^
-        //             first    last
-
-        // first is now pointing past the last deleted element, but we cannot
-        // use this iterator, because it may have been invalidated by the
-        // resize call. Instead, we can return begin() + offset.
-        return Container::begin() + offset;
+        return insert(std::move(value)).first;
     }
 
-    size_type count(const key_type& key) const
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return 1;
-            }
-        }
-        return 0;
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    size_type count(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return 1;
-            }
-        }
-        return 0;
-    }
-
-    iterator find(const key_type& key)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return it;
-            }
-        }
-        return Container::end();
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    iterator find(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return it;
-            }
-        }
-        return Container::end();
-    }
-
-    const_iterator find(const key_type& key) const
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return it;
-            }
-        }
-        return Container::end();
-    }
-
-    std::pair<iterator, bool> insert( value_type&& value )
-    {
-        return emplace(value.first, std::move(value.second));
-    }
-
-    std::pair<iterator, bool> insert( const value_type& value )
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, value.first))
-            {
-                return {it, false};
-            }
-        }
-        Container::push_back(value);
-        return {--this->end(), true};
-    }
-
+    // keep SFINAE’d range-insert like the original
     template<typename InputIt>
-    using require_input_iter = typename std::enable_if<std::is_convertible<typename std::iterator_traits<InputIt>::iterator_category,
-        std::input_iterator_tag>::value>::type;
+    using require_input_iter = typename std::enable_if <
+        std::is_base_of<std::input_iterator_tag,
+                        typename std::iterator_traits<InputIt>::iterator_category>::value
+        // ReSharper disable once CppUseTypeTraitAlias
+        >::type;
 
     template<typename InputIt, typename = require_input_iter<InputIt>>
     void insert(InputIt first, InputIt last)
     {
-        for (auto it = first; it != last; ++it)
+        // Optional micro-optimization: reserve only when the iterator is at least forward
+        reserve_index_for_range(m_index, first, last);
+
+        for (; first != last; ++first)
         {
-            insert(*it);
+            insert(*first);
         }
     }
 
-private:
-    JSON_NO_UNIQUE_ADDRESS key_compare m_compare = key_compare();
+    // vector-compat helpers (used by tests)
+    void push_back(const value_type& v)
+    {
+        (void)insert(v);
+    }
+    void push_back(value_type&& v)
+    {
+        (void)insert(std::move(v));
+    }
+
+    // emplace
+    std::pair<iterator, bool> emplace(const key_type& key, T&& t)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it != m_index.end())
+        {
+            return std::make_pair(iterator(it->second), false);
+        }
+        m_list.emplace_back(key, std::forward<T>(t));
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        if (it != m_index.end())
+        {
+            return std::make_pair(iterator(it->second), false);
+        }
+        m_list.emplace_back(k, std::forward<T>(t));
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
+    }
+
+    // emplace_hint (hint ignored)
+    iterator emplace_hint(const_iterator /*hint*/, const key_type& key, T&& t)
+    {
+        return emplace(key, std::forward<T>(t)).first;
+    }
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator emplace_hint(const_iterator /*hint*/, KeyType && key, T && t)
+    {
+        return emplace(std::forward<KeyType>(key), std::forward<T>(t)).first;
+    }
+
+    // erase
+    size_type erase(const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it == m_index.end())
+        {
+            return 0;
+        }
+        m_list.erase(it->second);
+        m_index.erase(it);
+        return 1;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type erase(KeyType && key)
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        if (it == m_index.end())
+        {
+            return 0;
+        }
+        m_list.erase(it->second);
+        m_index.erase(it);
+        return 1;
+    }
+
+    iterator erase(iterator pos)
+    {
+        auto hit = m_index.find(key_ref(pos->first));
+        if (hit != m_index.end())
+        {
+            m_index.erase(hit);
+        }
+        list_iterator next = m_list.erase(pos.base());
+        return iterator(next);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        auto hit = m_index.find(key_ref(pos->first));
+        if (hit != m_index.end())
+        {
+            m_index.erase(hit);
+        }
+        list_iterator next = m_list.erase(pos.base());
+        return iterator(next);
+    }
+
+    iterator erase(iterator first, iterator last)
+    {
+        for (iterator it = first; it != last; ++it)
+        {
+            auto hit = m_index.find(key_ref(it->first));
+            if (hit != m_index.end())
+            {
+                m_index.erase(hit);
+            }
+        }
+        list_iterator ret = m_list.erase(first.base(), last.base());
+        return iterator(ret);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        for (const_iterator it = first; it != last; ++it)
+        {
+            auto hit = m_index.find(key_ref(it->first));
+            if (hit != m_index.end())
+            {
+                m_index.erase(hit);
+            }
+        }
+        list_iterator ret = m_list.erase(first.base(), last.base());
+        return iterator(ret);
+    }
+
+    // lookup
+    size_type count(const Key& key) const
+    {
+        return static_cast<size_type>(m_index.count(key_ref(key)));
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type count(KeyType && key) const
+    {
+        key_type k(std::forward<KeyType>(key));
+        return static_cast<size_type>(m_index.count(key_ref(k)));
+    }
+
+    iterator find(const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        return (it == m_index.end()) ? iterator(m_list.end()) : iterator(it->second);
+    }
+
+    const_iterator find(const Key& key) const
+    {
+        auto it = m_index.find(key_ref(key));
+        return (it == m_index.end()) ? const_iterator(m_list.end()) : const_iterator(it->second);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator find(KeyType && key)
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        return (it == m_index.end()) ? iterator(m_list.end()) : iterator(it->second);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const_iterator find(KeyType && key) const
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        return (it == m_index.end()) ? const_iterator(m_list.end()) : const_iterator(it->second);
+    }
+
+    // comparison (preserve vector-like sequence comparison)
+    friend bool operator==(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return lhs.m_list == rhs.m_list;
+    }
+    friend bool operator!=(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return !(lhs == rhs);
+    }
+    friend bool operator<(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return std::lexicographical_compare(lhs.m_list.begin(), lhs.m_list.end(),
+                                            rhs.m_list.begin(), rhs.m_list.end());
+    }
+    friend bool operator>(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return rhs < lhs;
+    }
+    friend bool operator<=(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return !(rhs < lhs);
+    }
+    friend bool operator>=(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return !(lhs < rhs);
+    }
+
+    // swap
+    void swap(ordered_map& other) noexcept
+    {
+        m_list.swap(other.m_list);
+        m_index.swap(other.m_index);
+    }
+    friend void swap(ordered_map& a, ordered_map& b) noexcept
+    {
+        a.swap(b);
+    }
 };
 
 NLOHMANN_JSON_NAMESPACE_END

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -52,9 +52,9 @@ template<class Key,
          class T,
          class IgnoredCompare = std::less<Key>, // Unused
          class Allocator = std::allocator<std::pair<const Key, T>>>
-struct ordered_map
+             struct ordered_map
 {
-private:
+    private:
     using value_pair    = std::pair<const Key, T>;
     using list_type     = std::list<value_pair, Allocator>;
     using list_iterator = typename list_type::iterator;
@@ -70,7 +70,7 @@ private:
     };
     struct key_ref_hash
     {
-        std::size_t operator()(const key_ref& kr) const noexcept
+        std::size_t operator()(const key_ref& kr) const
         {
             return std::hash<Key> {}(*kr.p);
         }
@@ -98,87 +98,87 @@ private:
         using reference         = Ref;
         using pointer           = Ptr;
 
-        iter_base() : it_() {}
-        explicit iter_base(ListIter it) : it_(it) {}
+    iter_base() : it_() {}
+    explicit iter_base(ListIter it) : it_(it) {}
 
-        reference operator*()  const
-        {
-            return *it_;
-        }
-        pointer   operator->() const
-        {
-            return std::addressof(*it_);
-        }
+    reference operator*()  const
+    {
+        return *it_;
+    }
+    pointer   operator->() const
+    {
+        return std::addressof(*it_);
+    }
 
-        Self& operator++()
-        {
-            ++it_;
-            return self();
-        }
-        Self  operator++(int)
-        {
-            Self tmp = self();
-            ++(*this);
-            return tmp;
-        }
-        Self& operator--()
-        {
-            --it_;
-            return self();
-        }
-        Self  operator--(int)
-        {
-            Self tmp = self();
-            --(*this);
-            return tmp;
-        }
+    Self& operator++()
+    {
+        ++it_;
+        return self();
+    }
+    Self  operator++(int)
+    {
+        Self tmp = self();
+        ++(*this);
+        return tmp;
+    }
+    Self& operator--()
+    {
+        --it_;
+        return self();
+    }
+    Self  operator--(int)
+    {
+        Self tmp = self();
+        --(*this);
+        return tmp;
+    }
 
-        // This is O(n), but used only by unit tests
-        Self operator+(difference_type n) const
-        {
-            Self tmp = self();
-            if (n >= 0)    // NOLINT(*-braces-around-statements)
-                while (n--)
-                {
-                    ++tmp.it_;
-                }
-            else            // NOLINT(*-braces-around-statements)
-                while (n++)
-                {
-                    --tmp.it_;
-                }
-            return tmp;
-        }
-        Self& operator+=(difference_type n)
-        {
-            *this = *this + n;
-            return self();
-        }
+    // This is O(n), but used only by unit tests
+    Self operator+(difference_type n) const
+    {
+        Self tmp = self();
+        if (n >= 0)    // NOLINT(*-braces-around-statements)
+            while (n--)
+            {
+                ++tmp.it_;
+            }
+        else            // NOLINT(*-braces-around-statements)
+            while (n++)
+            {
+                --tmp.it_;
+            }
+        return tmp;
+    }
+    Self& operator+=(difference_type n)
+    {
+        *this = *this + n;
+        return self();
+    }
 
-        bool operator==(const Self& o) const
-        {
-            return it_ == o.it_;
-        }
-        bool operator!=(const Self& o) const
-        {
-            return it_ != o.it_;
-        }
+    bool operator==(const Self& o) const
+    {
+        return it_ == o.it_;
+    }
+    bool operator!=(const Self& o) const
+    {
+        return it_ != o.it_;
+    }
 
-        ListIter base() const
-        {
-            return it_;
-        }
+    ListIter base() const
+    {
+        return it_;
+    }
 
     private:
-        ListIter it_;
-        Self& self()
-        {
-            return static_cast<Self&>(*this);
-        }
-        const Self& self() const
-        {
-            return static_cast<const Self&>(*this);
-        }
+    ListIter it_;
+    Self& self()
+    {
+        return static_cast<Self&>(*this);
+    }
+    const Self& self() const
+    {
+        return static_cast<const Self&>(*this);
+    }
     };
 
     // Strong-safety rebuild: build a temporary index, then swap.
@@ -318,7 +318,8 @@ public:
     {
         if (this != &other)
         {
-            m_list = other.m_list;
+            list_type tmp(other.m_list);  // may throw; strong guarantee
+            m_list.swap(tmp);
             rebuild_index();
         }
         return *this;
@@ -328,7 +329,8 @@ public:
     {
         if (this != &other)
         {
-            m_list = std::move(other.m_list);
+            list_type tmp(std::move(other.m_list)); // noexcept move-construct
+            m_list.swap(tmp);
             rebuild_index();
         }
         return *this;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19812,14 +19812,18 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 
-#include <functional> // equal_to, less
-#include <initializer_list> // initializer_list
-#include <iterator> // input_iterator_tag, iterator_traits
-#include <memory> // allocator
-#include <stdexcept> // for out_of_range
-#include <type_traits> // enable_if, is_convertible
-#include <utility> // pair
-#include <vector> // vector
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
@@ -19827,74 +19831,398 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief Insertion-order-preserving map with O(1) average lookup
 
-/// ordered_map: a minimal map-like container that preserves insertion order
-/// for use within nlohmann::basic_json<ordered_map>
-template <class Key, class T, class IgnoredLess = std::less<Key>,
-          class Allocator = std::allocator<std::pair<const Key, T>>>
-              struct ordered_map : std::vector<std::pair<const Key, T>, Allocator>
+Internally uses a std::list to contain the <key,value> pairs, plus
+an index (effectively keyed by a pointer-to-key) for O(1) lookups.
+
+This implements all the methods of std::map except:
+- Ordering-dependent operations (lower_bound, upper_bound, equal_range,
+  key_comp and value_comp, etc.); these simply make no sense without
+  lexicographic ordering.
+- Extensions added after C++11 (try_emplace, insert_or_assign, contains,
+  erase_if, etc.).
+
+It also has iterator arithmetic (it+n), which is not used by the library
+but needed by some unit tests of the original implementation.
+
+Stable iterators guarantee: insertion and value updates do not invalidate
+iterators (except for the iterator to an element that is erased).
+
+Size complexity is linear to the size of contained data; time complexity
+is on average O(1) for all access methods and all methods that change a
+single element, O(N) when N elements are affected.
+*/
+template<class Key,
+         class T,
+         class IgnoredCompare = std::less<Key>, // Unused
+         class Allocator = std::allocator<std::pair<const Key, T>>>
+             struct ordered_map
 {
-    using key_type = Key;
-    using mapped_type = T;
-    using Container = std::vector<std::pair<const Key, T>, Allocator>;
-    using iterator = typename Container::iterator;
-    using const_iterator = typename Container::const_iterator;
-    using size_type = typename Container::size_type;
-    using value_type = typename Container::value_type;
-#ifdef JSON_HAS_CPP_14
-    using key_compare = std::equal_to<>;
+    private:
+    using value_pair    = std::pair<const Key, T>;
+    using list_type     = std::list<value_pair, Allocator>;
+    using list_iterator = typename list_type::iterator;
+    using list_const_iterator = typename list_type::const_iterator;
+
+    // --- pointer-to-key index machinery ---
+    struct key_ref
+    {
+        const Key* p;
+        key_ref() : p(nullptr) {}
+        explicit key_ref(const Key& k) : p(std::addressof(k)) {}
+        explicit key_ref(const Key* pk) : p(pk) {}
+    };
+    struct key_ref_hash
+    {
+        std::size_t operator()(const key_ref& kr) const
+        {
+            return std::hash<Key> {}(*kr.p);
+        }
+    };
+    struct key_ref_equal
+    {
+        bool operator()(const key_ref& a, const key_ref& b) const noexcept
+        {
+            return std::equal_to<Key> {}(*a.p, *b.p);
+        }
+    };
+
+    using index_type = std::unordered_map<key_ref, list_iterator, key_ref_hash, key_ref_equal>;
+
+    list_type  m_list;
+    index_type m_index;
+
+    // iterator wrapper that supports it+n for tests which do om.begin()+k
+    template <typename ListIter, typename Self, typename Ref, typename Ptr>
+    struct iter_base
+    {
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type        = value_pair;
+        using difference_type   = typename list_type::difference_type;
+        using reference         = Ref;
+        using pointer           = Ptr;
+
+    iter_base() : it_() {}
+    explicit iter_base(ListIter it) : it_(it) {}
+
+    reference operator*()  const
+    {
+        return *it_;
+    }
+    pointer   operator->() const
+    {
+        return std::addressof(*it_);
+    }
+
+    Self& operator++()
+    {
+        ++it_;
+        return self();
+    }
+    Self  operator++(int)
+    {
+        Self tmp = self();
+        ++(*this);
+        return tmp;
+    }
+    Self& operator--()
+    {
+        --it_;
+        return self();
+    }
+    Self  operator--(int)
+    {
+        Self tmp = self();
+        --(*this);
+        return tmp;
+    }
+
+    // This is O(n), but used only by unit tests
+    Self operator+(difference_type n) const
+    {
+        Self tmp = self();
+        if (n >= 0)    // NOLINT(*-braces-around-statements)
+            while (n--)
+            {
+                ++tmp.it_;
+            }
+        else            // NOLINT(*-braces-around-statements)
+            while (n++)
+            {
+                --tmp.it_;
+            }
+        return tmp;
+    }
+    Self& operator+=(difference_type n)
+    {
+        *this = *this + n;
+        return self();
+    }
+
+    bool operator==(const Self& o) const
+    {
+        return it_ == o.it_;
+    }
+    bool operator!=(const Self& o) const
+    {
+        return it_ != o.it_;
+    }
+
+    ListIter base() const
+    {
+        return it_;
+    }
+
+    private:
+    ListIter it_;
+    Self& self()
+    {
+        return static_cast<Self&>(*this);
+    }
+    const Self& self() const
+    {
+        return static_cast<const Self&>(*this);
+    }
+    };
+
+    // Strong-safety rebuild: build a temporary index, then swap.
+    void rebuild_index()
+    {
+#ifndef JSON_NOEXCEPTION
+        index_type tmp;
+        tmp.reserve(m_index.size());
+        for (list_iterator it = m_list.begin(); it != m_list.end(); ++it)
+        {
+            tmp.emplace(key_ref(std::addressof(it->first)), it);
+        }
+        m_index.swap(tmp);
 #else
-    using key_compare = std::equal_to<Key>;
+        m_index.clear();
+        for (list_iterator it = m_list.begin(); it != m_list.end(); ++it)
+        {
+            m_index.emplace(key_ref(std::addressof(it->first)), it);
+        }
+#endif
+    }
+
+    // ---- C++11-safe helper: reserve index only when the iterator is at least forward ----
+    template<typename It>
+    static void reserve_index_for_range(index_type& idx, It first, It last)
+    {
+        using cat_t = typename std::iterator_traits<It>::iterator_category;
+        reserve_index_for_range_impl(idx, first, last, cat_t{});
+    }
+
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::input_iterator_tag tag)
+    {
+        // single-pass; no pre-reserve possible
+    }
+
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::forward_iterator_tag tag)
+    {
+        (void)tag;
+        using size_type2 = typename index_type::size_type;
+        const auto add = static_cast<size_type2>(std::distance(first, last));
+        idx.reserve(idx.size() + add);
+    }
+
+    // Also reserve for bidirectional iterators
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::bidirectional_iterator_tag tag)
+    {
+        (void)tag;
+        using size_type2 = typename index_type::size_type;
+        const auto add = static_cast<size_type2>(std::distance(first, last));
+        idx.reserve(idx.size() + add);
+    }
+
+    // And for random-access iterators
+    template<typename It>
+    static void reserve_index_for_range_impl(index_type& idx, It first, It last, std::random_access_iterator_tag tag)
+    {
+        (void) tag;
+        using size_type2 = typename index_type::size_type;
+        const auto add = static_cast<size_type2>(std::distance(first, last));
+        idx.reserve(idx.size() + add);
+    }
+
+public:
+    // types (match original)
+    using key_type             = Key;
+    using mapped_type          = T;
+    using value_type           = value_pair;
+    using allocator_type       = Allocator;
+    using size_type            = typename list_type::size_type;
+    using difference_type      = typename list_type::difference_type;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using pointer              = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename std::allocator_traits<Allocator>::const_pointer;
+
+#if defined(JSON_HAS_CPP_14)
+    using key_compare          = std::equal_to<>;
+#else
+    using key_compare          = std::equal_to<Key>;
 #endif
 
-    // Explicit constructors instead of `using Container::Container`
-    // otherwise older compilers choke on it (GCC <= 5.5, xcode <= 9.4)
-    ordered_map() noexcept(noexcept(Container())) : Container{} {}
-    explicit ordered_map(const Allocator& alloc) noexcept(noexcept(Container(alloc))) : Container{alloc} {}
-    template <class It>
-    ordered_map(It first, It last, const Allocator& alloc = Allocator())
-        : Container{first, last, alloc} {}
-    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
-        : Container{init, alloc} {}
+    // compatibility alias (original inherited std::vector<value_type>)
+    using Container            = std::vector<value_type, Allocator>;
 
-    std::pair<iterator, bool> emplace(const key_type& key, T&& t)
+    struct iterator : iter_base<list_iterator, iterator, value_type&, value_type*>
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return {it, false};
-            }
-        }
-        Container::emplace_back(key, std::forward<T>(t));
-        return {std::prev(this->end()), true};
+        iterator() : iter_base<list_iterator, iterator, value_type &, value_type*>() {}
+        explicit iterator(list_iterator it) : iter_base<list_iterator, iterator, value_type &, value_type*>(it) {}
+    };
+
+    struct const_iterator : iter_base<list_const_iterator, const_iterator, const value_type&, const value_type*>
+    {
+        const_iterator() : iter_base<list_const_iterator, const_iterator, const value_type &, const value_type*>() {}
+        explicit const_iterator(list_const_iterator it) : iter_base<list_const_iterator, const_iterator, const value_type &, const value_type*>(it) {}
+        const_iterator(iterator it) : iter_base<list_const_iterator, const_iterator, const value_type &, const value_type*>(it.base()) {}
+    };
+
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    // constructors
+    ordered_map() noexcept
+        : m_list(), m_index() {}
+
+    explicit ordered_map(const Allocator& alloc) noexcept
+        : m_list(alloc), m_index() {}
+
+    template<class InputIt>
+    ordered_map(InputIt first, InputIt last, const Allocator& alloc = Allocator())
+        : m_list(alloc), m_index()
+    {
+        insert(first, last);
     }
 
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator())
+        : m_list(alloc), m_index()
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return {it, false};
-            }
-        }
-        Container::emplace_back(std::forward<KeyType>(key), std::forward<T>(t));
-        return {std::prev(this->end()), true};
+        insert(init.begin(), init.end());
     }
 
-    T& operator[](const key_type& key)
+    ordered_map(const ordered_map& other)
+        : m_list(other.m_list), m_index()
     {
-        return emplace(key, T{}).first->second;
+        rebuild_index();
+    }
+
+    ordered_map(ordered_map&& other) noexcept
+        : m_list(std::move(other.m_list)), m_index()
+    {
+        rebuild_index();
+    }
+
+    ordered_map& operator=(const ordered_map& other)
+    {
+        if (this != &other)
+        {
+            list_type tmp(other.m_list);  // may throw; strong guarantee
+            m_list.swap(tmp);
+            rebuild_index();
+        }
+        return *this;
+    }
+
+    ordered_map& operator=(ordered_map&& other) noexcept
+    {
+        if (this != &other)
+        {
+            list_type tmp(std::move(other.m_list)); // noexcept move-construct
+            m_list.swap(tmp);
+            rebuild_index();
+        }
+        return *this;
+    }
+
+    ~ordered_map() noexcept = default;
+
+    allocator_type get_allocator() const noexcept
+    {
+        return m_list.get_allocator();
+    }
+
+    // element access
+    T& at(const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it == m_index.end())
+        {
+            JSON_THROW(std::out_of_range("key not found"));
+        }
+        return it->second->second;
+    }
+
+    const T& at(const Key& key) const
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it == m_index.end())
+        {
+            JSON_THROW(std::out_of_range("key not found"));
+        }
+        return it->second->second;
+    }
+
+    T& operator[](const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it != m_index.end())
+        {
+            return it->second->second;
+        }
+        m_list.emplace_back(key, T{});
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return lit->second;
     }
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     T & operator[](KeyType && key)
     {
-        return emplace(std::forward<KeyType>(key), T{}).first->second;
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        if (it != m_index.end())
+        {
+            return it->second->second;
+        }
+        m_list.emplace_back(k, T{});
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return lit->second;
     }
 
     const T& operator[](const key_type& key) const
@@ -19906,260 +20234,400 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     const T & operator[](KeyType && key) const
     {
-        return at(std::forward<KeyType>(key));
+        return at(key_type(std::forward<KeyType>(key)));
     }
 
-    T& at(const key_type& key)
+    // iterators
+    iterator       begin()        noexcept
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        return iterator(m_list.begin());
+    }
+    iterator       end()          noexcept
+    {
+        return iterator(m_list.end());
+    }
+    const_iterator begin()  const noexcept
+    {
+        return const_iterator(m_list.begin());
+    }
+    const_iterator end()    const noexcept
+    {
+        return const_iterator(m_list.end());
+    }
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(m_list.begin());
+    }
+    const_iterator cend()   const noexcept
+    {
+        return const_iterator(m_list.end());
+    }
+
+    reverse_iterator       rbegin()        noexcept
+    {
+        return reverse_iterator(end());
+    }
+    reverse_iterator       rend()          noexcept
+    {
+        return reverse_iterator(begin());
+    }
+    const_reverse_iterator rbegin()  const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    const_reverse_iterator rend()    const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(cend());
+    }
+    const_reverse_iterator crend()   const noexcept
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+    // capacity
+    bool empty() const noexcept
+    {
+        return m_list.empty();
+    }
+    size_type size() const noexcept
+    {
+        return m_index.size();
+    }
+    size_type max_size() const noexcept
+    {
+        return m_list.max_size();
+    }
+
+    // modifiers
+    void clear() noexcept
+    {
+        m_list.clear();
+        m_index.clear();
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        auto it = m_index.find(key_ref(value.first));
+        if (it != m_index.end())
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            return std::make_pair(iterator(it->second), false);
         }
+        m_list.push_back(value);
+        list_iterator lit = --m_list.end();
 
-        JSON_THROW(std::out_of_range("key not found"));
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    T & at(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
         }
-
-        JSON_THROW(std::out_of_range("key not found"));
-    }
-
-    const T& at(const key_type& key) const
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        JSON_CATCH(...)
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
         }
-
-        JSON_THROW(std::out_of_range("key not found"));
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
     }
 
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    const T & at(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
+    std::pair<iterator, bool> insert(value_type&& value)
     {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        auto it = m_index.find(key_ref(value.first));
+        if (it != m_index.end())
         {
-            if (m_compare(it->first, key))
-            {
-                return it->second;
-            }
+            return std::make_pair(iterator(it->second), false);
         }
+        m_list.push_back(std::move(value));
+        list_iterator lit = --m_list.end();
 
-        JSON_THROW(std::out_of_range("key not found"));
-    }
-
-    size_type erase(const key_type& key)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
         {
-            if (m_compare(it->first, key))
-            {
-                // Since we cannot move const Keys, re-construct them in place
-                for (auto next = it; ++next != this->end(); ++it)
-                {
-                    it->~value_type(); // Destroy but keep allocation
-                    new (&*it) value_type{std::move(*next)};
-                }
-                Container::pop_back();
-                return 1;
-            }
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
         }
-        return 0;
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    size_type erase(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
+        JSON_CATCH(...)
         {
-            if (m_compare(it->first, key))
-            {
-                // Since we cannot move const Keys, re-construct them in place
-                for (auto next = it; ++next != this->end(); ++it)
-                {
-                    it->~value_type(); // Destroy but keep allocation
-                    new (&*it) value_type{std::move(*next)};
-                }
-                Container::pop_back();
-                return 1;
-            }
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
         }
-        return 0;
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
     }
 
-    iterator erase(iterator pos)
+    // hint overloads (the hint is ignored)
+    iterator insert(const_iterator /*hint*/, const value_type& value)
     {
-        return erase(pos, std::next(pos));
+        return insert(value).first;
     }
-
-    iterator erase(iterator first, iterator last)
+    iterator insert(const_iterator /*hint*/, value_type&& value)
     {
-        if (first == last)
-        {
-            return first;
-        }
-
-        const auto elements_affected = std::distance(first, last);
-        const auto offset = std::distance(Container::begin(), first);
-
-        // This is the start situation. We need to delete elements_affected
-        // elements (3 in this example: e, f, g), and need to return an
-        // iterator past the last deleted element (h in this example).
-        // Note that offset is the distance from the start of the vector
-        // to first. We will need this later.
-
-        // [ a, b, c, d, e, f, g, h, i, j ]
-        //               ^        ^
-        //             first    last
-
-        // Since we cannot move const Keys, we re-construct them in place.
-        // We start at first and re-construct (viz. copy) the elements from
-        // the back of the vector. Example for the first iteration:
-
-        //               ,--------.
-        //               v        |   destroy e and re-construct with h
-        // [ a, b, c, d, e, f, g, h, i, j ]
-        //               ^        ^
-        //               it       it + elements_affected
-
-        for (auto it = first; std::next(it, elements_affected) != Container::end(); ++it)
-        {
-            it->~value_type(); // destroy but keep allocation
-            new (&*it) value_type{std::move(*std::next(it, elements_affected))}; // "move" next element to it
-        }
-
-        // [ a, b, c, d, h, i, j, h, i, j ]
-        //               ^        ^
-        //             first    last
-
-        // remove the unneeded elements at the end of the vector
-        Container::resize(this->size() - static_cast<size_type>(elements_affected));
-
-        // [ a, b, c, d, h, i, j ]
-        //               ^        ^
-        //             first    last
-
-        // first is now pointing past the last deleted element, but we cannot
-        // use this iterator, because it may have been invalidated by the
-        // resize call. Instead, we can return begin() + offset.
-        return Container::begin() + offset;
+        return insert(std::move(value)).first;
     }
 
-    size_type count(const key_type& key) const
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return 1;
-            }
-        }
-        return 0;
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    size_type count(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return 1;
-            }
-        }
-        return 0;
-    }
-
-    iterator find(const key_type& key)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return it;
-            }
-        }
-        return Container::end();
-    }
-
-    template<class KeyType, detail::enable_if_t<
-                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    iterator find(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return it;
-            }
-        }
-        return Container::end();
-    }
-
-    const_iterator find(const key_type& key) const
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, key))
-            {
-                return it;
-            }
-        }
-        return Container::end();
-    }
-
-    std::pair<iterator, bool> insert( value_type&& value )
-    {
-        return emplace(value.first, std::move(value.second));
-    }
-
-    std::pair<iterator, bool> insert( const value_type& value )
-    {
-        for (auto it = this->begin(); it != this->end(); ++it)
-        {
-            if (m_compare(it->first, value.first))
-            {
-                return {it, false};
-            }
-        }
-        Container::push_back(value);
-        return {--this->end(), true};
-    }
-
+    // keep SFINAE’d range-insert like the original
     template<typename InputIt>
-    using require_input_iter = typename std::enable_if<std::is_convertible<typename std::iterator_traits<InputIt>::iterator_category,
-        std::input_iterator_tag>::value>::type;
+    using require_input_iter = typename std::enable_if <
+        std::is_base_of<std::input_iterator_tag,
+                        typename std::iterator_traits<InputIt>::iterator_category>::value
+        // ReSharper disable once CppUseTypeTraitAlias
+        >::type;
 
     template<typename InputIt, typename = require_input_iter<InputIt>>
     void insert(InputIt first, InputIt last)
     {
-        for (auto it = first; it != last; ++it)
+        // Optional micro-optimization: reserve only when the iterator is at least forward
+        reserve_index_for_range(m_index, first, last);
+
+        for (; first != last; ++first)
         {
-            insert(*it);
+            insert(*first);
         }
     }
 
-private:
-    JSON_NO_UNIQUE_ADDRESS key_compare m_compare = key_compare();
+    // vector-compat helpers (used by tests)
+    void push_back(const value_type& v)
+    {
+        (void)insert(v);
+    }
+    void push_back(value_type&& v)
+    {
+        (void)insert(std::move(v));
+    }
+
+    // emplace
+    std::pair<iterator, bool> emplace(const key_type& key, T&& t)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it != m_index.end())
+        {
+            return std::make_pair(iterator(it->second), false);
+        }
+        m_list.emplace_back(key, std::forward<T>(t));
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        if (it != m_index.end())
+        {
+            return std::make_pair(iterator(it->second), false);
+        }
+        m_list.emplace_back(k, std::forward<T>(t));
+        list_iterator lit = --m_list.end();
+
+#ifndef JSON_NOEXCEPTION
+        JSON_TRY
+        {
+            m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+        }
+        JSON_CATCH(...)
+        {
+            m_list.pop_back();
+            JSON_THROW(std::bad_alloc());
+        }
+#else
+        m_index.emplace(key_ref(std::addressof(lit->first)), lit);
+#endif
+        return std::make_pair(iterator(lit), true);
+    }
+
+    // emplace_hint (hint ignored)
+    iterator emplace_hint(const_iterator /*hint*/, const key_type& key, T&& t)
+    {
+        return emplace(key, std::forward<T>(t)).first;
+    }
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator emplace_hint(const_iterator /*hint*/, KeyType && key, T && t)
+    {
+        return emplace(std::forward<KeyType>(key), std::forward<T>(t)).first;
+    }
+
+    // erase
+    size_type erase(const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        if (it == m_index.end())
+        {
+            return 0;
+        }
+        m_list.erase(it->second);
+        m_index.erase(it);
+        return 1;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type erase(KeyType && key)
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        if (it == m_index.end())
+        {
+            return 0;
+        }
+        m_list.erase(it->second);
+        m_index.erase(it);
+        return 1;
+    }
+
+    iterator erase(iterator pos)
+    {
+        auto hit = m_index.find(key_ref(pos->first));
+        if (hit != m_index.end())
+        {
+            m_index.erase(hit);
+        }
+        list_iterator next = m_list.erase(pos.base());
+        return iterator(next);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        auto hit = m_index.find(key_ref(pos->first));
+        if (hit != m_index.end())
+        {
+            m_index.erase(hit);
+        }
+        list_iterator next = m_list.erase(pos.base());
+        return iterator(next);
+    }
+
+    iterator erase(iterator first, iterator last)
+    {
+        for (iterator it = first; it != last; ++it)
+        {
+            auto hit = m_index.find(key_ref(it->first));
+            if (hit != m_index.end())
+            {
+                m_index.erase(hit);
+            }
+        }
+        list_iterator ret = m_list.erase(first.base(), last.base());
+        return iterator(ret);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        for (const_iterator it = first; it != last; ++it)
+        {
+            auto hit = m_index.find(key_ref(it->first));
+            if (hit != m_index.end())
+            {
+                m_index.erase(hit);
+            }
+        }
+        list_iterator ret = m_list.erase(first.base(), last.base());
+        return iterator(ret);
+    }
+
+    // lookup
+    size_type count(const Key& key) const
+    {
+        return static_cast<size_type>(m_index.count(key_ref(key)));
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type count(KeyType && key) const
+    {
+        key_type k(std::forward<KeyType>(key));
+        return static_cast<size_type>(m_index.count(key_ref(k)));
+    }
+
+    iterator find(const Key& key)
+    {
+        auto it = m_index.find(key_ref(key));
+        return (it == m_index.end()) ? iterator(m_list.end()) : iterator(it->second);
+    }
+
+    const_iterator find(const Key& key) const
+    {
+        auto it = m_index.find(key_ref(key));
+        return (it == m_index.end()) ? const_iterator(m_list.end()) : const_iterator(it->second);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator find(KeyType && key)
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        return (it == m_index.end()) ? iterator(m_list.end()) : iterator(it->second);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const_iterator find(KeyType && key) const
+    {
+        key_type k(std::forward<KeyType>(key));
+        auto it = m_index.find(key_ref(k));
+        return (it == m_index.end()) ? const_iterator(m_list.end()) : const_iterator(it->second);
+    }
+
+    // comparison (preserve vector-like sequence comparison)
+    friend bool operator==(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return lhs.m_list == rhs.m_list;
+    }
+    friend bool operator!=(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return !(lhs == rhs);
+    }
+    friend bool operator<(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return std::lexicographical_compare(lhs.m_list.begin(), lhs.m_list.end(),
+                                            rhs.m_list.begin(), rhs.m_list.end());
+    }
+    friend bool operator>(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return rhs < lhs;
+    }
+    friend bool operator<=(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return !(rhs < lhs);
+    }
+    friend bool operator>=(const ordered_map& lhs, const ordered_map& rhs)
+    {
+        return !(lhs < rhs);
+    }
+
+    // swap
+    void swap(ordered_map& other) noexcept
+    {
+        m_list.swap(other.m_list);
+        m_index.swap(other.m_index);
+    }
+    friend void swap(ordered_map& a, ordered_map& b) noexcept
+    {
+        a.swap(b);
+    }
 };
 
 NLOHMANN_JSON_NAMESPACE_END

--- a/tests/src/unit-ordered-json-performance.cpp
+++ b/tests/src/unit-ordered-json-performance.cpp
@@ -1,0 +1,245 @@
+//
+// Created by Andrea Cocito on 05/10/25.
+//
+#include "doctest.h"
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if defined(__APPLE__)
+    #include <mach/mach.h>
+    #include <sys/resource.h>
+#elif defined(__unix__) || defined(__linux__)
+    #include <sys/resource.h>
+    #include <unistd.h>
+#endif
+
+using nlohmann::ordered_json;
+
+namespace
+{
+
+// ---- timing & memory helpers ------------------------------------------------
+
+using clock_tp = std::chrono::steady_clock::time_point;
+
+inline clock_tp now()
+{
+    return std::chrono::steady_clock::now();
+}
+
+struct CpuTimes
+{
+    long long user_us = 0;
+    long long sys_us  = 0;
+};
+
+inline CpuTimes cpu_now()
+{
+    CpuTimes t{};
+#if defined(__APPLE__) || defined(__unix__) || defined(__linux__)
+    rusage ru {};
+    getrusage(RUSAGE_SELF, &ru);
+    t.user_us = static_cast<long long>(ru.ru_utime.tv_sec) * 1000000LL + ru.ru_utime.tv_usec;
+    t.sys_us  = static_cast<long long>(ru.ru_stime.tv_sec) * 1000000LL + ru.ru_stime.tv_usec;
+#endif
+    return t;
+}
+
+inline std::size_t current_rss_bytes()
+{
+#if defined(__APPLE__)
+    mach_task_basic_info info {};
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &count) == KERN_SUCCESS)
+    {
+        return static_cast<std::size_t>(info.resident_size);
+    }
+    return 0;
+#elif defined(__linux__)
+    // ru_maxrss is in kilobytes on Linux — it's *peak* RSS, not current.
+    rusage ru{};
+    getrusage(RUSAGE_SELF, &ru);
+    return static_cast<std::size_t>(ru.ru_maxrss) * 1024ULL;
+#elif defined(__unix__)
+    // Fallback POSIX: ru_maxrss unit is implementation-defined. Treat as bytes if huge, else KB.
+    rusage ru{};
+    getrusage(RUSAGE_SELF, &ru);
+    std::size_t v = static_cast<std::size_t>(ru.ru_maxrss);
+    if (v < (1ULL << 20))
+    {
+        v *= 1024ULL;    // heuristic: likely KB
+    }
+    return v;
+#else
+    return 0; // unsupported platform
+#endif
+}
+
+inline std::string fmt_bytes(std::size_t b)
+{
+    const char* units[] = {"B", "KiB", "MiB", "GiB", "TiB"};
+    double val = static_cast<double>(b);
+    int u = 0;
+    while (val >= 1024.0 && u < 4)
+    {
+        val /= 1024.0;
+        ++u;
+    }
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2) << val << ' ' << units[u];
+    return oss.str();
+}
+
+struct PhaseTimer
+{
+    clock_tp  w0 = now();
+    CpuTimes  c0 = cpu_now();
+    std::size_t rss0 = current_rss_bytes();
+
+    void print(const char* label)
+    {
+        auto w1 = now();
+        CpuTimes c1 = cpu_now();
+        std::size_t rss1 = current_rss_bytes();
+
+        const double wall_ms = std::chrono::duration<double, std::milli>(w1 - w0).count();
+        const double cpu_ms  = static_cast<double>((c1.user_us - c0.user_us) + (c1.sys_us - c0.sys_us)) / 1000.0;
+
+        std::cout << std::left << std::setw(28) << label
+                  << " | wall: " << std::setw(10) << std::fixed << std::setprecision(3) << wall_ms << " ms"
+                  << " | cpu: "  << std::setw(10) << std::fixed << std::setprecision(3) << cpu_ms  << " ms"
+                  << " | RSS: "  << fmt_bytes(rss1)
+#if !defined(__APPLE__)
+                  << " (peak on this platform)"
+#endif
+                  << '\n';
+        // reset for next phase
+        w0 = w1;
+        c0 = c1;
+        rss0 = rss1;
+    }
+};
+
+// ---- random data helpers ----------------------------------------------------
+
+inline std::string random_hex32(std::mt19937_64& rng)
+{
+    static const char* hex = "0123456789abcdef";
+    // 16 random bytes -> 32 hex chars
+    char out[32];
+    for (int i = 0; i < 4; ++i)
+    {
+        uint64_t x = rng();
+        // take 16 hex chars from 64 bits (we need 32 total -> 4*8 nibbles)
+        for (int n = 0; n < 8; ++n)
+        {
+            out[i * 8 + (7 - n)] = hex[(x & 0xFULL)];
+            x >>= 4;
+        }
+    }
+    return std::string(out, out + 32);
+}
+
+inline std::vector<std::string> make_keys(std::size_t N, std::mt19937_64& rng)
+{
+    std::vector<std::string> v;
+    v.reserve(N);
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        v.push_back(random_hex32(rng));
+    }
+    return v;
+}
+
+inline std::vector<std::size_t> shuffled_indices(std::size_t N, std::mt19937_64& rng)
+{
+    std::vector<std::size_t> idx(N);
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        idx[i] = i;
+    }
+    std::shuffle(idx.begin(), idx.end(), rng);
+    return idx;
+}
+
+} // namespace
+
+TEST_CASE("ordered_map perf: fill, access, erase")
+{
+    // N: default 20000; override with env NLOHMANN_OM_BENCH_N
+    std::size_t N = 20000;
+    if (const char* env = std::getenv("NLOHMANN_OM_BENCH_N"))
+    {
+        try
+        {
+            N = static_cast<std::size_t>(std::stoull(env));
+        }
+        catch (...) { /* keep default */ }
+    }
+    // RNG seed: fixed by default for repeatability; override with env NLOHMANN_OM_BENCH_SEED
+    uint64_t seed = 0xC0FFEE123456789ULL;
+    if (const char* s = std::getenv("NLOHMANN_OM_BENCH_SEED"))
+    {
+        try
+        {
+            seed = std::stoull(s);
+        }
+        catch (...) {}
+    }
+    std::mt19937_64 rng(seed);
+
+    std::cout << "[ordered_map perf] N=" << N << "  seed=" << seed << "\n";
+
+    PhaseTimer T;
+
+    // (a) make base keys and 3 random orders
+    auto keys   = make_keys(N, rng);
+    auto order1 = shuffled_indices(N, rng);
+    auto order2 = shuffled_indices(N, rng);
+    auto order3 = shuffled_indices(N, rng);
+    T.print("a) generated keys & shuffles");
+
+    // (b) fill ordered_json j with j[keys[order1[i]]] = i
+    ordered_json j = ordered_json::object();
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        j[keys[order1[i]]] = static_cast<int>(i);
+    }
+    // sanity
+    CHECK(j.size() == N);
+    T.print("b) filled object");
+
+    // (c) access in random order and sum results
+    volatile std::uint64_t sum = 0;
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        const auto& k = keys[order2[i]];
+        sum += static_cast<std::uint64_t>(j[k].get<int>());
+    }
+    // keep compiler from optimizing away
+    std::cout << "    sum=" << sum << "\n";
+    T.print("c) random access");
+
+    // (d) erase in random order
+    std::size_t removed = 0;
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        const auto& k = keys[order3[i]];
+        removed += j.erase(k);
+    }
+    CHECK(removed == N);
+    CHECK(j.empty());
+    T.print("d) random erase");
+}

--- a/tests/src/unit-ordered-map-2.cpp
+++ b/tests/src/unit-ordered-map-2.cpp
@@ -1,0 +1,310 @@
+// tests/src/unit-ordered-map-2.cpp
+//
+// Extra tests for nlohmann::ordered_map – aims to exercise all public API
+// paths we rely on (C++11), including iterator arithmetic and exception
+// safety.  This file intentionally does NOT define a doctest main
+// (the project already provides one).
+
+#include "doctest.h"
+
+#include <nlohmann/ordered_map.hpp>
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <stdexcept>
+
+// ---------- Throwing key to exercise strong-exception-safety paths ----------
+struct ThrowingKey
+{
+    std::string s;
+    static bool inject; // toggled by tests
+
+    ThrowingKey() = default;
+    /* implicit */ ThrowingKey(const char* cs) : s(cs) {}
+    explicit ThrowingKey(std::string v) : s(std::move(v)) {}
+
+    bool operator==(const ThrowingKey& o) const noexcept
+    {
+        return s == o.s;
+    }
+    bool operator!=(const ThrowingKey& o) const noexcept
+    {
+        return !(*this == o);
+    }
+};
+
+bool ThrowingKey::inject = false;
+
+namespace std
+{
+template<> struct hash<ThrowingKey>
+{
+    size_t operator()(const ThrowingKey& k) const
+    {
+#ifndef JSON_NOEXCEPTION
+        if (ThrowingKey::inject)
+        {
+            throw std::bad_alloc();
+        }
+#endif
+        return std::hash<std::string> {}(k.s);
+    }
+};
+template<> struct equal_to<ThrowingKey>
+{
+    bool operator()(const ThrowingKey& a, const ThrowingKey& b) const noexcept
+    {
+        return a.s == b.s;
+    }
+};
+} // namespace std
+
+// ---------- aliases ----------
+using OM  = nlohmann::ordered_map<std::string, int>;
+using VP  = std::pair<const std::string, int>;
+using OMX = nlohmann::ordered_map<ThrowingKey, int>;
+
+TEST_CASE("ordered_map: basic construction, capacity, element access")
+{
+    OM m;
+    CHECK(m.empty());
+    CHECK(m.size() == 0);
+
+    // operator[] default insert and update
+    m["a"] = 1;
+    m["b"] = 2;
+    CHECK_FALSE(m.empty());
+    CHECK(m.size() == 2);
+    CHECK(m["a"] == 1);
+    CHECK(m["b"] == 2);
+
+    // overwrite existing
+    m["a"] = 3;
+    CHECK(m["a"] == 3);
+    CHECK(m.size() == 2);
+
+    // at()
+    CHECK(m.at("b") == 2);
+#ifndef JSON_NOEXCEPTION
+    CHECK_THROWS_AS(m.at("zzz"), std::out_of_range);
+#endif
+
+    // initializer-list and range constructor
+    OM m2{{"x", 7}, {"y", 8}};
+    CHECK(m2.size() == 2);
+    std::vector<VP> v{{VP{"q", 1}}, {VP{"w", 2}}};
+    OM m3(v.begin(), v.end());
+    CHECK(m3.size() == 2);
+
+    // copy / move construction (rebuild_index under the hood)
+    OM mc(m);
+    CHECK(mc.size() == m.size());
+    CHECK(mc.find("a") != mc.end());
+    OM mm(std::move(m2));
+    CHECK(mm.size() == 2);
+    CHECK(mm.find("x") != mm.end());
+    CHECK(mm.find("y") != mm.end());
+
+    // move assignment (uses move + rebuild)
+    OM mz;
+    mz = std::move(mm);
+    CHECK(mz.size() == 2);
+    CHECK(mz.find("x") != mz.end());
+    CHECK(mz.find("y") != mz.end());
+
+    // const operator[]
+    const OM& cm = mc;
+    CHECK(cm["a"] == 3);
+
+    // begin/end iteration order
+    {
+        OM seq;
+        seq["a"] = 1;
+        seq["b"] = 2;
+        seq["c"] = 3;
+
+        auto it = seq.begin();
+        CHECK(it->first == "a");
+        ++it;
+        CHECK(it->first == "b");
+        ++it;
+        CHECK(it->first == "c");
+        ++it;
+        CHECK(it == seq.end());
+
+        // const_iterator
+        const OM& cseq = seq;
+        auto cit = cseq.begin();
+        CHECK(cit->first == "a");
+        ++cit;
+        CHECK(cit->first == "b");
+        ++cit;
+        CHECK(cit->first == "c");
+        ++cit;
+        CHECK(cit == cseq.end());
+
+        // iterator arithmetic (+ and +=) – O(n), provided for test compatibility
+        it = seq.begin();
+        CHECK((it + 1)->first == "b");
+        it += 2;
+        CHECK(it->first == "c");
+
+        // reverse iterators
+        auto rit = seq.rbegin();
+        CHECK(rit->first == "c");
+        ++rit;
+        CHECK(rit->first == "b");
+        ++rit;
+        CHECK(rit->first == "a");
+        ++rit;
+        CHECK(rit == seq.rend());
+    }
+}
+
+TEST_CASE("ordered_map: insert/emplace, find/count, erase variants, swap/clear, comparisons")
+{
+    OM om;
+
+    // insert(value) (new key) and duplicate insert
+    auto p1 = om.insert(VP{"a", 1});
+    CHECK(p1.second == true);
+    CHECK(p1.first->first == "a");
+    auto p1b = om.insert(VP{"a", 111});
+    CHECK(p1b.second == false);
+    CHECK(p1b.first->second == 1);
+
+    // insert(rvalue)
+    auto p2 = om.insert(VP{"b", 2});
+    CHECK(p2.second);
+    CHECK(om.size() == 2);
+
+    // hint overloads (ignored)
+    auto itb = om.insert(om.begin(), VP{"c", 3});
+    CHECK(itb->first == "c");
+    CHECK(om.size() == 3);
+
+    // range insert + push_back – also exercises reserve_index_for_range(forward)
+    std::vector<VP> more = {VP{"d", 4}, VP{"e", 5}, VP{"f", 6}};
+    om.insert(more.begin(), more.end());
+    CHECK(om.size() == 6);
+    om.push_back(VP{"g", 7});
+    CHECK(om.size() == 7);
+
+    // emplace and emplace_hint (hint ignored)
+    auto e1 = om.emplace(std::string("h"), 8);
+    CHECK(e1.second);
+    CHECK(om.size() == 8);
+    auto eh = om.emplace_hint(om.begin(), std::string("i"), 9);
+    CHECK(eh->first == "i");
+    CHECK(om.size() == 9);
+
+    // find / count
+    CHECK(om.count("a") == 1);
+    CHECK(om.find("a") != om.end());
+    CHECK(om.count("zzz") == 0);
+    CHECK(om.find("zzz") == om.end());
+
+    // erase by key (present / absent)
+    CHECK(om.erase("b") == 1);
+    CHECK(om.erase("b") == 0);
+    CHECK(om.find("b") == om.end());
+
+    // erase by iterator (returns next)
+    auto ita = om.find("a");
+    auto next = om.erase(ita);
+    CHECK(next != om.end());
+    CHECK(next->first != "a");
+    CHECK(om.find("a") == om.end());
+
+    // erase by const_iterator
+    const OM& com = om;
+    auto itc = com.find("c");
+    auto after = om.erase(itc);
+    CHECK(after != om.end());
+    CHECK(om.find("c") == om.end());
+
+    // erase range
+    auto first = om.begin();
+    auto last  = om.begin();
+    last += 2; // erase two items if present
+    om.erase(first, last);
+    // size reduced by two (when possible – map had at least 4 elements here)
+    CHECK(om.size() >= 3);
+
+    // swap
+    OM a{{"a", 1}, {"b", 2}};
+    OM b{{"a", 1}, {"c", 2}};
+    a.swap(b);
+    CHECK(a.find("c") != a.end());
+    CHECK(b.find("b") != b.end());
+
+    // clear
+    a.clear();
+    CHECK(a.empty());
+
+    // comparisons (lexicographic on insertion order)
+    OM x{{"a", 1}, {"b", 2}};
+    OM y{{"a", 1}, {"c", 2}};
+    CHECK(x != y);
+    CHECK_UNARY( (x < y) || (y < x) );    // one must be less
+    CHECK_UNARY( (x <= y) || (y <= x) );
+    CHECK_UNARY( (x >= y) || (y >= x) );
+}
+
+TEST_CASE("ordered_map: strong exception safety on operator[]/insert/emplace (hash throws)")
+{
+#ifndef JSON_NOEXCEPTION
+    OMX om;
+    om.emplace(ThrowingKey{"ok1"}, 1);
+    om.emplace(ThrowingKey{"ok2"}, 2);
+    const auto before_size = om.size();
+
+    // operator[] path
+    ThrowingKey::inject = true;
+    CHECK_THROWS_AS( (void)om[ThrowingKey{"boom"}], std::bad_alloc );
+    ThrowingKey::inject = false;
+    CHECK(om.size() == before_size);
+    CHECK(om.find(ThrowingKey{"ok1"}) != om.end());
+    CHECK(om.find(ThrowingKey{"ok2"}) != om.end());
+    CHECK(om.find(ThrowingKey{"boom"}) == om.end());
+
+    // insert(value) path
+    ThrowingKey::inject = true;
+    CHECK_THROWS_AS( (void)om.insert( std::make_pair(ThrowingKey{"boom2"}, 3) ), std::bad_alloc );
+    ThrowingKey::inject = false;
+    CHECK(om.size() == before_size);
+    CHECK(om.find(ThrowingKey{"boom2"}) == om.end());
+
+    // emplace path
+    ThrowingKey::inject = true;
+    CHECK_THROWS_AS( (void)om.emplace(ThrowingKey{"boom3"}, 4), std::bad_alloc );
+    ThrowingKey::inject = false;
+    CHECK(om.size() == before_size);
+    CHECK(om.find(ThrowingKey{"boom3"}) == om.end());
+#endif
+}
+
+TEST_CASE("ordered_map: const overloads and reverse iteration")
+{
+    OM m{{"a", 1}, {"b", 2}, {"c", 3}};
+    const OM& cm = m;
+
+    CHECK(cm.find("a") != cm.end());
+    CHECK(cm.count("x") == 0);
+    CHECK(cm.at("b") == 2);
+
+#ifndef JSON_NOEXCEPTION
+    CHECK_THROWS_AS(cm.at("nope"), std::out_of_range);
+#endif
+
+    // reverse const iteration
+    auto rcit = cm.rbegin();
+    CHECK(rcit->first == "c");
+    ++rcit;
+    CHECK(rcit->first == "b");
+    ++rcit;
+    CHECK(rcit->first == "a");
+    ++rcit;
+    CHECK(rcit == cm.rend());
+}


### PR DESCRIPTION
This is a re-implementation of ordered_map. 

Besides adding a couple unit-tests the only changed "production" file is ordered_map.hpp
The new implementation uses an std::list to store the pair<key,value> entries, plus a std::unordered_map<Key*, list::iterator> for lookup.

- Changes in detail

WHAT:
The new implementation is not a subclass of vector<>neither of map<>, thus does not "automatically" expose all methods supported by them; however the following have been implemented:
- All methods of map<> except those strictly related to ordering and those introduced after C++11; this is all the main library depends on (Also reverse iterators and other stuff missing in the previous ordered_map<>).
- Some methods actually unused by the library but used by the old unit tests have been implemented aswell (iterator+int), here not taking care of performance for obvious reasons

WHY: 
See considerations and performance tests below *.

- If applicable, an existing issue is referenced.
- 
All this starts from https://github.com/nlohmann/json/discussions/3469; I proposed an approach in which we have a "json::pointer" subclass that can be used as an iterator to walk through the tree; I have the code almost ready but this code relies on three things to be "efficient": 
a. json::pointer syntax/manipulation (PR #4860)
b. json::pointer object ( a very simple PR, coming soon, which simply makes json pointers internals to use a list instead of a vector, that's a four-line patch).
c. object access by "key" (This PR)

I decided to propose four separate PRs, one for each of the above and one for the "three walking pointer/itertor"; to make things clear none of these four PRs "depends" on any of the other 3 to work, it's just a matter of performance/optimization: using the forecoming tree walker without these changes can cause severe performance issues.

- Code coverage (https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
I added a unit-ordered-map-2.cpp which SHOULD cover all the code, coverall will tell, in case it's needed I'll act properly. For the sake of safety I left the previous coverage test untouched.

- If applicable, the [documentation](https://json.nlohmann.me) is updated.

As it's all "internal" this is probably not needed; main class has doxygen-style comments; if anything else is needed let me know.

- The source code is amalgamated by running `make amalgamate`.

Sure.

*) Performance.

I have also added a quick unit-ordered-json-performance.cpp unit; needless to say the new implementation wins hands down on "big" objects (from hundreds of members above), the change for 64K keys in an object is orders of magnitude without noticeable impact on memory usage.

For "small" objects there is a marginal memory impact (in my calculations about 8 pointers per key in total) with an advantage in reduced memory fragmentation (appending to the tail of a vector is the root of all memory storms in C++...).

See below some comparison between "old" and "new" implementation.

Point is that there are two practical uses of this library in my experience: "document like" collections and "data"; for "document like" stuff this implementation does not change much (we are in a range where it is really hard to make performance comparisons); for "data" this makes a change, even just the current unit-unicode* unit tests would take forever with the old ordered_map stuff.

Using "inefficient" approaches (in terms of complexity) behind the scenes exposes to serious risks every time you expose a new feature; say the "three walker" thing gets in and one thinks <<Nice, let me iterate over this ten-thousand {"uuid": {object}, ...}>> and set X to Y in every object... if that's ordered_json with the current implementation the time complexity explodes.

Once again: The last PR I will propose for the three like iterator does not "depend" formally in any way from PR3469, from this one or the one I am about to post for json_iterator as std::list; nor any of these 3 depends on the othe two; it's just that I would not use the tree iterator withOUT the other 3 optimizations.

```
/// OLD implementation C++11
blackye@undici:~/tmp/json export NLOHMANN_OM_BENCH_N=32768 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=32768  seed=869193496018642825
a) generated keys & shuffles | wall: 7.111      ms | cpu: 7.111      ms | RSS: 4.38 MiB
b) filled object             | wall: 1058.353   ms | cpu: 1058.340   ms | RSS: 8.45 MiB
    sum=536854528
c) random access             | wall: 1026.345   ms | cpu: 1026.329   ms | RSS: 8.45 MiB
d) random erase              | wall: 7102.973   ms | cpu: 7102.946   ms | RSS: 8.47 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/tmp/json export NLOHMANN_OM_BENCH_N=65536 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=65536  seed=869193496018642825
a) generated keys & shuffles | wall: 13.227     ms | cpu: 13.227     ms | RSS: 7.38 MiB
b) filled object             | wall: 4180.156   ms | cpu: 4180.050   ms | RSS: 15.47 MiB
    sum=2147450880
c) random access             | wall: 4119.692   ms | cpu: 4119.667   ms | RSS: 15.47 MiB
d) random erase              | wall: 32022.963  ms | cpu: 32022.774  ms | RSS: 15.50 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/tmp/json export NLOHMANN_OM_BENCH_N=130072 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=130072  seed=869193496018642825
a) generated keys & shuffles | wall: 24.858     ms | cpu: 24.859     ms | RSS: 13.31 MiB
b) filled object             | wall: 16857.965  ms | cpu: 16852.024  ms | RSS: 30.03 MiB
    sum=8459297556
c) random access             | wall: 16787.402  ms | cpu: 16787.260  ms | RSS: 30.03 MiB
d) random erase              | wall: 119044.936 ms | cpu: 118960.874 ms | RSS: 34.34 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/tmp/json export NLOHMANN_OM_BENCH_N=32 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=32  seed=869193496018642825
a) generated keys & shuffles | wall: 0.034      ms | cpu: 0.034      ms | RSS: 1.53 MiB
b) filled object             | wall: 0.035      ms | cpu: 0.035      ms | RSS: 1.55 MiB
    sum=496
c) random access             | wall: 0.021      ms | cpu: 0.020      ms | RSS: 1.55 MiB
d) random erase              | wall: 0.030      ms | cpu: 0.030      ms | RSS: 1.55 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/tmp/json export NLOHMANN_OM_BENCH_N=16 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=16  seed=869193496018642825
a) generated keys & shuffles | wall: 0.013      ms | cpu: 0.012      ms | RSS: 1.38 MiB
b) filled object             | wall: 0.028      ms | cpu: 0.029      ms | RSS: 1.39 MiB
    sum=120
c) random access             | wall: 0.016      ms | cpu: 0.016      ms | RSS: 1.39 MiB
d) random erase              | wall: 0.015      ms | cpu: 0.014      ms | RSS: 1.39 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/tmp/json 

/// ... and using C++23 (OLD implementation)
test 57
    Start 57: test-ordered-json-performance_cpp11

57: Test command: /Users/blackye/tmp/json/build-cxx23/tests/test-ordered-json-performance_cpp11 "--no-skip"
57: Working Directory: /Users/blackye/tmp/json
57: Test timeout computed to be: 1500
57: [doctest] doctest version is "2.4.12"
57: [doctest] run with "--help" for options
57: [ordered_map perf] N=4  seed=869193496018642825
57: a) generated keys & shuffles | wall: 0.003      ms | cpu: 0.003      ms | RSS: 1.38 MiB
57: b) filled object             | wall: 0.007      ms | cpu: 0.007      ms | RSS: 1.39 MiB
57:     sum=6
57: c) random access             | wall: 0.003      ms | cpu: 0.003      ms | RSS: 1.39 MiB
57: d) random erase              | wall: 0.003      ms | cpu: 0.003      ms | RSS: 1.39 MiB
57: ===============================================================================
57: [doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
57: [doctest] assertions: 3 | 3 passed | 0 failed |
57: [doctest] Status: SUCCESS!
2/2 Test #57: test-ordered-json-performance_cpp11 ...   Passed    0.00 sec

The following tests passed:
	download_test_data
	test-ordered-json-performance_cpp11

100% tests passed, 0 tests failed out of 2

Label Time Summary:
all    =   0.00 sec*proc (1 test)

Total Test time (real) =   0.12 sec

//---
test 57
    Start 57: test-ordered-json-performance_cpp11

57: Test command: /Users/blackye/tmp/json/build-cxx23/tests/test-ordered-json-performance_cpp11 "--no-skip"
57: Working Directory: /Users/blackye/tmp/json
57: Test timeout computed to be: 1500
57: [doctest] doctest version is "2.4.12"
57: [doctest] run with "--help" for options
57: [ordered_map perf] N=130072  seed=869193496018642825
57: a) generated keys & shuffles | wall: 9.284      ms | cpu: 9.279      ms | RSS: 13.31 MiB
57: b) filled object             | wall: 16700.414  ms | cpu: 16700.232  ms | RSS: 31.12 MiB
57:     sum=8459297556
57: c) random access             | wall: 16784.313  ms | cpu: 16784.221  ms | RSS: 31.12 MiB
57: d) random erase              | wall: 120201.214 ms | cpu: 120053.619 ms | RSS: 34.44 MiB
57: ===============================================================================
57: [doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
57: [doctest] assertions: 3 | 3 passed | 0 failed |
57: [doctest] Status: SUCCESS!
2/2 Test #57: test-ordered-json-performance_cpp11 ...   Passed  153.70 sec

The following tests passed:
	download_test_data
	test-ordered-json-performance_cpp11

100% tests passed, 0 tests failed out of 2

Label Time Summary:
all    = 153.70 sec*proc (1 test)

Total Test time (real) = 153.83 sec

// ************************* //

/// NEW implementation C++11
blackye@undici:~/json export NLOHMANN_OM_BENCH_N=32768 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=32768  seed=869193496018642825
a) generated keys & shuffles | wall: 7.543      ms | cpu: 7.508      ms | RSS: 4.45 MiB
b) filled object             | wall: 7.107      ms | cpu: 7.049      ms | RSS: 10.09 MiB
    sum=536854528
c) random access             | wall: 4.663      ms | cpu: 4.664      ms | RSS: 10.09 MiB
d) random erase              | wall: 7.795      ms | cpu: 7.738      ms | RSS: 10.09 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/json export NLOHMANN_OM_BENCH_N=65536 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=65536  seed=869193496018642825
a) generated keys & shuffles | wall: 13.854     ms | cpu: 13.843     ms | RSS: 7.48 MiB
b) filled object             | wall: 25.389     ms | cpu: 25.279     ms | RSS: 18.33 MiB
    sum=2147450880
c) random access             | wall: 22.872     ms | cpu: 22.834     ms | RSS: 18.34 MiB
d) random erase              | wall: 24.552     ms | cpu: 24.528     ms | RSS: 18.34 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/json export NLOHMANN_OM_BENCH_N=130072 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=130072  seed=869193496018642825
a) generated keys & shuffles | wall: 24.475     ms | cpu: 24.475     ms | RSS: 13.44 MiB
b) filled object             | wall: 50.777     ms | cpu: 50.777     ms | RSS: 34.55 MiB
    sum=8459297556
c) random access             | wall: 36.487     ms | cpu: 36.477     ms | RSS: 34.55 MiB
d) random erase              | wall: 50.337     ms | cpu: 50.332     ms | RSS: 34.56 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/json export NLOHMANN_OM_BENCH_N=32 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=32  seed=869193496018642825
a) generated keys & shuffles | wall: 0.024      ms | cpu: 0.024      ms | RSS: 1.39 MiB
b) filled object             | wall: 0.048      ms | cpu: 0.048      ms | RSS: 1.41 MiB
    sum=496
c) random access             | wall: 0.018      ms | cpu: 0.017      ms | RSS: 1.41 MiB
d) random erase              | wall: 0.015      ms | cpu: 0.015      ms | RSS: 1.41 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/json export NLOHMANN_OM_BENCH_N=16 ; ./build/tests/test-ordered-json-performance_cpp11 --no-skip
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
[ordered_map perf] N=16  seed=869193496018642825
a) generated keys & shuffles | wall: 0.053      ms | cpu: 0.053      ms | RSS: 1.53 MiB
b) filled object             | wall: 0.048      ms | cpu: 0.047      ms | RSS: 1.56 MiB
    sum=120
c) random access             | wall: 0.020      ms | cpu: 0.020      ms | RSS: 1.56 MiB
d) random erase              | wall: 0.016      ms | cpu: 0.017      ms | RSS: 1.56 MiB
===============================================================================
[doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
[doctest] assertions: 3 | 3 passed | 0 failed |
[doctest] Status: SUCCESS!
blackye@undici:~/json 

/// ... and using C++23 (NEW implementation)
test 57
    Start 57: test-ordered-json-performance_cpp11

57: Test command: /Users/blackye/json/build-cxx23/tests/test-ordered-json-performance_cpp11 "--no-skip"
57: Working Directory: /Users/blackye/json
57: Test timeout computed to be: 1500
57: [doctest] doctest version is "2.4.12"
57: [doctest] run with "--help" for options
57: [ordered_map perf] N=4  seed=869193496018642825
57: a) generated keys & shuffles | wall: 0.003      ms | cpu: 0.003      ms | RSS: 1.38 MiB
57: b) filled object             | wall: 0.006      ms | cpu: 0.006      ms | RSS: 1.38 MiB
57:     sum=6
57: c) random access             | wall: 0.003      ms | cpu: 0.003      ms | RSS: 1.38 MiB
57: d) random erase              | wall: 0.003      ms | cpu: 0.002      ms | RSS: 1.38 MiB
57: ===============================================================================
57: [doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
57: [doctest] assertions: 3 | 3 passed | 0 failed |
57: [doctest] Status: SUCCESS!
2/2 Test #57: test-ordered-json-performance_cpp11 ...   Passed    0.00 sec

The following tests passed:
	download_test_data
	test-ordered-json-performance_cpp11

100% tests passed, 0 tests failed out of 2

Label Time Summary:
all    =   0.00 sec*proc (1 test)

Total Test time (real) =   0.12 sec

//---
test 57
    Start 57: test-ordered-json-performance_cpp11

57: Test command: /Users/blackye/json/build-cxx23/tests/test-ordered-json-performance_cpp11 "--no-skip"
57: Working Directory: /Users/blackye/json
57: Test timeout computed to be: 1500
57: [doctest] doctest version is "2.4.12"
57: [doctest] run with "--help" for options
57: [ordered_map perf] N=130072  seed=869193496018642825
57: a) generated keys & shuffles | wall: 9.347      ms | cpu: 9.342      ms | RSS: 13.42 MiB
57: b) filled object             | wall: 28.416     ms | cpu: 28.417     ms | RSS: 34.55 MiB
57:     sum=8459297556
57: c) random access             | wall: 34.393     ms | cpu: 34.389     ms | RSS: 34.55 MiB
57: d) random erase              | wall: 46.727     ms | cpu: 46.723     ms | RSS: 34.55 MiB
57: ===============================================================================
57: [doctest] test cases: 1 | 1 passed | 0 failed | 0 skipped
57: [doctest] assertions: 3 | 3 passed | 0 failed |
57: [doctest] Status: SUCCESS!
2/2 Test #57: test-ordered-json-performance_cpp11 ...   Passed    0.12 sec

The following tests passed:
	download_test_data
	test-ordered-json-performance_cpp11

100% tests passed, 0 tests failed out of 2

Label Time Summary:
all    =   0.12 sec*proc (1 test)

Total Test time (real) =   0.24 sec


```


