### PR TITLE
Reference tuple from json

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -474,16 +474,16 @@ auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*un
     return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
 
-template<std::size_t PTagV, typename BasicJsonType, template<typename...> class TupleT, typename... Types>
-using tuple_type = TupleT<decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types>{}, detail::priority_tag<PTagV>{}))...>;
+template<std::size_t PTagValue, typename BasicJsonType, typename... Types>
+using tuple_type = std::tuple<decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types>{}, detail::priority_tag<PTagValue>{}))...>;
 
-template<std::size_t PTagV, typename BasicJsonType, typename... Args, std::size_t... Idx>
-tuple_type<PTagV, BasicJsonType, std::tuple, Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
+template<std::size_t PTagValue, typename... Args, typename BasicJsonType, std::size_t... Idx>
+tuple_type<PTagValue, BasicJsonType, Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
 {
-    return tuple_type<PTagV, BasicJsonType, std::tuple, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args>{}, detail::priority_tag<PTagV>{})...);
+    return tuple_type<PTagValue, BasicJsonType, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args>{}, detail::priority_tag<PTagValue>{})...);
 }
 
-template<std::size_t PTagV, typename BasicJsonType>
+template<std::size_t PTagValue, typename BasicJsonType>
 std::tuple<> from_json_tuple_impl_base(BasicJsonType& /*unused*/, index_sequence<> /*unused*/)
 {
     return {};
@@ -507,13 +507,13 @@ std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tu
 {
     static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
         "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
-    return from_json_tuple_impl_base<2, BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    return from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename... Args>
 inline void from_json_tuple_impl(BasicJsonType&& j, std::tuple<Args...>& t, priority_tag<3> /*unused*/)
 {
-    t = from_json_tuple_impl_base<3, BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    t = from_json_tuple_impl_base<3, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename TupleRelated>

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -453,7 +453,7 @@ detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::iden
 }
 
 template<typename BasicJsonType, typename Type,
-         typename ConstType = detail::enable_if_t<std::is_reference<Type>::value, typename std::remove_reference<Type>::type const&>>
+         typename ConstType = typename std::remove_reference<Type>::type const&>
 auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
     -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, ConstType>
 {

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -453,23 +453,15 @@ detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::iden
 }
 
 template<typename BasicJsonType, typename Type,
-         typename ConstType = typename std::remove_reference<Type>::type const&,
-         detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, int> = 0>
-ConstType from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
-{
-    return std::forward<BasicJsonType>(j).template get_ref<ConstType>();
-}
-
-template<typename BasicJsonType, typename Type,
          detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, int> = 0>
-Type from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
+Type from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get_ref<Type>();
 }
 
 template<typename BasicJsonType, typename Type,
          detail::enable_if_t<std::is_arithmetic<uncvref_t<Type>>::value, int> = 0>
-detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
+detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
@@ -507,13 +499,13 @@ std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tu
 {
     static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
                   "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
-    return from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    return from_json_tuple_impl_base<1, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename... Args>
 inline void from_json_tuple_impl(BasicJsonType&& j, std::tuple<Args...>& t, priority_tag<3> /*unused*/)
 {
-    t = from_json_tuple_impl_base<3, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    t = from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename TupleRelated>

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -453,34 +453,34 @@ detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::iden
 }
 
 template<typename BasicJsonType, typename Type,
-         typename ConstType = typename std::remove_reference<Type>::type const&>
-auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
-    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, ConstType>
+         typename ConstType = typename std::remove_reference<Type>::type const&,
+         detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, int> = 0>
+ConstType from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get_ref<ConstType>();
 }
 
-template<typename BasicJsonType, typename Type>
-auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
-    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, Type>
+template<typename BasicJsonType, typename Type,
+         detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, int> = 0>
+Type from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get_ref<Type>();
 }
 
-template<typename BasicJsonType, typename Type>
-auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
-    -> detail::enable_if_t<std::is_arithmetic<uncvref_t<Type>>::value, detail::uncvref_t<Type>>
+template<typename BasicJsonType, typename Type,
+         detail::enable_if_t<std::is_arithmetic<uncvref_t<Type>>::value, int> = 0>
+detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
 
 template<std::size_t PTagValue, typename BasicJsonType, typename... Types>
-using tuple_type = std::tuple<decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types>{}, detail::priority_tag<PTagValue>{}))...>;
+using tuple_type = std::tuple < decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types> {}, detail::priority_tag<PTagValue> {}))... >;
 
 template<std::size_t PTagValue, typename... Args, typename BasicJsonType, std::size_t... Idx>
 tuple_type<PTagValue, BasicJsonType, Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
 {
-    return tuple_type<PTagValue, BasicJsonType, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args>{}, detail::priority_tag<PTagValue>{})...);
+    return tuple_type<PTagValue, BasicJsonType, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args> {}, detail::priority_tag<PTagValue> {})...);
 }
 
 template<std::size_t PTagValue, typename BasicJsonType>
