### PR TITLE
fix(meson): install CMake package config files

### DIFF
--- a/cmake/nlohmann_jsonTargets.cmake
+++ b/cmake/nlohmann_jsonTargets.cmake
@@ -1,0 +1,13 @@
+# Installed by Meson for find_package(nlohmann_json) compatibility with the CMake build.
+
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    get_filename_component(
+        _nlohmann_json_include_dir
+        "${CMAKE_CURRENT_LIST_DIR}/../../../include"
+        ABSOLUTE)
+    add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
+    set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
+        INTERFACE_COMPILE_FEATURES "cxx_std_11"
+        INTERFACE_INCLUDE_DIRECTORIES "${_nlohmann_json_include_dir}"
+    )
+endif()

--- a/meson.build
+++ b/meson.build
@@ -21,4 +21,35 @@ pkgc.generate(name: 'nlohmann_json',
     version: meson.project_version(),
     description: 'JSON for Modern C++'
 )
+
+cmake_dir = get_option('datadir') / 'cmake' / meson.project_name()
+version_parts = meson.project_version().split('.')
+
+cmake_conf = configuration_data()
+cmake_conf.set('PROJECT_NAME', meson.project_name())
+cmake_conf.set('NLOHMANN_JSON_TARGET_NAME', meson.project_name())
+cmake_conf.set('NLOHMANN_JSON_TARGETS_EXPORT_NAME', meson.project_name() + 'Targets')
+cmake_conf.set('PROJECT_VERSION', meson.project_version())
+cmake_conf.set('PROJECT_VERSION_MAJOR', version_parts[0])
+
+configure_file(
+    input: 'cmake/config.cmake.in',
+    output: meson.project_name() + 'Config.cmake',
+    configuration: cmake_conf,
+    install: true,
+    install_dir: cmake_dir,
+)
+
+configure_file(
+    input: 'cmake/nlohmann_jsonConfigVersion.cmake.in',
+    output: meson.project_name() + 'ConfigVersion.cmake',
+    configuration: cmake_conf,
+    install: true,
+    install_dir: cmake_dir,
+)
+
+install_data(
+    'cmake/nlohmann_jsonTargets.cmake',
+    install_dir: cmake_dir,
+)
 endif


### PR DESCRIPTION
## Summary
- Install `nlohmann_jsonConfig.cmake`, `nlohmann_jsonConfigVersion.cmake`, and `nlohmann_jsonTargets.cmake` when building/installing with Meson.
- Add a static `cmake/nlohmann_jsonTargets.cmake` for the header-only imported target.
- Align Meson installs with CMake `find_package(nlohmann_json)` expectations.

Fixes #3885

## Test plan
- [ ] `meson setup build && meson install -C build` places `*.cmake` under `share/cmake/nlohmann_json/`
- [ ] `cmake -DCMAKE_PREFIX_PATH=... -DJSON_BuildTests=ON` finds the package (consumer smoke test)