### PR TITLE
Fix UBSAN errors when converting types using from_json

### DIFF
--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -105,11 +105,13 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_float:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
-            if (!std::isfinite(temp))   // flush NaN and Inf to zero
+            // flush NaN and Inf to zero before converting to a type that cannot represent them
+            bool valueIsFinite = std::isfinite(temp);
+            if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
                 val = 0;
-            else if (temp < std::numeric_limits<ArithmeticType>::lowest())
+            else if (valueIsFinite && temp < std::numeric_limits<ArithmeticType>::lowest())
                 val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (temp > std::numeric_limits<ArithmeticType>::max())
+            else if (valueIsFinite && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -458,11 +460,13 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_float:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
-            if (!std::isfinite(temp))   // flush NaN and Inf to zero
+            // flush NaN and Inf to zero before converting to a type that cannot represent them
+            bool valueIsFinite = std::isfinite(temp);
+            if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
                 val = 0;
-            else if (temp < std::numeric_limits<ArithmeticType>::lowest())
+            else if (valueIsFinite && temp < std::numeric_limits<ArithmeticType>::lowest())
                 val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (temp > std::numeric_limits<ArithmeticType>::max())
+            else if (valueIsFinite && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -470,8 +474,7 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         }
         case value_t::boolean:
         {
-            // comparison forces the value to be 0 or 1, which is in range for all types
-            auto temp = (0 != (*j.template get_ptr<const typename BasicJsonType::boolean_t*>()));
+            auto temp = *j.template get_ptr<const typename BasicJsonType::boolean_t*>();
             val = static_cast<ArithmeticType>(temp);
             break;
         }

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -19,6 +19,8 @@
 #include <unordered_map> // unordered_map
 #include <utility> // pair, declval
 #include <valarray> // valarray
+#include <cmath> // isfinite
+#include <limits> // max, lowest
 
 #include <nlohmann/detail/exceptions.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
@@ -80,17 +82,34 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
     {
         case value_t::number_unsigned:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
+            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                temp = std::numeric_limits<ArithmeticType>::lowest();
+            if (temp > std::numeric_limits<ArithmeticType>::max())
+                temp = std::numeric_limits<ArithmeticType>::max();
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_integer:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
+            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                temp = std::numeric_limits<ArithmeticType>::lowest();
+            if (temp > std::numeric_limits<ArithmeticType>::max())
+                temp = std::numeric_limits<ArithmeticType>::max();
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_float:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
+            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                temp = std::numeric_limits<ArithmeticType>::lowest();
+            if (temp > std::numeric_limits<ArithmeticType>::max())
+                temp = std::numeric_limits<ArithmeticType>::max();
+            if (!std::isfinite(temp))   // flush NaN and Inf to zero
+                temp = 0.0;
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
 
@@ -413,22 +432,41 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
     {
         case value_t::number_unsigned:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
+            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                temp = std::numeric_limits<ArithmeticType>::lowest();
+            if (temp > std::numeric_limits<ArithmeticType>::max())
+                temp = std::numeric_limits<ArithmeticType>::max();
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_integer:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
+            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                temp = std::numeric_limits<ArithmeticType>::lowest();
+            if (temp > std::numeric_limits<ArithmeticType>::max())
+                temp = std::numeric_limits<ArithmeticType>::max();
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_float:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
+            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                temp = std::numeric_limits<ArithmeticType>::lowest();
+            if (temp > std::numeric_limits<ArithmeticType>::max())
+                temp = std::numeric_limits<ArithmeticType>::max();
+            if (!std::isfinite(temp))   // flush NaN and Inf to zero before converting to another type!
+                temp = 0.0;
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::boolean:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+            // comparison forces the value to be 0 or 1, which is in range for all types
+            auto temp = (0 != (*j.template get_ptr<const typename BasicJsonType::boolean_t*>()));
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
 

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -83,9 +83,8 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_unsigned:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
-            if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (temp > std::numeric_limits<ArithmeticType>::max())
+           if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -94,9 +93,11 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_integer:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
-            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+            if (std::numeric_limits<typename BasicJsonType::number_integer_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                && temp < std::numeric_limits<ArithmeticType>::lowest())
                 val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (temp > std::numeric_limits<ArithmeticType>::max())
+            else if (std::numeric_limits<typename BasicJsonType::number_integer_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -109,9 +110,13 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
             bool valueIsFinite = std::isfinite(temp);
             if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
                 val = 0;
-            else if (valueIsFinite && temp < std::numeric_limits<ArithmeticType>::lowest())
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                    && valueIsFinite
+                    && temp < std::numeric_limits<ArithmeticType>::lowest())
                 val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (valueIsFinite && temp > std::numeric_limits<ArithmeticType>::max())
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                    && valueIsFinite
+                    && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -438,9 +443,8 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_unsigned:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
-            if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (temp > std::numeric_limits<ArithmeticType>::max())
+            if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -449,9 +453,11 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_integer:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
-            if (temp < std::numeric_limits<ArithmeticType>::lowest())
+            if (std::numeric_limits<typename BasicJsonType::number_integer_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                && temp < std::numeric_limits<ArithmeticType>::lowest())
                 val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (temp > std::numeric_limits<ArithmeticType>::max())
+            else if (std::numeric_limits<typename BasicJsonType::number_integer_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);
@@ -464,9 +470,13 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
             bool valueIsFinite = std::isfinite(temp);
             if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
                 val = 0;
-            else if (valueIsFinite && temp < std::numeric_limits<ArithmeticType>::lowest())
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                    && valueIsFinite
+                    && temp < std::numeric_limits<ArithmeticType>::lowest())
                 val = std::numeric_limits<ArithmeticType>::lowest();
-            else if (valueIsFinite && temp > std::numeric_limits<ArithmeticType>::max())
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                    && valueIsFinite
+                    && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
                 val = static_cast<ArithmeticType>(temp);

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -83,7 +83,7 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_unsigned:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
-           if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
+            if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
                 && temp > std::numeric_limits<ArithmeticType>::max())
                 val = std::numeric_limits<ArithmeticType>::max();
             else
@@ -106,7 +106,7 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_float:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
-            // flush NaN and Inf to zero before converting to a type that cannot represent them
+            // flush NaN and Inf to zero before converting to a type that cannot represent them - otherwise results are undefined.
             bool valueIsFinite = std::isfinite(temp);
             if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
                 val = 0;
@@ -466,7 +466,7 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         case value_t::number_float:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
-            // flush NaN and Inf to zero before converting to a type that cannot represent them
+            // flush NaN and Inf to zero before converting to a type that cannot represent them - otherwise results are undefined.
             bool valueIsFinite = std::isfinite(temp);
             if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
                 val = 0;

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -84,23 +84,33 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
             if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
-                && temp > std::numeric_limits<ArithmeticType>::max())
+                    && temp > std::numeric_limits<ArithmeticType>::max())
+            {
                 val = std::numeric_limits<ArithmeticType>::max();
+            }
             else
+            {
                 val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_integer:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
             if (std::numeric_limits<typename BasicJsonType::number_integer_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
-                && temp < std::numeric_limits<ArithmeticType>::lowest())
+                    && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
                 val = std::numeric_limits<ArithmeticType>::lowest();
+            }
             else if (std::numeric_limits<typename BasicJsonType::number_integer_t>::max() > std::numeric_limits<ArithmeticType>::max()
-                && temp > std::numeric_limits<ArithmeticType>::max())
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
                 val = std::numeric_limits<ArithmeticType>::max();
+            }
             else
+            {
                 val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_float:
@@ -109,17 +119,25 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
             // flush NaN and Inf to zero before converting to a type that cannot represent them - otherwise results are undefined.
             bool valueIsFinite = std::isfinite(temp);
             if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
+            {
                 val = 0;
+            }
             else if (std::numeric_limits<typename BasicJsonType::number_float_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
-                    && valueIsFinite
-                    && temp < std::numeric_limits<ArithmeticType>::lowest())
+                     && valueIsFinite
+                     && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
                 val = std::numeric_limits<ArithmeticType>::lowest();
+            }
             else if (std::numeric_limits<typename BasicJsonType::number_float_t>::max() > std::numeric_limits<ArithmeticType>::max()
-                    && valueIsFinite
-                    && temp > std::numeric_limits<ArithmeticType>::max())
+                     && valueIsFinite
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
                 val = std::numeric_limits<ArithmeticType>::max();
+            }
             else
+            {
                 val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
 
@@ -444,23 +462,33 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
             if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
-                && temp > std::numeric_limits<ArithmeticType>::max())
+                    && temp > std::numeric_limits<ArithmeticType>::max())
+            {
                 val = std::numeric_limits<ArithmeticType>::max();
+            }
             else
+            {
                 val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_integer:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
             if (std::numeric_limits<typename BasicJsonType::number_integer_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
-                && temp < std::numeric_limits<ArithmeticType>::lowest())
+                    && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
                 val = std::numeric_limits<ArithmeticType>::lowest();
+            }
             else if (std::numeric_limits<typename BasicJsonType::number_integer_t>::max() > std::numeric_limits<ArithmeticType>::max()
-                && temp > std::numeric_limits<ArithmeticType>::max())
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
                 val = std::numeric_limits<ArithmeticType>::max();
+            }
             else
+            {
                 val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_float:
@@ -469,17 +497,25 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
             // flush NaN and Inf to zero before converting to a type that cannot represent them - otherwise results are undefined.
             bool valueIsFinite = std::isfinite(temp);
             if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
+            {
                 val = 0;
+            }
             else if (std::numeric_limits<typename BasicJsonType::number_float_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
-                    && valueIsFinite
-                    && temp < std::numeric_limits<ArithmeticType>::lowest())
+                     && valueIsFinite
+                     && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
                 val = std::numeric_limits<ArithmeticType>::lowest();
+            }
             else if (std::numeric_limits<typename BasicJsonType::number_float_t>::max() > std::numeric_limits<ArithmeticType>::max()
-                    && valueIsFinite
-                    && temp > std::numeric_limits<ArithmeticType>::max())
+                     && valueIsFinite
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
                 val = std::numeric_limits<ArithmeticType>::max();
+            }
             else
+            {
                 val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::boolean:

--- a/include/nlohmann/detail/conversions/from_json.hpp
+++ b/include/nlohmann/detail/conversions/from_json.hpp
@@ -84,32 +84,35 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
             if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                temp = std::numeric_limits<ArithmeticType>::lowest();
-            if (temp > std::numeric_limits<ArithmeticType>::max())
-                temp = std::numeric_limits<ArithmeticType>::max();
-            val = static_cast<ArithmeticType>(temp);
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            else if (temp > std::numeric_limits<ArithmeticType>::max())
+                val = std::numeric_limits<ArithmeticType>::max();
+            else
+                val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_integer:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
             if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                temp = std::numeric_limits<ArithmeticType>::lowest();
-            if (temp > std::numeric_limits<ArithmeticType>::max())
-                temp = std::numeric_limits<ArithmeticType>::max();
-            val = static_cast<ArithmeticType>(temp);
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            else if (temp > std::numeric_limits<ArithmeticType>::max())
+                val = std::numeric_limits<ArithmeticType>::max();
+            else
+                val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_float:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
-            if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                temp = std::numeric_limits<ArithmeticType>::lowest();
-            if (temp > std::numeric_limits<ArithmeticType>::max())
-                temp = std::numeric_limits<ArithmeticType>::max();
             if (!std::isfinite(temp))   // flush NaN and Inf to zero
-                temp = 0.0;
-            val = static_cast<ArithmeticType>(temp);
+                val = 0;
+            else if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            else if (temp > std::numeric_limits<ArithmeticType>::max())
+                val = std::numeric_limits<ArithmeticType>::max();
+            else
+                val = static_cast<ArithmeticType>(temp);
             break;
         }
 
