### PR TITLE
Attach a ready-to-apply patch when the amalgamation check fails

### DIFF
--- a/.github/workflows/check_amalgamation.yml
+++ b/.github/workflows/check_amalgamation.yml
@@ -57,22 +57,42 @@ jobs:
           python3 -mvenv venv
           venv/bin/pip3 install -r $MAIN_DIR/tools/astyle/requirements.txt
 
-      - name: Check amalgamation
+      - name: Regenerate amalgamation and formatting
         run: |
           cd $MAIN_DIR
 
-          rm -fr $INCLUDE_DIR/json.hpp~ $INCLUDE_DIR/json_fwd.hpp~
-          cp $INCLUDE_DIR/json.hpp $INCLUDE_DIR/json.hpp~
-          cp $INCLUDE_DIR/json_fwd.hpp $INCLUDE_DIR/json_fwd.hpp~
-
           python3 $TOOL_DIR/amalgamate.py -c $TOOL_DIR/config_json.json -s .
           python3 $TOOL_DIR/amalgamate.py -c $TOOL_DIR/config_json_fwd.json -s .
-          echo "Format (1)"
-          ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=none --quiet $INCLUDE_DIR/json.hpp $INCLUDE_DIR/json_fwd.hpp
 
-          diff $INCLUDE_DIR/json.hpp~ $INCLUDE_DIR/json.hpp
-          diff $INCLUDE_DIR/json_fwd.hpp~ $INCLUDE_DIR/json_fwd.hpp
+          ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=none --quiet \
+            $INCLUDE_DIR/json.hpp $INCLUDE_DIR/json_fwd.hpp
 
-          ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=orig $(find docs/examples include tests -type f \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' \) -not -path 'tests/thirdparty/*' -not -path 'tests/abi/include/nlohmann/*' | sort)
-          echo Check
-          find $MAIN_DIR -name '*.orig' -exec false {} \+
+          ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=none --quiet \
+            $(find docs/examples include tests -type f \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' \) -not -path 'tests/thirdparty/*' -not -path 'tests/abi/include/nlohmann/*' | sort)
+
+      - name: Build patch and check for differences
+        id: diff
+        run: |
+          cd $MAIN_DIR
+          mkdir -p ${{ github.workspace }}/patch
+          git diff --patch --no-color > ${{ github.workspace }}/patch/amalgamation.patch
+          if [ -s ${{ github.workspace }}/patch/amalgamation.patch ]; then
+            echo "The source code has not been amalgamated/formatted correctly. Diff:"
+            cat ${{ github.workspace }}/patch/amalgamation.patch
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Uploaded so contributors can fix their PR with `git apply amalgamation.patch`
+      # instead of installing the pinned astyle version locally.
+      - name: Upload patch
+        if: steps.diff.outputs.has_diff == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: amalgamation-patch
+          path: patch/amalgamation.patch
+
+      - name: Fail if not amalgamated/formatted
+        if: steps.diff.outputs.has_diff == 'true'
+        run: exit 1

--- a/.github/workflows/comment_check_amalgamation.yml
+++ b/.github/workflows/comment_check_amalgamation.yml
@@ -24,6 +24,7 @@ jobs:
           egress-policy: audit
 
       - name: 'Download artifact'
+        id: download
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -43,6 +44,9 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+            var hasPatch = artifacts.data.artifacts.some((artifact) => artifact.name == "amalgamation-patch");
+            core.setOutput('has_patch', String(hasPatch));
       - run: unzip pr.zip
 
       - name: 'Comment on PR'
@@ -70,12 +74,20 @@ jobs:
                 break
               }
             }
+            const hasPatch = '${{ steps.download.outputs.has_patch }}' === 'true';
+            const runUrl = '${{ github.event.workflow_run.html_url }}';
+
             await github.rest.issues.createComment({
               issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '## 🔴 Amalgamation check failed! 🔴\nThe source code has not been amalgamated.'
-                    + (first ? ' @' + author + ' Please read and follow the [Contribution Guidelines]'
+              body: '## 🔴 Amalgamation check failed! 🔴\nThe source code has not been amalgamated and/or formatted correctly.'
+                    + (hasPatch ? '\n\n📎 A ready-to-apply patch is attached to the [failed workflow run](' + runUrl + ') as the `amalgamation-patch` artifact.'
+                                  + ' Download it, then apply it locally from the repository root with:'
+                                  + '\n\n```shell\ngit apply amalgamation.patch\n```\n\n'
+                                  + 'This does not require installing astyle yourself.'
+                                : '')
+                    + (first ? '\n\n@' + author + ' Please read and follow the [Contribution Guidelines]'
                                + '(https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).'
                              : '')
               })


### PR DESCRIPTION
## Motivation

The astyle-version / amalgamation friction is a recurring contributor blocker: when a PR isn't amalgamated or formatted correctly, the `Check amalgamation` job fails, but fixing it requires reproducing the exact pinned astyle version locally (`make amalgamate`). Contributors regularly get this wrong (wrong astyle version → different formatting → still failing), which stalls otherwise-good PRs.

## What this changes

The failing check now hands the contributor the exact fix instead of making them regenerate it:

- **`check_amalgamation.yml`** regenerates the amalgamation and re-runs astyle in place, then captures the resulting difference with `git diff` into `amalgamation.patch` and uploads it as the `amalgamation-patch` artifact (only when there is a difference), before failing.
- **`comment_check_amalgamation.yml`** appends a note to the existing failure comment linking to that artifact and instructing the contributor to run `git apply amalgamation.patch` — no local astyle install required.

## What does **not** change

- The pass/fail verdict is identical: the same PRs fail as before, and the check still enforces both amalgamation (stale `single_include`) and source formatting.
- A correctly amalgamated PR uploads nothing and passes silently.

## Notes

- The `git diff`-based detection replaces the previous backup-copy + `.orig`-file scheme; it covers the same set of files (`single_include`, `include`, `tests`, `docs/examples`) in a single pass.
- `comment_check_amalgamation.yml` is `workflow_run`-triggered, so its new behavior only takes effect once this file is on `develop`. The first failing PR after merge is the one to eyeball to confirm the comment renders as intended.

## Testing

Validated end-to-end in a throwaway private repo (faithful copy of the amalgamation tooling + source, `develop` as default branch): an un-amalgamated PR fails the check, uploads a correct `amalgamation.patch` (only the `single_include` diff, `git apply`-able from the repo root), and the comment posts with a working link + instructions. `actionlint` reports no structural/expression errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)