### PR TITLE
fix unit-algorithms test reliance on implementation specific behaviour

### DIFF
--- a/tests/src/unit-algorithms.cpp
+++ b/tests/src/unit-algorithms.cpp
@@ -229,7 +229,10 @@ TEST_CASE("algorithms")
         {
             json j = {13, 29, 3, {{"one", 1}, {"two", 2}}, true, false, {1, 2, 3}, "foo", "baz", nullptr};
             std::partial_sort(j.begin(), j.begin() + 4, j.end());
-            CHECK(j == json({nullptr, false, true, 3, {{"one", 1}, {"two", 2}}, 29, {1, 2, 3}, "foo", "baz", 13}));
+            // only the first four elements are expected to be sorted, the rest are
+            // unspecified by the standard
+            const json expected({nullptr, false, true, 3});
+            CHECK(std::equal(j.begin(), j.begin() + 4, begin(expected)));
         }
     }
 


### PR DESCRIPTION
the standard only specifies that the first elements are sorted after invoking std::partial_sort.

quoting cppreference:

> The order of equal elements is not guaranteed to be preserved. The order of the remaining elements in the range [middle, last) is unspecified. 

I agree with the Developer Certificate of Origin Version 1.1.