### PR TITLE
docs: flesh out architecture overview

### DIFF
--- a/docs/mkdocs/docs/home/architecture.md
+++ b/docs/mkdocs/docs/home/architecture.md
@@ -9,15 +9,23 @@
 
 The main structure is class [nlohmann::basic_json](../api/basic_json/index.md).
 
-- public API
-- container interface
-- iterators
+It combines three roles in one type:
+
+- the public JSON API (`parse`, `dump`, element access, conversion helpers, binary format support),
+- the container-like interface for arrays and objects, and
+- the iterator types that make JSON values integrate with generic STL-style code.
+
+Most of the implementation details live in the `nlohmann::detail` namespace. `basic_json` ties these helpers together and
+exposes the stable API surface used by the `json` and `ordered_json` aliases.
 
 ## Template specializations
 
-- describe template parameters of `basic_json`
-- [`json`](../api/json.md)
-- [`ordered_json`](../api/ordered_json.md) via [`ordered_map`](../api/ordered_map.md)
+`basic_json` is heavily parameterized so the same implementation can be reused with different object, array, string,
+number, allocator, serializer, and binary container types.
+
+- [`json`](../api/json.md) is the default alias used throughout the documentation.
+- [`ordered_json`](../api/ordered_json.md) swaps the default object type for [`ordered_map`](../api/ordered_map.md) to
+  preserve insertion order during object iteration and serialization.
 
 ## Value storage
 
@@ -70,7 +78,8 @@ union json_value {
 
 ## Parsing inputs (deserialization)
 
-Input is read via **input adapters** that abstract a source with a common interface:
+Text and binary parsing start by normalizing the input through **input adapters**. These wrappers present different
+source types behind a shared interface:
 
 ```cpp
 /// read a single character
@@ -82,15 +91,30 @@ template<class T>
 std::size_t get_elements(T* dest, std::size_t count = 1);
 ```
 
-List examples of input adapters.
+Common examples are `file_input_adapter` for `FILE*`, `input_stream_adapter` for `std::istream`,
+`iterator_input_adapter` for iterator pairs, and the span/contiguous-byte adapters used for buffers in memory. Once an
+adapter is created, `detail::parser` handles textual JSON and `detail::binary_reader` handles CBOR, MessagePack,
+UBJSON, BSON, and BJData.
 
 ## SAX Interface
 
-TODO
+The parser is event-driven internally. The public SAX entry point is
+[`basic_json::sax_parse`](../api/basic_json/sax_parse.md), which emits callbacks defined by
+[`json_sax`](../api/json_sax/index.md) such as `null`, `key`, `start_object`, and `parse_error`.
+
+The same interface is reused by internal consumers:
+
+- `json_sax_dom_parser` builds a complete DOM,
+- `json_sax_dom_callback_parser` applies the user callback used by `parse`, and
+- `json_sax_acceptor` validates input for `accept` without materializing a JSON value.
+
+The dedicated [SAX interface page](../features/parsing/sax_interface.md) contains the full callback list and a minimal
+custom handler example.
 
 ## Writing outputs (serialization)
 
-Output is written via **output adapters**:
+Serialization follows the same pattern in the other direction: serializers write to **output adapters** instead of
+talking to strings, streams, or byte buffers directly.
 
 ```cpp
 template<typename T>
@@ -100,7 +124,9 @@ template<typename CharType>
 void write_characters(const CharType* s, std::size_t length);
 ```
 
-List examples of output adapters.
+Examples include `output_string_adapter` for `std::string`, `output_stream_adapter` for `std::ostream`, and
+`output_vector_adapter` for byte-oriented containers. These adapters are used by the text serializer as well as the
+binary writers behind functions such as `to_cbor`, `to_msgpack`, and `to_bson`.
 
 ## Value conversion
 


### PR DESCRIPTION

**Repo:** nlohmann/json (⭐ 45000)
**Type:** docs
**Files changed:** 1
**Lines:** +37/-11

## What
Expanded the contributor-facing architecture overview in `docs/mkdocs/docs/home/architecture.md` by replacing placeholder bullets and a visible `TODO` with concrete descriptions of `basic_json`, template specializations, input/output adapters, the parser flow, and the SAX-based internal architecture.

## Why
The architecture page is intended to orient new contributors, but it still exposed unfinished notes like `TODO` and "List examples..." placeholders. Filling those gaps makes the page more useful for onboarding and code navigation without changing library behavior or generated headers.

## Testing
Verified the referenced documentation files exist, confirmed the edited page no longer contains `TODO`, and ran `git diff --check` to ensure the patch is clean. No code or test-suite execution was needed for this docs-only change.

## Risk
Low / Documentation-only change with no runtime impact.
