### PR TITLE
docs: Fix missing newline necessary in docs website

### DIFF
--- a/docs/mkdocs/docs/features/modules.md
+++ b/docs/mkdocs/docs/features/modules.md
@@ -38,9 +38,3 @@ Only the following symbols are exported from `nlohmann.json`:
 - `nlohmann::to_string`
 - `nlohmann::literals::json_literals::operator""_json`
 - `nlohmann::literals::json_literals::operator""_json_pointer`
-
-The following specialisations of `std` symbols are also exported:
-
-- `std::hash`
-- `std::less`
-- `std::swap`

--- a/docs/mkdocs/docs/features/modules.md
+++ b/docs/mkdocs/docs/features/modules.md
@@ -28,6 +28,7 @@ It should be noted that as modules do not export macros, the `nlohmann.json` mod
 
 ## Exported symbols
 Only the following symbols are exported from `nlohmann.json`:
+
 - `nlohmann::adl_serializer`
 - `nlohmann::basic_json`
 - `nlohmann::json`
@@ -39,6 +40,7 @@ Only the following symbols are exported from `nlohmann.json`:
 - `nlohmann::literals::json_literals::operator""_json_pointer`
 
 The following specialisations of `std` symbols are also exported:
+
 - `std::hash`
 - `std::less`
 - `std::swap`


### PR DESCRIPTION
- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

In my previous PR, #5137, I didn't add a newline at the beginning of the bullet-point lists, which caused the list of exported symbols on the documentation page to not render correctly. This PR adds the needed newlines so that the list renders correctly. This furthermore removes the mention of exporting symbols from `std`, as this is not actually necessary to access these specialisations (and was removed in a previous PR, #5164).