@@ -434,32 +437,35 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
             if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                temp = std::numeric_limits<ArithmeticType>::lowest();
-            if (temp > std::numeric_limits<ArithmeticType>::max())
-                temp = std::numeric_limits<ArithmeticType>::max();
-            val = static_cast<ArithmeticType>(temp);
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            else if (temp > std::numeric_limits<ArithmeticType>::max())
+                val = std::numeric_limits<ArithmeticType>::max();
+            else
+                val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_integer:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
             if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                temp = std::numeric_limits<ArithmeticType>::lowest();
-            if (temp > std::numeric_limits<ArithmeticType>::max())
-                temp = std::numeric_limits<ArithmeticType>::max();
-            val = static_cast<ArithmeticType>(temp);
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            else if (temp > std::numeric_limits<ArithmeticType>::max())
+                val = std::numeric_limits<ArithmeticType>::max();
+            else
+                val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::number_float:
         {
             auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
-            if (temp < std::numeric_limits<ArithmeticType>::lowest())
-                temp = std::numeric_limits<ArithmeticType>::lowest();
-            if (temp > std::numeric_limits<ArithmeticType>::max())
-                temp = std::numeric_limits<ArithmeticType>::max();
-            if (!std::isfinite(temp))   // flush NaN and Inf to zero before converting to another type!
-                temp = 0.0;
-            val = static_cast<ArithmeticType>(temp);
+            if (!std::isfinite(temp))   // flush NaN and Inf to zero
+                val = 0;
+            else if (temp < std::numeric_limits<ArithmeticType>::lowest())
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            else if (temp > std::numeric_limits<ArithmeticType>::max())
+                val = std::numeric_limits<ArithmeticType>::max();
+            else
+                val = static_cast<ArithmeticType>(temp);
             break;
         }
         case value_t::boolean:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -189,6 +189,8 @@
 #include <unordered_map> // unordered_map
 #include <utility> // pair, declval
 #include <valarray> // valarray
+#include <cmath> // isfinite
+#include <limits> // max, lowest
 
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
@@ -5190,17 +5192,62 @@ void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
     {
         case value_t::number_unsigned:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
+            if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                    && temp > std::numeric_limits<ArithmeticType>::max())
+            {
+                val = std::numeric_limits<ArithmeticType>::max();
+            }
+            else
+            {
+                val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_integer:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
+            if (std::numeric_limits<typename BasicJsonType::number_integer_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                    && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            }
+            else if (std::numeric_limits<typename BasicJsonType::number_integer_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
+                val = std::numeric_limits<ArithmeticType>::max();
+            }
+            else
+            {
+                val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_float:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
+            // flush NaN and Inf to zero before converting to a type that cannot represent them - otherwise results are undefined.
+            bool valueIsFinite = std::isfinite(temp);
+            if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
+            {
+                val = 0;
+            }
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                     && valueIsFinite
+                     && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            }
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                     && valueIsFinite
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
+                val = std::numeric_limits<ArithmeticType>::max();
+            }
+            else
+            {
+                val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
 
@@ -5523,22 +5570,68 @@ inline void from_json(const BasicJsonType& j, ArithmeticType& val)
     {
         case value_t::number_unsigned:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>();
+            if (std::numeric_limits<typename BasicJsonType::number_unsigned_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                    && temp > std::numeric_limits<ArithmeticType>::max())
+            {
+                val = std::numeric_limits<ArithmeticType>::max();
+            }
+            else
+            {
+                val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_integer:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_integer_t*>();
+            if (std::numeric_limits<typename BasicJsonType::number_integer_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                    && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            }
+            else if (std::numeric_limits<typename BasicJsonType::number_integer_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
+                val = std::numeric_limits<ArithmeticType>::max();
+            }
+            else
+            {
+                val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::number_float:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::number_float_t*>();
+            // flush NaN and Inf to zero before converting to a type that cannot represent them - otherwise results are undefined.
+            bool valueIsFinite = std::isfinite(temp);
+            if (!std::numeric_limits<ArithmeticType>::has_infinity && !valueIsFinite)
+            {
+                val = 0;
+            }
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::lowest() < std::numeric_limits<ArithmeticType>::lowest()
+                     && valueIsFinite
+                     && temp < std::numeric_limits<ArithmeticType>::lowest())
+            {
+                val = std::numeric_limits<ArithmeticType>::lowest();
+            }
+            else if (std::numeric_limits<typename BasicJsonType::number_float_t>::max() > std::numeric_limits<ArithmeticType>::max()
+                     && valueIsFinite
+                     && temp > std::numeric_limits<ArithmeticType>::max())
+            {
+                val = std::numeric_limits<ArithmeticType>::max();
+            }
+            else
+            {
+                val = static_cast<ArithmeticType>(temp);
+            }
             break;
         }
         case value_t::boolean:
         {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+            auto temp = *j.template get_ptr<const typename BasicJsonType::boolean_t*>();
+            val = static_cast<ArithmeticType>(temp);
             break;
         }
 

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -2826,13 +2826,13 @@ TEST_CASE("value conversion")
         SECTION("float")
         {
             auto n = j.get<float>();
-            CHECK(n == float_reference);
+            CHECK(n == std::numeric_limits<float>::infinity());
         }
         
         SECTION("double")
         {
             auto n = j.get<double>();
-            CHECK(n == float_reference);
+            CHECK(n == std::numeric_limits<double>::infinity());
         }
         
         SECTION("short")
@@ -3037,13 +3037,13 @@ TEST_CASE("value conversion")
         SECTION("float")
         {
             auto n = j.get<float>();
-            CHECK(n == float_reference);
+            CHECK(n == -std::numeric_limits<float>::infinity());
         }
         
         SECTION("double")
         {
             auto n = j.get<double>();
-            CHECK(n == float_reference);
+            CHECK(n == -std::numeric_limits<double>::infinity());
         }
         
         SECTION("short")

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1834,6 +1834,13 @@ TEST_CASE("value conversion")
             if (std::numeric_limits<double>::max() < jMax)
                 CHECK(n == std::numeric_limits<double>::max());
         }
+
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
+            if (std::numeric_limits<long double>::max() < jMax)
+                CHECK(n == std::numeric_limits<long double>::max());
+        }
     }
     
     SECTION("overflow unsigned integer")
@@ -2080,6 +2087,13 @@ TEST_CASE("value conversion")
             if (std::numeric_limits<double>::max() < jMax)
                 CHECK(n == std::numeric_limits<double>::max());
         }
+
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
+            if (std::numeric_limits<long double>::max() < jMax)
+                CHECK(n == std::numeric_limits<long double>::max());
+        }
     }
 
     SECTION("underflow integer")
@@ -2323,6 +2337,13 @@ TEST_CASE("value conversion")
         SECTION("double")
         {
             auto n = j.get<double>();
+            if (std::numeric_limits<double>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<double>::lowest());
+        }
+
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
             if (std::numeric_limits<double>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<double>::lowest());
         }
@@ -2571,6 +2592,13 @@ TEST_CASE("value conversion")
             if (std::numeric_limits<double>::max() < jMax)
                 CHECK(n == std::numeric_limits<double>::max());
         }
+
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
+            if (std::numeric_limits<long double>::max() < jMax)
+                CHECK(n == std::numeric_limits<long double>::max());
+        }
     }
 
     SECTION("underflow float")
@@ -2816,6 +2844,13 @@ TEST_CASE("value conversion")
             if (std::numeric_limits<double>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<double>::lowest());
         }
+
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
+            if (std::numeric_limits<long double>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<long double>::lowest());
+        }
     }
 
     SECTION("Infinity float")
@@ -2833,6 +2868,12 @@ TEST_CASE("value conversion")
         {
             auto n = j.get<double>();
             CHECK(n == std::numeric_limits<double>::infinity());
+        }
+        
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
+            CHECK(n == std::numeric_limits<long double>::infinity());
         }
         
         SECTION("short")
@@ -3046,6 +3087,12 @@ TEST_CASE("value conversion")
             CHECK(n == -std::numeric_limits<double>::infinity());
         }
         
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
+            CHECK(n == -std::numeric_limits<long double>::infinity());
+        }
+        
         SECTION("short")
         {
             auto n = j.get<short>();
@@ -3253,6 +3300,12 @@ TEST_CASE("value conversion")
         SECTION("double")
         {
             auto n = j.get<double>();
+            CHECK( std::isnan(n) );
+        }
+        
+        SECTION("long double")
+        {
+            auto n = j.get<long double>();
             CHECK( std::isnan(n) );
         }
         

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1589,510 +1589,650 @@ TEST_CASE("value conversion")
             }
         }
     }
-    
+
     SECTION("overflow integer")
     {
         constexpr json::number_integer_t jMax = std::numeric_limits<json::number_integer_t>::max();
         // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
-        const json::number_integer_t int_reference{ std::numeric_limits<json::number_integer_t>::max() -3 };
+        const json::number_integer_t int_reference{ std::numeric_limits<json::number_integer_t>::max() - 3 };
         json j(int_reference);
 
         SECTION("short")
         {
             auto n = j.get<short>();
             if (std::numeric_limits<short>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<short>::max());
+            }
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
             if (std::numeric_limits<unsigned short>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned short>::max());
+            }
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
             if (std::numeric_limits<int>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int>::max());
+            }
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
             if (std::numeric_limits<unsigned int>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned int>::max());
+            }
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
             if (std::numeric_limits<long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long>::max());
+            }
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
             if (std::numeric_limits<unsigned long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned long>::max());
+            }
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
             if (std::numeric_limits<long long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long long>::max());
+            }
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
             if (std::numeric_limits<unsigned long long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned long long>::max());
+            }
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
             if (std::numeric_limits<int8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int8_t>::max());
+            }
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
             if (std::numeric_limits<int16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int16_t>::max());
+            }
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
             if (std::numeric_limits<int32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int32_t>::max());
+            }
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
             if (std::numeric_limits<int64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int64_t>::max());
+            }
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
             if (std::numeric_limits<int_fast8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast8_t>::max());
+            }
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
             if (std::numeric_limits<int_fast16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast16_t>::max());
+            }
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
             if (std::numeric_limits<int_fast32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast32_t>::max());
+            }
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
             if (std::numeric_limits<int_fast64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast64_t>::max());
+            }
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
             if (std::numeric_limits<int_least8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least8_t>::max());
+            }
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
             if (std::numeric_limits<int_least16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least16_t>::max());
+            }
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
             if (std::numeric_limits<int_least32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least32_t>::max());
+            }
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
             if (std::numeric_limits<int_least64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least64_t>::max());
+            }
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
             if (std::numeric_limits<uint8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint8_t>::max());