@@ -506,7 +506,7 @@ template<typename BasicJsonType, typename... Args>
 std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tuple<Args...>> /*unused*/, priority_tag<2> /*unused*/)
 {
     static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
-        "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
+                  "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
     return from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -469,7 +469,7 @@ auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*un
 
 template<typename BasicJsonType, typename Type>
 auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
-    -> detail::enable_if_t<std::is_integral<uncvref_t<Type>>::value, detail::uncvref_t<Type>>
+    -> detail::enable_if_t<std::is_arithmetic<uncvref_t<Type>>::value, detail::uncvref_t<Type>>
 {
     return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -26,6 +26,7 @@
 #include <nlohmann/detail/meta/identity_tag.hpp>
 #include <nlohmann/detail/meta/std_fs.hpp>
 #include <nlohmann/detail/meta/type_traits.hpp>
+#include <nlohmann/detail/meta/logic.hpp>
 #include <nlohmann/detail/string_concat.hpp>
 #include <nlohmann/detail/value_t.hpp>
 
@@ -445,13 +446,44 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
     }
 }
 
-template<typename BasicJsonType, typename... Args, std::size_t... Idx>
-std::tuple<Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
+template<typename BasicJsonType, typename Type>
+detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<0> /*unused*/)
 {
-    return std::make_tuple(std::forward<BasicJsonType>(j).at(Idx).template get<Args>()...);
+    return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
 
-template<typename BasicJsonType>
+template<typename BasicJsonType, typename Type,
+         typename ConstType = detail::enable_if_t<std::is_reference<Type>::value, typename std::remove_reference<Type>::type const&>>
+auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
+    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, ConstType>
+{
+    return std::forward<BasicJsonType>(j).template get_ref<ConstType>();
+}
+
+template<typename BasicJsonType, typename Type>
+auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
+    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, Type>
+{
+    return std::forward<BasicJsonType>(j).template get_ref<Type>();
+}
+
+template<typename BasicJsonType, typename Type>
+auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
+    -> detail::enable_if_t<std::is_integral<uncvref_t<Type>>::value, detail::uncvref_t<Type>>
+{
+    return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
+}
+
+template<std::size_t PTagV, typename BasicJsonType, template<typename...> class TupleT, typename... Types>
+using tuple_type = TupleT<decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types>{}, detail::priority_tag<PTagV>{}))...>;
+
+template<std::size_t PTagV, typename BasicJsonType, typename... Args, std::size_t... Idx>
+tuple_type<PTagV, BasicJsonType, std::tuple, Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
+{
+    return tuple_type<PTagV, BasicJsonType, std::tuple, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args>{}, detail::priority_tag<PTagV>{})...);
+}
+
+template<std::size_t PTagV, typename BasicJsonType>
 std::tuple<> from_json_tuple_impl_base(BasicJsonType& /*unused*/, index_sequence<> /*unused*/)
 {
     return {};
@@ -473,13 +505,15 @@ inline void from_json_tuple_impl(BasicJsonType&& j, std::pair<A1, A2>& p, priori
 template<typename BasicJsonType, typename... Args>
 std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tuple<Args...>> /*unused*/, priority_tag<2> /*unused*/)
 {
-    return from_json_tuple_impl_base<BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
+        "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
+    return from_json_tuple_impl_base<2, BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename... Args>
 inline void from_json_tuple_impl(BasicJsonType&& j, std::tuple<Args...>& t, priority_tag<3> /*unused*/)
 {
-    t = from_json_tuple_impl_base<BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    t = from_json_tuple_impl_base<3, BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename TupleRelated>

--- a/include/nlohmann/detail/meta/logic.hpp
+++ b/include/nlohmann/detail/meta/logic.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <nlohmann/detail/macro_scope.hpp>
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+#ifdef JSON_HAS_CPP_17
+
+template<bool... Booleans>
+struct cxpr_or_impl : std::integral_constant<bool, (Booleans ||...)> {};
+
+template<bool... Booleans>
+struct cxpr_and_impl : std::integral_constant<bool, (Booleans &&...)> {};
+
+#else
+
+template<bool... Booleans>
+struct cxpr_or_impl : std::false_type {};
+
+template<bool... Booleans>
+struct cxpr_or_impl<true, Booleans...> : std::true_type {};
+
+template<bool... Booleans>
+struct cxpr_or_impl<false, Booleans...> : cxpr_or_impl<Booleans...> {};
+
+template<bool... Booleans>
+struct cxpr_and_impl : std::true_type {};
+
+template<bool... Booleans>
+struct cxpr_and_impl<true, Booleans...> : cxpr_and_impl<Booleans...> {};
+
+template<bool... Booleans>
+struct cxpr_and_impl<false, Booleans...> : std::false_type {};
+
+#endif
+
+template<class Boolean>
+struct cxpr_not : std::integral_constant<bool, !Boolean::value> {};
+
+template<class... Booleans>
+struct cxpr_or : cxpr_or_impl<Booleans::value...> {};
+
+template<bool... Booleans>
+struct cxpr_or_c : cxpr_or_impl<Booleans...> {};
+
+template<class... Booleans>
+struct cxpr_and : cxpr_and_impl<Booleans::value...> {};
+
+template<bool... Booleans>
+struct cxpr_and_c : cxpr_and_impl<Booleans...> {};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END

--- a/include/nlohmann/detail/meta/logic.hpp
+++ b/include/nlohmann/detail/meta/logic.hpp
@@ -8,10 +8,10 @@ namespace detail
 #ifdef JSON_HAS_CPP_17
 
 template<bool... Booleans>
-struct cxpr_or_impl : std::integral_constant<bool, (Booleans ||...)> {};
+struct cxpr_or_impl : std::integral_constant < bool, (Booleans || ...) > {};
 
 template<bool... Booleans>
-struct cxpr_and_impl : std::integral_constant<bool, (Booleans &&...)> {};
+struct cxpr_and_impl : std::integral_constant < bool, (Booleans &&...) > {};
 
 #else
 
@@ -36,7 +36,7 @@ struct cxpr_and_impl<false, Booleans...> : std::false_type {};
 #endif
 
 template<class Boolean>
-struct cxpr_not : std::integral_constant<bool, !Boolean::value> {};
+struct cxpr_not : std::integral_constant < bool, !Boolean::value > {};
 
 template<class... Booleans>
 struct cxpr_or : cxpr_or_impl<Booleans::value...> {};

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -559,6 +559,20 @@ template<typename BasicJsonType, typename CompatibleType>
 struct is_compatible_type
     : is_compatible_type_impl<BasicJsonType, CompatibleType> {};
 
+template<typename BasicJsonType, typename CompatibleReferenceType, typename = void>
+struct is_compatible_reference_type_impl: std::false_type {};
+
+template<typename BasicJsonType, typename CompatibleReferenceType>
+struct is_compatible_reference_type_impl <
+    BasicJsonType, CompatibleReferenceType,
+    enable_if_t<std::is_reference<CompatibleReferenceType>::value,
+                void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())>>>
+    : std::true_type {};
+
+template<typename BasicJsonType, typename CompatibleReferenceType>
+struct is_compatible_reference_type
+    : is_compatible_reference_type_impl<BasicJsonType, CompatibleReferenceType> {};
+
 template<typename T1, typename T2>
 struct is_constructible_tuple : std::false_type {};
 

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -559,15 +559,23 @@ template<typename BasicJsonType, typename CompatibleType>
 struct is_compatible_type
     : is_compatible_type_impl<BasicJsonType, CompatibleType> {};
 
-template<typename BasicJsonType, typename CompatibleReferenceType, typename = void>
-struct is_compatible_reference_type_impl: std::false_type {};
-
 template<typename BasicJsonType, typename CompatibleReferenceType>
-struct is_compatible_reference_type_impl <
-    BasicJsonType, CompatibleReferenceType,
-    enable_if_t<std::is_reference<CompatibleReferenceType>::value,
-void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())> >>
-    : std::true_type {};
+struct is_compatible_reference_type_impl
+{
+    using JsonType = uncvref_t<BasicJsonType>;
+    using CVType = typename std::remove_reference<CompatibleReferenceType>::type;
+    using Type = typename std::remove_cv<CVType>::type;
+    constexpr static bool value = std::is_reference<CompatibleReferenceType>::value &&
+                                  (!std::is_const<typename std::remove_reference<BasicJsonType>::type>::value || std::is_const<CVType>::value) &&
+                                  (std::is_same<typename JsonType::boolean_t, Type>::value ||
+                                   std::is_same<typename JsonType::number_float_t, Type>::value ||
+                                   std::is_same<typename JsonType::number_integer_t, Type>::value ||
+                                   std::is_same<typename JsonType::number_unsigned_t, Type>::value ||
+                                   std::is_same<typename JsonType::string_t, Type>::value ||
+                                   std::is_same<typename JsonType::binary_t, Type>::value ||
+                                   std::is_same<typename JsonType::object_t, Type>::value ||
+                                   std::is_same<typename JsonType::array_t, Type>::value);
+};
 
 template<typename BasicJsonType, typename CompatibleReferenceType>
 struct is_compatible_reference_type

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -566,7 +566,7 @@ template<typename BasicJsonType, typename CompatibleReferenceType>
 struct is_compatible_reference_type_impl <
     BasicJsonType, CompatibleReferenceType,
     enable_if_t<std::is_reference<CompatibleReferenceType>::value,
-                void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())>>>
+void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())> >>
     : std::true_type {};
 
 template<typename BasicJsonType, typename CompatibleReferenceType>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5356,23 +5356,15 @@ detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::iden
 }
 
 template<typename BasicJsonType, typename Type,
