### PR TITLE
docs: HTTPS external links in README and package managers guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1800,13 +1800,13 @@ The library itself consists of a single header file licensed under the MIT licen
 - [**amalgamate.py - Amalgamate C source and header files**](https://github.com/edlund/amalgamate) to create a single header file
 - [**American fuzzy lop**](https://lcamtuf.coredump.cx/afl/) for fuzz testing
 - [**AppVeyor**](https://www.appveyor.com) for [continuous integration](https://ci.appveyor.com/project/nlohmann/json) on Windows
-- [**Artistic Style**](http://astyle.sourceforge.net) for automatic source code indentation
+- [**Artistic Style**](https://sourceforge.net/projects/astyle/) for automatic source code indentation
 - [**Clang**](https://clang.llvm.org) for compilation with code sanitizers
 - [**CMake**](https://cmake.org) for build automation
 - [**Codacy**](https://www.codacy.com) for further [code analysis](https://app.codacy.com/gh/nlohmann/json/dashboard)
 - [**Coveralls**](https://coveralls.io) to measure [code coverage](https://coveralls.io/github/nlohmann/json)
 - [**Coverity Scan**](https://scan.coverity.com) for [static analysis](https://scan.coverity.com/projects/nlohmann-json)
-- [**cppcheck**](http://cppcheck.sourceforge.net) for static analysis
+- [**cppcheck**](https://cppcheck.sourceforge.io/) for static analysis
 - [**doctest**](https://github.com/onqtam/doctest) for the unit tests
 - [**GitHub Changelog Generator**](https://github.com/skywinder/github-changelog-generator) to generate the [ChangeLog](https://github.com/nlohmann/json/blob/develop/ChangeLog.md)
 - [**Google Benchmark**](https://github.com/google/benchmark) to implement the benchmarks

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -44,7 +44,7 @@ When executed, this program should create output similar to
     - :octicons-file-24: File issues at the [Homebrew issue tracker](https://github.com/Homebrew/homebrew-core/issues)
     - :octicons-question-24: [Homebrew website](https://brew.sh)
 
-If you are using [Homebrew](http://brew.sh), you can install the library with
+If you are using [Homebrew](https://brew.sh), you can install the library with
 
 ```sh
 brew install nlohmann-json
@@ -110,7 +110,7 @@ The header can be used directly in your code or via CMake.
     - :octicons-file-24: File issues at the [library issue tracker](https://github.com/nlohmann/json/issues)
     - :octicons-question-24: [Meson website](https://mesonbuild.com/index.html)
 
-If you are using the [Meson Build System](http://mesonbuild.com), add this source tree as a [meson subproject](https://mesonbuild.com/Subprojects.html#using-a-subproject). You may also use the
+If you are using the [Meson Build System](https://mesonbuild.com), add this source tree as a [meson subproject](https://mesonbuild.com/Subprojects.html#using-a-subproject). You may also use the
 `include.zip` published in this project's [Releases](https://github.com/nlohmann/json/releases) to reduce the size of the vendored source tree. Alternatively,
 you can get a wrap file by downloading it from [Meson WrapDB](https://mesonbuild.com/Wrapdb-projects.html), or use
 
@@ -392,7 +392,7 @@ and follow the then displayed descriptions. Please see the vcpkg project for any
     - :octicons-file-24: File issues at the [cget issue tracker](https://github.com/pfultz2/cget-recipes/issues)
     - :octicons-question-24: [cget website](https://cget.readthedocs.io/)
 
-If you are using [cget](http://cget.readthedocs.io/en/latest/), you can install the latest `master` version with
+If you are using [cget](https://cget.readthedocs.io/en/latest/), you can install the latest `master` version with
 
 ```shell
 cget install nlohmann/json
@@ -624,7 +624,7 @@ conda install -c conda-forge nlohmann_json
 
 ## MSYS2
 
-If you are using [MSYS2](http://www.msys2.org/), you can use the [mingw-w64-nlohmann-json](https://packages.msys2.org/base/mingw-w64-nlohmann-json) package, type `pacman -S mingw-w64-i686-nlohmann-json` or `pacman -S mingw-w64-x86_64-nlohmann-json` for installation. Please file issues [here](https://github.com/msys2/MINGW-packages/issues/new?title=%5Bnlohmann-json%5D) if you experience problems with the packages.
+If you are using [MSYS2](https://www.msys2.org/), you can use the [mingw-w64-nlohmann-json](https://packages.msys2.org/base/mingw-w64-nlohmann-json) package, type `pacman -S mingw-w64-i686-nlohmann-json` or `pacman -S mingw-w64-x86_64-nlohmann-json` for installation. Please file issues [here](https://github.com/msys2/MINGW-packages/issues/new?title=%5Bnlohmann-json%5D) if you experience problems with the packages.
 
 [![MSYS2 clang64 package](https://repology.org/badge/version-for-repo/msys2_clang64/nlohmann-json.svg)](https://repology.org/project/nlohmann-json/versions)
 [![MSYS2 clangarm64 package](https://repology.org/badge/version-for-repo/msys2_clangarm64/nlohmann-json.svg)](https://repology.org/project/nlohmann-json/versions)

--- a/tools/amalgamate/README.md
+++ b/tools/amalgamate/README.md
@@ -7,7 +7,7 @@ Mirror: https://github.com/edlund/amalgamate
 `amalgamate.py` aims to make it easy to use SQLite-style C source and header
 amalgamation in projects.
 
-For more information, please refer to: http://sqlite.org/amalgamation.html
+For more information, please refer to: https://www.sqlite.org/amalgamation.html
 
 ## Here be dragons
 


### PR DESCRIPTION
## Summary

Updates external documentation links from HTTP to HTTPS:

- `README.md` — Artistic Style, cppcheck (acknowledgements)
- `docs/mkdocs/docs/integration/package_managers.md` — Homebrew, Meson, cget, MSYS2
- `tools/amalgamate/README.md` — SQLite amalgamation reference

Documentation-only; no code changes.

## Test plan

- [x] Link targets verified
- [x] No build or test impact