+            }
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
             if (std::numeric_limits<uint16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint16_t>::max());
+            }
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
             if (std::numeric_limits<uint32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint32_t>::max());
+            }
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
             if (std::numeric_limits<uint64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint64_t>::max());
+            }
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
             if (std::numeric_limits<uint_fast8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast8_t>::max());
+            }
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
             if (std::numeric_limits<uint_fast16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast16_t>::max());
+            }
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
             if (std::numeric_limits<uint_fast32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast32_t>::max());
+            }
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
             if (std::numeric_limits<uint_fast64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast64_t>::max());
+            }
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
             if (std::numeric_limits<uint_least8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least8_t>::max());
+            }
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
             if (std::numeric_limits<uint_least16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least16_t>::max());
+            }
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
             if (std::numeric_limits<uint_least32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least32_t>::max());
+            }
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
             if (std::numeric_limits<uint_least64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least64_t>::max());
+            }
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
             if (std::numeric_limits<float>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<float>::max());
+            }
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
             if (std::numeric_limits<double>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<double>::max());
+            }
         }
 
         SECTION("long double")
         {
             auto n = j.get<long double>();
             if (std::numeric_limits<long double>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long double>::max());
+            }
         }
     }
-    
+
     SECTION("overflow unsigned integer")
     {
         constexpr json::number_unsigned_t jMax = std::numeric_limits<json::number_unsigned_t>::max();
         // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
-        const json::number_unsigned_t unsigned_reference{ std::numeric_limits<json::number_unsigned_t>::max() -3 };
+        const json::number_unsigned_t unsigned_reference{ std::numeric_limits<json::number_unsigned_t>::max() - 3 };
         json j(unsigned_reference);
 
         SECTION("short")
         {
             auto n = j.get<short>();
             if (std::numeric_limits<short>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<short>::max());
+            }
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
             if (std::numeric_limits<unsigned short>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned short>::max());
+            }
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
             if (std::numeric_limits<int>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int>::max());
+            }
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
             if (std::numeric_limits<unsigned int>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned int>::max());
+            }
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
             if (std::numeric_limits<long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long>::max());
+            }
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
             if (std::numeric_limits<unsigned long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned long>::max());
+            }
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
             if (std::numeric_limits<long long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long long>::max());
+            }
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
             if (std::numeric_limits<unsigned long long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned long long>::max());
+            }
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
             if (std::numeric_limits<int8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int8_t>::max());
+            }
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
             if (std::numeric_limits<int16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int16_t>::max());
+            }
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
             if (std::numeric_limits<int32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int32_t>::max());
+            }
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
             if (std::numeric_limits<int64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int64_t>::max());
+            }
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
             if (std::numeric_limits<int_fast8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast8_t>::max());
+            }
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
             if (std::numeric_limits<int_fast16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast16_t>::max());
+            }
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
             if (std::numeric_limits<int_fast32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast32_t>::max());
+            }
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
             if (std::numeric_limits<int_fast64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast64_t>::max());
+            }
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
             if (std::numeric_limits<int_least8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least8_t>::max());
+            }
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
             if (std::numeric_limits<int_least16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least16_t>::max());
+            }
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
             if (std::numeric_limits<int_least32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least32_t>::max());
+            }
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
             if (std::numeric_limits<int_least64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least64_t>::max());
+            }
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
             if (std::numeric_limits<uint8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint8_t>::max());
+            }
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
             if (std::numeric_limits<uint16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint16_t>::max());
+            }
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
             if (std::numeric_limits<uint32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint32_t>::max());
+            }
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
             if (std::numeric_limits<uint64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint64_t>::max());
+            }
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
             if (std::numeric_limits<uint_fast8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast8_t>::max());
+            }
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
             if (std::numeric_limits<uint_fast16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast16_t>::max());
+            }
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
             if (std::numeric_limits<uint_fast32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast32_t>::max());
+            }
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
             if (std::numeric_limits<uint_fast64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast64_t>::max());
+            }
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
             if (std::numeric_limits<uint_least8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least8_t>::max());
+            }
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
             if (std::numeric_limits<uint_least16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least16_t>::max());
+            }
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
             if (std::numeric_limits<uint_least32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least32_t>::max());
+            }
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
             if (std::numeric_limits<uint_least64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least64_t>::max());
+            }
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
             if (std::numeric_limits<float>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<float>::max());
+            }
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
             if (std::numeric_limits<double>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<double>::max());
+            }
         }
 
         SECTION("long double")
         {
             auto n = j.get<long double>();
             if (std::numeric_limits<long double>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long double>::max());
+            }
         }
     }
 
@@ -2107,245 +2247,315 @@ TEST_CASE("value conversion")
         {
             auto n = j.get<short>();
             if (std::numeric_limits<short>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<short>::lowest());
+            }
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
             if (std::numeric_limits<unsigned short>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned short>::lowest());
+            }
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
             if (std::numeric_limits<int>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int>::lowest());
+            }
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
             if (std::numeric_limits<unsigned int>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned int>::lowest());
+            }
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
             if (std::numeric_limits<long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<long>::lowest());
+            }
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
             if (std::numeric_limits<unsigned long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned long>::lowest());
+            }
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
             if (std::numeric_limits<long long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<long long>::lowest());
+            }
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
             if (std::numeric_limits<unsigned long long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned long long>::lowest());
+            }
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
             if (std::numeric_limits<int8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int8_t>::lowest());
+            }
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
             if (std::numeric_limits<int16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int16_t>::lowest());
+            }
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
             if (std::numeric_limits<int32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int32_t>::lowest());
+            }
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
             if (std::numeric_limits<int64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int64_t>::lowest());
+            }
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
             if (std::numeric_limits<int_fast8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast8_t>::lowest());
+            }
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
             if (std::numeric_limits<int_fast16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast16_t>::lowest());
+            }
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
             if (std::numeric_limits<int_fast32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast32_t>::lowest());
+            }
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
             if (std::numeric_limits<int_fast64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast64_t>::lowest());
+            }
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
             if (std::numeric_limits<int_least8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least8_t>::lowest());
+            }
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
             if (std::numeric_limits<int_least16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least16_t>::lowest());
+            }
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
             if (std::numeric_limits<int_least32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least32_t>::lowest());
+            }
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
             if (std::numeric_limits<int_least64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least64_t>::lowest());
+            }
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
             if (std::numeric_limits<uint8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint8_t>::lowest());
+            }
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
             if (std::numeric_limits<uint16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint16_t>::lowest());
+            }
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
             if (std::numeric_limits<uint32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint32_t>::lowest());
+            }
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
             if (std::numeric_limits<uint64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint64_t>::lowest());
+            }
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
             if (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast8_t>::lowest());
+            }
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
             if (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast16_t>::lowest());
+            }
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
             if (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast32_t>::lowest());
+            }
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
             if (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast64_t>::lowest());
+            }
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
             if (std::numeric_limits<uint_least8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least8_t>::lowest());
+            }
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
             if (std::numeric_limits<uint_least16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least16_t>::lowest());
+            }
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
             if (std::numeric_limits<uint_least32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least32_t>::lowest());
+            }
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
             if (std::numeric_limits<uint_least64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least64_t>::lowest());
+            }
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
             if (std::numeric_limits<float>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<float>::lowest());
+            }
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
             if (std::numeric_limits<double>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<double>::lowest());
+            }
         }
 
         SECTION("long double")
         {
             auto n = j.get<long double>();
             if (std::numeric_limits<double>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<double>::lowest());
+            }
         }
     }
 
@@ -2359,245 +2569,315 @@ TEST_CASE("value conversion")
         {
             auto n = j.get<short>();
             if (std::numeric_limits<short>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<short>::max());
+            }
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
             if (std::numeric_limits<unsigned short>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned short>::max());
+            }
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
             if (std::numeric_limits<int>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int>::max());
+            }
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
             if (std::numeric_limits<unsigned int>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned int>::max());
+            }
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
             if (std::numeric_limits<long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long>::max());
+            }
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
             if (std::numeric_limits<unsigned long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned long>::max());
+            }
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
             if (std::numeric_limits<long long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long long>::max());
+            }
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
             if (std::numeric_limits<unsigned long long>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<unsigned long long>::max());
+            }
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
             if (std::numeric_limits<int8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int8_t>::max());
+            }
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
             if (std::numeric_limits<int16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int16_t>::max());
+            }
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
             if (std::numeric_limits<int32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int32_t>::max());
+            }
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
             if (std::numeric_limits<int64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int64_t>::max());
+            }
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
             if (std::numeric_limits<int_fast8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast8_t>::max());
+            }
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
             if (std::numeric_limits<int_fast16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast16_t>::max());
+            }
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
             if (std::numeric_limits<int_fast32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast32_t>::max());
+            }
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
             if (std::numeric_limits<int_fast64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_fast64_t>::max());
+            }
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
             if (std::numeric_limits<int_least8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least8_t>::max());
+            }
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
             if (std::numeric_limits<int_least16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least16_t>::max());
+            }
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
             if (std::numeric_limits<int_least32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least32_t>::max());
+            }
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
             if (std::numeric_limits<int_least64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<int_least64_t>::max());
+            }
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
             if (std::numeric_limits<uint8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint8_t>::max());
+            }
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
             if (std::numeric_limits<uint16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint16_t>::max());
+            }
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
             if (std::numeric_limits<uint32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint32_t>::max());
+            }
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
             if (std::numeric_limits<uint64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint64_t>::max());
+            }
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
             if (std::numeric_limits<uint_fast8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast8_t>::max());
+            }
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
             if (std::numeric_limits<uint_fast16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast16_t>::max());
+            }
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
             if (std::numeric_limits<uint_fast32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast32_t>::max());
+            }
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
             if (std::numeric_limits<uint_fast64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_fast64_t>::max());
+            }
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
             if (std::numeric_limits<uint_least8_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least8_t>::max());
+            }
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
             if (std::numeric_limits<uint_least16_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least16_t>::max());
+            }
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
             if (std::numeric_limits<uint_least32_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least32_t>::max());
+            }
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
             if (std::numeric_limits<uint_least64_t>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<uint_least64_t>::max());
+            }
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
             if (std::numeric_limits<float>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<float>::max());
+            }
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
             if (std::numeric_limits<double>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<double>::max());
+            }
         }
 
         SECTION("long double")
         {
             auto n = j.get<long double>();
             if (std::numeric_limits<long double>::max() < jMax)
+            {
                 CHECK(n == std::numeric_limits<long double>::max());
+            }
         }
     }
 
@@ -2606,250 +2886,320 @@ TEST_CASE("value conversion")
         constexpr json::number_float_t jMin = std::numeric_limits<json::number_float_t>::lowest();
         const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::lowest() };
         json j(float_reference);
-        
+
         SECTION("short")
         {
             auto n = j.get<short>();
             if (std::numeric_limits<short>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<short>::lowest());
+            }
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
             if (std::numeric_limits<unsigned short>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned short>::lowest());
+            }
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
             if (std::numeric_limits<int>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int>::lowest());
+            }
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
             if (std::numeric_limits<unsigned int>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned int>::lowest());
+            }
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
             if (std::numeric_limits<long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<long>::lowest());
