### PR TITLE
fix: support constructing json from C++20 range views (#4916)

### DIFF
--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -177,8 +177,11 @@ struct external_constructor<value_t::array>
     }
 
     template < typename BasicJsonType, typename CompatibleArrayType,
-               enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value,
-                             int > = 0 >
+               enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
+#ifdef JSON_HAS_CPP_20
+                             && !std::ranges::view<CompatibleArrayType>
+#endif
+                             , int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
     {
         using std::begin;
@@ -218,6 +221,24 @@ struct external_constructor<value_t::array>
         j.set_parents();
         j.assert_invariant();
     }
+
+#ifdef JSON_HAS_CPP_20
+    template<typename BasicJsonType, typename CompatibleArrayType,
+             enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
+    static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
+    {
+        auto view = arr;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = value_t::array;
+        for (const auto& x : view)
+        {
+            j.m_data.m_value.array->push_back(x);
+            j.set_parent(j.m_data.m_value.array->back());
+        }
+        j.assert_invariant();
+    }
+#endif
 };
 
 template<>

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -178,7 +178,7 @@ struct external_constructor<value_t::array>
 
     template < typename BasicJsonType, typename CompatibleArrayType,
                enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
-#ifdef JSON_HAS_CPP_20
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
                              && !std::ranges::view<CompatibleArrayType>
 #endif
                              , int > = 0 >
@@ -222,7 +222,9 @@ struct external_constructor<value_t::array>
         j.assert_invariant();
     }
 
-#ifdef JSON_HAS_CPP_20
+    // std::ranges does not work properly on MinGW due to incomplete C++20 support
+    // see https://github.com/nlohmann/json/issues/4916
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
     template<typename BasicJsonType, typename CompatibleArrayType,
              enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -232,7 +232,7 @@ struct external_constructor<value_t::array>
         j.m_data.m_value.destroy(j.m_data.m_type);
         j.m_data.m_type = value_t::array;
         j.m_data.m_value = value_t::array;