-         typename ConstType = typename std::remove_reference<Type>::type const&,
-         detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, int> = 0>
-ConstType from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
-{
-    return std::forward<BasicJsonType>(j).template get_ref<ConstType>();
-}
-
-template<typename BasicJsonType, typename Type,
          detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, int> = 0>
-Type from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
+Type from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get_ref<Type>();
 }
 
 template<typename BasicJsonType, typename Type,
          detail::enable_if_t<std::is_arithmetic<uncvref_t<Type>>::value, int> = 0>
-detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
+detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
@@ -5410,13 +5402,13 @@ std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tu
 {
     static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
                   "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
-    return from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    return from_json_tuple_impl_base<1, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename... Args>
 inline void from_json_tuple_impl(BasicJsonType&& j, std::tuple<Args...>& t, priority_tag<3> /*unused*/)
 {
-    t = from_json_tuple_impl_base<3, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    t = from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename TupleRelated>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3499,71 +3499,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-#include <cstdint> // int64_t, uint64_t
-#include <map> // map
-#include <memory> // allocator
-#include <string> // string
-#include <vector> // vector
+    #include <cstdint> // int64_t, uint64_t
+    #include <map> // map
+    #include <memory> // allocator
+    #include <string> // string
+    #include <vector> // vector
 
-// #include <nlohmann/detail/abi_macros.hpp>
+    // #include <nlohmann/detail/abi_macros.hpp>
 
 
-/*!
-@brief namespace for Niels Lohmann
-@see https://github.com/nlohmann
-@since version 1.0.0
-*/
-NLOHMANN_JSON_NAMESPACE_BEGIN
+    /*!
+    @brief namespace for Niels Lohmann
+    @see https://github.com/nlohmann
+    @since version 1.0.0
+    */
+    NLOHMANN_JSON_NAMESPACE_BEGIN
 
-/*!
-@brief default JSONSerializer template argument
+    /*!
+    @brief default JSONSerializer template argument
 
-This serializer ignores the template arguments and uses ADL
-([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-for serialization.
-*/
-template<typename T = void, typename SFINAE = void>
-struct adl_serializer;
+    This serializer ignores the template arguments and uses ADL
+    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+    for serialization.
+    */
+    template<typename T = void, typename SFINAE = void>
+    struct adl_serializer;
 
-/// a class to store JSON values
-/// @sa https://json.nlohmann.me/api/basic_json/
-template<template<typename U, typename V, typename... Args> class ObjectType =
-         std::map,
-         template<typename U, typename... Args> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
-         class NumberIntegerType = std::int64_t,
-         class NumberUnsignedType = std::uint64_t,
-         class NumberFloatType = double,
-         template<typename U> class AllocatorType = std::allocator,
-         template<typename T, typename SFINAE = void> class JSONSerializer =
-         adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-         class CustomBaseClass = void>
-class basic_json;
+    /// a class to store JSON values
+    /// @sa https://json.nlohmann.me/api/basic_json/
+    template<template<typename U, typename V, typename... Args> class ObjectType =
+    std::map,
+    template<typename U, typename... Args> class ArrayType = std::vector,
+    class StringType = std::string, class BooleanType = bool,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
+    class NumberFloatType = double,
+    template<typename U> class AllocatorType = std::allocator,
+    template<typename T, typename SFINAE = void> class JSONSerializer =
+    adl_serializer,
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
+    class basic_json;
 
-/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-/// @sa https://json.nlohmann.me/api/json_pointer/
-template<typename RefStringType>
-class json_pointer;
+    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+    /// @sa https://json.nlohmann.me/api/json_pointer/
+    template<typename RefStringType>
+    class json_pointer;
 
-/*!
-@brief default specialization
-@sa https://json.nlohmann.me/api/json/
-*/
-using json = basic_json<>;
+    /*!
+    @brief default specialization
+    @sa https://json.nlohmann.me/api/json/
+    */
+    using json = basic_json<>;
 
-/// @brief a minimal map-like container that preserves insertion order
-/// @sa https://json.nlohmann.me/api/ordered_map/
-template<class Key, class T, class IgnoredLess, class Allocator>
-struct ordered_map;
+    /// @brief a minimal map-like container that preserves insertion order
+    /// @sa https://json.nlohmann.me/api/ordered_map/
+    template<class Key, class T, class IgnoredLess, class Allocator>
+    struct ordered_map;
 
-/// @brief specialization that maintains the insertion order of object keys
-/// @sa https://json.nlohmann.me/api/ordered_json/
-using ordered_json = basic_json<nlohmann::ordered_map>;
+    /// @brief specialization that maintains the insertion order of object keys
+    /// @sa https://json.nlohmann.me/api/ordered_json/
+    using ordered_json = basic_json<nlohmann::ordered_map>;
 
-NLOHMANN_JSON_NAMESPACE_END
+    NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -4110,7 +4110,7 @@ template<typename BasicJsonType, typename CompatibleReferenceType>
 struct is_compatible_reference_type_impl <
     BasicJsonType, CompatibleReferenceType,
     enable_if_t<std::is_reference<CompatibleReferenceType>::value,
-                void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())>>>
+void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())> >>
     : std::true_type {};
 
 template<typename BasicJsonType, typename CompatibleReferenceType>
