### PR TITLE
Fix compile error when using nlohmann ordered_map with WITH_DEFAULT macros

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -388,14 +388,10 @@ inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
 
     ConstructibleObjectType ret;
     const auto* inner_object = j.template get_ptr<const typename BasicJsonType::object_t*>();
-    using value_type = typename ConstructibleObjectType::value_type;
-    std::transform(
-        inner_object->begin(), inner_object->end(),
-        std::inserter(ret, ret.begin()),
-        [](typename BasicJsonType::object_t::value_type const & p)
+    for (const auto& p : *inner_object)
     {
-        return value_type(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
-    });
+        ret.emplace(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
+    }
     obj = std::move(ret);
 }
 

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -51,6 +51,39 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
     ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
         : Container{init, alloc} {}
 
+    // The inherited std::vector copy/move assignment operators require
+    // value_type to be CopyAssignable / MoveAssignable when the element
+    // copy/move path triggers. value_type here is std::pair<const Key, T>,
+    // whose copy- and move-assignment are deleted because of the const Key.
+    // That breaks any code that assigns an ordered_map, including the
+    // NLOHMANN_JSON_FROM_WITH_DEFAULT macro's ternary which forces
+    // copy-assignment of the field. Provide assignment operators that
+    // rebuild via clear + push_back (copy) or transfer the underlying
+    // vector (move), both of which only need construction of value_type,
+    // never assignment. See nlohmann/json#5122.
+    ordered_map(const ordered_map&) = default;
+    ordered_map(ordered_map&&) noexcept(std::is_nothrow_move_constructible<Container>::value) = default;
+
+    ordered_map& operator=(const ordered_map& other)
+    {
+        if (this != &other)
+        {
+            Container::clear();
+            Container::reserve(other.size());
+            for (const auto& entry : other)
+            {
+                Container::push_back(entry);
+            }
+        }
+        return *this;
+    }
+
+    ordered_map& operator=(ordered_map&& other) noexcept(noexcept(std::declval<Container&>() = std::declval < Container && > ()))
+    {
+        Container::operator=(std::move(static_cast<Container&>(other)));
+        return *this;
+    }
+
     std::pair<iterator, bool> emplace(const key_type& key, T&& t)
     {
         for (auto it = this->begin(); it != this->end(); ++it)

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -56,19 +56,12 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     ordered_map& operator=(const ordered_map& other)
     {
-        if (this != &other)
-        {
-            Container::clear();
-            Container::reserve(other.size());
-            for (const auto& entry : other)
-            {
-                Container::push_back(entry);
-            }
-        }
+        ordered_map tmp(other);
+        Container::operator=(std::move(static_cast<Container&>(tmp)));
         return *this;
     }
 
-    ordered_map& operator=(ordered_map&& other) noexcept(noexcept(std::declval<Container&>() = std::declval < Container && > ()))
+    ordered_map& operator=(ordered_map&& other) noexcept(std::is_nothrow_move_assignable<Container>::value)
     {
         Container::operator=(std::move(static_cast<Container&>(other)));
         return *this;

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -56,8 +56,11 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     ordered_map& operator=(const ordered_map& other)
     {
-        ordered_map tmp(other);
-        Container::operator=(std::move(static_cast<Container&>(tmp)));
+        if (this != &other)
+        {
+            ordered_map tmp(other);
+            Container::operator=(std::move(static_cast<Container&>(tmp)));
+        }
         return *this;
     }
 

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -52,6 +52,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         : Container{init, alloc} {}
     ordered_map(const ordered_map&) = default;
     ordered_map(ordered_map&&) noexcept(std::is_nothrow_move_constructible<Container>::value) = default;
+    ~ordered_map() = default;
 
     ordered_map& operator=(const ordered_map& other)
     {

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -50,17 +50,6 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         : Container{first, last, alloc} {}
     ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
         : Container{init, alloc} {}
-
-    // The inherited std::vector copy/move assignment operators require
-    // value_type to be CopyAssignable / MoveAssignable when the element
-    // copy/move path triggers. value_type here is std::pair<const Key, T>,
-    // whose copy- and move-assignment are deleted because of the const Key.
-    // That breaks any code that assigns an ordered_map, including the
-    // NLOHMANN_JSON_FROM_WITH_DEFAULT macro's ternary which forces
-    // copy-assignment of the field. Provide assignment operators that
-    // rebuild via clear + push_back (copy) or transfer the underlying
-    // vector (move), both of which only need construction of value_type,
-    // never assignment. See nlohmann/json#5122.
     ordered_map(const ordered_map&) = default;
     ordered_map(ordered_map&&) noexcept(std::is_nothrow_move_constructible<Container>::value) = default;
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -5306,14 +5306,10 @@ inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
 
     ConstructibleObjectType ret;
     const auto* inner_object = j.template get_ptr<const typename BasicJsonType::object_t*>();
-    using value_type = typename ConstructibleObjectType::value_type;
-    std::transform(
-        inner_object->begin(), inner_object->end(),
-        std::inserter(ret, ret.begin()),
-        [](typename BasicJsonType::object_t::value_type const & p)
+    for (const auto& p : *inner_object)
     {
-        return value_type(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
-    });
+        ret.emplace(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
+    }
     obj = std::move(ret);
 }
 
@@ -19994,6 +19990,39 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         : Container{first, last, alloc} {}
     ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
         : Container{init, alloc} {}
+
+    // The inherited std::vector copy/move assignment operators require
+    // value_type to be CopyAssignable / MoveAssignable when the element
+    // copy/move path triggers. value_type here is std::pair<const Key, T>,
+    // whose copy- and move-assignment are deleted because of the const Key.
+    // That breaks any code that assigns an ordered_map, including the
+    // NLOHMANN_JSON_FROM_WITH_DEFAULT macro's ternary which forces
+    // copy-assignment of the field. Provide assignment operators that
+    // rebuild via clear + push_back (copy) or transfer the underlying
+    // vector (move), both of which only need construction of value_type,
+    // never assignment. See nlohmann/json#5122.
+    ordered_map(const ordered_map&) = default;
+    ordered_map(ordered_map&&) noexcept(std::is_nothrow_move_constructible<Container>::value) = default;
+
+    ordered_map& operator=(const ordered_map& other)
+    {
+        if (this != &other)
+        {
+            Container::clear();
+            Container::reserve(other.size());
+            for (const auto& entry : other)
+            {
+                Container::push_back(entry);
+            }
+        }
+        return *this;
+    }
+
+    ordered_map& operator=(ordered_map&& other) noexcept(noexcept(std::declval<Container&>() = std::declval < Container && > ()))
+    {
+        Container::operator=(std::move(static_cast<Container&>(other)));
+        return *this;
+    }
 
     std::pair<iterator, bool> emplace(const key_type& key, T&& t)
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19992,6 +19992,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         : Container{init, alloc} {}
     ordered_map(const ordered_map&) = default;
     ordered_map(ordered_map&&) noexcept(std::is_nothrow_move_constructible<Container>::value) = default;
+    ~ordered_map() = default;
 
     ordered_map& operator=(const ordered_map& other)
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19996,8 +19996,11 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     ordered_map& operator=(const ordered_map& other)
     {
-        ordered_map tmp(other);
-        Container::operator=(std::move(static_cast<Container&>(tmp)));
+        if (this != &other)
+        {
+            ordered_map tmp(other);
+            Container::operator=(std::move(static_cast<Container&>(tmp)));
+        }
         return *this;
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19996,19 +19996,12 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     ordered_map& operator=(const ordered_map& other)
     {
-        if (this != &other)
-        {
-            Container::clear();
-            Container::reserve(other.size());
-            for (const auto& entry : other)
-            {
-                Container::push_back(entry);
-            }
-        }
+        ordered_map tmp(other);
+        Container::operator=(std::move(static_cast<Container&>(tmp)));
         return *this;
     }
 
-    ordered_map& operator=(ordered_map&& other) noexcept(noexcept(std::declval<Container&>() = std::declval < Container && > ()))
+    ordered_map& operator=(ordered_map&& other) noexcept(std::is_nothrow_move_assignable<Container>::value)
     {
         Container::operator=(std::move(static_cast<Container&>(other)));
         return *this;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19990,17 +19990,6 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         : Container{first, last, alloc} {}
     ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
         : Container{init, alloc} {}
-
-    // The inherited std::vector copy/move assignment operators require
-    // value_type to be CopyAssignable / MoveAssignable when the element
-    // copy/move path triggers. value_type here is std::pair<const Key, T>,
-    // whose copy- and move-assignment are deleted because of the const Key.
-    // That breaks any code that assigns an ordered_map, including the
-    // NLOHMANN_JSON_FROM_WITH_DEFAULT macro's ternary which forces
-    // copy-assignment of the field. Provide assignment operators that
-    // rebuild via clear + push_back (copy) or transfer the underlying
-    // vector (move), both of which only need construction of value_type,
-    // never assignment. See nlohmann/json#5122.
     ordered_map(const ordered_map&) = default;
     ordered_map(ordered_map&&) noexcept(std::is_nothrow_move_constructible<Container>::value) = default;
 

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1240,4 +1240,33 @@ TEST_CASE("regression test #5074 - single-element brace init with JSON_BRACE_INI
 }
 #endif
 
+struct Example_5122
+{
+    float b = 2;
+    nlohmann::ordered_map<std::string, std::string> c;
+    int a = 1;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_5122, b, c, a)
+};
+
+TEST_CASE("regression test #5122 - from_json into types holding nlohmann::ordered_map")
+{
+    Example_5122 src;
+    src.c.emplace("first", "1");
+    src.c.emplace("second", "2");
+
+    ordered_json const j = src;
+    Example_5122 const dst = j.get<Example_5122>();
+
+    CHECK(dst.b == src.b);
+    CHECK(dst.a == src.a);
+    REQUIRE(dst.c.size() == src.c.size());
+    auto src_it = src.c.begin();
+    auto dst_it = dst.c.begin();
+    for (; src_it != src.c.end(); ++src_it, ++dst_it)
+    {
+        CHECK(dst_it->first == src_it->first);
+        CHECK(dst_it->second == src_it->second);
+    }
+}
+
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1243,7 +1243,7 @@ TEST_CASE("regression test #5074 - single-element brace init with JSON_BRACE_INI
 struct Example_5122
 {
     float b = 2;
-    nlohmann::ordered_map<std::string, std::string> c;
+    nlohmann::ordered_map<std::string, std::string> c{};
     int a = 1;
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_5122, b, c, a)
 };

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1243,7 +1243,7 @@ TEST_CASE("regression test #5074 - single-element brace init with JSON_BRACE_INI
 struct Example_5122
 {
     float b = 2;
-    nlohmann::ordered_map<std::string, std::string> c{};
+    nlohmann::ordered_map<std::string, std::string> c{}; // NOLINT(readability-redundant-member-init): needed for GCC -Weffc++
     int a = 1;
     NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Example_5122, b, c, a)
 };

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1269,4 +1269,52 @@ TEST_CASE("regression test #5122 - from_json into types holding nlohmann::ordere
     }
 }
 
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wself-assign-overloaded")
+
+TEST_CASE("regression test #5122 - nlohmann::ordered_map copy-assignment is self-assignment safe")
+{
+    nlohmann::ordered_map<std::string, std::string> m;
+    m.emplace("first", "1");
+    m.emplace("second", "2");
+
+    // Insertion order is preserved by ordered_map, so we can check it directly.
+    m = m;
+
+    REQUIRE(m.size() == 2);
+    auto it = m.begin();
+    CHECK(it->first == "first");
+    CHECK(it->second == "1");
+    ++it;
+    CHECK(it->first == "second");
+    CHECK(it->second == "2");
+}
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfers contents")
+{
+    nlohmann::ordered_map<std::string, std::string> src;
+    src.emplace("first", "1");
+    src.emplace("second", "2");
+
+    nlohmann::ordered_map<std::string, std::string> dst;
+    dst.emplace("stale", "x");
+    dst = std::move(src);
+
+    REQUIRE(dst.size() == 2);
+    auto it = dst.begin();
+    CHECK(it->first == "first");
+    CHECK(it->second == "1");
+    ++it;
+    CHECK(it->first == "second");
+    CHECK(it->second == "2");
+
+    // Re-assigning into the moved-from object must leave it in a usable state.
+    src = nlohmann::ordered_map<std::string, std::string>{};
+    src.emplace("after-move", "3");
+    REQUIRE(src.size() == 1);
+    CHECK(src.begin()->first == "after-move");
+}
+
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1269,19 +1269,15 @@ TEST_CASE("regression test #5122 - from_json into types holding nlohmann::ordere
     }
 }
 
-#define JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED 0
-#if defined(__clang__)
-    #if defined(__has_warning)
-        #if __has_warning("-Wself-assign-overloaded")
-            #undef JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
-            #define JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED 1
-        #endif
-    #endif
-#endif
-
-#if JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
+// -Wself-assign-overloaded was introduced in Clang 7. Gate the pragma on
+// __has_warning so older Clang versions do not error with "unknown warning
+// group". The __has_warning check has to stay inside the __clang__ branch
+// because GCC does not provide it and would tokenize-error on the argument.
+#if defined(__clang__) && defined(__has_warning)
+    #if __has_warning("-Wself-assign-overloaded")
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wself-assign-overloaded")
+    #endif
 #endif
 
 TEST_CASE("regression test #5122 - nlohmann::ordered_map copy-assignment is self-assignment safe")
@@ -1302,10 +1298,11 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map copy-assignment is self
     CHECK(it->second == "2");
 }
 
-#if JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
+#if defined(__clang__) && defined(__has_warning)
+    #if __has_warning("-Wself-assign-overloaded")
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    #endif
 #endif
-#undef JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
 
 TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfers contents")
 {

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1269,8 +1269,20 @@ TEST_CASE("regression test #5122 - from_json into types holding nlohmann::ordere
     }
 }
 
+#define JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED 0
+#if defined(__clang__)
+    #if defined(__has_warning)
+        #if __has_warning("-Wself-assign-overloaded")
+            #undef JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
+            #define JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED 1
+        #endif
+    #endif
+#endif
+
+#if JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wself-assign-overloaded")
+#endif
 
 TEST_CASE("regression test #5122 - nlohmann::ordered_map copy-assignment is self-assignment safe")
 {
@@ -1290,7 +1302,10 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map copy-assignment is self
     CHECK(it->second == "2");
 }
 
+#if JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#endif
+#undef JSON_TEST_5122_SUPPRESS_SELF_ASSIGN_OVERLOADED
 
 TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfers contents")
 {


### PR DESCRIPTION
When deserializing into a struct that contains a nlohmann ordered_map field via NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT, the build fails with `pair operator= is deleted` (issue #5122). The macro expands to a ternary whose common type forces copy-assignment of ordered_map, and the inherited std vector copy-assignment uses pair operator= element-wise, which is deleted whenever the key is const. This change gives ordered_map its own copy and move assignment that rebuild via clear plus push_back or transfer the underlying buffer, plus replaces the transform-and-inserter idiom in the map from_json overload with a range-for plus emplace so the same hazard does not surface there. Built and ran the full ctest suite, all 102 targets pass including the new regression test that round-trips a struct with ordered_map<string, string>.