### PR TITLE
docs: fix typo in basic_json::value documentation

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/value.md
+++ b/docs/mkdocs/docs/api/basic_json/value.md
@@ -110,7 +110,7 @@ changes to any JSON value.
     The value function is a template, and the return type of the function is determined by the type of the provided
     default value unless otherwise specified. This can have unexpected effects. In the example below, we store a 64-bit
     unsigned integer. We get exactly that value when using [`operator[]`](operator[].md). However, when we call `value`
-    and provide `#!c 0` as default value, then `#!c -1` is returned. The occurs, because `#!c 0` has type `#!c int`
+    and provide `#!c 0` as default value, then `#!c -1` is returned. This occurs, because `#!c 0` has type `#!c int`
     which overflows when handling the value `#!c 18446744073709551615`.
 
     To address this issue, either provide a correctly typed default value or use the template parameter to specify the


### PR DESCRIPTION
This pull request fixes a typo in the `basic_json::value` documentation.

Changed `The occurs, because` to `This occurs, because`.
