### PR TITLE
Updated copyright year in MIT License

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,6 +1,6 @@
 MIT License 
 
-Copyright (c) 2013-2025 Niels Lohmann
+Copyright (c) 2013-2026 Niels Lohmann
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**This pull request updates the year in the MIT License to reflect the current year.**
No functional or behavioral changes are introduced; the update is purely administrative to keep the licensing information accurate and up to date.

**Changes**
Updated the year in the MIT License file

**Impact**
No impact on code, behavior, or public API

Licensing information remains correct and current.