### PR TITLE
Fix missing exports from `json.cppm`

### DIFF
--- a/docs/mkdocs/docs/features/modules.md
+++ b/docs/mkdocs/docs/features/modules.md
@@ -39,3 +39,8 @@ Only the following symbols are exported from `nlohmann.json`:
 - `nlohmann::detail::unknown_size`
 - `nlohmann::literals::json_literals::operator""_json`
 - `nlohmann::literals::json_literals::operator""_json_pointer`
+
+The following specialisations of `std` symbols are also exported:
+- `std::hash`
+- `std::less`
+- `std::swap`

--- a/docs/mkdocs/docs/features/modules.md
+++ b/docs/mkdocs/docs/features/modules.md
@@ -24,11 +24,18 @@ json data = json::parse(f);
 ```
 
 ## Modules do not export macros
-It should be noted that as modules do not export macros, the `nlohmann.json` module will not export any macros, but rather only the following symbols:
+It should be noted that as modules do not export macros, the `nlohmann.json` module will not export any macros.
 
+## Exported symbols
+Only the following symbols are exported from `nlohmann.json`:
 - `nlohmann::adl_serializer`
 - `nlohmann::basic_json`
 - `nlohmann::json`
 - `nlohmann::json_pointer`
-- `nlohmann::ordered_map`
 - `nlohmann::ordered_json`
+- `nlohmann::ordered_map`
+- `nlohmann::to_string`
+- `nlohmann::detail::json_sax_dom_callback_parser`
+- `nlohmann::detail::unknown_size`
+- `nlohmann::literals::json_literals::operator""_json`
+- `nlohmann::literals::json_literals::operator""_json_pointer`

--- a/docs/mkdocs/docs/features/modules.md
+++ b/docs/mkdocs/docs/features/modules.md
@@ -35,8 +35,6 @@ Only the following symbols are exported from `nlohmann.json`:
 - `nlohmann::ordered_json`
 - `nlohmann::ordered_map`
 - `nlohmann::to_string`
-- `nlohmann::detail::json_sax_dom_callback_parser`
-- `nlohmann::detail::unknown_size`
 - `nlohmann::literals::json_literals::operator""_json`
 - `nlohmann::literals::json_literals::operator""_json_pointer`
 

--- a/src/modules/json.cppm
+++ b/src/modules/json.cppm
@@ -27,8 +27,8 @@ inline namespace literals
 {
 inline namespace json_literals
 {
-    using NLOHMANN_JSON_NAMESPACE::literals::operator""_json;
-    using NLOHMANN_JSON_NAMESPACE::literals::operator""_json_pointer;
+    using NLOHMANN_JSON_NAMESPACE::literals::json_literals::operator""_json;
+    using NLOHMANN_JSON_NAMESPACE::literals::json_literals::operator""_json_pointer;
 } // namespace json_literals
 } // namespace literals
 

--- a/src/modules/json.cppm
+++ b/src/modules/json.cppm
@@ -32,6 +32,14 @@ inline namespace json_literals
 } // namespace json_literals
 } // namespace literals
 
+// Note: the following nlohmann::detail symbols must be exported due to
+// an MSVC bug failing to compile without these symbols visible (ticket #3970)
+namespace detail
+{
+    using NLOHMANN_JSON_NAMESPACE::detail::json_sax_dom_callback_parser;
+    using NLOHMANN_JSON_NAMESPACE::detail::unknown_size;
+} // namespace detail
+
 NLOHMANN_JSON_NAMESPACE_END
 
 export namespace std

--- a/src/modules/json.cppm
+++ b/src/modules/json.cppm
@@ -1,32 +1,48 @@
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.12.0
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2026 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
 module;
 
 #include <nlohmann/json.hpp>
 
 export module nlohmann.json;
 
-export namespace nlohmann {
-    using ::nlohmann::adl_serializer;
-    using ::nlohmann::basic_json;
-    using ::nlohmann::json;
-    using ::nlohmann::json_pointer;
-    using ::nlohmann::ordered_json;
-    using ::nlohmann::ordered_map;
-}  // namespace nlohmann
-
+export
 NLOHMANN_JSON_NAMESPACE_BEGIN
+
+using NLOHMANN_JSON_NAMESPACE::adl_serializer;
+using NLOHMANN_JSON_NAMESPACE::basic_json;
+using NLOHMANN_JSON_NAMESPACE::json;
+using NLOHMANN_JSON_NAMESPACE::json_pointer;
+using NLOHMANN_JSON_NAMESPACE::ordered_json;
+using NLOHMANN_JSON_NAMESPACE::ordered_map;
+using NLOHMANN_JSON_NAMESPACE::to_string;
+
+inline namespace literals
+{
+inline namespace json_literals
+{
+    using NLOHMANN_JSON_NAMESPACE::literals::operator""_json;
+    using NLOHMANN_JSON_NAMESPACE::literals::operator""_json_pointer;
+} // namespace json_literals
+} // namespace literals
 
 namespace detail
 {
-    export using NLOHMANN_JSON_NAMESPACE::detail::json_sax_dom_callback_parser;
-    export using NLOHMANN_JSON_NAMESPACE::detail::unknown_size;
+    using NLOHMANN_JSON_NAMESPACE::detail::json_sax_dom_callback_parser;
+    using NLOHMANN_JSON_NAMESPACE::detail::unknown_size;
 } // namespace detail
 
-export using NLOHMANN_JSON_NAMESPACE::adl_serializer;
-export using NLOHMANN_JSON_NAMESPACE::basic_json;
-export using NLOHMANN_JSON_NAMESPACE::json;
-export using NLOHMANN_JSON_NAMESPACE::json_pointer;
-export using NLOHMANN_JSON_NAMESPACE::ordered_json;
-export using NLOHMANN_JSON_NAMESPACE::ordered_map;
-export using NLOHMANN_JSON_NAMESPACE::to_string;
-
 NLOHMANN_JSON_NAMESPACE_END
+
+export namespace std
+{
+    using std::hash;
+    using std::less;
+    using std::swap;
+} // namespace std

--- a/src/modules/json.cppm
+++ b/src/modules/json.cppm
@@ -32,12 +32,6 @@ inline namespace json_literals
 } // namespace json_literals
 } // namespace literals
 
-namespace detail
-{
-    using NLOHMANN_JSON_NAMESPACE::detail::json_sax_dom_callback_parser;
-    using NLOHMANN_JSON_NAMESPACE::detail::unknown_size;
-} // namespace detail
-
 NLOHMANN_JSON_NAMESPACE_END
 
 export namespace std


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line and make sure you follow the checklist.]

This pull request restores some missing symbols that were present in the `<nlohmann/json.hpp>` header, but weren't exported in `json.cppm`. These include specialisations in namespace `std` (such as `hash<>` and `less<>`), as well as `nlohmann::literals::json_literals::*`. This is necessary as without this those specialisations and symbols are inaccessible from the module.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

