### PR TITLE
Harden JSON_HAS_RANGES detection for incomplete C++20 ranges implementations

### DIFF
--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -137,6 +137,12 @@
     // ranges header shipping in GCC 11.1.0 (released 2021-04-27) has a syntax error
     #if defined(__GLIBCXX__) && __GLIBCXX__ == 20210427
         #define JSON_HAS_RANGES 0
+        // libstdc++ < 12 has incomplete C++20 ranges (issue #4440)
+    #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
+        #define JSON_HAS_RANGES 0
+        // libc++ < 16 has incomplete C++20 ranges (issue #4440)
+    #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
+        #define JSON_HAS_RANGES 0
     #elif defined(__cpp_lib_ranges)
         #define JSON_HAS_RANGES 1
     #else

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -137,10 +137,13 @@
     // ranges header shipping in GCC 11.1.0 (released 2021-04-27) has a syntax error
     #if defined(__GLIBCXX__) && __GLIBCXX__ == 20210427
         #define JSON_HAS_RANGES 0
-        // libstdc++ < 12 has incomplete C++20 ranges (issue #4440)
-    #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
+        // libstdc++ < 11 has incomplete C++20 ranges (issue #4440)
+    #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 11
         #define JSON_HAS_RANGES 0
         // libc++ < 16 has incomplete C++20 ranges (issue #4440)
+    #elif defined(__clang__) && !defined(__apple_build_version__) \
+        && __clang_major__ < 16 && defined(__GLIBCXX__)
+        #define JSON_HAS_RANGES 0
     #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
         #define JSON_HAS_RANGES 0
     #elif defined(__cpp_lib_ranges)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2501,6 +2501,12 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     // ranges header shipping in GCC 11.1.0 (released 2021-04-27) has a syntax error
     #if defined(__GLIBCXX__) && __GLIBCXX__ == 20210427
         #define JSON_HAS_RANGES 0
+        // libstdc++ < 12 has incomplete C++20 ranges (issue #4440)
+    #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
+        #define JSON_HAS_RANGES 0
+        // libc++ < 16 has incomplete C++20 ranges (issue #4440)
+    #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
+        #define JSON_HAS_RANGES 0
     #elif defined(__cpp_lib_ranges)
         #define JSON_HAS_RANGES 1
     #else

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2501,10 +2501,13 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     // ranges header shipping in GCC 11.1.0 (released 2021-04-27) has a syntax error
     #if defined(__GLIBCXX__) && __GLIBCXX__ == 20210427
         #define JSON_HAS_RANGES 0
-        // libstdc++ < 12 has incomplete C++20 ranges (issue #4440)
-    #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
+        // libstdc++ < 11 has incomplete C++20 ranges (issue #4440)
+    #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 11
         #define JSON_HAS_RANGES 0
         // libc++ < 16 has incomplete C++20 ranges (issue #4440)
+    #elif defined(__clang__) && !defined(__apple_build_version__) \
+        && __clang_major__ < 16 && defined(__GLIBCXX__)
+        #define JSON_HAS_RANGES 0
     #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
         #define JSON_HAS_RANGES 0
     #elif defined(__cpp_lib_ranges)

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -66,6 +66,11 @@ using ordered_json = nlohmann::ordered_json;
     #endif
 #endif
 
+// for #4440
+#if JSON_HAS_RANGES == 1
+    #include <ranges>
+#endif
+
 // NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
@@ -1134,6 +1139,20 @@ TEST_CASE("regression tests 2")
         CHECK(!result.has_value());
     }
 #endif
+
+#if JSON_HAS_RANGES == 1
+    SECTION("issue #4440 - assert when using std::views::filter and GCC 10")
+    {
+        auto noOpFilter = std::views::filter([](auto&&) noexcept
+        {
+            return true;
+        });
+        json j = {1, 2, 3};
+        auto filtered = j | noOpFilter;
+        CHECK(*filtered.begin() == 1);
+    }
+#endif
+
 }
 
 TEST_CASE_TEMPLATE("issue #4798 - nlohmann::json::to_msgpack() encode float NaN as double", T, double, float) // NOLINT(readability-math-missing-parentheses, bugprone-throwing-static-initialization)


### PR DESCRIPTION
Some standard libraries advertise `__cpp_lib_ranges` but ship an incomplete
C++20 ranges implementation. Constructing a `basic_json` from a view (e.g.
`j | std::views::filter(...)`) then asserts or fails to compile on those
toolchains.

This PR refines the `JSON_HAS_RANGES` feature detection to disable ranges
support on the affected standard libraries:

- libstdc++ < 11 (GCC 10) — assertion failure (closes #4440)
- libc++ < 16
- Clang < 16 combined with libstdc++ — compile error unless
  `JSON_HAS_RANGES=0` was set manually (closes #4051)

On these toolchains the library now falls back to `JSON_HAS_RANGES 0`
instead of enabling a broken code path. Toolchains with complete ranges
support are unaffected.

It also adds a regression test (`unit-regression2.cpp`) reproducing #4440
with `std::views::filter`, guarded by `JSON_HAS_RANGES == 1` so it only runs
where ranges are actually available.

Closes #4440.
Closes #4051.