-        for (auto& x : std::forward<CompatibleArrayType>(arr))
+        for (auto&& x : std::forward<CompatibleArrayType>(arr))
         {
             j.m_data.m_value.array->push_back(x);
             j.set_parent(j.m_data.m_value.array->back());

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -178,7 +178,7 @@ struct external_constructor<value_t::array>
 
     template < typename BasicJsonType, typename CompatibleArrayType,
                enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
-#if JSON_HAS_RANGES && !defined(__MINGW32__)
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
                              && !std::ranges::view<CompatibleArrayType>
 #endif
                              , int > = 0 >
@@ -224,7 +224,7 @@ struct external_constructor<value_t::array>
 
     // std::ranges does not work properly on MinGW due to incomplete C++20 support
     // see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__)
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
     template<typename BasicJsonType, typename CompatibleArrayType,
              enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -232,7 +232,7 @@ struct external_constructor<value_t::array>
         j.m_data.m_value.destroy(j.m_data.m_type);
         j.m_data.m_type = value_t::array;
         j.m_data.m_value = value_t::array;
-        for (auto& x : arr)
+        for (auto& x : std::forward<CompatibleArrayType>(arr))
         {
             j.m_data.m_value.array->push_back(x);
             j.set_parent(j.m_data.m_value.array->back());

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -226,14 +226,13 @@ struct external_constructor<value_t::array>
     // see https://github.com/nlohmann/json/issues/4916
 #if JSON_HAS_RANGES && !defined(__MINGW32__)
     template<typename BasicJsonType, typename CompatibleArrayType,
-             enable_if_t<is_compatible_range_view<std::remove_cv_t<CompatibleArrayType>>::value, int> = 0>
-    static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
+             enable_if_t<is_compatible_range_view<std::remove_cvref_t<CompatibleArrayType>>::value, int> = 0>
+    static void construct(BasicJsonType& j, CompatibleArrayType && arr)
     {
-        auto view = arr;
         j.m_data.m_value.destroy(j.m_data.m_type);
         j.m_data.m_type = value_t::array;
         j.m_data.m_value = value_t::array;
-        for (const auto& x : view)
+        for (auto& x : arr)
         {
             j.m_data.m_value.array->push_back(x);
             j.set_parent(j.m_data.m_value.array->back());
@@ -378,12 +377,28 @@ template < typename BasicJsonType, typename CompatibleArrayType,
                          !is_compatible_object_type<BasicJsonType, CompatibleArrayType>::value&&
                          !is_compatible_string_type<BasicJsonType, CompatibleArrayType>::value&&
                          !std::is_same<typename BasicJsonType::binary_t, CompatibleArrayType>::value&&
-                         !is_basic_json<CompatibleArrayType>::value,
+                         !is_basic_json<CompatibleArrayType>::value
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+    && !is_compatible_range_view<CompatibleArrayType>::value
+#endif
+                         ,
                          int > = 0 >
 inline void to_json(BasicJsonType& j, const CompatibleArrayType& arr)
 {
     external_constructor<value_t::array>::construct(j, arr);
 }
+
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+template < typename BasicJsonType, typename T,
+           enable_if_t < is_compatible_range_view<std::remove_cvref_t<T>>::value
+                         && !is_compatible_string_type<BasicJsonType, std::remove_cvref_t<T>>::value
+                         && !is_compatible_object_type<BasicJsonType, std::remove_cvref_t<T>>::value
+                         && !is_basic_json<std::remove_cvref_t<T>>::value, int > = 0 >
+inline void to_json(BasicJsonType& j, T && arr)
+{
+    external_constructor<value_t::array>::construct(j, std::forward<T>(arr));
+}
+#endif
 
 template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, const typename BasicJsonType::binary_t& bin)

--- a/include/nlohmann/detail/conversions/to_json.hpp
+++ b/include/nlohmann/detail/conversions/to_json.hpp
@@ -178,8 +178,8 @@ struct external_constructor<value_t::array>
 
     template < typename BasicJsonType, typename CompatibleArrayType,
                enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
-#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
-                             && !std::ranges::view<CompatibleArrayType>
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+                             && !is_compatible_range_view<CompatibleArrayType>::value
 #endif
                              , int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
@@ -224,9 +224,9 @@ struct external_constructor<value_t::array>
 
     // std::ranges does not work properly on MinGW due to incomplete C++20 support
     // see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
     template<typename BasicJsonType, typename CompatibleArrayType,
-             enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
+             enable_if_t<is_compatible_range_view<std::remove_cv_t<CompatibleArrayType>>::value, int> = 0>
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
     {
         auto view = arr;

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -470,7 +470,7 @@ struct is_compatible_array_type_impl <
 
 // std::ranges does not work properly on MinGW due to incomplete C++20 support
 // see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__)
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type_impl <
     BasicJsonType, CompatibleArrayType,

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -468,7 +468,9 @@ struct is_compatible_array_type_impl <
         range_value_t<CompatibleArrayType>>::value;
 };
 
-#ifdef JSON_HAS_CPP_20
+// std::ranges does not work properly on MinGW due to incomplete C++20 support
+// see https://github.com/nlohmann/json/issues/4916
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type_impl <
     BasicJsonType, CompatibleArrayType,
@@ -480,7 +482,6 @@ struct is_compatible_array_type_impl <
     static constexpr bool value = is_constructible<BasicJsonType,
                           std::ranges::range_value_t<CompatibleArrayType>>::value;
 };
-
 #endif
 
 

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -468,6 +468,22 @@ struct is_compatible_array_type_impl <
         range_value_t<CompatibleArrayType>>::value;
 };
 
+#ifdef JSON_HAS_CPP_20
+template<typename BasicJsonType, typename CompatibleArrayType>
+struct is_compatible_array_type_impl <
+    BasicJsonType, CompatibleArrayType,
+    enable_if_t < std::ranges::range<CompatibleArrayType>
+    && std::ranges::view<CompatibleArrayType>
+    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, char>::value
+    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, wchar_t>::value >>
+{
+    static constexpr bool value = is_constructible<BasicJsonType,
+                          std::ranges::range_value_t<CompatibleArrayType>>::value;
+};
+
+#endif
+
+
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type
     : is_compatible_array_type_impl<BasicJsonType, CompatibleArrayType> {};

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -13,14 +13,14 @@
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
-#ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
-#endif
 #if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
     #include <cstddef> // byte
 #endif
 #include <nlohmann/detail/iterators/iterator_traits.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #include <nlohmann/detail/meta/call_std/begin.hpp>
 #include <nlohmann/detail/meta/call_std/end.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -450,6 +450,41 @@ struct is_constructible_string_type
         value_type_t, laundered_type >>::value;
 };
 
