### PR TITLE
Add missing overload to ordered_map::find

### DIFF
--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -340,6 +340,20 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::end();
     }
 
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const_iterator find(KeyType && key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+
     std::pair<iterator, bool> insert( value_type&& value )
     {
         return emplace(value.first, std::move(value.second));

--- a/include/nlohmann/ordered_map.hpp
+++ b/include/nlohmann/ordered_map.hpp
@@ -342,7 +342,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    const_iterator find(KeyType && key) const
+    const_iterator find(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20331,7 +20331,6 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::end();
     }
 
-    /*
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     const_iterator find(KeyType && key) const
@@ -20345,7 +20344,6 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         }
         return Container::end();
     }
-    */
 
     std::pair<iterator, bool> insert( value_type&& value )
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20333,7 +20333,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    const_iterator find(KeyType && key) const
+    const_iterator find(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20331,6 +20331,22 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
         return Container::end();
     }
 
+    /*
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const_iterator find(KeyType && key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+    */
+
     std::pair<iterator, bool> insert( value_type&& value )
     {
         return emplace(value.first, std::move(value.second));

--- a/tests/src/unit-ordered_map.cpp
+++ b/tests/src/unit-ordered_map.cpp
@@ -269,6 +269,11 @@ TEST_CASE("ordered_map")
         CHECK(com.find("vier") == com.end());
         CHECK(com.find(std::string("vier")) == com.end());
         CHECK(com.find(vier) == com.end());
+
+#ifdef JSON_HAS_CPP_17
+        CHECK(om.find(std::string_view("eins")) == com.begin());
+        CHECK(com.find(std::string_view("eins")) == com.begin());
+#endif
     }
 
     SECTION("insert")

--- a/tests/src/unit-ordered_map.cpp
+++ b/tests/src/unit-ordered_map.cpp
@@ -271,7 +271,7 @@ TEST_CASE("ordered_map")
         CHECK(com.find(vier) == com.end());
 
 #ifdef JSON_HAS_CPP_17
-        CHECK(om.find(std::string_view("eins")) == com.begin());
+        CHECK(om.find(std::string_view("eins")) == om.begin());
         CHECK(com.find(std::string_view("eins")) == com.begin());
 #endif
     }


### PR DESCRIPTION
`ordered_map` provides four lookup variants for `emplace`, `at`, `count`, and the non-const `find`, but only **three** variants for `const` lookup: one exact-key non-const, one template non-const, and one exact-key const. The template const overload is absent:

```cpp
// present
iterator find(const key_type& key);                    // exact, non-const
iterator find(KeyType&& key);                          // template, non-const  ✓
const_iterator find(const key_type& key) const;        // exact, const         ✓

// MISSING
const_iterator find(KeyType&& key) const;              // template, const      ✗
```

This PR adds the mission overload and a test.