### PR TITLE
Get text after JSON (parse with strict=false)

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -14,6 +14,7 @@
 #include <iterator> // begin, end, iterator_traits, random_access_iterator_tag, distance, next
 #include <memory> // shared_ptr, make_shared, addressof
 #include <numeric> // accumulate
+#include <span> //span
 #include <streambuf> // streambuf
 #include <string> // string, char_traits
 #include <type_traits> // enable_if, is_base_of, is_pointer, is_integral, remove_pointer
@@ -196,6 +197,17 @@ class iterator_input_adapter
         }
         return count * sizeof(T);
     }
+
+#ifdef __cpp_lib_span
+    inline constexpr std::span<char_type> as_span()
+    {
+        return std::span<char_type>(current, end);
+    }
+    inline constexpr std::span<const char_type> as_span() const
+    {
+        return std::span<const char_type>(current, end);
+    }
+#endif
 
   private:
     IteratorType current;

--- a/include/nlohmann/detail/input/parser.hpp
+++ b/include/nlohmann/detail/input/parser.hpp
@@ -176,6 +176,12 @@ class parser
         return result;
     }
 
+    /// return position of last read token
+    constexpr position_t get_position() const noexcept
+    {
+        return m_lexer.get_position();
+    }
+
   private:
     template<typename SAX>
     JSON_HEDLEY_NON_NULL(2)

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -27,6 +27,7 @@
 #endif  // JSON_NO_IO
 #include <iterator> // random_access_iterator_tag
 #include <memory> // unique_ptr
+#include <span> // span
 #include <string> // string, stoi, to_string
 #include <utility> // declval, forward, move, pair, swap
 #include <vector> // vector
@@ -4054,6 +4055,23 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         return result;
     }
 
+    /// @brief deserialize one JSON object from a compatible input
+    /// @sa https://json.nlohmann.me/api/basic_json/parse/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static std::pair<basic_json, detail::position_t> parse_some(InputType&& i,
+                                                                parser_callback_t cb = nullptr,
+                                                                const bool allow_exceptions = true,
+                                                                const bool ignore_comments = false,
+                                                                const bool ignore_trailing_commas = false)
+    {
+        basic_json result;
+        auto p = parser(detail::input_adapter(std::forward<InputType>(i)), std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas); // cppcheck-suppress[accessMoved,accessForwarded]
+        p.parse(false, result);
+        detail::position_t& end = p.get_position();
+        return {result, end};
+    }
+
     /// @brief deserialize from a pair of character iterators
     /// @sa https://json.nlohmann.me/api/basic_json/parse/
     template<typename IteratorType>
@@ -4070,6 +4088,24 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         return result;
     }
 
+    /// @brief deserialize from a pair of character iterators
+    /// @sa https://json.nlohmann.me/api/basic_json/parse/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static std::pair<basic_json, IteratorType> parse_some(IteratorType first,
+                                                          IteratorType last,
+                                                          parser_callback_t cb = nullptr,
+                                                          const bool allow_exceptions = true,
+                                                          const bool ignore_comments = false,
+                                                          const bool ignore_trailing_commas = false)
+    {
+        basic_json result;
+        auto p = parser(detail::input_adapter(std::move(first), std::move(last)), std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas); // cppcheck-suppress[accessMoved]
+        p.parse(false, result);
+        IteratorType end = first + p.get_position();
+        return {result, end};
+    }
+
     JSON_HEDLEY_WARN_UNUSED_RESULT
     JSON_HEDLEY_DEPRECATED_FOR(3.8.0, parse(ptr, ptr + len))
     static basic_json parse(detail::span_input_adapter&& i,
@@ -4082,6 +4118,23 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         parser(i.get(), std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas).parse(true, result); // cppcheck-suppress[accessMoved]
         return result;
     }
+
+#ifdef __cpp_lib_span
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, parse(ptr, ptr + len))
+    static std::pair<basic_json, std::span<char>> parse_some(detail::span_input_adapter&& i,
+                                                             parser_callback_t cb = nullptr,
+                                                             const bool allow_exceptions = true,
+                                                             const bool ignore_comments = false,
+                                                             const bool ignore_trailing_commas = false)
+    {
+        basic_json result;
+        auto p = parser(i.get(), std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas); // cppcheck-suppress[accessMoved]
+        p.parse(false, result);
+        ::std::span<char> remainder = i.get().as_span().subspan(p.get_position());
+        return {result, remainder};
+    }
+#endif
 
     /// @brief check if the input is valid JSON
     /// @sa https://json.nlohmann.me/api/basic_json/accept/


### PR DESCRIPTION
Hi, I had a need for `parse` where `strict=false`. To be explicit, I need to have a string which starts with JSON but is followed by a text.

```
{ "my_key": "my_value" }That was a cool Json!
["a", "b", "c"]What a nice Array.
[{ "my_key": "my_value" }, { "my_key": "another_value"}]Can we also do an array of objects?
```

Currently the only way I found is to use exceptions to control flow, which I don't like.
```cpp
// https://godbolt.org/z/vveqod138
std::pair<json, std::size_t> parse_some(const std::string& input)
{
    try {
        // If the whole string is pure JSON, this succeeds.
        json j = json::parse(input);
        return {j, input.size()};
    } catch (const json::parse_error& e) {
        // e.byte is the 1-based index of the error location in the input.
        // In the "trailing text" case, that position is the first non-JSON char.
        std::size_t offset = (e.byte > 0) ? (e.byte - 1) : 0;

        // Try parsing up to the error position; if trailing text caused the error,
        // this substring is valid JSON.
        try {
            json j = json::parse(input.substr(0, offset));
            return {j, offset};
        } catch (...) {
            // Not a trailing-text situation; rethrow the original error.
            throw;
        }
    }
}
```
OK, there may be another one where I pre-parse it manually but I don't really see that as an option.
So I've tried implementing `parse_some` that returns not only the object but also the data after it (either as an offset, or span).

In the MR are my proposed changes, with no tests. **Please tell me if you like the idea** and way of doing it.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [ ] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [ ] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.