+// Forward declarations: iteration_proxy.hpp includes this file, so we cannot
+// include it here.
+template<typename IteratorType> class iteration_proxy;
+template<typename IteratorType> class iteration_proxy_value;
+
+// Identifies nlohmann's internal iteration-proxy types. These must be excluded
+// before evaluating any std::ranges concept to avoid circular constraints.
+template<typename T> struct is_iteration_proxy_type : std::false_type {};
+template<typename T> struct is_iteration_proxy_type<iteration_proxy<T>>       : std::true_type {};
+template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : std::true_type {};
+
+// std::ranges does not work properly on MinGW due to incomplete C++20 support
+// see https://github.com/nlohmann/json/issues/4916
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+
+// SafeToCheck guards against types that trigger circular constraints when
+// std::ranges::view<T> is evaluated on GCC 12 / libstdc++ 12:
+//   - iteration_proxy / iteration_proxy_value directly
+//   - views wrapping the above (e.g. owning_view<iteration_proxy<...>>)
+//   - views wrapping basic_json (e.g. ref_view<json>) — same circularity
+//     via json's constructors → is_compatible_array_type → here
+// nlohmann's plain range_value_t (iterator_traits-based) is safe to call
+// before any std::ranges concept is touched, so we use it for the checks.
+template < typename T, bool SafeToCheck =
+           !is_iteration_proxy_type<T>::value &&
+           !is_iteration_proxy_type<detected_t<range_value_t, T>>::value &&
+           !is_basic_json<detected_t<range_value_t, T>>::value >
+struct is_compatible_range_view : std::false_type {};
+
+template<typename T>
+struct is_compatible_range_view<T, true>
+    : std::bool_constant<std::ranges::view<T>> {};
+
+#endif
+
 template<typename BasicJsonType, typename CompatibleArrayType, typename = void>
 struct is_compatible_array_type_impl : std::false_type {};
 
@@ -461,26 +496,33 @@ struct is_compatible_array_type_impl <
     is_iterator_traits<iterator_traits<detected_t<iterator_t, CompatibleArrayType>>>::value&&
 // special case for types like std::filesystem::path whose iterator's value_type are themselves
 // c.f. https://github.com/nlohmann/json/pull/3073
-    !std::is_same<CompatibleArrayType, detected_t<range_value_t, CompatibleArrayType>>::value >>
+    !std::is_same<CompatibleArrayType, detected_t<range_value_t, CompatibleArrayType>>::value
+// When range-view support is enabled, std::ranges::view types (e.g. std::string_view,
+// filter_view) can match BOTH this iterator-based specialization AND the view-based one
+// below, causing ambiguity. Exclude views here so the two specializations are mutually
+// exclusive: this one handles plain iterable containers, the other handles views.
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+&& !is_compatible_range_view<CompatibleArrayType>::value
+#endif
+            >>
 {
     static constexpr bool value =
         is_constructible<BasicJsonType,
         range_value_t<CompatibleArrayType>>::value;
 };
 
-// std::ranges does not work properly on MinGW due to incomplete C++20 support
-// see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type_impl <
     BasicJsonType, CompatibleArrayType,
-    enable_if_t < std::ranges::range<CompatibleArrayType>
-    && std::ranges::view<CompatibleArrayType>
-    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, char>::value
-    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, wchar_t>::value >>
+    enable_if_t < is_compatible_range_view<CompatibleArrayType>::value
+    && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, char>::value
+    && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, wchar_t>::value >>
 {
-    static constexpr bool value = is_constructible<BasicJsonType,
-                          std::ranges::range_value_t<CompatibleArrayType>>::value;
+    // Character-sequence views (string_view etc.) are excluded in the enable_if
+    // above via nlohmann's plain range_value_t, so any view reaching here can
+    // be stored as a json array.
+    static constexpr bool value = true;
 };
 #endif
 

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -13,6 +13,9 @@
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
     #include <cstddef> // byte
 #endif
@@ -461,6 +464,8 @@ template<typename T> struct is_iteration_proxy_type : std::false_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy<T>>       : std::true_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : std::true_type {};
 
+// In C++26, std::optional satisfies std::ranges::view; exclude it so the
+// range-view overload does not hijack the optional serializer.
 #ifdef JSON_HAS_CPP_17
 template<typename T> struct is_range_view_optional_type : std::false_type {};
 template<typename T> struct is_range_view_optional_type<std::optional<T>> : std::true_type {};
@@ -478,7 +483,6 @@ template<typename T> struct is_range_view_optional_type : std::false_type {};
 //   - views wrapping the above (e.g. owning_view<iteration_proxy<...>>)
 //   - views wrapping basic_json (e.g. ref_view<json>) — same circularity
 //     via json's constructors → is_compatible_array_type → here
-//   - std::optional (which satisfies std::ranges::view in C++26)
 // nlohmann's plain range_value_t (iterator_traits-based) is safe to call
 // before any std::ranges concept is touched, so we use it for the checks.
 template < typename T, bool SafeToCheck =

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -461,6 +461,13 @@ template<typename T> struct is_iteration_proxy_type : std::false_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy<T>>       : std::true_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : std::true_type {};
 
+#ifdef JSON_HAS_CPP_17
+template<typename T> struct is_range_view_optional_type : std::false_type {};
+template<typename T> struct is_range_view_optional_type<std::optional<T>> : std::true_type {};
+#else
+template<typename T> struct is_range_view_optional_type : std::false_type {};
+#endif
+
 // std::ranges does not work properly on MinGW due to incomplete C++20 support
 // see https://github.com/nlohmann/json/issues/4916
 #if JSON_HAS_RANGES && !defined(__MINGW32__)