@@ -4883,10 +4883,10 @@ namespace detail
 #ifdef JSON_HAS_CPP_17
 
 template<bool... Booleans>
-struct cxpr_or_impl : std::integral_constant<bool, (Booleans ||...)> {};
+struct cxpr_or_impl : std::integral_constant < bool, (Booleans || ...) > {};
 
 template<bool... Booleans>
-struct cxpr_and_impl : std::integral_constant<bool, (Booleans &&...)> {};
+struct cxpr_and_impl : std::integral_constant < bool, (Booleans &&...) > {};
 
 #else
 
@@ -4911,7 +4911,7 @@ struct cxpr_and_impl<false, Booleans...> : std::false_type {};
 #endif
 
 template<class Boolean>
-struct cxpr_not : std::integral_constant<bool, !Boolean::value> {};
+struct cxpr_not : std::integral_constant < bool, !Boolean::value > {};
 
 template<class... Booleans>
 struct cxpr_or : cxpr_or_impl<Booleans::value...> {};
@@ -5356,34 +5356,34 @@ detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::iden
 }
 
 template<typename BasicJsonType, typename Type,
-         typename ConstType = detail::enable_if_t<std::is_reference<Type>::value, typename std::remove_reference<Type>::type const&>>
-auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
-    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, ConstType>
+         typename ConstType = typename std::remove_reference<Type>::type const&,
+         detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, int> = 0>
+ConstType from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get_ref<ConstType>();
 }
 
