### PR TITLE
Add documentation comment to example.cpp for better code understanding

### DIFF
--- a/docs/mkdocs/docs/integration/example.cpp
+++ b/docs/mkdocs/docs/integration/example.cpp
@@ -1,3 +1,5 @@
+// This example demonstrates how to output the JSON library's meta information in a formatted way.
+
 #include <nlohmann/json.hpp>
 #include <iostream>
 #include <iomanip>


### PR DESCRIPTION
**Problem:** The example code file `docs/mkdocs/docs/integration/example.cpp` lacks documentation comments, which hinders code understanding and maintenance for developers and users. This can lead to confusion about the example's purpose, especially in a well-documented project like nlohmann/json.

**Solution:** Added a descriptive comment at the beginning of the file to clearly state the example's functionality. The comment reads: "// This example demonstrates how to output the JSON library's meta information in a formatted way." This aligns with the project's documentation standards and improves readability.

**Verification:** The change is minimal and only adds a comment, so it does not alter the code's behavior or API. It can be verified by reviewing the comment for accuracy and ensuring the example still compiles and runs correctly. Additionally, the comment enhances maintainability without introducing any breaking changes.