@@ -471,12 +478,14 @@ template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : 
 //   - views wrapping the above (e.g. owning_view<iteration_proxy<...>>)
 //   - views wrapping basic_json (e.g. ref_view<json>) — same circularity
 //     via json's constructors → is_compatible_array_type → here
+//   - std::optional (which satisfies std::ranges::view in C++26)
 // nlohmann's plain range_value_t (iterator_traits-based) is safe to call
 // before any std::ranges concept is touched, so we use it for the checks.
 template < typename T, bool SafeToCheck =
            !is_iteration_proxy_type<T>::value &&
            !is_iteration_proxy_type<detected_t<range_value_t, T>>::value &&
-           !is_basic_json<detected_t<range_value_t, T>>::value >
+           !is_basic_json<detected_t<range_value_t, T>>::value &&
+           !is_range_view_optional_type<T>::value >
 struct is_compatible_range_view : std::false_type {};
 
 template<typename T>

--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -519,10 +519,11 @@ struct is_compatible_array_type_impl <
     && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, char>::value
     && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, wchar_t>::value >>
 {
-    // Character-sequence views (string_view etc.) are excluded in the enable_if
-    // above via nlohmann's plain range_value_t, so any view reaching here can
-    // be stored as a json array.
-    static constexpr bool value = true;
+    // CompatibleArrayType is a std::ranges::view here, so std::ranges::range_value_t
+    // is safe and correctly handles C++20 iterators that may lack classic iterator_traits.
+    static constexpr bool value =
+        is_constructible<BasicJsonType,
+        std::ranges::range_value_t<CompatibleArrayType>>::value;
 };
 #endif
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3592,6 +3592,9 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 #if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
     #include <cstddef> // byte
 #endif
@@ -4223,6 +4226,8 @@ template<typename T> struct is_iteration_proxy_type : std::false_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy<T>>       : std::true_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : std::true_type {};
 
+// In C++26, std::optional satisfies std::ranges::view; exclude it so the
+// range-view overload does not hijack the optional serializer.
 #ifdef JSON_HAS_CPP_17
 template<typename T> struct is_range_view_optional_type : std::false_type {};
 template<typename T> struct is_range_view_optional_type<std::optional<T>> : std::true_type {};
@@ -4240,7 +4245,6 @@ template<typename T> struct is_range_view_optional_type : std::false_type {};
 //   - views wrapping the above (e.g. owning_view<iteration_proxy<...>>)
 //   - views wrapping basic_json (e.g. ref_view<json>) — same circularity
 //     via json's constructors → is_compatible_array_type → here
-//   - std::optional (which satisfies std::ranges::view in C++26)
 // nlohmann's plain range_value_t (iterator_traits-based) is safe to call
 // before any std::ranges concept is touched, so we use it for the checks.
 template < typename T, bool SafeToCheck =

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4212,6 +4212,41 @@ struct is_constructible_string_type
         value_type_t, laundered_type >>::value;
 };
 
+// Forward declarations: iteration_proxy.hpp includes this file, so we cannot
+// include it here.
+template<typename IteratorType> class iteration_proxy;
+template<typename IteratorType> class iteration_proxy_value;
+
+// Identifies nlohmann's internal iteration-proxy types. These must be excluded
+// before evaluating any std::ranges concept to avoid circular constraints.
+template<typename T> struct is_iteration_proxy_type : std::false_type {};
+template<typename T> struct is_iteration_proxy_type<iteration_proxy<T>>       : std::true_type {};
+template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : std::true_type {};
+
+// std::ranges does not work properly on MinGW due to incomplete C++20 support
+// see https://github.com/nlohmann/json/issues/4916
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+
+// SafeToCheck guards against types that trigger circular constraints when
+// std::ranges::view<T> is evaluated on GCC 12 / libstdc++ 12:
+//   - iteration_proxy / iteration_proxy_value directly
+//   - views wrapping the above (e.g. owning_view<iteration_proxy<...>>)
+//   - views wrapping basic_json (e.g. ref_view<json>) — same circularity
+//     via json's constructors → is_compatible_array_type → here
+// nlohmann's plain range_value_t (iterator_traits-based) is safe to call
+// before any std::ranges concept is touched, so we use it for the checks.
+template < typename T, bool SafeToCheck =
+           !is_iteration_proxy_type<T>::value &&
+           !is_iteration_proxy_type<detected_t<range_value_t, T>>::value &&
+           !is_basic_json<detected_t<range_value_t, T>>::value >
+struct is_compatible_range_view : std::false_type {};
+
+template<typename T>
+struct is_compatible_range_view<T, true>
+    : std::bool_constant<std::ranges::view<T>> {};
+
+#endif
+
 template<typename BasicJsonType, typename CompatibleArrayType, typename = void>
 struct is_compatible_array_type_impl : std::false_type {};
 