-template<typename BasicJsonType, typename Type>
-auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
-    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, Type>
+template<typename BasicJsonType, typename Type,
+         detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, int> = 0>
+Type from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get_ref<Type>();
 }
 
-template<typename BasicJsonType, typename Type>
-auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
-    -> detail::enable_if_t<std::is_integral<uncvref_t<Type>>::value, detail::uncvref_t<Type>>
+template<typename BasicJsonType, typename Type,
+         detail::enable_if_t<std::is_arithmetic<uncvref_t<Type>>::value, int> = 0>
+detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType && j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
 {
     return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
 
 template<std::size_t PTagValue, typename BasicJsonType, typename... Types>
-using tuple_type = std::tuple<decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types>{}, detail::priority_tag<PTagValue>{}))...>;
+using tuple_type = std::tuple < decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types> {}, detail::priority_tag<PTagValue> {}))... >;
 
 template<std::size_t PTagValue, typename... Args, typename BasicJsonType, std::size_t... Idx>
 tuple_type<PTagValue, BasicJsonType, Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
 {
-    return tuple_type<PTagValue, BasicJsonType, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args>{}, detail::priority_tag<PTagValue>{})...);
+    return tuple_type<PTagValue, BasicJsonType, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args> {}, detail::priority_tag<PTagValue> {})...);
 }
 
 template<std::size_t PTagValue, typename BasicJsonType>
@@ -5409,7 +5409,7 @@ template<typename BasicJsonType, typename... Args>
 std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tuple<Args...>> /*unused*/, priority_tag<2> /*unused*/)
 {
     static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
-        "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
+                  "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
     return from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
@@ -5531,7 +5531,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
- // JSON_HAS_CPP_17
+// JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -20359,10 +20359,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-    )
+                                 )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -21060,8 +21060,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                           std::forward<CompatibleType>(val))))
+            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                       std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -21855,7 +21855,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -21897,7 +21897,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -22047,7 +22047,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4103,15 +4103,23 @@ template<typename BasicJsonType, typename CompatibleType>
 struct is_compatible_type
     : is_compatible_type_impl<BasicJsonType, CompatibleType> {};
 
-template<typename BasicJsonType, typename CompatibleReferenceType, typename = void>
-struct is_compatible_reference_type_impl: std::false_type {};
-
 template<typename BasicJsonType, typename CompatibleReferenceType>
-struct is_compatible_reference_type_impl <
-    BasicJsonType, CompatibleReferenceType,
-    enable_if_t<std::is_reference<CompatibleReferenceType>::value,
-void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())> >>
-    : std::true_type {};
+struct is_compatible_reference_type_impl
+{
+    using JsonType = uncvref_t<BasicJsonType>;
+    using CVType = typename std::remove_reference<CompatibleReferenceType>::type;
+    using Type = typename std::remove_cv<CVType>::type;
+    constexpr static bool value = std::is_reference<CompatibleReferenceType>::value &&
+                                  (!std::is_const<typename std::remove_reference<BasicJsonType>::type>::value || std::is_const<CVType>::value) &&
+                                  (std::is_same<typename JsonType::boolean_t, Type>::value ||
+                                   std::is_same<typename JsonType::number_float_t, Type>::value ||
+                                   std::is_same<typename JsonType::number_integer_t, Type>::value ||
+                                   std::is_same<typename JsonType::number_unsigned_t, Type>::value ||
+                                   std::is_same<typename JsonType::string_t, Type>::value ||
+                                   std::is_same<typename JsonType::binary_t, Type>::value ||
+                                   std::is_same<typename JsonType::object_t, Type>::value ||
+                                   std::is_same<typename JsonType::array_t, Type>::value);
+};
 
 template<typename BasicJsonType, typename CompatibleReferenceType>
 struct is_compatible_reference_type

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3499,71 +3499,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -4102,6 +4102,20 @@ struct is_compatible_type_impl <
 template<typename BasicJsonType, typename CompatibleType>
 struct is_compatible_type
     : is_compatible_type_impl<BasicJsonType, CompatibleType> {};
+
+template<typename BasicJsonType, typename CompatibleReferenceType, typename = void>
+struct is_compatible_reference_type_impl: std::false_type {};
+
+template<typename BasicJsonType, typename CompatibleReferenceType>
+struct is_compatible_reference_type_impl <
+    BasicJsonType, CompatibleReferenceType,
+    enable_if_t<std::is_reference<CompatibleReferenceType>::value,
+                void_t<decltype(std::declval<BasicJsonType>().template get_ptr<typename std::add_pointer<CompatibleReferenceType>::type>())>>>
+    : std::true_type {};
+
+template<typename BasicJsonType, typename CompatibleReferenceType>
+struct is_compatible_reference_type
+    : is_compatible_reference_type_impl<BasicJsonType, CompatibleReferenceType> {};
 
 template<typename T1, typename T2>
 struct is_constructible_tuple : std::false_type {};
