### PR TITLE
Fix incomplete-type error in set_parents with ordered_json

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -741,10 +741,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 #endif
     }
 
-    iterator set_parents(iterator it, typename iterator::difference_type count_set_parents)
+    iterator set_parents(iterator it, std::ptrdiff_t count_set_parents)
     {
 #if JSON_DIAGNOSTICS
-        for (typename iterator::difference_type i = 0; i < count_set_parents; ++i)
+        for (std::ptrdiff_t i = 0; i < count_set_parents; ++i)
         {
             (it + i)->m_parent = this;
         }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21020,10 +21020,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 #endif
     }
 
-    iterator set_parents(iterator it, typename iterator::difference_type count_set_parents)
+    iterator set_parents(iterator it, std::ptrdiff_t count_set_parents)
     {
 #if JSON_DIAGNOSTICS
-        for (typename iterator::difference_type i = 0; i < count_set_parents; ++i)
+        for (std::ptrdiff_t i = 0; i < count_set_parents; ++i)
         {
             (it + i)->m_parent = this;
         }

--- a/tests/src/unit-ordered_json.cpp
+++ b/tests/src/unit-ordered_json.cpp
@@ -69,3 +69,15 @@ TEST_CASE("ordered_json")
     CHECK(oj1.size() == 4);
     CHECK(oj1.dump() == "{\"c\":1,\"b\":2,\"a\":3,\"d\":42}");
 }
+
+TEST_CASE("regression test for issue #3732 - iteration_proxy_value<iter_impl<ordered_json>>")
+{
+    // Naming the proxy type in a function-parameter position forces eager
+    // instantiation of basic_json<ordered_map>; previously this hit an
+    // incomplete-type error in set_parents().
+    auto fn = [](nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> const& val)
+    {
+        return val.value();
+    };
+    static_cast<void>(fn);
+}


### PR DESCRIPTION
Fixes #3732 (label: confirmed).

If you name `detail::iteration_proxy_value<detail::iter_impl<ordered_json>>` where it has to be complete (function or lambda parameter), the compile blows up:

```
error: invalid use of incomplete type
'using ... basic_json<ordered_map>::iterator = ... iter_impl<...>'
```

The cascade is `proxy -> iter_impl<ordered_json> -> basic_json<ordered_map>`, and during `basic_json`'s instantiation the compiler hits `set_parents(iterator, typename iterator::difference_type)` before `iterator` is complete.

`basic_json::difference_type` is already `std::ptrdiff_t`, so just using the underlying type directly avoids the dependent lookup. Same behavior, no ABI change. This was suggested in the issue thread.

Added a regression case in `tests/src/unit-ordered_json.cpp` (lambda parameter naming the proxy type — same trigger as the minimal repro). Full local `ctest` run passes (102/102).

The frozen ABI snapshot at `tests/abi/include/nlohmann/json_v3_10_5.hpp` is intentionally left alone.

- [x] The changes are described in detail, both the what and why.
- [x] An existing issue is referenced (#3732).
- [x] Code coverage: a regression test is added for the changed lines.
- [x] No documentation change is required.
- [x] The source code is amalgamated (`single_include/nlohmann/json.hpp` updated to match).