### PR TITLE
Enable string_view keys in operator[] by updating is_usable_as_basic_json_key_type (#3912)

### DIFF
--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -621,11 +621,14 @@ using is_usable_as_key_type = typename std::conditional <
 template<typename BasicJsonType, typename KeyTypeCVRef, bool RequireTransparentComparator = true,
          bool ExcludeObjectKeyType = RequireTransparentComparator, typename KeyType = uncvref_t<KeyTypeCVRef>>
 using is_usable_as_basic_json_key_type = typename std::conditional <
-    is_usable_as_key_type<typename BasicJsonType::object_comparator_t,
-    typename BasicJsonType::object_t::key_type, KeyTypeCVRef,
-    RequireTransparentComparator, ExcludeObjectKeyType>::value
-    && !is_json_iterator_of<BasicJsonType, KeyType>::value,
-    std::true_type,
+    (is_usable_as_key_type<typename BasicJsonType::object_comparator_t,
+     typename BasicJsonType::object_t::key_type, KeyTypeCVRef,
+     RequireTransparentComparator, ExcludeObjectKeyType>::value
+     && !is_json_iterator_of<BasicJsonType, KeyType>::value)
+#ifdef JSON_HAS_CPP_17
+    || std::is_convertible<KeyType, std::string_view>::value
+#endif
+    , std::true_type,
     std::false_type >::type;
 
 template<typename ObjectType, typename KeyType>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4164,11 +4164,14 @@ using is_usable_as_key_type = typename std::conditional <
 template<typename BasicJsonType, typename KeyTypeCVRef, bool RequireTransparentComparator = true,
          bool ExcludeObjectKeyType = RequireTransparentComparator, typename KeyType = uncvref_t<KeyTypeCVRef>>
 using is_usable_as_basic_json_key_type = typename std::conditional <
-    is_usable_as_key_type<typename BasicJsonType::object_comparator_t,
-    typename BasicJsonType::object_t::key_type, KeyTypeCVRef,
-    RequireTransparentComparator, ExcludeObjectKeyType>::value
-    && !is_json_iterator_of<BasicJsonType, KeyType>::value,
-    std::true_type,
+    (is_usable_as_key_type<typename BasicJsonType::object_comparator_t,
+     typename BasicJsonType::object_t::key_type, KeyTypeCVRef,
+     RequireTransparentComparator, ExcludeObjectKeyType>::value
+     && !is_json_iterator_of<BasicJsonType, KeyType>::value)
+#ifdef JSON_HAS_CPP_17
+    || std::is_convertible<KeyType, std::string_view>::value
+#endif
+    , std::true_type,
     std::false_type >::type;
 
 template<typename ObjectType, typename KeyType>

--- a/tests/src/unit-element_access2.cpp
+++ b/tests/src/unit-element_access2.cpp
@@ -1790,3 +1790,55 @@ TEST_CASE_TEMPLATE("element access 2 (additional value() tests)", Json, nlohmann
 #endif
     }
 }
+
+#ifdef JSON_HAS_CPP_17
+TEST_CASE("operator[] with user-defined std::string_view-convertible types")
+{
+    using json = nlohmann::json;
+
+    class TestClass
+    {
+        std::string key_data_ = "foo";
+
+      public:
+        operator std::string_view() const
+        {
+            return key_data_;
+        }
+    };
+
+    struct TestStruct
+    {
+        operator std::string_view() const
+        {
+            return "bar";
+        }
+    };
+
+    json j = {{"foo", "from_class"}, {"bar", "from_struct"}};
+    TestClass foo_obj;
+    TestStruct bar_obj;
+
+    SECTION("read access")
+    {
+        CHECK(j[foo_obj] == "from_class");
+        CHECK(j[TestClass{}] == "from_class");
+        CHECK(j[bar_obj] == "from_struct");
+        CHECK(j[TestStruct{}] == "from_struct");
+    }
+
+    SECTION("write access")
+    {
+        j[TestClass{}] = "updated_class";
+        j[TestStruct{}] = "updated_struct";
+        CHECK(j["foo"] == "updated_class");
+        CHECK(j["bar"] == "updated_struct");
+
+        SECTION("direct std::string_view access")
+        {
+            CHECK(j[std::string_view{"foo"}] == "updated_class");
+            CHECK(j[std::string_view{"bar"}] == "updated_struct");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This pull request adds std::string_view support for operator[] to improve usability with modern C++ (C++17 and later). The behavior now matches the existing std::string overloads. Additionally, the exception messages were updated for consistency when operator[] is used with non-object types and a string_view key.

This change addresses and fixes issue #3912.

- [x] The changes are described in detail, both the what and why.
- [x] An existing issue is referenced (Fixes #3912).
- [x] The Code coverage remains at 100%.. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.