### PR TITLE
fix grammatical wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ json data = json::parse(f);
 
 ### Creating `json` objects from JSON literals
 
-Assume you want to create hard-code this literal JSON value in a file, as a `json` object:
+Assume you want to hard-code this literal JSON value as a `json` object:
 
 ```json
 {


### PR DESCRIPTION
## Description

This PR fixes a minor grammatical issue in the README.

The original wording in the documentation contained a small phrasing inconsistency.
This change improves clarity and correctness without altering meaning or behavior.

## Related Issue

Closes #5091

## Type of Change

Documentation fix (no functional changes)

## Checklist

- [x] The change is limited to documentation

- [x] No code changes were made

- [x] No test updates required