### PR TITLE
Add null pointer check

### DIFF
--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15802,6 +15802,9 @@ class output_string_adapter : public output_adapter_protocol<CharType>
     JSON_HEDLEY_NON_NULL(2)
     void write_characters(const CharType* s, std::size_t length) override
     {
+        if (s == nullptr) {
+        return;
+        }
         str.append(s, length);
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15803,7 +15803,7 @@ class output_string_adapter : public output_adapter_protocol<CharType>
     void write_characters(const CharType* s, std::size_t length) override
     {
         if (s == nullptr) {
-        return;
+            return;
         }
         str.append(s, length);
     }


### PR DESCRIPTION
The `write_characters` method directly calls `str.append(s, length)` without checking if `s` is null. When `s` is null and `length` is non-zero, `std::string::append()` attempts to read from the null pointer, causing the segmentation fault.