@@ -4223,26 +4258,33 @@ struct is_compatible_array_type_impl <
     is_iterator_traits<iterator_traits<detected_t<iterator_t, CompatibleArrayType>>>::value&&
 // special case for types like std::filesystem::path whose iterator's value_type are themselves
 // c.f. https://github.com/nlohmann/json/pull/3073
-    !std::is_same<CompatibleArrayType, detected_t<range_value_t, CompatibleArrayType>>::value >>
+    !std::is_same<CompatibleArrayType, detected_t<range_value_t, CompatibleArrayType>>::value
+// When range-view support is enabled, std::ranges::view types (e.g. std::string_view,
+// filter_view) can match BOTH this iterator-based specialization AND the view-based one
+// below, causing ambiguity. Exclude views here so the two specializations are mutually
+// exclusive: this one handles plain iterable containers, the other handles views.
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+&& !is_compatible_range_view<CompatibleArrayType>::value
+#endif
+            >>
 {
     static constexpr bool value =
         is_constructible<BasicJsonType,
         range_value_t<CompatibleArrayType>>::value;
 };
 
-// std::ranges does not work properly on MinGW due to incomplete C++20 support
-// see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type_impl <
     BasicJsonType, CompatibleArrayType,
-    enable_if_t < std::ranges::range<CompatibleArrayType>
-    && std::ranges::view<CompatibleArrayType>
-    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, char>::value
-    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, wchar_t>::value >>
+    enable_if_t < is_compatible_range_view<CompatibleArrayType>::value
+    && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, char>::value
+    && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, wchar_t>::value >>
 {
-    static constexpr bool value = is_constructible<BasicJsonType,
-                          std::ranges::range_value_t<CompatibleArrayType>>::value;
+    // Character-sequence views (string_view etc.) are excluded in the enable_if
+    // above via nlohmann's plain range_value_t, so any view reaching here can
+    // be stored as a json array.
+    static constexpr bool value = true;
 };
 #endif
 
@@ -6223,8 +6265,8 @@ struct external_constructor<value_t::array>
 
     template < typename BasicJsonType, typename CompatibleArrayType,
                enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
-#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
-                             && !std::ranges::view<CompatibleArrayType>
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+                             && !is_compatible_range_view<CompatibleArrayType>::value
 #endif
                              , int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
@@ -6269,9 +6311,9 @@ struct external_constructor<value_t::array>
 
     // std::ranges does not work properly on MinGW due to incomplete C++20 support
     // see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
     template<typename BasicJsonType, typename CompatibleArrayType,
-             enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
+             enable_if_t<is_compatible_range_view<std::remove_cv_t<CompatibleArrayType>>::value, int> = 0>
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
     {
         auto view = arr;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4223,6 +4223,13 @@ template<typename T> struct is_iteration_proxy_type : std::false_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy<T>>       : std::true_type {};
 template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : std::true_type {};
 
+#ifdef JSON_HAS_CPP_17
+template<typename T> struct is_range_view_optional_type : std::false_type {};
+template<typename T> struct is_range_view_optional_type<std::optional<T>> : std::true_type {};
+#else
+template<typename T> struct is_range_view_optional_type : std::false_type {};
+#endif
+
 // std::ranges does not work properly on MinGW due to incomplete C++20 support
 // see https://github.com/nlohmann/json/issues/4916
 #if JSON_HAS_RANGES && !defined(__MINGW32__)
@@ -4233,12 +4240,14 @@ template<typename T> struct is_iteration_proxy_type<iteration_proxy_value<T>> : 
 //   - views wrapping the above (e.g. owning_view<iteration_proxy<...>>)
 //   - views wrapping basic_json (e.g. ref_view<json>) — same circularity
 //     via json's constructors → is_compatible_array_type → here
+//   - std::optional (which satisfies std::ranges::view in C++26)
 // nlohmann's plain range_value_t (iterator_traits-based) is safe to call
 // before any std::ranges concept is touched, so we use it for the checks.
 template < typename T, bool SafeToCheck =
            !is_iteration_proxy_type<T>::value &&
            !is_iteration_proxy_type<detected_t<range_value_t, T>>::value &&
-           !is_basic_json<detected_t<range_value_t, T>>::value >
+           !is_basic_json<detected_t<range_value_t, T>>::value &&
+           !is_range_view_optional_type<T>::value >
 struct is_compatible_range_view : std::false_type {};
 
 template<typename T>

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4230,7 +4230,9 @@ struct is_compatible_array_type_impl <
         range_value_t<CompatibleArrayType>>::value;
 };
 