@@ -4857,6 +4871,63 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/meta/type_traits.hpp>
 
+// #include <nlohmann/detail/meta/logic.hpp>
+
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+#ifdef JSON_HAS_CPP_17
+
+template<bool... Booleans>
+struct cxpr_or_impl : std::integral_constant<bool, (Booleans ||...)> {};
+
+template<bool... Booleans>
+struct cxpr_and_impl : std::integral_constant<bool, (Booleans &&...)> {};
+
+#else
+
+template<bool... Booleans>
+struct cxpr_or_impl : std::false_type {};
+
+template<bool... Booleans>
+struct cxpr_or_impl<true, Booleans...> : std::true_type {};
+
+template<bool... Booleans>
+struct cxpr_or_impl<false, Booleans...> : cxpr_or_impl<Booleans...> {};
+
+template<bool... Booleans>
+struct cxpr_and_impl : std::true_type {};
+
+template<bool... Booleans>
+struct cxpr_and_impl<true, Booleans...> : cxpr_and_impl<Booleans...> {};
+
+template<bool... Booleans>
+struct cxpr_and_impl<false, Booleans...> : std::false_type {};
+
+#endif
+
+template<class Boolean>
+struct cxpr_not : std::integral_constant<bool, !Boolean::value> {};
+
+template<class... Booleans>
+struct cxpr_or : cxpr_or_impl<Booleans::value...> {};
+
+template<bool... Booleans>
+struct cxpr_or_c : cxpr_or_impl<Booleans...> {};
+
+template<class... Booleans>
+struct cxpr_and : cxpr_and_impl<Booleans::value...> {};
+
+template<bool... Booleans>
+struct cxpr_and_c : cxpr_and_impl<Booleans...> {};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
 // #include <nlohmann/detail/string_concat.hpp>
 
 // #include <nlohmann/detail/value_t.hpp>
@@ -5278,13 +5349,44 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
     }
 }
 
-template<typename BasicJsonType, typename... Args, std::size_t... Idx>
-std::tuple<Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
+template<typename BasicJsonType, typename Type>
+detail::uncvref_t<Type> from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<0> /*unused*/)
 {
-    return std::make_tuple(std::forward<BasicJsonType>(j).at(Idx).template get<Args>()...);
+    return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
 }
 