+            }
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
             if (std::numeric_limits<unsigned long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned long>::lowest());
+            }
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
             if (std::numeric_limits<long long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<long long>::lowest());
+            }
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
             if (std::numeric_limits<unsigned long long>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<unsigned long long>::lowest());
+            }
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
             if (std::numeric_limits<int8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int8_t>::lowest());
+            }
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
             if (std::numeric_limits<int16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int16_t>::lowest());
+            }
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
             if (std::numeric_limits<int32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int32_t>::lowest());
+            }
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
             if (std::numeric_limits<int64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int64_t>::lowest());
+            }
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
             if (std::numeric_limits<int_fast8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast8_t>::lowest());
+            }
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
             if (std::numeric_limits<int_fast16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast16_t>::lowest());
+            }
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
             if (std::numeric_limits<int_fast32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast32_t>::lowest());
+            }
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
             if (std::numeric_limits<int_fast64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_fast64_t>::lowest());
+            }
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
             if (std::numeric_limits<int_least8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least8_t>::lowest());
+            }
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
             if (std::numeric_limits<int_least16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least16_t>::lowest());
+            }
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
             if (std::numeric_limits<int_least32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least32_t>::lowest());
+            }
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
             if (std::numeric_limits<int_least64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<int_least64_t>::lowest());
+            }
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
             if (std::numeric_limits<uint8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint8_t>::lowest());
+            }
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
             if (std::numeric_limits<uint16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint16_t>::lowest());
+            }
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
             if (std::numeric_limits<uint32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint32_t>::lowest());
+            }
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
             if (std::numeric_limits<uint64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint64_t>::lowest());
+            }
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
             if (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast8_t>::lowest());
+            }
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
             if (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast16_t>::lowest());
+            }
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
             if (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast32_t>::lowest());
+            }
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
             if (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_fast64_t>::lowest());
+            }
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
             if (std::numeric_limits<uint_least8_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least8_t>::lowest());
+            }
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
             if (std::numeric_limits<uint_least16_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least16_t>::lowest());
+            }
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
             if (std::numeric_limits<uint_least32_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least32_t>::lowest());
+            }
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
             if (std::numeric_limits<uint_least64_t>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<uint_least64_t>::lowest());
+            }
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
             if (std::numeric_limits<float>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<float>::lowest());
+            }
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
             if (std::numeric_limits<double>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<double>::lowest());
+            }
         }
 
         SECTION("long double")
         {
             auto n = j.get<long double>();
             if (std::numeric_limits<long double>::lowest() > jMin)
+            {
                 CHECK(n == std::numeric_limits<long double>::lowest());
+            }
         }
     }
 
@@ -2857,25 +3207,25 @@ TEST_CASE("value conversion")
     {
         const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::infinity() };
         json j(float_reference);
-        
+
         SECTION("float")
         {
             auto n = j.get<float>();
             CHECK(n == std::numeric_limits<float>::infinity());
         }
-        
+
         SECTION("double")
         {
             auto n = j.get<double>();
             CHECK(n == std::numeric_limits<double>::infinity());
         }
-        
+
         SECTION("long double")
         {
             auto n = j.get<long double>();
             CHECK(n == std::numeric_limits<long double>::infinity());
         }
-        
+
         SECTION("short")
         {
             auto n = j.get<short>();
@@ -3074,25 +3424,25 @@ TEST_CASE("value conversion")
     {
         const json::number_float_t float_reference{ -std::numeric_limits<json::number_float_t>::infinity() };
         json j(float_reference);
-        
+
         SECTION("float")
         {
             auto n = j.get<float>();
             CHECK(n == -std::numeric_limits<float>::infinity());
         }
-        
+
         SECTION("double")
         {
             auto n = j.get<double>();
             CHECK(n == -std::numeric_limits<double>::infinity());
         }
-        
+
         SECTION("long double")
         {
             auto n = j.get<long double>();
             CHECK(n == -std::numeric_limits<long double>::infinity());
         }
-        
+
         SECTION("short")
         {
             auto n = j.get<short>();
@@ -3285,30 +3635,30 @@ TEST_CASE("value conversion")
             CHECK(n == 0);
         }
     }
-    
+
     SECTION("NaN float")
     {
         const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::quiet_NaN() };
         json j(float_reference);
-        
+
         SECTION("float")
         {
             auto n = j.get<float>();
             CHECK( std::isnan(n) );
         }
-        
+
         SECTION("double")
         {
             auto n = j.get<double>();
             CHECK( std::isnan(n) );
         }
-        
+
         SECTION("long double")
         {
             auto n = j.get<long double>();
             CHECK( std::isnan(n) );
         }
-        
+
         SECTION("short")
         {
             auto n = j.get<short>();

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -31,6 +31,8 @@ using nlohmann::json;
 #include <unordered_map>
 #include <unordered_set>
 #include <valarray>
+#include <cmath>
+#include <limits>
 
 // NLOHMANN_JSON_SERIALIZE_ENUM uses a static std::pair
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
@@ -1587,6 +1589,507 @@ TEST_CASE("value conversion")
             }
         }
     }
+    
+    SECTION("overflow integer")
+    {
+        const json::number_integer_t jMax = std::numeric_limits<json::number_integer_t>::max();
+        // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
+        const json::number_integer_t int_reference{ std::numeric_limits<json::number_integer_t>::max() -3 };
+        json j(int_reference);
+
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            if constexpr (std::numeric_limits<short>::max() < jMax)
+                CHECK(n == std::numeric_limits<short>::max());
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            if constexpr (std::numeric_limits<unsigned short>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned short>::max());
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            if constexpr (std::numeric_limits<int>::max() < jMax)
+                CHECK(n == std::numeric_limits<int>::max());
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            if constexpr (std::numeric_limits<unsigned int>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned int>::max());
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            if constexpr (std::numeric_limits<long>::max() < jMax)
+                CHECK(n == std::numeric_limits<long>::max());
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            if constexpr (std::numeric_limits<unsigned long>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned long>::max());
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            if constexpr (std::numeric_limits<long long>::max() < jMax)
+                CHECK(n == std::numeric_limits<long long>::max());
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            if constexpr (std::numeric_limits<unsigned long long>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned long long>::max());
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            if constexpr (std::numeric_limits<int8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int8_t>::max());
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            if constexpr (std::numeric_limits<int16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int16_t>::max());
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            if constexpr (std::numeric_limits<int32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int32_t>::max());
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            if constexpr (std::numeric_limits<int64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int64_t>::max());
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            if constexpr (std::numeric_limits<int_fast8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast8_t>::max());
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            if constexpr (std::numeric_limits<int_fast16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast16_t>::max());
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            if constexpr (std::numeric_limits<int_fast32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast32_t>::max());
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            if constexpr (std::numeric_limits<int_fast64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast64_t>::max());
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            if constexpr (std::numeric_limits<int_least8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least8_t>::max());
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            if constexpr (std::numeric_limits<int_least16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least16_t>::max());
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            if constexpr (std::numeric_limits<int_least32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least32_t>::max());
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            if constexpr (std::numeric_limits<int_least64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least64_t>::max());
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            if constexpr (std::numeric_limits<uint8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint8_t>::max());
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            if constexpr (std::numeric_limits<uint16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint16_t>::max());
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            if constexpr (std::numeric_limits<uint32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint32_t>::max());
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            if constexpr (std::numeric_limits<uint64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint64_t>::max());
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            if constexpr (std::numeric_limits<uint_fast8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast8_t>::max());
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            if constexpr (std::numeric_limits<uint_fast16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast16_t>::max());
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            if constexpr (std::numeric_limits<uint_fast32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast32_t>::max());
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            if constexpr (std::numeric_limits<uint_fast64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast64_t>::max());
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            if constexpr (std::numeric_limits<uint_least8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least8_t>::max());
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            if constexpr (std::numeric_limits<uint_least16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least16_t>::max());
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            if constexpr (std::numeric_limits<uint_least32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least32_t>::max());
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            if constexpr (std::numeric_limits<uint_least64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least64_t>::max());
+        }
+
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            if constexpr (std::numeric_limits<float>::max() < jMax)
+                CHECK(n == std::numeric_limits<float>::max());
+        }
+
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            if constexpr (std::numeric_limits<double>::max() < jMax)
+                CHECK(n == std::numeric_limits<double>::max());
+        }
+    }
+    
+    SECTION("overflow unsigned integer")
+    {
+        const json::number_unsigned_t jMax = std::numeric_limits<json::number_unsigned_t>::max();
+        // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
+        const json::number_unsigned_t unsigned_reference{ std::numeric_limits<json::number_unsigned_t>::max() -3 };
+        json j(unsigned_reference);
+
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            if constexpr (std::numeric_limits<short>::max() < jMax)
+                CHECK(n == std::numeric_limits<short>::max());
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            if constexpr (std::numeric_limits<unsigned short>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned short>::max());
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            if constexpr (std::numeric_limits<int>::max() < jMax)
+                CHECK(n == std::numeric_limits<int>::max());
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            if constexpr (std::numeric_limits<unsigned int>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned int>::max());
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            if constexpr (std::numeric_limits<long>::max() < jMax)
+                CHECK(n == std::numeric_limits<long>::max());
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            if constexpr (std::numeric_limits<unsigned long>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned long>::max());
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            if constexpr (std::numeric_limits<long long>::max() < jMax)
+                CHECK(n == std::numeric_limits<long long>::max());
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            if constexpr (std::numeric_limits<unsigned long long>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned long long>::max());
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            if constexpr (std::numeric_limits<int8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int8_t>::max());
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            if constexpr (std::numeric_limits<int16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int16_t>::max());
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            if constexpr (std::numeric_limits<int32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int32_t>::max());
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            if constexpr (std::numeric_limits<int64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int64_t>::max());
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            if constexpr (std::numeric_limits<int_fast8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast8_t>::max());
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            if constexpr (std::numeric_limits<int_fast16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast16_t>::max());
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            if constexpr (std::numeric_limits<int_fast32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast32_t>::max());
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            if constexpr (std::numeric_limits<int_fast64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast64_t>::max());
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            if constexpr (std::numeric_limits<int_least8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least8_t>::max());
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            if constexpr (std::numeric_limits<int_least16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least16_t>::max());
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            if constexpr (std::numeric_limits<int_least32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least32_t>::max());
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            if constexpr (std::numeric_limits<int_least64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least64_t>::max());
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            if constexpr (std::numeric_limits<uint8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint8_t>::max());
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            if constexpr (std::numeric_limits<uint16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint16_t>::max());
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            if constexpr (std::numeric_limits<uint32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint32_t>::max());
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            if constexpr (std::numeric_limits<uint64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint64_t>::max());
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            if constexpr (std::numeric_limits<uint_fast8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast8_t>::max());
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            if constexpr (std::numeric_limits<uint_fast16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast16_t>::max());
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            if constexpr (std::numeric_limits<uint_fast32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast32_t>::max());
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            if constexpr (std::numeric_limits<uint_fast64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast64_t>::max());
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            if constexpr (std::numeric_limits<uint_least8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least8_t>::max());
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            if constexpr (std::numeric_limits<uint_least16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least16_t>::max());
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            if constexpr (std::numeric_limits<uint_least32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least32_t>::max());
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            if constexpr (std::numeric_limits<uint_least64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least64_t>::max());
+        }
+
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            if constexpr (std::numeric_limits<float>::max() < jMax)
+                CHECK(n == std::numeric_limits<float>::max());
+        }
+
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            if constexpr (std::numeric_limits<double>::max() < jMax)
+                CHECK(n == std::numeric_limits<double>::max());
+        }
+    }
+
+// TODO - underflow from signed
+
+
+// TODO - overflow float
+// TODO - underflow float
+// TODO - Inf float
+// TODO - NaN float
+
 }
 
 enum class cards {kreuz, pik, herz, karo};

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1600,238 +1600,238 @@ TEST_CASE("value conversion")
         SECTION("short")
         {
             auto n = j.get<short>();
-            if constexpr (std::numeric_limits<short>::max() < jMax)
+            if (std::numeric_limits<short>::max() < jMax)
                 CHECK(n == std::numeric_limits<short>::max());
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
-            if constexpr (std::numeric_limits<unsigned short>::max() < jMax)
+            if (std::numeric_limits<unsigned short>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned short>::max());
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
-            if constexpr (std::numeric_limits<int>::max() < jMax)
+            if (std::numeric_limits<int>::max() < jMax)
                 CHECK(n == std::numeric_limits<int>::max());
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
-            if constexpr (std::numeric_limits<unsigned int>::max() < jMax)
+            if (std::numeric_limits<unsigned int>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned int>::max());
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
-            if constexpr (std::numeric_limits<long>::max() < jMax)
+            if (std::numeric_limits<long>::max() < jMax)
                 CHECK(n == std::numeric_limits<long>::max());
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
-            if constexpr (std::numeric_limits<unsigned long>::max() < jMax)
+            if (std::numeric_limits<unsigned long>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned long>::max());
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
-            if constexpr (std::numeric_limits<long long>::max() < jMax)
+            if (std::numeric_limits<long long>::max() < jMax)
                 CHECK(n == std::numeric_limits<long long>::max());
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
-            if constexpr (std::numeric_limits<unsigned long long>::max() < jMax)
+            if (std::numeric_limits<unsigned long long>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned long long>::max());
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
-            if constexpr (std::numeric_limits<int8_t>::max() < jMax)
+            if (std::numeric_limits<int8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int8_t>::max());
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
-            if constexpr (std::numeric_limits<int16_t>::max() < jMax)
+            if (std::numeric_limits<int16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int16_t>::max());
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
-            if constexpr (std::numeric_limits<int32_t>::max() < jMax)
+            if (std::numeric_limits<int32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int32_t>::max());
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
-            if constexpr (std::numeric_limits<int64_t>::max() < jMax)
+            if (std::numeric_limits<int64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int64_t>::max());
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
-            if constexpr (std::numeric_limits<int_fast8_t>::max() < jMax)
+            if (std::numeric_limits<int_fast8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast8_t>::max());
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
-            if constexpr (std::numeric_limits<int_fast16_t>::max() < jMax)
+            if (std::numeric_limits<int_fast16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast16_t>::max());
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
-            if constexpr (std::numeric_limits<int_fast32_t>::max() < jMax)
+            if (std::numeric_limits<int_fast32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast32_t>::max());
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
-            if constexpr (std::numeric_limits<int_fast64_t>::max() < jMax)
+            if (std::numeric_limits<int_fast64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast64_t>::max());
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
-            if constexpr (std::numeric_limits<int_least8_t>::max() < jMax)
+            if (std::numeric_limits<int_least8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least8_t>::max());
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
-            if constexpr (std::numeric_limits<int_least16_t>::max() < jMax)
+            if (std::numeric_limits<int_least16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least16_t>::max());
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
-            if constexpr (std::numeric_limits<int_least32_t>::max() < jMax)
+            if (std::numeric_limits<int_least32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least32_t>::max());
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
-            if constexpr (std::numeric_limits<int_least64_t>::max() < jMax)
+            if (std::numeric_limits<int_least64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least64_t>::max());
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
-            if constexpr (std::numeric_limits<uint8_t>::max() < jMax)
+            if (std::numeric_limits<uint8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint8_t>::max());
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
-            if constexpr (std::numeric_limits<uint16_t>::max() < jMax)
+            if (std::numeric_limits<uint16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint16_t>::max());
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
-            if constexpr (std::numeric_limits<uint32_t>::max() < jMax)
+            if (std::numeric_limits<uint32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint32_t>::max());
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
-            if constexpr (std::numeric_limits<uint64_t>::max() < jMax)
+            if (std::numeric_limits<uint64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint64_t>::max());
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
-            if constexpr (std::numeric_limits<uint_fast8_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast8_t>::max());
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
-            if constexpr (std::numeric_limits<uint_fast16_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast16_t>::max());
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
-            if constexpr (std::numeric_limits<uint_fast32_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast32_t>::max());
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
-            if constexpr (std::numeric_limits<uint_fast64_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast64_t>::max());
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
-            if constexpr (std::numeric_limits<uint_least8_t>::max() < jMax)
+            if (std::numeric_limits<uint_least8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least8_t>::max());
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
-            if constexpr (std::numeric_limits<uint_least16_t>::max() < jMax)
+            if (std::numeric_limits<uint_least16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least16_t>::max());
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
-            if constexpr (std::numeric_limits<uint_least32_t>::max() < jMax)
+            if (std::numeric_limits<uint_least32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least32_t>::max());
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
-            if constexpr (std::numeric_limits<uint_least64_t>::max() < jMax)
+            if (std::numeric_limits<uint_least64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least64_t>::max());
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
-            if constexpr (std::numeric_limits<float>::max() < jMax)
+            if (std::numeric_limits<float>::max() < jMax)
                 CHECK(n == std::numeric_limits<float>::max());
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
-            if constexpr (std::numeric_limits<double>::max() < jMax)
+            if (std::numeric_limits<double>::max() < jMax)
                 CHECK(n == std::numeric_limits<double>::max());
         }
     }
