### PR TITLE
fix(cbor): reject overflowing negative integers

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -425,6 +425,25 @@ class binary_reader
 
     @return whether a valid CBOR value was passed to the SAX parser
     */
+
+    template<typename NumberType>
+    bool get_cbor_negative_integer()
+    {
+        NumberType number{};
+        if (JSON_HEDLEY_UNLIKELY(!get_number(input_format_t::cbor, number)))
+        {
+            return false;
+        }
+        const auto max_val = static_cast<NumberType>((std::numeric_limits<number_integer_t>::max)());
+        if (number > max_val)
+        {
+            return sax->parse_error(chars_read, get_token_string(),
+                                    parse_error::create(112, chars_read,
+                                            exception_message(input_format_t::cbor, "negative integer overflow", "value"), nullptr));
+        }
+        return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
+    }
+
     bool parse_cbor_internal(const bool get_char,
                              const cbor_tag_handler_t tag_handler)
     {
@@ -513,39 +532,16 @@ class binary_reader
                 return sax->number_integer(static_cast<std::int8_t>(0x20 - 1 - current));
 
             case 0x38: // Negative integer (one-byte uint8_t follows)
-            {
-                std::uint8_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
+                return get_cbor_negative_integer<std::uint8_t>();
 
             case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
-            {
-                std::uint16_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
+                return get_cbor_negative_integer<std::uint16_t>();
 
             case 0x3A: // Negative integer -1-n (four-byte uint32_t follows)
-            {
-                std::uint32_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
+                return get_cbor_negative_integer<std::uint32_t>();
 
             case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
-            {
-                std::uint64_t number{};
-                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format_t::cbor, number)))
-                {
-                    return false;
-                }
-                const auto max_val = static_cast<std::uint64_t>((std::numeric_limits<number_integer_t>::max)());
-                if (number > max_val)
-                {
-                    return sax->parse_error(chars_read, get_token_string(),
-                                            parse_error::create(112, chars_read,
-                                                    exception_message(input_format_t::cbor, "negative integer overflow", "value"), nullptr));
-                }
-                return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
-            }
+                return get_cbor_negative_integer<std::uint64_t>();
 
             // Binary data (0x00..0x17 bytes follow)
             case 0x40:

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -533,8 +533,18 @@ class binary_reader
             case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
             {
                 std::uint64_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1)
-                        - static_cast<number_integer_t>(number));
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format_t::cbor, number)))
+                {
+                    return false;
+                }
+                const auto max_val = static_cast<std::uint64_t>((std::numeric_limits<number_integer_t>::max)());
+                if (number > max_val)
+                {
+                    return sax->parse_error(chars_read, get_token_string(),
+                                            parse_error::create(112, chars_read,
+                                                    exception_message(input_format_t::cbor, "negative integer overflow", "value"), nullptr));
+                }
+                return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
             }
 
             // Binary data (0x00..0x17 bytes follow)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10371,8 +10371,18 @@ class binary_reader
             case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
             {
                 std::uint64_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1)
-                        - static_cast<number_integer_t>(number));
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format_t::cbor, number)))
+                {
+                    return false;
+                }
+                const auto max_val = static_cast<std::uint64_t>((std::numeric_limits<number_integer_t>::max)());
+                if (number > max_val)
+                {
+                    return sax->parse_error(chars_read, get_token_string(),
+                                            parse_error::create(112, chars_read,
+                                                    exception_message(input_format_t::cbor, "negative integer overflow", "value"), nullptr));
+                }
+                return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
             }
 
             // Binary data (0x00..0x17 bytes follow)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10263,6 +10263,25 @@ class binary_reader
 
     @return whether a valid CBOR value was passed to the SAX parser
     */