-template<typename BasicJsonType>
+template<typename BasicJsonType, typename Type,
+         typename ConstType = detail::enable_if_t<std::is_reference<Type>::value, typename std::remove_reference<Type>::type const&>>
+auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<1> /*unused*/)
+    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, ConstType>::value, ConstType>
+{
+    return std::forward<BasicJsonType>(j).template get_ref<ConstType>();
+}
+
+template<typename BasicJsonType, typename Type>
+auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<2> /*unused*/)
+    -> detail::enable_if_t<detail::is_compatible_reference_type<BasicJsonType, Type>::value, Type>
+{
+    return std::forward<BasicJsonType>(j).template get_ref<Type>();
+}
+
+template<typename BasicJsonType, typename Type>
+auto from_json_tuple_get_impl(BasicJsonType&& j, detail::identity_tag<Type> /*unused*/, detail::priority_tag<3> /*unused*/)
+    -> detail::enable_if_t<std::is_integral<uncvref_t<Type>>::value, detail::uncvref_t<Type>>
+{
+    return std::forward<BasicJsonType>(j).template get<detail::uncvref_t<Type>>();
+}
+
+template<std::size_t PTagValue, typename BasicJsonType, typename... Types>
+using tuple_type = std::tuple<decltype(from_json_tuple_get_impl(std::declval<BasicJsonType>(), detail::identity_tag<Types>{}, detail::priority_tag<PTagValue>{}))...>;
+
+template<std::size_t PTagValue, typename... Args, typename BasicJsonType, std::size_t... Idx>
+tuple_type<PTagValue, BasicJsonType, Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
+{
+    return tuple_type<PTagValue, BasicJsonType, Args...>(from_json_tuple_get_impl(std::forward<BasicJsonType>(j).at(Idx), detail::identity_tag<Args>{}, detail::priority_tag<PTagValue>{})...);
+}
+
+template<std::size_t PTagValue, typename BasicJsonType>
 std::tuple<> from_json_tuple_impl_base(BasicJsonType& /*unused*/, index_sequence<> /*unused*/)
 {
     return {};
@@ -5306,13 +5408,15 @@ inline void from_json_tuple_impl(BasicJsonType&& j, std::pair<A1, A2>& p, priori
 template<typename BasicJsonType, typename... Args>
 std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tuple<Args...>> /*unused*/, priority_tag<2> /*unused*/)
 {
-    return from_json_tuple_impl_base<BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    static_assert(cxpr_and<cxpr_or<cxpr_not<std::is_reference<Args>>, is_compatible_reference_type<BasicJsonType, Args>>...>::value,
+        "Can not return a tuple containing references to types not contained in a Json, try Json::get_to()");
+    return from_json_tuple_impl_base<2, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename... Args>
 inline void from_json_tuple_impl(BasicJsonType&& j, std::tuple<Args...>& t, priority_tag<3> /*unused*/)
 {
-    t = from_json_tuple_impl_base<BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+    t = from_json_tuple_impl_base<3, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
 }
 
 template<typename BasicJsonType, typename TupleRelated>
@@ -5427,7 +5531,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
-// JSON_HAS_CPP_17
+ // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -20255,10 +20359,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -20956,8 +21060,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                       std::forward<CompatibleType>(val))))
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -21751,7 +21855,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -21793,7 +21897,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -21943,7 +22047,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;

--- a/tests/src/unit-constructor1.cpp
+++ b/tests/src/unit-constructor1.cpp
@@ -283,19 +283,19 @@ TEST_CASE("constructors")
 
         SECTION("std::tuple tie")
         {
-            auto a = 1.0;
-            auto b = "string";
-            auto c = 42;
-            auto d = std::vector<int> {0, 2};
-            size_t e = 1234;
+            const auto a = 1.0;
+            const auto* const b = "string";
+            const auto c = 42;
+            const auto d = std::vector<int> {0, 2};
+            const size_t e = 1234;
             auto t = std::tie(a, b, c, d, e);
             json const j(t);
 
-            double a_out;
+            double a_out = 0;
             std::string b_out;
-            int c_out;
+            int c_out = 0;
             std::vector<int> d_out;
-            int64_t e_out;
+            int64_t e_out = 0;
             auto t_out = std::tie(a_out, b_out, c_out, d_out, e_out);
             j.get_to(t_out);
             CHECK(a_out == a);
@@ -308,7 +308,7 @@ TEST_CASE("constructors")
         SECTION("std::tuple of references to elements")
         {
             const auto a = 1.0;
-            const auto b = "string";
+            const auto* const b = "string";
             const auto c = 42;
             const size_t d = 1234;
             const auto t = std::tie(a, b, c, d);
@@ -326,6 +326,32 @@ TEST_CASE("constructors")
             CHECK(std::get<1>(t_out) == b);
             CHECK(std::get<2>(t_out) == c);
             CHECK(std::get<3>(t_out) == d);
+        }
+
+        SECTION("std::tuple mixed arithmetic types")
+        {
+            using j_float_t = json::number_float_t;
+            using j_int_t = json::number_integer_t;
+            using j_uint_t = json::number_unsigned_t;
+            const j_float_t a = 1.0;
+            const j_int_t b = 1234;
+            const j_uint_t c = 42;
+            json const j(std::tie(a, b, c, c));
+
+            auto t1 = j.get<std::tuple<j_int_t, j_uint_t, j_float_t, const j_uint_t&>>();
+            j_uint_t a2 = 0;
+            j_float_t b2 = 0;
+            j_int_t c2 = 0;
+            auto t2 = std::tie(a2, b2, c2);
+            j.get_to(t2);
+
+            CHECK(std::get<0>(t1) == a);
+            CHECK(std::get<1>(t1) == b);
+            CHECK(std::get<2>(t1) == c);
+            // t1[3] exists only to force usage of the no-default-constructor version
+            CHECK(a2 == a);
+            CHECK(b2 == b);
+            CHECK(c2 == c);
         }
 
         SECTION("std::pair/tuple/array failures")

--- a/tests/src/unit-constructor1.cpp
+++ b/tests/src/unit-constructor1.cpp
@@ -345,13 +345,13 @@ TEST_CASE("constructors")
             auto t2 = std::tie(a2, b2, c2);
             j.get_to(t2);
 
-            CHECK(std::get<0>(t1) == a);
-            CHECK(std::get<1>(t1) == b);
-            CHECK(std::get<2>(t1) == c);
+            CHECK(std::get<0>(t1) == static_cast<j_int_t>(a));
+            CHECK(std::get<1>(t1) == static_cast<j_uint_t>(b));
+            CHECK(std::get<2>(t1) == static_cast<j_float_t>(c));
             // t1[3] exists only to force usage of the no-default-constructor version
-            CHECK(a2 == a);
-            CHECK(b2 == b);
-            CHECK(c2 == c);
+            CHECK(a2 == static_cast<j_uint_t>(a));
+            CHECK(b2 == static_cast<j_float_t>(b));
+            CHECK(c2 == static_cast<j_int_t>(c));
         }
 
         SECTION("std::pair/tuple/array failures")

--- a/tests/src/unit-constructor1.cpp
+++ b/tests/src/unit-constructor1.cpp
@@ -286,7 +286,7 @@ TEST_CASE("constructors")
             auto a = 1.0;
             auto b = "string";
             auto c = 42;
-            auto d = std::vector<int>{0, 2};
+            auto d = std::vector<int> {0, 2};
             size_t e = 1234;
             auto t = std::tie(a, b, c, d, e);
             json const j(t);
@@ -315,9 +315,9 @@ TEST_CASE("constructors")
             json const j(t);
 
             auto t_out = j.get<std::tuple<const json::number_float_t&,
-                                          const json::string_t&,
-                                          const json::number_integer_t&,
-                                          const json::number_unsigned_t&>>();
+                 const json::string_t&,
+                 const json::number_integer_t&,
+                 const json::number_unsigned_t&>>();
             CHECK(&std::get<0>(t_out) == j[0].get_ptr<const json::number_float_t*>());
             CHECK(&std::get<1>(t_out) == j[1].get_ptr<const json::string_t*>());
             CHECK(&std::get<2>(t_out) == j[2].get_ptr<const json::number_integer_t*>());

--- a/tests/src/unit-constructor1.cpp
+++ b/tests/src/unit-constructor1.cpp
@@ -281,6 +281,53 @@ TEST_CASE("constructors")
             // CHECK(std::get<2>(t) == j[2]); // commented out due to CI issue, see https://github.com/nlohmann/json/pull/3985 and https://github.com/nlohmann/json/issues/4025
         }
 
+        SECTION("std::tuple tie")
+        {
+            auto a = 1.0;
+            auto b = "string";
+            auto c = 42;
+            auto d = std::vector<int>{0, 2};
+            size_t e = 1234;
+            auto t = std::tie(a, b, c, d, e);
+            json const j(t);
+
+            double a_out;
+            std::string b_out;
+            int c_out;
+            std::vector<int> d_out;
+            int64_t e_out;
+            auto t_out = std::tie(a_out, b_out, c_out, d_out, e_out);
+            j.get_to(t_out);
+            CHECK(a_out == a);
+            CHECK(b_out == b);
+            CHECK(c_out == c);
+            CHECK(d_out == d);
+            CHECK(e_out == e);
+        }
+
+        SECTION("std::tuple of references to elements")
+        {
+            const auto a = 1.0;
+            const auto b = "string";
+            const auto c = 42;
+            const size_t d = 1234;
+            const auto t = std::tie(a, b, c, d);
+            json const j(t);
+
+            auto t_out = j.get<std::tuple<const json::number_float_t&,
+                                          const json::string_t&,
+                                          const json::number_integer_t&,
+                                          const json::number_unsigned_t&>>();
+            CHECK(&std::get<0>(t_out) == j[0].get_ptr<const json::number_float_t*>());
+            CHECK(&std::get<1>(t_out) == j[1].get_ptr<const json::string_t*>());
+            CHECK(&std::get<2>(t_out) == j[2].get_ptr<const json::number_integer_t*>());
+            CHECK(&std::get<3>(t_out) == j[3].get_ptr<const json::number_unsigned_t*>());
+            CHECK(std::get<0>(t_out) == a);
+            CHECK(std::get<1>(t_out) == b);
+            CHECK(std::get<2>(t_out) == c);
+            CHECK(std::get<3>(t_out) == d);
+        }
+
         SECTION("std::pair/tuple/array failures")
         {
             json const j{1};


### PR DESCRIPTION
The current std::tuple from_json implementations fail to work with std::tie, aka tuples with reference types. The reason for this is that the template types are maintained all the way to the call to `get<Args>()` resulting in things like `get<int&>()`. The PR modifies this behavior to remove the references from all incoming types if those references are incompatible with the json type being used.

Ultimately this change allows for the result of std::tie to be used with get_to and allows the get method to create std::tuples of references to contained values.

The specific set of changes needed to achieve this are:

1. The addition of the `is_compatible_reference_type` metaprogramming struct that contains ::value = true if the BasicJsonType given has a get_ref instantiation that accepts CompatibleReferenceType (I used get_ptr because SFINAE was not working correctly with get_ref). This allows for overload resolution to decide to use get (and decay the type) or get_ref if a reference type is available for the individual elements of the tuple.
2. The addition of the meta/logic.hpp header adding cxpr_or, cxpr_and, and cxpr_not that allow for c++ 17 fold expressions for `||` and `&&` (with not for semantic consistency) in version older than 17. This is needed for the static assert (which I discuss later)
3. The addition of the `from_json_tuple_get_impl` overload set. In reverse priority order they:
   1. decay all types to values and calls `get<T>` on the json, returning by value
   3. if a type is a compatible reference type, calls get_ref and returns exactly the type given.
   4. if a type is an arethmetic type, call get and return by value. This one specifically exists to allow std::ties containing number_xxx_t to not fail when the type is some other number type.
4. a template using statement `tuple_type` that figures out the return type of a call to `from_json_tuple_get_impl` so that a tuple of exactly the correct types can be constructed from calls to it.
5. modifications to `from_json_tuple_impl_base` implementations adding a priority tag value template argument (to circumvent the `from_json_tuple_get_impl(..., priority_tag<2>)` implementation for calls to get references to members) and to return `tuple_type` and use `from_json_tuple_get_impl`.
6. add a static assert to `from_json_tuple_impl(..., identity_tag<std::tuple<Args...>>, ...)` to explicitly disallow reference types that are not compatible with the json type. This is done because this function _must_ return exactly the type in the identity_tag, but the function it calls will return values when dealing with incompatible references. This creates a dangling reference in the return. If desired, this static assert could be moved into an enable_if on the return to preserve SFINAE, but I could not think of a scenario where SFINAE would allow for recovery from this point during instantiation.
7. The addition of tests for `get_to(std::tie(...))` and `get<std::tuple<const T&,...>>()` and to confirm arithmetic types do not try to pull references even when they are number types.

I would also like to potentially discuss modifying `get_to` to allow for rvalue references in cases like std::tie and mutable range views such as std::span (if it has not already been discussed).

- [x] The changes are described in detail, both the what and why.
- [x] ~If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.~
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

(edited to reflect current implementation as of Nov 29)