@@ -1846,238 +1846,238 @@ TEST_CASE("value conversion")
         SECTION("short")
         {
             auto n = j.get<short>();
-            if constexpr (std::numeric_limits<short>::max() < jMax)
+            if (std::numeric_limits<short>::max() < jMax)
                 CHECK(n == std::numeric_limits<short>::max());
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
-            if constexpr (std::numeric_limits<unsigned short>::max() < jMax)
+            if (std::numeric_limits<unsigned short>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned short>::max());
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
-            if constexpr (std::numeric_limits<int>::max() < jMax)
+            if (std::numeric_limits<int>::max() < jMax)
                 CHECK(n == std::numeric_limits<int>::max());
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
-            if constexpr (std::numeric_limits<unsigned int>::max() < jMax)
+            if (std::numeric_limits<unsigned int>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned int>::max());
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
-            if constexpr (std::numeric_limits<long>::max() < jMax)
+            if (std::numeric_limits<long>::max() < jMax)
                 CHECK(n == std::numeric_limits<long>::max());
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
-            if constexpr (std::numeric_limits<unsigned long>::max() < jMax)
+            if (std::numeric_limits<unsigned long>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned long>::max());
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
-            if constexpr (std::numeric_limits<long long>::max() < jMax)
+            if (std::numeric_limits<long long>::max() < jMax)
                 CHECK(n == std::numeric_limits<long long>::max());
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
-            if constexpr (std::numeric_limits<unsigned long long>::max() < jMax)
+            if (std::numeric_limits<unsigned long long>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned long long>::max());
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
-            if constexpr (std::numeric_limits<int8_t>::max() < jMax)
+            if (std::numeric_limits<int8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int8_t>::max());
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
-            if constexpr (std::numeric_limits<int16_t>::max() < jMax)
+            if (std::numeric_limits<int16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int16_t>::max());
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
-            if constexpr (std::numeric_limits<int32_t>::max() < jMax)
+            if (std::numeric_limits<int32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int32_t>::max());
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
-            if constexpr (std::numeric_limits<int64_t>::max() < jMax)
+            if (std::numeric_limits<int64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int64_t>::max());
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
-            if constexpr (std::numeric_limits<int_fast8_t>::max() < jMax)
+            if (std::numeric_limits<int_fast8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast8_t>::max());
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
-            if constexpr (std::numeric_limits<int_fast16_t>::max() < jMax)
+            if (std::numeric_limits<int_fast16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast16_t>::max());
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
-            if constexpr (std::numeric_limits<int_fast32_t>::max() < jMax)
+            if (std::numeric_limits<int_fast32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast32_t>::max());
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
-            if constexpr (std::numeric_limits<int_fast64_t>::max() < jMax)
+            if (std::numeric_limits<int_fast64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast64_t>::max());
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
-            if constexpr (std::numeric_limits<int_least8_t>::max() < jMax)
+            if (std::numeric_limits<int_least8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least8_t>::max());
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
-            if constexpr (std::numeric_limits<int_least16_t>::max() < jMax)
+            if (std::numeric_limits<int_least16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least16_t>::max());
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
-            if constexpr (std::numeric_limits<int_least32_t>::max() < jMax)
+            if (std::numeric_limits<int_least32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least32_t>::max());
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
-            if constexpr (std::numeric_limits<int_least64_t>::max() < jMax)
+            if (std::numeric_limits<int_least64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least64_t>::max());
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
-            if constexpr (std::numeric_limits<uint8_t>::max() < jMax)
+            if (std::numeric_limits<uint8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint8_t>::max());
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
-            if constexpr (std::numeric_limits<uint16_t>::max() < jMax)
+            if (std::numeric_limits<uint16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint16_t>::max());
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
-            if constexpr (std::numeric_limits<uint32_t>::max() < jMax)
+            if (std::numeric_limits<uint32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint32_t>::max());
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
-            if constexpr (std::numeric_limits<uint64_t>::max() < jMax)
+            if (std::numeric_limits<uint64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint64_t>::max());
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
-            if constexpr (std::numeric_limits<uint_fast8_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast8_t>::max());
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
-            if constexpr (std::numeric_limits<uint_fast16_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast16_t>::max());
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
-            if constexpr (std::numeric_limits<uint_fast32_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast32_t>::max());
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
-            if constexpr (std::numeric_limits<uint_fast64_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast64_t>::max());
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
-            if constexpr (std::numeric_limits<uint_least8_t>::max() < jMax)
+            if (std::numeric_limits<uint_least8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least8_t>::max());
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
-            if constexpr (std::numeric_limits<uint_least16_t>::max() < jMax)
+            if (std::numeric_limits<uint_least16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least16_t>::max());
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
-            if constexpr (std::numeric_limits<uint_least32_t>::max() < jMax)
+            if (std::numeric_limits<uint_least32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least32_t>::max());
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
-            if constexpr (std::numeric_limits<uint_least64_t>::max() < jMax)
+            if (std::numeric_limits<uint_least64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least64_t>::max());
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
-            if constexpr (std::numeric_limits<float>::max() < jMax)
+            if (std::numeric_limits<float>::max() < jMax)
                 CHECK(n == std::numeric_limits<float>::max());
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
-            if constexpr (std::numeric_limits<double>::max() < jMax)
+            if (std::numeric_limits<double>::max() < jMax)
                 CHECK(n == std::numeric_limits<double>::max());
         }
     }