+
+    template<typename NumberType>
+    bool get_cbor_negative_integer()
+    {
+        NumberType number{};
+        if (JSON_HEDLEY_UNLIKELY(!get_number(input_format_t::cbor, number)))
+        {
+            return false;
+        }
+        const auto max_val = static_cast<NumberType>((std::numeric_limits<number_integer_t>::max)());
+        if (number > max_val)
+        {
+            return sax->parse_error(chars_read, get_token_string(),
+                                    parse_error::create(112, chars_read,
+                                            exception_message(input_format_t::cbor, "negative integer overflow", "value"), nullptr));
+        }
+        return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
+    }
+
     bool parse_cbor_internal(const bool get_char,
                              const cbor_tag_handler_t tag_handler)
     {
@@ -10351,39 +10370,16 @@ class binary_reader
                 return sax->number_integer(static_cast<std::int8_t>(0x20 - 1 - current));
 
             case 0x38: // Negative integer (one-byte uint8_t follows)
-            {
-                std::uint8_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
+                return get_cbor_negative_integer<std::uint8_t>();
 
             case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
-            {
-                std::uint16_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
+                return get_cbor_negative_integer<std::uint16_t>();
 
             case 0x3A: // Negative integer -1-n (four-byte uint32_t follows)
-            {
-                std::uint32_t number{};
-                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
+                return get_cbor_negative_integer<std::uint32_t>();
 
             case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
-            {
-                std::uint64_t number{};
-                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format_t::cbor, number)))
-                {
-                    return false;
-                }
-                const auto max_val = static_cast<std::uint64_t>((std::numeric_limits<number_integer_t>::max)());
-                if (number > max_val)
-                {
-                    return sax->parse_error(chars_read, get_token_string(),
-                                            parse_error::create(112, chars_read,
-                                                    exception_message(input_format_t::cbor, "negative integer overflow", "value"), nullptr));
-                }
-                return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
-            }
+                return get_cbor_negative_integer<std::uint64_t>();
 
             // Binary data (0x00..0x17 bytes follow)
             case 0x40:

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -1705,6 +1705,9 @@ TEST_CASE("CBOR")
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3b})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3b, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x62})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x62, 0x60})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x7F})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR string: unexpected end of input", json::parse_error&);
@@ -1733,6 +1736,9 @@ TEST_CASE("CBOR")
             CHECK(json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3b}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3b, 0x00}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x62}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x62, 0x60}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x7F}), true, false).is_discarded());
@@ -2678,6 +2684,49 @@ TEST_CASE("Tagged values")
             CHECK_THROWS_AS(_ = json::from_cbor(v_tagged), json::parse_error);
             CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
             CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore), json::parse_error);
+        }
+    }
+
+    SECTION("negative integer overflow")
+    {
+        // CBOR encodes negative integers as -1 - n, where n is uint64_t.
+        // When n > INT64_MAX, the result cannot be represented in int64_t.
+        // The library should reject such values with a parse error.
+
+        SECTION("n = INT64_MAX is valid (result = INT64_MIN)")
+        {
+            // n = 0x7FFFFFFFFFFFFFFF (INT64_MAX), result = -1 - INT64_MAX = INT64_MIN
+            const std::vector<uint8_t> input = {0x3B, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+            const auto result = json::from_cbor(input);
+            CHECK(result.is_number_integer());
+            CHECK(result.get<int64_t>() == (std::numeric_limits<int64_t>::min)());
+        }
+
+        SECTION("n = INT64_MAX + 1 causes overflow")
+        {
+            // n = 0x8000000000000000 (INT64_MAX + 1), result would be -9223372036854775809
+            const std::vector<uint8_t> input = {0x3B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            json _;
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(input),
+                                 "[json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: negative integer overflow",
+                                 json::parse_error);
+        }
+
+        SECTION("n = UINT64_MAX causes overflow")
+        {
+            // n = 0xFFFFFFFFFFFFFFFF (UINT64_MAX), result would be -18446744073709551616
+            const std::vector<uint8_t> input = {0x3B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+            json _;
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(input),
+                                 "[json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: negative integer overflow",
+                                 json::parse_error);
+        }
+
+        SECTION("overflow with allow_exceptions=false returns discarded")
+        {
+            const std::vector<uint8_t> input = {0x3B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            const auto result = json::from_cbor(input, true, false);
+            CHECK(result.is_discarded());
         }
     }
 

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -2689,22 +2689,37 @@ TEST_CASE("Tagged values")
 
     SECTION("negative integer overflow")
     {
-        // CBOR encodes negative integers as -1 - n, where n is uint64_t.
-        // When n > INT64_MAX, the result cannot be represented in int64_t.
-        // The library should reject such values with a parse error.
+        // CBOR type 0x3B encodes negative integers as: result = -1 - n
+        // where n is an 8-byte uint64_t. Valid range for n is [0, INT64_MAX]
+        // which produces results in [INT64_MIN, -1].
+        // When n > INT64_MAX, the result exceeds int64_t range and is rejected.
+        //
+        // Note: result = 0 is not possible with type 0x3B since n is an
+        // unsigned integer, so the formula -1 - n always produces a negative result.
+
+        SECTION("n = 0 is valid (result = -1)")
+        {
+            // n = 0, result = -1 - 0 = -1 (smallest magnitude negative)
+            const std::vector<uint8_t> input = {0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            const auto result = json::from_cbor(input);
+            CHECK(result.is_number_integer());
+            CHECK(result.get<int64_t>() == -1);
+        }
 
         SECTION("n = INT64_MAX is valid (result = INT64_MIN)")
         {
-            // n = 0x7FFFFFFFFFFFFFFF (INT64_MAX), result = -1 - INT64_MAX = INT64_MIN
+            // n = INT64_MAX (0x7FFFFFFFFFFFFFFF)
+            // result = -1 - INT64_MAX = INT64_MIN (-9223372036854775808)
             const std::vector<uint8_t> input = {0x3B, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
             const auto result = json::from_cbor(input);
             CHECK(result.is_number_integer());
             CHECK(result.get<int64_t>() == (std::numeric_limits<int64_t>::min)());
         }
 
-        SECTION("n = INT64_MAX + 1 causes overflow")
+        SECTION("n = INT64_MAX + 1 is rejected (overflow)")
         {
-            // n = 0x8000000000000000 (INT64_MAX + 1), result would be -9223372036854775809
+            // n = INT64_MAX + 1 (0x8000000000000000)
+            // result = -1 - n = -9223372036854775809, which exceeds int64_t range
             const std::vector<uint8_t> input = {0x3B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
             json _;
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(input),
@@ -2712,9 +2727,10 @@ TEST_CASE("Tagged values")
                                  json::parse_error);
         }
 
-        SECTION("n = UINT64_MAX causes overflow")
+        SECTION("n = UINT64_MAX is rejected (overflow)")
         {
-            // n = 0xFFFFFFFFFFFFFFFF (UINT64_MAX), result would be -18446744073709551616
+            // n = UINT64_MAX (0xFFFFFFFFFFFFFFFF)
+            // result = -1 - n = -18446744073709551616, which exceeds int64_t range
             const std::vector<uint8_t> input = {0x3B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
             json _;
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(input),

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -1705,6 +1705,13 @@ TEST_CASE("CBOR")
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 7: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x38})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x39})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x39, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3a})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3a, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3a, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 4: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3a, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3b})), "[json.exception.parse_error.110] parse error at byte 2: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3b, 0x00})), "[json.exception.parse_error.110] parse error at byte 3: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
             CHECK_THROWS_WITH_AS(_ = json::from_cbor(std::vector<uint8_t>({0x3b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})), "[json.exception.parse_error.110] parse error at byte 9: syntax error while parsing CBOR number: unexpected end of input", json::parse_error&);
