### PR TITLE
Fix: update() parent pointers not updated after recursive merge with JSON_DIAGNOSTICS

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3497,6 +3497,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 if (it2 != m_data.m_value.object->end())
                 {
                     it2->second.update(it.value(), true);
+#if JSON_DIAGNOSTICS
+                    it2->second.set_parents();
+#endif
                     continue;
                 }
             }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -24000,6 +24000,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 if (it2 != m_data.m_value.object->end())
                 {
                     it2->second.update(it.value(), true);
+#if JSON_DIAGNOSTICS
+                    it2->second.set_parents();
+#endif
                     continue;
                 }
             }

--- a/tests/src/unit-diagnostics.cpp
+++ b/tests/src/unit-diagnostics.cpp
@@ -262,4 +262,16 @@ TEST_CASE("Regression tests for extended diagnostics")
 
         CHECK(k.dump() == "{\"prop1\":\"prop1_value\",\"root\":\"root_str\"}");
     }
+
+    SECTION("Regression test for issue #4813 - update() with merge_objects=true triggers JSON_ASSERT with JSON_DIAGNOSTICS")
+    {
+        // https://github.com/nlohmann/json/issues/4813
+        nlohmann::ordered_json j1 = {{"numbers", {{"one", 1}}}};
+        nlohmann::ordered_json const j2 = {{"numbers", {{"two", 2}}}, {"string", "t"}};
+        CHECK_NOTHROW(j1.update(j2, true));
+        CHECK(j1["numbers"]["one"] == 1);
+        CHECK(j1["numbers"]["two"] == 2);
+        CHECK(j1["string"] == "t");
+    }
 }
+

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1330,3 +1330,16 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfe
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+TEST_CASE("regression test #4813 - update() with merge_objects=true triggers JSON_ASSERT with JSON_DIAGNOSTICS")
+{
+    // https://github.com/nlohmann/json/issues/4813
+    nlohmann::ordered_json j1 = {{"numbers", {{"one", 1}}}};
+    nlohmann::ordered_json const j2 = {{"numbers", {{"two", 2}}}, {"string", "t"}};
+    CHECK_NOTHROW(j1.update(j2, true));
+    CHECK(j1["numbers"]["one"] == 1);
+    CHECK(j1["numbers"]["two"] == 2);
+    CHECK(j1["string"] == "t");
+}
+
+

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1330,16 +1330,3 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfe
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
-
-TEST_CASE("regression test #4813 - update() with merge_objects=true triggers JSON_ASSERT with JSON_DIAGNOSTICS")
-{
-    // https://github.com/nlohmann/json/issues/4813
-    nlohmann::ordered_json j1 = {{"numbers", {{"one", 1}}}};
-    nlohmann::ordered_json const j2 = {{"numbers", {{"two", 2}}}, {"string", "t"}};
-    CHECK_NOTHROW(j1.update(j2, true));
-    CHECK(j1["numbers"]["one"] == 1);
-    CHECK(j1["numbers"]["two"] == 2);
-    CHECK(j1["string"] == "t");
-}
-
-


### PR DESCRIPTION
## Issue
Fixes #4813

## Overview
Added a set_parents() call under `#if JSON_DIAGNOSTICS` in the `update()` iterator overload after a recursive merge.

When update() is called with merge_objects=true, nested objects are recursively merged via `it2->second.update(it.value(), true)`. After this recursive call, the child nodes inside the merged object have stale `m_parent pointers`, causing the parent consistency assertion to fire when `JSON_DIAGNOSTICS=1` is enabled. Calling `set_parents()` after the recursive merge walks the subtree and fixes all parent pointers correctly.

## Changes
- `include/nlohmann/json.hpp` — 3 line fix in `update()` iterator overload
- `single_include/nlohmann/json.hpp` — regenerated via `make amalgamate`

The changes were tested locally which gave the results:

<img width="522" height="190" alt="Screenshot 2026-05-21 193726" src="https://github.com/user-attachments/assets/5e03efa2-080d-4b0f-96e8-964f8df3cadc" />

---

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issue/4813) is referenced.
- [ ] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