@@ -2092,238 +2092,238 @@ TEST_CASE("value conversion")
         SECTION("short")
         {
             auto n = j.get<short>();
-            if constexpr (std::numeric_limits<short>::lowest() > jMin)
+            if (std::numeric_limits<short>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<short>::lowest());
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
-            if constexpr (std::numeric_limits<unsigned short>::lowest() > jMin)
+            if (std::numeric_limits<unsigned short>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned short>::lowest());
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
-            if constexpr (std::numeric_limits<int>::lowest() > jMin)
+            if (std::numeric_limits<int>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int>::lowest());
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
-            if constexpr (std::numeric_limits<unsigned int>::lowest() > jMin)
+            if (std::numeric_limits<unsigned int>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned int>::lowest());
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
-            if constexpr (std::numeric_limits<long>::lowest() > jMin)
+            if (std::numeric_limits<long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<long>::lowest());
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
-            if constexpr (std::numeric_limits<unsigned long>::lowest() > jMin)
+            if (std::numeric_limits<unsigned long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned long>::lowest());
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
-            if constexpr (std::numeric_limits<long long>::lowest() > jMin)
+            if (std::numeric_limits<long long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<long long>::lowest());
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
-            if constexpr (std::numeric_limits<unsigned long long>::lowest() > jMin)
+            if (std::numeric_limits<unsigned long long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned long long>::lowest());
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
-            if constexpr (std::numeric_limits<int8_t>::lowest() > jMin)
+            if (std::numeric_limits<int8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int8_t>::lowest());
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
-            if constexpr (std::numeric_limits<int16_t>::lowest() > jMin)
+            if (std::numeric_limits<int16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int16_t>::lowest());
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
-            if constexpr (std::numeric_limits<int32_t>::lowest() > jMin)
+            if (std::numeric_limits<int32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int32_t>::lowest());
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
-            if constexpr (std::numeric_limits<int64_t>::lowest() > jMin)
+            if (std::numeric_limits<int64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int64_t>::lowest());
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
-            if constexpr (std::numeric_limits<int_fast8_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast8_t>::lowest());
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
-            if constexpr (std::numeric_limits<int_fast16_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast16_t>::lowest());
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
-            if constexpr (std::numeric_limits<int_fast32_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast32_t>::lowest());
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
-            if constexpr (std::numeric_limits<int_fast64_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast64_t>::lowest());
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
-            if constexpr (std::numeric_limits<int_least8_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least8_t>::lowest());
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
-            if constexpr (std::numeric_limits<int_least16_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least16_t>::lowest());
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
-            if constexpr (std::numeric_limits<int_least32_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least32_t>::lowest());
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
-            if constexpr (std::numeric_limits<int_least64_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least64_t>::lowest());
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
-            if constexpr (std::numeric_limits<uint8_t>::lowest() > jMin)
+            if (std::numeric_limits<uint8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint8_t>::lowest());
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
-            if constexpr (std::numeric_limits<uint16_t>::lowest() > jMin)
+            if (std::numeric_limits<uint16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint16_t>::lowest());
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
-            if constexpr (std::numeric_limits<uint32_t>::lowest() > jMin)
+            if (std::numeric_limits<uint32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint32_t>::lowest());
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
-            if constexpr (std::numeric_limits<uint64_t>::lowest() > jMin)
+            if (std::numeric_limits<uint64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint64_t>::lowest());
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
-            if constexpr (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast8_t>::lowest());
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
-            if constexpr (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast16_t>::lowest());
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
-            if constexpr (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast32_t>::lowest());
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
-            if constexpr (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast64_t>::lowest());
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
-            if constexpr (std::numeric_limits<uint_least8_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least8_t>::lowest());
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
-            if constexpr (std::numeric_limits<uint_least16_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least16_t>::lowest());
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
-            if constexpr (std::numeric_limits<uint_least32_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least32_t>::lowest());
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
-            if constexpr (std::numeric_limits<uint_least64_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least64_t>::lowest());
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
-            if constexpr (std::numeric_limits<float>::lowest() > jMin)
+            if (std::numeric_limits<float>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<float>::lowest());
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
-            if constexpr (std::numeric_limits<double>::lowest() > jMin)
+            if (std::numeric_limits<double>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<double>::lowest());
         }
     }
@@ -2337,238 +2337,238 @@ TEST_CASE("value conversion")
         SECTION("short")
         {
             auto n = j.get<short>();
-            if constexpr (std::numeric_limits<short>::max() < jMax)
+            if (std::numeric_limits<short>::max() < jMax)
                 CHECK(n == std::numeric_limits<short>::max());
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
-            if constexpr (std::numeric_limits<unsigned short>::max() < jMax)
+            if (std::numeric_limits<unsigned short>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned short>::max());
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
-            if constexpr (std::numeric_limits<int>::max() < jMax)
+            if (std::numeric_limits<int>::max() < jMax)
                 CHECK(n == std::numeric_limits<int>::max());
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
-            if constexpr (std::numeric_limits<unsigned int>::max() < jMax)
+            if (std::numeric_limits<unsigned int>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned int>::max());
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
-            if constexpr (std::numeric_limits<long>::max() < jMax)
+            if (std::numeric_limits<long>::max() < jMax)
                 CHECK(n == std::numeric_limits<long>::max());
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
-            if constexpr (std::numeric_limits<unsigned long>::max() < jMax)
+            if (std::numeric_limits<unsigned long>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned long>::max());
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
-            if constexpr (std::numeric_limits<long long>::max() < jMax)
+            if (std::numeric_limits<long long>::max() < jMax)
                 CHECK(n == std::numeric_limits<long long>::max());
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
-            if constexpr (std::numeric_limits<unsigned long long>::max() < jMax)
+            if (std::numeric_limits<unsigned long long>::max() < jMax)
                 CHECK(n == std::numeric_limits<unsigned long long>::max());
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
-            if constexpr (std::numeric_limits<int8_t>::max() < jMax)
+            if (std::numeric_limits<int8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int8_t>::max());
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
-            if constexpr (std::numeric_limits<int16_t>::max() < jMax)
+            if (std::numeric_limits<int16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int16_t>::max());
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
-            if constexpr (std::numeric_limits<int32_t>::max() < jMax)
+            if (std::numeric_limits<int32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int32_t>::max());
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
-            if constexpr (std::numeric_limits<int64_t>::max() < jMax)
+            if (std::numeric_limits<int64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int64_t>::max());
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
-            if constexpr (std::numeric_limits<int_fast8_t>::max() < jMax)
+            if (std::numeric_limits<int_fast8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast8_t>::max());
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
-            if constexpr (std::numeric_limits<int_fast16_t>::max() < jMax)
+            if (std::numeric_limits<int_fast16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast16_t>::max());
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
-            if constexpr (std::numeric_limits<int_fast32_t>::max() < jMax)
+            if (std::numeric_limits<int_fast32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast32_t>::max());
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
-            if constexpr (std::numeric_limits<int_fast64_t>::max() < jMax)
+            if (std::numeric_limits<int_fast64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_fast64_t>::max());
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
-            if constexpr (std::numeric_limits<int_least8_t>::max() < jMax)
+            if (std::numeric_limits<int_least8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least8_t>::max());
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
-            if constexpr (std::numeric_limits<int_least16_t>::max() < jMax)
+            if (std::numeric_limits<int_least16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least16_t>::max());
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
-            if constexpr (std::numeric_limits<int_least32_t>::max() < jMax)
+            if (std::numeric_limits<int_least32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least32_t>::max());
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
-            if constexpr (std::numeric_limits<int_least64_t>::max() < jMax)
+            if (std::numeric_limits<int_least64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<int_least64_t>::max());
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
-            if constexpr (std::numeric_limits<uint8_t>::max() < jMax)
+            if (std::numeric_limits<uint8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint8_t>::max());
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
-            if constexpr (std::numeric_limits<uint16_t>::max() < jMax)
+            if (std::numeric_limits<uint16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint16_t>::max());
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
-            if constexpr (std::numeric_limits<uint32_t>::max() < jMax)
+            if (std::numeric_limits<uint32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint32_t>::max());
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
-            if constexpr (std::numeric_limits<uint64_t>::max() < jMax)
+            if (std::numeric_limits<uint64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint64_t>::max());
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
-            if constexpr (std::numeric_limits<uint_fast8_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast8_t>::max());
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
-            if constexpr (std::numeric_limits<uint_fast16_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast16_t>::max());
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
-            if constexpr (std::numeric_limits<uint_fast32_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast32_t>::max());
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
-            if constexpr (std::numeric_limits<uint_fast64_t>::max() < jMax)
+            if (std::numeric_limits<uint_fast64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_fast64_t>::max());
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
-            if constexpr (std::numeric_limits<uint_least8_t>::max() < jMax)
+            if (std::numeric_limits<uint_least8_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least8_t>::max());
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
-            if constexpr (std::numeric_limits<uint_least16_t>::max() < jMax)
+            if (std::numeric_limits<uint_least16_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least16_t>::max());
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
-            if constexpr (std::numeric_limits<uint_least32_t>::max() < jMax)
+            if (std::numeric_limits<uint_least32_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least32_t>::max());
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
-            if constexpr (std::numeric_limits<uint_least64_t>::max() < jMax)
+            if (std::numeric_limits<uint_least64_t>::max() < jMax)
                 CHECK(n == std::numeric_limits<uint_least64_t>::max());
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
-            if constexpr (std::numeric_limits<float>::max() < jMax)
+            if (std::numeric_limits<float>::max() < jMax)
                 CHECK(n == std::numeric_limits<float>::max());
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
-            if constexpr (std::numeric_limits<double>::max() < jMax)
+            if (std::numeric_limits<double>::max() < jMax)
                 CHECK(n == std::numeric_limits<double>::max());
         }
     }