-#ifdef JSON_HAS_CPP_20
+// std::ranges does not work properly on MinGW due to incomplete C++20 support
+// see https://github.com/nlohmann/json/issues/4916
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type_impl <
     BasicJsonType, CompatibleArrayType,
@@ -4242,7 +4244,6 @@ struct is_compatible_array_type_impl <
     static constexpr bool value = is_constructible<BasicJsonType,
                           std::ranges::range_value_t<CompatibleArrayType>>::value;
 };
-
 #endif
 
 
@@ -6222,7 +6223,7 @@ struct external_constructor<value_t::array>
 
     template < typename BasicJsonType, typename CompatibleArrayType,
                enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
-#ifdef JSON_HAS_CPP_20
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
                              && !std::ranges::view<CompatibleArrayType>
 #endif
                              , int > = 0 >
@@ -6266,7 +6267,9 @@ struct external_constructor<value_t::array>
         j.assert_invariant();
     }
 
-#ifdef JSON_HAS_CPP_20
+    // std::ranges does not work properly on MinGW due to incomplete C++20 support
+    // see https://github.com/nlohmann/json/issues/4916
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
     template<typename BasicJsonType, typename CompatibleArrayType,
              enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6320,7 +6320,7 @@ struct external_constructor<value_t::array>
         j.m_data.m_value.destroy(j.m_data.m_type);
         j.m_data.m_type = value_t::array;
         j.m_data.m_value = value_t::array;
-        for (auto& x : arr)
+        for (auto& x : std::forward<CompatibleArrayType>(arr))
         {
             j.m_data.m_value.array->push_back(x);
             j.set_parent(j.m_data.m_value.array->back());

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4232,7 +4232,7 @@ struct is_compatible_array_type_impl <
 
 // std::ranges does not work properly on MinGW due to incomplete C++20 support
 // see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__)
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type_impl <
     BasicJsonType, CompatibleArrayType,
@@ -6223,7 +6223,7 @@ struct external_constructor<value_t::array>
 
     template < typename BasicJsonType, typename CompatibleArrayType,
                enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
-#if JSON_HAS_RANGES && !defined(__MINGW32__)
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
                              && !std::ranges::view<CompatibleArrayType>
 #endif
                              , int > = 0 >
@@ -6269,7 +6269,7 @@ struct external_constructor<value_t::array>
 
     // std::ranges does not work properly on MinGW due to incomplete C++20 support
     // see https://github.com/nlohmann/json/issues/4916
-#if JSON_HAS_RANGES && !defined(__MINGW32__)
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 12)
     template<typename BasicJsonType, typename CompatibleArrayType,
              enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -6320,7 +6320,7 @@ struct external_constructor<value_t::array>
         j.m_data.m_value.destroy(j.m_data.m_type);
         j.m_data.m_type = value_t::array;
         j.m_data.m_value = value_t::array;
