### PR TITLE
Make MSVC Release build build binaries with default Release optimization.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,12 +63,12 @@ target_compile_definitions(test_main PUBLIC
     JSON_TEST_USING_MULTIPLE_HEADERS=$<BOOL:${JSON_MultipleHeaders}>)
 target_compile_features(test_main PRIVATE cxx_std_11)
 target_compile_options(test_main PUBLIC
-    $<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>
+    $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
     # MSVC: Force to always compile with W4
     #       Disable warning C4566: character represented by universal-character-name '\uFF01'
     #                              cannot be represented in the current code page (1252)
     #       Disable warning C4996: 'nlohmann::basic_json<...>::operator <<': was declared deprecated
-    $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4566 /wd4996>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4;/wd4566;/wd4996;$<$<CONFIG:Release>:/wd4702>>
     # https://github.com/nlohmann/json/issues/1114
     $<$<CXX_COMPILER_ID:MSVC>:/bigobj> $<$<BOOL:${MINGW}>:-Wa,-mbig-obj>
 

--- a/tests/abi/CMakeLists.txt
+++ b/tests/abi/CMakeLists.txt
@@ -5,9 +5,9 @@ target_compile_definitions(abi_compat_common INTERFACE
     JSON_TEST_KEEP_MACROS)
 target_compile_features(abi_compat_common INTERFACE cxx_std_11)
 target_compile_options(abi_compat_common INTERFACE
-    $<$<CXX_COMPILER_ID:MSVC>:/EHsc;$<$<CONFIG:Release>:/Od>>
+    $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
     # MSVC: Force to always compile with W4
-    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4;$<$<CONFIG:Release>:/wd4702>>
 
     # https://github.com/nlohmann/json/pull/3229
     $<$<CXX_COMPILER_ID:Intel>:-diag-disable=2196>


### PR DESCRIPTION
MSVC `Release` build of library tests disabled all optimizations by using `/Od` compiler flag. This produced the binaries that despite having all debug helpers and infos disabled, still produced "debug friendly" and totally unoptimized code.

The patch changes two things:
 * removes forced /Od flag in MSVC Release builds
 * adds /wd4702 to disable `warning C4702: unreachable code` in MSVC Release build, which would otherwise prevent the tests to run on CI which enforces "treat warnings as errors" policy.