@@ -2582,238 +2582,238 @@ TEST_CASE("value conversion")
         SECTION("short")
         {
             auto n = j.get<short>();
-            if constexpr (std::numeric_limits<short>::lowest() > jMin)
+            if (std::numeric_limits<short>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<short>::lowest());
         }
 
         SECTION("unsigned short")
         {
             auto n = j.get<unsigned short>();
-            if constexpr (std::numeric_limits<unsigned short>::lowest() > jMin)
+            if (std::numeric_limits<unsigned short>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned short>::lowest());
         }
 
         SECTION("int")
         {
             const int n = j.get<int>();
-            if constexpr (std::numeric_limits<int>::lowest() > jMin)
+            if (std::numeric_limits<int>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int>::lowest());
         }
 
         SECTION("unsigned int")
         {
             auto n = j.get<unsigned int>();
-            if constexpr (std::numeric_limits<unsigned int>::lowest() > jMin)
+            if (std::numeric_limits<unsigned int>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned int>::lowest());
         }
 
         SECTION("long")
         {
             const long n = j.get<long>();
-            if constexpr (std::numeric_limits<long>::lowest() > jMin)
+            if (std::numeric_limits<long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<long>::lowest());
         }
 
         SECTION("unsigned long")
         {
             auto n = j.get<unsigned long>();
-            if constexpr (std::numeric_limits<unsigned long>::lowest() > jMin)
+            if (std::numeric_limits<unsigned long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned long>::lowest());
         }
 
         SECTION("long long")
         {
             auto n = j.get<long long>();
-            if constexpr (std::numeric_limits<long long>::lowest() > jMin)
+            if (std::numeric_limits<long long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<long long>::lowest());
         }
 
         SECTION("unsigned long long")
         {
             auto n = j.get<unsigned long long>();
-            if constexpr (std::numeric_limits<unsigned long long>::lowest() > jMin)
+            if (std::numeric_limits<unsigned long long>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<unsigned long long>::lowest());
         }
 
         SECTION("int8_t")
         {
             auto n = j.get<int8_t>();
-            if constexpr (std::numeric_limits<int8_t>::lowest() > jMin)
+            if (std::numeric_limits<int8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int8_t>::lowest());
         }
 
         SECTION("int16_t")
         {
             auto n = j.get<int16_t>();
-            if constexpr (std::numeric_limits<int16_t>::lowest() > jMin)
+            if (std::numeric_limits<int16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int16_t>::lowest());
         }
 
         SECTION("int32_t")
         {
             auto n = j.get<int32_t>();
-            if constexpr (std::numeric_limits<int32_t>::lowest() > jMin)
+            if (std::numeric_limits<int32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int32_t>::lowest());
         }
 
         SECTION("int64_t")
         {
             auto n = j.get<int64_t>();
-            if constexpr (std::numeric_limits<int64_t>::lowest() > jMin)
+            if (std::numeric_limits<int64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int64_t>::lowest());
         }
 
         SECTION("int8_fast_t")
         {
             auto n = j.get<int_fast8_t>();
-            if constexpr (std::numeric_limits<int_fast8_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast8_t>::lowest());
         }
 
         SECTION("int16_fast_t")
         {
             auto n = j.get<int_fast16_t>();
-            if constexpr (std::numeric_limits<int_fast16_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast16_t>::lowest());
         }
 
         SECTION("int32_fast_t")
         {
             auto n = j.get<int_fast32_t>();
-            if constexpr (std::numeric_limits<int_fast32_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast32_t>::lowest());
         }
 
         SECTION("int64_fast_t")
         {
             auto n = j.get<int_fast64_t>();
-            if constexpr (std::numeric_limits<int_fast64_t>::lowest() > jMin)
+            if (std::numeric_limits<int_fast64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_fast64_t>::lowest());
         }
 
         SECTION("int8_least_t")
         {
             auto n = j.get<int_least8_t>();
-            if constexpr (std::numeric_limits<int_least8_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least8_t>::lowest());
         }
 
         SECTION("int16_least_t")
         {
             auto n = j.get<int_least16_t>();
-            if constexpr (std::numeric_limits<int_least16_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least16_t>::lowest());
         }
 
         SECTION("int32_least_t")
         {
             auto n = j.get<int_least32_t>();
-            if constexpr (std::numeric_limits<int_least32_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least32_t>::lowest());
         }
 
         SECTION("int64_least_t")
         {
             auto n = j.get<int_least64_t>();
-            if constexpr (std::numeric_limits<int_least64_t>::lowest() > jMin)
+            if (std::numeric_limits<int_least64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<int_least64_t>::lowest());
         }
 
         SECTION("uint8_t")
         {
             auto n = j.get<uint8_t>();
-            if constexpr (std::numeric_limits<uint8_t>::lowest() > jMin)
+            if (std::numeric_limits<uint8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint8_t>::lowest());
         }
 
         SECTION("uint16_t")
         {
             auto n = j.get<uint16_t>();
-            if constexpr (std::numeric_limits<uint16_t>::lowest() > jMin)
+            if (std::numeric_limits<uint16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint16_t>::lowest());
         }
 
         SECTION("uint32_t")
         {
             auto n = j.get<uint32_t>();
-            if constexpr (std::numeric_limits<uint32_t>::lowest() > jMin)
+            if (std::numeric_limits<uint32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint32_t>::lowest());
         }
 
         SECTION("uint64_t")
         {
             auto n = j.get<uint64_t>();
-            if constexpr (std::numeric_limits<uint64_t>::lowest() > jMin)
+            if (std::numeric_limits<uint64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint64_t>::lowest());
         }
 
         SECTION("uint8_fast_t")
         {
             auto n = j.get<uint_fast8_t>();
-            if constexpr (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast8_t>::lowest());
         }
 
         SECTION("uint16_fast_t")
         {
             auto n = j.get<uint_fast16_t>();
-            if constexpr (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast16_t>::lowest());
         }
 
         SECTION("uint32_fast_t")
         {
             auto n = j.get<uint_fast32_t>();
-            if constexpr (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast32_t>::lowest());
         }
 
         SECTION("uint64_fast_t")
         {
             auto n = j.get<uint_fast64_t>();
-            if constexpr (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_fast64_t>::lowest());
         }
 
         SECTION("uint8_least_t")
         {
             auto n = j.get<uint_least8_t>();
-            if constexpr (std::numeric_limits<uint_least8_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least8_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least8_t>::lowest());
         }
 
         SECTION("uint16_least_t")
         {
             auto n = j.get<uint_least16_t>();
-            if constexpr (std::numeric_limits<uint_least16_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least16_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least16_t>::lowest());
         }
 
         SECTION("uint32_least_t")
         {
             auto n = j.get<uint_least32_t>();
-            if constexpr (std::numeric_limits<uint_least32_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least32_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least32_t>::lowest());
         }
 
         SECTION("uint64_least_t")
         {
             auto n = j.get<uint_least64_t>();
-            if constexpr (std::numeric_limits<uint_least64_t>::lowest() > jMin)
+            if (std::numeric_limits<uint_least64_t>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<uint_least64_t>::lowest());
         }
 
         SECTION("float")
         {
             auto n = j.get<float>();
-            if constexpr (std::numeric_limits<float>::lowest() > jMin)
+            if (std::numeric_limits<float>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<float>::lowest());
         }
 
         SECTION("double")
         {
             auto n = j.get<double>();
-            if constexpr (std::numeric_limits<double>::lowest() > jMin)
+            if (std::numeric_limits<double>::lowest() > jMin)
                 CHECK(n == std::numeric_limits<double>::lowest());
         }
     }

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -2818,11 +2818,636 @@ TEST_CASE("value conversion")
         }
     }
 
+    SECTION("Infinity float")
+    {
+        const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::infinity() };
+        json j(float_reference);
+        
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            CHECK(n == float_reference);
+        }
+        
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            CHECK(n == float_reference);
+        }
+        
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            CHECK(n == 0);
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            CHECK(n == 0);
+        }
+    }
 
 
-// TODO - Inf float
-// TODO - NaN float
+    SECTION("-Infinity float")
+    {
+        const json::number_float_t float_reference{ -std::numeric_limits<json::number_float_t>::infinity() };
+        json j(float_reference);
+        
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            CHECK(n == float_reference);
+        }
+        
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            CHECK(n == float_reference);
+        }
+        
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            CHECK(n == 0);
+        }
 
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            CHECK(n == 0);
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            CHECK(n == 0);
+        }
+    }
+    
+    SECTION("NaN float")
+    {
+        const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::quiet_NaN() };
+        json j(float_reference);
+        
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            CHECK( std::isnan(n) );
+        }
+        
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            CHECK( std::isnan(n) );
+        }
+        
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            CHECK(n == 0);
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            CHECK(n == 0);
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            CHECK(n == 0);
+        }
+    }
 }
 
 enum class cards {kreuz, pik, herz, karo};

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1592,7 +1592,7 @@ TEST_CASE("value conversion")
     
     SECTION("overflow integer")
     {
-        const json::number_integer_t jMax = std::numeric_limits<json::number_integer_t>::max();
+        constexpr json::number_integer_t jMax = std::numeric_limits<json::number_integer_t>::max();
         // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
         const json::number_integer_t int_reference{ std::numeric_limits<json::number_integer_t>::max() -3 };
         json j(int_reference);
@@ -1838,7 +1838,7 @@ TEST_CASE("value conversion")
     
     SECTION("overflow unsigned integer")
     {
-        const json::number_unsigned_t jMax = std::numeric_limits<json::number_unsigned_t>::max();
+        constexpr json::number_unsigned_t jMax = std::numeric_limits<json::number_unsigned_t>::max();
         // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
         const json::number_unsigned_t unsigned_reference{ std::numeric_limits<json::number_unsigned_t>::max() -3 };
         json j(unsigned_reference);
@@ -2082,11 +2082,744 @@ TEST_CASE("value conversion")
         }
     }
 