-        for (auto& x : std::forward<CompatibleArrayType>(arr))
+        for (auto&& x : std::forward<CompatibleArrayType>(arr))
         {
             j.m_data.m_value.array->push_back(x);
             j.set_parent(j.m_data.m_value.array->back());

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4281,10 +4281,11 @@ struct is_compatible_array_type_impl <
     && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, char>::value
     && !std::is_same<detected_t<range_value_t, CompatibleArrayType>, wchar_t>::value >>
 {
-    // Character-sequence views (string_view etc.) are excluded in the enable_if
-    // above via nlohmann's plain range_value_t, so any view reaching here can
-    // be stored as a json array.
-    static constexpr bool value = true;
+    // CompatibleArrayType is a std::ranges::view here, so std::ranges::range_value_t
+    // is safe and correctly handles C++20 iterators that may lack classic iterator_traits.
+    static constexpr bool value =
+        is_constructible<BasicJsonType,
+        std::ranges::range_value_t<CompatibleArrayType>>::value;
 };
 #endif
 
@@ -6313,14 +6314,13 @@ struct external_constructor<value_t::array>
     // see https://github.com/nlohmann/json/issues/4916
 #if JSON_HAS_RANGES && !defined(__MINGW32__)
     template<typename BasicJsonType, typename CompatibleArrayType,
-             enable_if_t<is_compatible_range_view<std::remove_cv_t<CompatibleArrayType>>::value, int> = 0>
-    static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
+             enable_if_t<is_compatible_range_view<std::remove_cvref_t<CompatibleArrayType>>::value, int> = 0>
+    static void construct(BasicJsonType& j, CompatibleArrayType && arr)
     {
-        auto view = arr;
         j.m_data.m_value.destroy(j.m_data.m_type);
         j.m_data.m_type = value_t::array;
         j.m_data.m_value = value_t::array;
-        for (const auto& x : view)
+        for (auto& x : arr)
         {
             j.m_data.m_value.array->push_back(x);
             j.set_parent(j.m_data.m_value.array->back());
@@ -6465,12 +6465,28 @@ template < typename BasicJsonType, typename CompatibleArrayType,
                          !is_compatible_object_type<BasicJsonType, CompatibleArrayType>::value&&
                          !is_compatible_string_type<BasicJsonType, CompatibleArrayType>::value&&
                          !std::is_same<typename BasicJsonType::binary_t, CompatibleArrayType>::value&&
-                         !is_basic_json<CompatibleArrayType>::value,
+                         !is_basic_json<CompatibleArrayType>::value
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+    && !is_compatible_range_view<CompatibleArrayType>::value
+#endif
+                         ,
                          int > = 0 >
 inline void to_json(BasicJsonType& j, const CompatibleArrayType& arr)
 {
     external_constructor<value_t::array>::construct(j, arr);
 }
+
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+template < typename BasicJsonType, typename T,
+           enable_if_t < is_compatible_range_view<std::remove_cvref_t<T>>::value
+                         && !is_compatible_string_type<BasicJsonType, std::remove_cvref_t<T>>::value
+                         && !is_compatible_object_type<BasicJsonType, std::remove_cvref_t<T>>::value
+                         && !is_basic_json<std::remove_cvref_t<T>>::value, int > = 0 >
+inline void to_json(BasicJsonType& j, T && arr)
+{
+    external_constructor<value_t::array>::construct(j, std::forward<T>(arr));
+}
+#endif
 
 template<typename BasicJsonType>
 inline void to_json(BasicJsonType& j, const typename BasicJsonType::binary_t& bin)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3592,9 +3592,6 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <tuple> // tuple
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
-#ifdef JSON_HAS_CPP_17
-    #include <optional> // optional
-#endif
 #if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603L
     #include <cstddef> // byte
 #endif
@@ -3666,6 +3663,9 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
+#ifdef JSON_HAS_CPP_17
+    #include <optional> // optional
+#endif
 // #include <nlohmann/detail/meta/call_std/begin.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -4230,6 +4230,22 @@ struct is_compatible_array_type_impl <
         range_value_t<CompatibleArrayType>>::value;
 };
 
+#ifdef JSON_HAS_CPP_20
+template<typename BasicJsonType, typename CompatibleArrayType>
+struct is_compatible_array_type_impl <
+    BasicJsonType, CompatibleArrayType,
+    enable_if_t < std::ranges::range<CompatibleArrayType>
+    && std::ranges::view<CompatibleArrayType>
+    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, char>::value
+    && !std::is_same<std::ranges::range_value_t<CompatibleArrayType>, wchar_t>::value >>
+{
+    static constexpr bool value = is_constructible<BasicJsonType,
+                          std::ranges::range_value_t<CompatibleArrayType>>::value;
+};
+
+#endif
+
+
 template<typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type
     : is_compatible_array_type_impl<BasicJsonType, CompatibleArrayType> {};
@@ -6205,8 +6221,11 @@ struct external_constructor<value_t::array>
     }
 
     template < typename BasicJsonType, typename CompatibleArrayType,
-               enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value,
-                             int > = 0 >
+               enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value
+#ifdef JSON_HAS_CPP_20
+                             && !std::ranges::view<CompatibleArrayType>
+#endif
+                             , int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
     {
         using std::begin;
@@ -6246,6 +6265,24 @@ struct external_constructor<value_t::array>
         j.set_parents();
         j.assert_invariant();
     }
+
+#ifdef JSON_HAS_CPP_20
+    template<typename BasicJsonType, typename CompatibleArrayType,
+             enable_if_t<std::ranges::view<std::remove_cv_t<CompatibleArrayType>>, int> = 0>
+    static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
+    {
+        auto view = arr;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = value_t::array;
+        for (const auto& x : view)
+        {
+            j.m_data.m_value.array->push_back(x);
+            j.set_parent(j.m_data.m_value.array->back());
+        }
+        j.assert_invariant();
+    }
+#endif
 };
 
 template<>

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1176,6 +1176,19 @@ TEST_CASE("regression tests 2")
         CHECK(j == json({37, 42, 21}));
     }
 #endif
+
+    // owning_view is not available in libstdc++ < 12
+#if JSON_HAS_RANGES && !defined(__MINGW32__) && !(defined(__GLIBCXX__) && _GLIBCXX_RELEASE < 12)
+    SECTION("issue #4916 - constructing array from prvalue C++20 ranges view (owning_view)")
+    {
+        json const j(std::vector<int> {1, 2, 37, 42, 21} | std::views::filter([](int i)
+        {
+            return i > 10;
+        }));
+        CHECK(j.type() == json::value_t::array);
+        CHECK(j == json({37, 42, 21}));
+    }
+#endif
 }
 
 TEST_CASE_TEMPLATE("issue #4798 - nlohmann::json::to_msgpack() encode float NaN as double", T, double, float) // NOLINT(readability-math-missing-parentheses, bugprone-throwing-static-initialization)

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1163,7 +1163,7 @@ TEST_CASE("regression tests 2")
     }
 #endif
 
