### PR TITLE
Handle 'moved' events in serve_header.py

### DIFF
--- a/tools/serve_header/serve_header.py
+++ b/tools/serve_header/serve_header.py
@@ -231,6 +231,12 @@ class WorkTrees(FileSystemEventHandler):
             elif event.event_type == 'deleted':
                 # check for deleted working trees
                 self.rescan(path)
+            elif event.event_type == 'moved':
+                # handle moved directories - treat source as deleted and dest as created
+                self.rescan(path)
+                if hasattr(event, 'dest_path'):
+                    dest_path = os.path.abspath(event.dest_path)
+                    self.created_bucket.add_dir(dest_path)
         elif event.event_type == 'closed':
             with self.tree_lock:
                 for tree in self.trees:


### PR DESCRIPTION
Fixes #3659

## Problem
The `serve_header.py` script wasn't detecting when directories were moved into or out of the monitored root directory. This made the development workflow less smooth when reorganizing projects while the server was running.

## Root Cause
The `on_any_event` handler only processed `'created'` and `'deleted'` events for directories, but file system watchers emit a separate `'moved'` event type that includes both source and destination paths.

## Solution
Added handling for `'moved'` events on directories by treating them as a combination of:
- **Delete** operation on the source path (remove any trees that were moved out)
- **Create** operation on the destination path (scan for new trees that were moved in)

This mirrors how the filesystem actually handles move operations and ensures the working tree list stays in sync.

## Testing
I tested this locally by:
1. Starting serve_header.py
2. Moving a project directory into the monitored root → now correctly detected and added
3. Moving a project directory out of the monitored root → now correctly detected and removed
4. Moving directories within the monitored root → both operations handled properly

The fix maintains backward compatibility and doesn't change behavior for other event types.