-// TODO - underflow from signed
+    SECTION("underflow integer")
+    {
+        constexpr json::number_integer_t jMin = std::numeric_limits<json::number_integer_t>::lowest();
+        // offset low bits so we don't get pure aliasing of 0xFF or 0x7F patterns
+        const json::number_integer_t int_reference{ std::numeric_limits<json::number_integer_t>::lowest() + 3 };
+        json j(int_reference);
+
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            if constexpr (std::numeric_limits<short>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<short>::lowest());
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            if constexpr (std::numeric_limits<unsigned short>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned short>::lowest());
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            if constexpr (std::numeric_limits<int>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int>::lowest());
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            if constexpr (std::numeric_limits<unsigned int>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned int>::lowest());
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            if constexpr (std::numeric_limits<long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<long>::lowest());
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            if constexpr (std::numeric_limits<unsigned long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned long>::lowest());
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            if constexpr (std::numeric_limits<long long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<long long>::lowest());
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            if constexpr (std::numeric_limits<unsigned long long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned long long>::lowest());
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            if constexpr (std::numeric_limits<int8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int8_t>::lowest());
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            if constexpr (std::numeric_limits<int16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int16_t>::lowest());
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            if constexpr (std::numeric_limits<int32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int32_t>::lowest());
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            if constexpr (std::numeric_limits<int64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int64_t>::lowest());
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            if constexpr (std::numeric_limits<int_fast8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast8_t>::lowest());
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            if constexpr (std::numeric_limits<int_fast16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast16_t>::lowest());
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            if constexpr (std::numeric_limits<int_fast32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast32_t>::lowest());
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            if constexpr (std::numeric_limits<int_fast64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast64_t>::lowest());
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            if constexpr (std::numeric_limits<int_least8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least8_t>::lowest());
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            if constexpr (std::numeric_limits<int_least16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least16_t>::lowest());
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            if constexpr (std::numeric_limits<int_least32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least32_t>::lowest());
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            if constexpr (std::numeric_limits<int_least64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least64_t>::lowest());
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            if constexpr (std::numeric_limits<uint8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint8_t>::lowest());
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            if constexpr (std::numeric_limits<uint16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint16_t>::lowest());
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            if constexpr (std::numeric_limits<uint32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint32_t>::lowest());
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            if constexpr (std::numeric_limits<uint64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint64_t>::lowest());
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            if constexpr (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast8_t>::lowest());
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            if constexpr (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast16_t>::lowest());
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            if constexpr (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast32_t>::lowest());
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            if constexpr (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast64_t>::lowest());
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            if constexpr (std::numeric_limits<uint_least8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least8_t>::lowest());
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            if constexpr (std::numeric_limits<uint_least16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least16_t>::lowest());
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            if constexpr (std::numeric_limits<uint_least32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least32_t>::lowest());
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            if constexpr (std::numeric_limits<uint_least64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least64_t>::lowest());
+        }
+
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            if constexpr (std::numeric_limits<float>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<float>::lowest());
+        }
+
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            if constexpr (std::numeric_limits<double>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<double>::lowest());
+        }
+    }
+
+    SECTION("overflow float")
+    {
+        constexpr json::number_float_t jMax = std::numeric_limits<json::number_float_t>::max();
+        const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::max() };
+        json j(float_reference);
+
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            if constexpr (std::numeric_limits<short>::max() < jMax)
+                CHECK(n == std::numeric_limits<short>::max());
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            if constexpr (std::numeric_limits<unsigned short>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned short>::max());
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            if constexpr (std::numeric_limits<int>::max() < jMax)
+                CHECK(n == std::numeric_limits<int>::max());
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            if constexpr (std::numeric_limits<unsigned int>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned int>::max());
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            if constexpr (std::numeric_limits<long>::max() < jMax)
+                CHECK(n == std::numeric_limits<long>::max());
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            if constexpr (std::numeric_limits<unsigned long>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned long>::max());
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            if constexpr (std::numeric_limits<long long>::max() < jMax)
+                CHECK(n == std::numeric_limits<long long>::max());
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            if constexpr (std::numeric_limits<unsigned long long>::max() < jMax)
+                CHECK(n == std::numeric_limits<unsigned long long>::max());
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            if constexpr (std::numeric_limits<int8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int8_t>::max());
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            if constexpr (std::numeric_limits<int16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int16_t>::max());
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            if constexpr (std::numeric_limits<int32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int32_t>::max());
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            if constexpr (std::numeric_limits<int64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int64_t>::max());
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            if constexpr (std::numeric_limits<int_fast8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast8_t>::max());
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            if constexpr (std::numeric_limits<int_fast16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast16_t>::max());
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            if constexpr (std::numeric_limits<int_fast32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast32_t>::max());
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            if constexpr (std::numeric_limits<int_fast64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_fast64_t>::max());
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            if constexpr (std::numeric_limits<int_least8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least8_t>::max());
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            if constexpr (std::numeric_limits<int_least16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least16_t>::max());
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            if constexpr (std::numeric_limits<int_least32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least32_t>::max());
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            if constexpr (std::numeric_limits<int_least64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<int_least64_t>::max());
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            if constexpr (std::numeric_limits<uint8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint8_t>::max());
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            if constexpr (std::numeric_limits<uint16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint16_t>::max());
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            if constexpr (std::numeric_limits<uint32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint32_t>::max());
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            if constexpr (std::numeric_limits<uint64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint64_t>::max());
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            if constexpr (std::numeric_limits<uint_fast8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast8_t>::max());
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            if constexpr (std::numeric_limits<uint_fast16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast16_t>::max());
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            if constexpr (std::numeric_limits<uint_fast32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast32_t>::max());
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            if constexpr (std::numeric_limits<uint_fast64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_fast64_t>::max());
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            if constexpr (std::numeric_limits<uint_least8_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least8_t>::max());
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            if constexpr (std::numeric_limits<uint_least16_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least16_t>::max());
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            if constexpr (std::numeric_limits<uint_least32_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least32_t>::max());
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            if constexpr (std::numeric_limits<uint_least64_t>::max() < jMax)
+                CHECK(n == std::numeric_limits<uint_least64_t>::max());
+        }
+
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            if constexpr (std::numeric_limits<float>::max() < jMax)
+                CHECK(n == std::numeric_limits<float>::max());
+        }
+
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            if constexpr (std::numeric_limits<double>::max() < jMax)
+                CHECK(n == std::numeric_limits<double>::max());
+        }
+    }
+
+    SECTION("underflow float")
+    {
+        constexpr json::number_float_t jMin = std::numeric_limits<json::number_float_t>::lowest();
+        const json::number_float_t float_reference{ std::numeric_limits<json::number_float_t>::lowest() };
+        json j(float_reference);
+        
+        SECTION("short")
+        {
+            auto n = j.get<short>();
+            if constexpr (std::numeric_limits<short>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<short>::lowest());
+        }
+
+        SECTION("unsigned short")
+        {
+            auto n = j.get<unsigned short>();
+            if constexpr (std::numeric_limits<unsigned short>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned short>::lowest());
+        }
+
+        SECTION("int")
+        {
+            const int n = j.get<int>();
+            if constexpr (std::numeric_limits<int>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int>::lowest());
+        }
+
+        SECTION("unsigned int")
+        {
+            auto n = j.get<unsigned int>();
+            if constexpr (std::numeric_limits<unsigned int>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned int>::lowest());
+        }
+
+        SECTION("long")
+        {
+            const long n = j.get<long>();
+            if constexpr (std::numeric_limits<long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<long>::lowest());
+        }
+
+        SECTION("unsigned long")
+        {
+            auto n = j.get<unsigned long>();
+            if constexpr (std::numeric_limits<unsigned long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned long>::lowest());
+        }
+
+        SECTION("long long")
+        {
+            auto n = j.get<long long>();
+            if constexpr (std::numeric_limits<long long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<long long>::lowest());
+        }
+
+        SECTION("unsigned long long")
+        {
+            auto n = j.get<unsigned long long>();
+            if constexpr (std::numeric_limits<unsigned long long>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<unsigned long long>::lowest());
+        }
+
+        SECTION("int8_t")
+        {
+            auto n = j.get<int8_t>();
+            if constexpr (std::numeric_limits<int8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int8_t>::lowest());
+        }
+
+        SECTION("int16_t")
+        {
+            auto n = j.get<int16_t>();
+            if constexpr (std::numeric_limits<int16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int16_t>::lowest());
+        }
+
+        SECTION("int32_t")
+        {
+            auto n = j.get<int32_t>();
+            if constexpr (std::numeric_limits<int32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int32_t>::lowest());
+        }
+
+        SECTION("int64_t")
+        {
+            auto n = j.get<int64_t>();
+            if constexpr (std::numeric_limits<int64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int64_t>::lowest());
+        }
+
+        SECTION("int8_fast_t")
+        {
+            auto n = j.get<int_fast8_t>();
+            if constexpr (std::numeric_limits<int_fast8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast8_t>::lowest());
+        }
+
+        SECTION("int16_fast_t")
+        {
+            auto n = j.get<int_fast16_t>();
+            if constexpr (std::numeric_limits<int_fast16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast16_t>::lowest());
+        }
+
+        SECTION("int32_fast_t")
+        {
+            auto n = j.get<int_fast32_t>();
+            if constexpr (std::numeric_limits<int_fast32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast32_t>::lowest());
+        }
+
+        SECTION("int64_fast_t")
+        {
+            auto n = j.get<int_fast64_t>();
+            if constexpr (std::numeric_limits<int_fast64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_fast64_t>::lowest());
+        }
+
+        SECTION("int8_least_t")
+        {
+            auto n = j.get<int_least8_t>();
+            if constexpr (std::numeric_limits<int_least8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least8_t>::lowest());
+        }
+
+        SECTION("int16_least_t")
+        {
+            auto n = j.get<int_least16_t>();
+            if constexpr (std::numeric_limits<int_least16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least16_t>::lowest());
+        }
+
+        SECTION("int32_least_t")
+        {
+            auto n = j.get<int_least32_t>();
+            if constexpr (std::numeric_limits<int_least32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least32_t>::lowest());
+        }
+
+        SECTION("int64_least_t")
+        {
+            auto n = j.get<int_least64_t>();
+            if constexpr (std::numeric_limits<int_least64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<int_least64_t>::lowest());
+        }
+
+        SECTION("uint8_t")
+        {
+            auto n = j.get<uint8_t>();
+            if constexpr (std::numeric_limits<uint8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint8_t>::lowest());
+        }
+
+        SECTION("uint16_t")
+        {
+            auto n = j.get<uint16_t>();
+            if constexpr (std::numeric_limits<uint16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint16_t>::lowest());
+        }
+
+        SECTION("uint32_t")
+        {
+            auto n = j.get<uint32_t>();
+            if constexpr (std::numeric_limits<uint32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint32_t>::lowest());
+        }
+
+        SECTION("uint64_t")
+        {
+            auto n = j.get<uint64_t>();
+            if constexpr (std::numeric_limits<uint64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint64_t>::lowest());
+        }
+
+        SECTION("uint8_fast_t")
+        {
+            auto n = j.get<uint_fast8_t>();
+            if constexpr (std::numeric_limits<uint_fast8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast8_t>::lowest());
+        }
+
+        SECTION("uint16_fast_t")
+        {
+            auto n = j.get<uint_fast16_t>();
+            if constexpr (std::numeric_limits<uint_fast16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast16_t>::lowest());
+        }
+
+        SECTION("uint32_fast_t")
+        {
+            auto n = j.get<uint_fast32_t>();
+            if constexpr (std::numeric_limits<uint_fast32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast32_t>::lowest());
+        }
+
+        SECTION("uint64_fast_t")
+        {
+            auto n = j.get<uint_fast64_t>();
+            if constexpr (std::numeric_limits<uint_fast64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_fast64_t>::lowest());
+        }
+
+        SECTION("uint8_least_t")
+        {
+            auto n = j.get<uint_least8_t>();
+            if constexpr (std::numeric_limits<uint_least8_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least8_t>::lowest());
+        }
+
+        SECTION("uint16_least_t")
+        {
+            auto n = j.get<uint_least16_t>();
+            if constexpr (std::numeric_limits<uint_least16_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least16_t>::lowest());
+        }
+
+        SECTION("uint32_least_t")
+        {
+            auto n = j.get<uint_least32_t>();
+            if constexpr (std::numeric_limits<uint_least32_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least32_t>::lowest());
+        }
+
+        SECTION("uint64_least_t")
+        {
+            auto n = j.get<uint_least64_t>();
+            if constexpr (std::numeric_limits<uint_least64_t>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<uint_least64_t>::lowest());
+        }
+
+        SECTION("float")
+        {
+            auto n = j.get<float>();
+            if constexpr (std::numeric_limits<float>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<float>::lowest());
+        }
+
+        SECTION("double")
+        {
+            auto n = j.get<double>();
+            if constexpr (std::numeric_limits<double>::lowest() > jMin)
+                CHECK(n == std::numeric_limits<double>::lowest());
+        }
+    }
 
 
-// TODO - overflow float
-// TODO - underflow float
+
 // TODO - Inf float
 // TODO - NaN float
 


### PR DESCRIPTION
Fixes  #5206

from_json.hpp
- Clamp ranges when converting from internal to external types.
- Flush NaN and Inf to 0 when converting float to int, preserve when converting to another float.
- Use compile time tests to remove the clamping when not necessary.

unit-conversions.cpp
- Test range problems (overflow and underflow) for integer and float types.
- Test +-Infinity and NaN conversions.

### Checklist
- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
    I'm not sure about this - this change doesn't really fit the current number_handling.md documentation.
- [x] The source code is amalgamated by running `make amalgamate`.
- [x] Make sure all ctests are run and passing.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

### Note
DCO does not appear to know about digital signatures - it should be removed or replaced with smarter tests.