@@ -1736,6 +1743,13 @@ TEST_CASE("CBOR")
             CHECK(json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x38}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x39}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x39, 0x00}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3a}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3a, 0x00}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3a, 0x00, 0x00}), true, false).is_discarded());
+            CHECK(json::from_cbor(std::vector<uint8_t>({0x3a, 0x00, 0x00, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x3b}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x3b, 0x00}), true, false).is_discarded());
             CHECK(json::from_cbor(std::vector<uint8_t>({0x3b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), true, false).is_discarded());
@@ -2689,13 +2703,10 @@ TEST_CASE("Tagged values")
 
     SECTION("negative integer overflow")
     {
-        // CBOR type 0x3B encodes negative integers as: result = -1 - n
-        // where n is an 8-byte uint64_t. Valid range for n is [0, INT64_MAX]
-        // which produces results in [INT64_MIN, -1].
+        // CBOR encodes negative integers as: result = -1 - n
+        // For type 0x3B, n is an 8-byte uint64_t. Valid range for n with
+        // the default int64_t is [0, INT64_MAX], producing results in [INT64_MIN, -1].
         // When n > INT64_MAX, the result exceeds int64_t range and is rejected.
-        //
-        // Note: result = 0 is not possible with type 0x3B since n is an
-        // unsigned integer, so the formula -1 - n always produces a negative result.
 
         SECTION("n = 0 is valid (result = -1)")
         {


### PR DESCRIPTION
## Motivation

CBOR encodes negative integers as "-1 - n" where _n_ is an unsigned integer. Per [RFC 8949 Section 5.5](https://www.rfc-editor.org/rfc/rfc8949.html#section-5.5):

>CBOR keeps the sign bit for its integer representation in the major type, it has one bit more for signed numbers of a certain length (e.g., -2^64..2^64-1 for 1+8-byte integers) than the typical platform signed integer representation of the same length (-2^63..2^63-1 for 8-byte int64_t).

and:

>a protocol that uses numbers should define its expectations on the handling of nontrivial numbers

When _n_ exceeds the representable range of `number_integer_t`, the computation causes undefined behaviour and silent data corruption.

For the default `int64_t` type:
- -9223372036854775809 (`n = 0x8000000000000000`) was incorrectly parsed as 9223372036854775807

For custom 32-bit configurations (`int32_t`):
- -2147483649 (`n = 0x80000000`) would similarly overflow

## Changes

Add bounds checks for all CBOR negative integer types (`0x38`,` 0x39`, `0x3A`, `0x3B`) to reject values exceeding `number_integer_t` range, returning `parse_error.112` instead of silently corrupting data.

Add regression tests for:

- Overflow detection at boundary values
- Truncated input handling
- Custom `int32_t` integer type configurations

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.