-#if JSON_HAS_RANGES == 1
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
     SECTION("issue #4916 - constructing array from C++20 ranges view does not work")
     {
         std::vector<int> nums{1, 2, 37, 42, 21};

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1189,6 +1189,20 @@ TEST_CASE("regression tests 2")
         CHECK(j == json({37, 42, 21}));
     }
 #endif
+
+#if JSON_HAS_RANGES && !defined(__MINGW32__)
+    SECTION("issue #4916 - constructing array from C++20 transform view (prvalue elements)")
+    {
+        std::vector<int> nums{1, 2, 3};
+        auto t = nums | std::views::transform([](int i)
+        {
+            return i * 2;
+        });
+        json const j(t);
+        CHECK(j.type() == json::value_t::array);
+        CHECK(j == json({2, 4, 6}));
+    }
+#endif
 }
 
 TEST_CASE_TEMPLATE("issue #4798 - nlohmann::json::to_msgpack() encode float NaN as double", T, double, float) // NOLINT(readability-math-missing-parentheses, bugprone-throwing-static-initialization)

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -28,7 +28,6 @@ using ordered_json = nlohmann::ordered_json;
 
 #include <cstdio>
 #include <list>
-#include <ranges>
 #include <type_traits>
 #include <utility>
 
@@ -1164,7 +1163,7 @@ TEST_CASE("regression tests 2")
     }
 #endif
 
-#if JSON_HAS_RANGES == 1 
+#if JSON_HAS_RANGES == 1
     SECTION("issue #4916 - constructing array from C++20 ranges view does not work")
     {
         std::vector<int> nums{1, 2, 37, 42, 21};

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -28,6 +28,7 @@ using ordered_json = nlohmann::ordered_json;
 
 #include <cstdio>
 #include <list>
+#include <ranges>
 #include <type_traits>
 #include <utility>
 
@@ -1163,6 +1164,19 @@ TEST_CASE("regression tests 2")
     }
 #endif
 
+#if JSON_HAS_RANGES == 1 
+    SECTION("issue #4916 - constructing array from C++20 ranges view does not work")
+    {
+        std::vector<int> nums{1, 2, 37, 42, 21};
+        auto filteredNums = nums | std::views::filter([](int i)
+        {
+            return i > 10;
+        });
+        json const j(filteredNums);
+        CHECK(j.type() == json::value_t::array);
+        CHECK(j == json({37, 42, 21}));
+    }
+#endif
 }
 
 TEST_CASE_TEMPLATE("issue #4798 - nlohmann::json::to_msgpack() encode float NaN as double", T, double, float) // NOLINT(readability-math-missing-parentheses, bugprone-throwing-static-initialization)

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1194,7 +1194,7 @@ TEST_CASE("regression tests 2")
     SECTION("issue #4916 - constructing array from C++20 transform view (prvalue elements)")
     {
         std::vector<int> nums{1, 2, 3};
-        auto t = nums | std::views::transform([](int i)
+        auto t = nums | std::views::transform([](int i) noexcept
         {
             return i * 2;
         });


### PR DESCRIPTION
## Description

Fixes #4916.

Constructing a `nlohmann::json` object from a C++20 range view (e.g. `std::views::filter`, `std::views::transform`) failed to compile because `is_compatible_array_type` did not recognize range views as compatible types.

### What changed

- `include/nlohmann/detail/meta/type_traits.hpp`: added a new partial specialization of `is_compatible_array_type_impl` for C++20 range views, guarded by `#ifdef JSON_HAS_CPP_20`. The specialization matches types satisfying `std::ranges::view` while excluding character sequences (e.g. `std::string_view`).
- `include/nlohmann/detail/conversions/to_json.hpp`: added a new `construct` overload for C++20 range views inside `external_constructor<value_t::array>`, also guarded by `#ifdef JSON_HAS_CPP_20`.
- The specialization uses `std::ranges::view` rather than just `std::ranges::range` to avoid ambiguity with standard containers like `std::string` and `std::string_view`, which already satisfy `std::ranges::range` but are handled by existing specializations. Character sequences are additionally excluded by checking that the range's value type is not char or wchar_t.

### How to test

```cpp
std::vector<int> nums{1, 2, 37, 42, 21};
auto filtered = nums | std::views::filter([](int i) { return i > 10; });
nlohmann::json j(filtered);
assert(j == nlohmann::json({37, 42, 21}));
```

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [ ] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`.