### PR TITLE
Bump codeql-action to v4.36.3 and group future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: pip
     directory: /docs/mkdocs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,14 +38,14 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         languages: c-cpp
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
## Summary
- Bumps `github/codeql-action/init`, `analyze`, and `autobuild` to v4.36.3 together (all three, in one commit). #5226, #5227, and #5228 each bumped only one of the three, which made CI fail with `Loaded a configuration file for version 'X', but running version 'Y'` since the actions must all agree on the CodeQL config version.
- Adds a `groups` entry to `.github/dependabot.yml` so future `github/codeql-action/*` bumps are grouped into a single PR, preventing this split-version failure from recurring.

Once this merges, #5226, #5227, and #5228 are superseded and can be closed.

## Test plan
- [x] CI (`CodeQL-Build` in particular) passes on this PR