### PR TITLE
Fix Cppcheck warning

### DIFF
--- a/cmake/requirements/requirements-cppcheck.txt
+++ b/cmake/requirements/requirements-cppcheck.txt
@@ -1,1 +1,1 @@
-cppcheck==1.5.0
+cppcheck==1.5.1

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -825,14 +825,27 @@ class serializer
         o->write_characters(begin, static_cast<size_t>(end - begin));
     }
 
+    JSON_HEDLEY_NON_NULL(1)
+    static int snprintf_float(char* buf, std::size_t size, int d, double x)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        return (std::snprintf)(buf, size, "%.*g", d, x);
+    }
+
+    JSON_HEDLEY_NON_NULL(1)
+    static int snprintf_float(char* buf, std::size_t size, int d, long double x)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        return (std::snprintf)(buf, size, "%.*lg", d, x);
+    }
+
     void dump_float(number_float_t x, std::false_type /*is_ieee_single_or_double*/)
     {
         // get the number of digits for a float -> text -> float round-trip
         static constexpr auto d = std::numeric_limits<number_float_t>::max_digits10;
 
         // the actual conversion
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        std::ptrdiff_t len = (std::snprintf)(number_buffer.data(), number_buffer.size(), "%.*g", d, x);
+        std::ptrdiff_t len = snprintf_float(number_buffer.data(), number_buffer.size(), d, x);
 
         // negative value indicates an error
         JSON_ASSERT(len > 0);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19807,14 +19807,27 @@ class serializer
         o->write_characters(begin, static_cast<size_t>(end - begin));
     }
 
+    JSON_HEDLEY_NON_NULL(1)
+    static int snprintf_float(char* buf, std::size_t size, int d, double x)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        return (std::snprintf)(buf, size, "%.*g", d, x);
+    }
+
+    JSON_HEDLEY_NON_NULL(1)
+    static int snprintf_float(char* buf, std::size_t size, int d, long double x)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        return (std::snprintf)(buf, size, "%.*lg", d, x);
+    }
+
     void dump_float(number_float_t x, std::false_type /*is_ieee_single_or_double*/)
     {
         // get the number of digits for a float -> text -> float round-trip
         static constexpr auto d = std::numeric_limits<number_float_t>::max_digits10;
 
         // the actual conversion
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        std::ptrdiff_t len = (std::snprintf)(number_buffer.data(), number_buffer.size(), "%.*g", d, x);
+        std::ptrdiff_t len = snprintf_float(number_buffer.data(), number_buffer.size(), d, x);
 
         // negative value indicates an error
         JSON_ASSERT(len > 0);

--- a/tests/src/unit-ordered_json.cpp
+++ b/tests/src/unit-ordered_json.cpp
@@ -75,7 +75,7 @@ TEST_CASE("regression test for issue #3732 - iteration_proxy_value<iter_impl<ord
     // Naming the proxy type in a function-parameter position forces eager
     // instantiation of basic_json<ordered_map>; previously this hit an
     // incomplete-type error in set_parents().
-    auto fn = [](nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> const& val)
+    auto fn = [](nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> const & val)
     {
         return val.value();
     };

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1275,8 +1275,8 @@ TEST_CASE("regression test #5122 - from_json into types holding nlohmann::ordere
 // because GCC does not provide it and would tokenize-error on the argument.
 #if defined(__clang__) && defined(__has_warning)
     #if __has_warning("-Wself-assign-overloaded")
-DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wself-assign-overloaded")
+        DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+        DOCTEST_CLANG_SUPPRESS_WARNING("-Wself-assign-overloaded")
     #endif
 #endif
 
@@ -1300,7 +1300,7 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map copy-assignment is self
 
 #if defined(__clang__) && defined(__has_warning)
     #if __has_warning("-Wself-assign-overloaded")
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
+        DOCTEST_CLANG_SUPPRESS_WARNING_POP
     #endif
 #endif
 
@@ -1323,7 +1323,7 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfe
     CHECK(it->second == "2");
 
     // Re-assigning into the moved-from object must leave it in a usable state.
-    src = nlohmann::ordered_map<std::string, std::string>{};
+    src = nlohmann::ordered_map<std::string, std::string> {};
     src.emplace("after-move", "3");
     REQUIRE(src.size() == 1);
     CHECK(src.begin()->first == "after-move");


### PR DESCRIPTION
Make sure `long double`s are properly dumped.

Second try of #4758. Fixes the same issue as #3929. Supersedes #4753.