### PR TITLE
Fix -Wtautological-constant-out-of-range-compare in serializer

### DIFF
--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -919,7 +919,7 @@ class serializer
             }
         };
 
-        JSON_ASSERT(byte < utf8d.size());
+        JSON_ASSERT(static_cast<std::size_t>(byte) < utf8d.size());
         const std::uint8_t type = utf8d[byte];
 
         codep = (state != UTF8_ACCEPT)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19754,7 +19754,7 @@ class serializer
             }
         };
 
-        JSON_ASSERT(byte < utf8d.size());
+        JSON_ASSERT(static_cast<std::size_t>(byte) < utf8d.size());
         const std::uint8_t type = utf8d[byte];
 
         codep = (state != UTF8_ACCEPT)


### PR DESCRIPTION
Fixing this compilation warning:

```
In file included from C:\Users\charles\git\vcpkg\installed\x64-windows\include\nlohmann/json.hpp:60:
C:\Users\charles\git\vcpkg\installed\x64-windows\include\nlohmann/detail/output/serializer.hpp:922:26: warning: result of comparison of constant 400 with expression of type 'const std::uint8_t' (aka 'const unsigned char') is always true [-Wtautological-constant-out-of-range-compare]
  922 |         JSON_ASSERT(byte < utf8d.size());
      |                     ~~~~ ^ ~~~~~~~~~~~~
C:\Users\charles\git\vcpkg\installed\x64-windows\include\nlohmann/detail/macro_scope.hpp:205:35: note: expanded from macro 'JSON_ASSERT'
  205 |     #define JSON_ASSERT(x) assert(x)
      |                                   ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\ucrt\assert.h:40:17: note: expanded from macro 'assert'
   40 |             (!!(expression)) ||                                                               \
      |                 ^~~~~~~~~~
In file included from C:/Users/charles/git/
```