### PR TITLE
Fix ADL leak of nlohmann::detail through basic_json's default base class

### DIFF
--- a/include/nlohmann/detail/json_custom_base_class.hpp
+++ b/include/nlohmann/detail/json_custom_base_class.hpp
@@ -13,8 +13,6 @@
 #include <nlohmann/detail/abi_macros.hpp>
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
-namespace detail
-{
 
 /*!
 @brief Default base class of the @ref basic_json class.
@@ -25,13 +23,27 @@ of @ref basic_json do not require complex case distinctions
 @ref basic_json always has a base class.
 By default, this class is used because it is empty and thus has no effect
 on the behavior of @ref basic_json.
+
+@note This class intentionally lives in namespace @ref nlohmann rather than
+      @ref nlohmann::detail. Every @ref basic_json specialization derives from
+      it (via @ref detail::json_base_class) unless a custom base class is
+      supplied, which makes its namespace an associated namespace of
+      @ref basic_json for the purpose of argument-dependent lookup (ADL). If
+      it lived in `nlohmann::detail`, that namespace - and with it the
+      library's internal `to_json`/`from_json` overloads - would leak into
+      ADL for any unqualified `to_json`/`from_json` call a user makes
+      involving a @ref basic_json argument, silently shadowing the user's own
+      overloads in some cases.
 */
 struct json_default_base {};
+
+namespace detail
+{
 
 template<class T>
 using json_base_class = typename std::conditional <
                         std::is_same<T, void>::value,
-                        json_default_base,
+                        ::nlohmann::json_default_base,
                         T
                         >::type;
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15094,8 +15094,6 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
-namespace detail
-{
 
 /*!
 @brief Default base class of the @ref basic_json class.
@@ -15106,13 +15104,27 @@ of @ref basic_json do not require complex case distinctions
 @ref basic_json always has a base class.
 By default, this class is used because it is empty and thus has no effect
 on the behavior of @ref basic_json.
+
+@note This class intentionally lives in namespace @ref nlohmann rather than
+      @ref nlohmann::detail. Every @ref basic_json specialization derives from
+      it (via @ref detail::json_base_class) unless a custom base class is
+      supplied, which makes its namespace an associated namespace of
+      @ref basic_json for the purpose of argument-dependent lookup (ADL). If
+      it lived in `nlohmann::detail`, that namespace - and with it the
+      library's internal `to_json`/`from_json` overloads - would leak into
+      ADL for any unqualified `to_json`/`from_json` call a user makes
+      involving a @ref basic_json argument, silently shadowing the user's own
+      overloads in some cases.
 */
 struct json_default_base {};
+
+namespace detail
+{
 
 template<class T>
 using json_base_class = typename std::conditional <
                         std::is_same<T, void>::value,
-                        json_default_base,
+                        ::nlohmann::json_default_base,
                         T
                         >::type;
 

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1358,4 +1358,100 @@ TEST_CASE("regression test #5122 - nlohmann::ordered_map move-assignment transfe
     CHECK(src.begin()->first == "after-move");
 }
 
+// Stand-in for a third-party library (e.g., Eigen as of 3.4, which added
+// STL-compatible begin()/end() to its vector types), living in its own
+// namespace with its own to_json overload for its vector type.
+namespace issue_4320_eigen
+{
+// "array-compatible" from the library's point of view (it has begin()/end()),
+// but for which this (fake) third-party namespace provides its own to_json.
+struct vector3
+{
+    double v[3]; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+    vector3(double x, double y, double z) : v{x, y, z} {} // NOLINT(hicpp-member-init,cppcoreguidelines-pro-type-member-init)
+    double x() const
+    {
+        return v[0];
+    }
+    double y() const
+    {
+        return v[1];
+    }
+    double z() const
+    {
+        return v[2];
+    }
+    double* begin()
+    {
+        return v;
+    }
+    double* end()
+    {
+        return v + 3;
+    }
+    const double* begin() const
+    {
+        return v;
+    }
+    const double* end() const
+    {
+        return v + 3;
+    }
+};
+
+inline void to_json(json& j, const vector3& v)
+{
+    j = {{"x", v.x()}, {"y", v.y()}, {"z", v.z()}};
+}
+} // namespace issue_4320_eigen
+
+// The user's own namespace, using the (fake) Eigen type as an implementation
+// detail behind a payload type that has nothing to do with vectors/arrays.
+namespace issue_4320
+{
+// Publicly derives from issue_4320_eigen::vector3 but does *not* define its
+// own to_json - it is only ever used as a temporary to reach the base
+// class's to_json via ADL.
+struct vector3_wrapper : issue_4320_eigen::vector3
+{
+    using issue_4320_eigen::vector3::vector3;
+};
+
+struct payload
+{
+    double x, y, z;
+};
+
+inline vector3_wrapper to_eigen(const payload& p)
+{
+    return vector3_wrapper(p.x, p.y, p.z);
+}
+
+inline void to_json(json& j, const payload& p)
+{
+    // Unqualified call, passing a *derived* vector3_wrapper: relies on ADL
+    // finding issue_4320_eigen::to_json(json&, const vector3&) through the
+    // vector3 base class, via a derived-to-base conversion. Must NOT resolve
+    // to the library's own generic array-compatible to_json (an exact-match
+    // template for vector3_wrapper, since it also has begin()/end()), which
+    // would serialize this as [x, y, z] instead of {"x":x, "y":y, "z":z}.
+    to_json(j, to_eigen(p));
+}
+} // namespace issue_4320
+
+TEST_CASE("issue #4320 - custom base class must not leak nlohmann::detail into ADL")
+{
+    // Before the fix, basic_json unconditionally derived from a type living in
+    // nlohmann::detail (json_default_base), which made nlohmann::detail an
+    // associated namespace of every basic_json for ADL purposes. That leaked
+    // the library's internal generic-array to_json overload into unqualified
+    // to_json() calls made from user code, silently bypassing user-defined
+    // to_json overloads reached via a derived-to-base conversion.
+    const issue_4320::payload p{1.0, 2.0, 3.0};
+
+    json j;
+    to_json(j, p);
+    CHECK(j == json({{"x", 1.0}, {"y", 2.0}, {"z", 3.0}}));
+}
+
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1367,7 +1367,7 @@ namespace issue_4320_eigen
 // but for which this (fake) third-party namespace provides its own to_json.
 struct vector3
 {
-    double v[3]; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+    double v[3]; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-default-member-init,modernize-use-default-member-init)
     vector3(double x, double y, double z) : v{x, y, z} {} // NOLINT(hicpp-member-init,cppcoreguidelines-pro-type-member-init)
     double x() const
     {
@@ -1399,7 +1399,7 @@ struct vector3
     }
 };
 
-inline void to_json(json& j, const vector3& v)
+inline void to_json(json& j, const vector3& v) // NOLINT(misc-use-internal-linkage)
 {
     j = {{"x", v.x()}, {"y", v.y()}, {"z", v.z()}};
 }
@@ -1422,12 +1422,12 @@ struct payload
     double x, y, z;
 };
 
-inline vector3_wrapper to_eigen(const payload& p)
+inline vector3_wrapper to_eigen(const payload& p) // NOLINT(misc-use-internal-linkage)
 {
-    return vector3_wrapper(p.x, p.y, p.z);
+    return {p.x, p.y, p.z};
 }
 
-inline void to_json(json& j, const payload& p)
+inline void to_json(json& j, const payload& p) // NOLINT(misc-use-internal-linkage)
 {
     // Unqualified call, passing a *derived* vector3_wrapper: relies on ADL
     // finding issue_4320_eigen::to_json(json&, const vector3&) through the


### PR DESCRIPTION
## Summary

Fixes #4320.

Since #3110 (3.11.3), `basic_json` unconditionally derives from `detail::json_base_class<CustomBaseClass>`, which resolves to `detail::json_default_base` when no custom base class is supplied (the default, `CustomBaseClass = void`). Because `json_default_base` lived in namespace `nlohmann::detail`, **every** `basic_json` specialization gained `nlohmann::detail` as an associated namespace for argument-dependent lookup (ADL) — even for users who never touch the custom-base-class feature.

This silently exposes the library's internal, ADL-only generic `to_json` overloads (e.g. the compatible-array-type overload in `detail/conversions/to_json.hpp`) to any unqualified `to_json()`/`from_json()` call a user makes involving a `basic_json` argument.

In #4320, the user's `to_json` for one type delegates via an unqualified `to_json()` call to a *base* type's `to_json` — a common pattern for thin wrapper/adapter types (there, a class deriving from `Eigen::Vector3d`). Because the delegated-to argument's type also has `begin()`/`end()` (true of `Eigen::Vector3d` since Eigen 3.4), overload resolution now also considers the library's own generic array serializer, newly visible via the `nlohmann::detail` ADL leak. That overload is an **exact-match template** for the derived type, whereas the user's intended overload requires a derived-to-base conversion — and an exact match beats a non-exact conversion regardless of template-ness, so the user's serializer is silently bypassed and the object gets serialized as `[x,y,z]` instead of `{"x":x,"y":y,"z":z}`.

## Fix

Move `json_default_base` out of `nlohmann::detail` into `nlohmann` itself. `detail::json_base_class<T>` keeps its alias-template location — alias templates don't affect ADL, only the referenced type's namespace does — so this doesn't change `basic_json`'s effective base class, `json_base_class_t`'s public signature, or any other public API. It only removes the accidental ADL exposure of `nlohmann::detail` for the default (no custom base class) case.

## Public API is unchanged

Two distinct names are involved here, and it's worth being precise about which one actually moved:

- **`detail::json_base_class<T>`** — the alias template that implements the `void → default` switch, and that `json_base_class_t` is documented in terms of (`using json_base_class_t = detail::json_base_class<CustomBaseClass>;`). **This stays in `nlohmann::detail`, unchanged.**
- **`json_default_base`** — the empty placeholder struct that `json_base_class<T>` resolves to when `T = void`. **This is the one that moves**, from `nlohmann::detail::json_default_base` to `nlohmann::json_default_base`.

`json_default_base` was never part of the documented API — only `CustomBaseClass` and `json_base_class_t` are documented, and neither of those names, namespaces, or signatures change. `json_base_class_t`'s definition still resolves through the same `nlohmann::detail::json_base_class` alias template it always did; only the *value* that alias produces for the default (no custom base class) case moves namespace. So no documented name, header path, or template signature changes — the only observable effect is the ADL fix itself.

## Test plan

- [x] Added a regression test in `unit-regression2.cpp` reproducing the exact overload-resolution scenario from #4320 (derived-to-base delegation to a `begin()`/`end()`-bearing base type's `to_json`), using a minimal stand-in for the Eigen type involved (no Eigen dependency needed).
- [x] Verified the new test **fails without this fix** (`[1.0,2.0,3.0]` instead of `{"x":1.0,"y":2.0,"z":3.0}`) and **passes with it**.
- [x] `tests/src/unit-custom-base-class.cpp`, `unit-regression2.cpp`, `unit-udt.cpp`, `unit-udt_macro.cpp` all pass against both the modular headers and the amalgamated `single_include` header, at C++11/14/17/20, with `-Wall -Wextra -Werror`.
- [x] Ran `make amalgamate` (astyle 3.4.13) — `single_include/nlohmann/json.hpp` is up to date.

*(This PR was prepared by Claude Code on behalf of @nlohmann, following up on the maintainer's own root-cause investigation of #4320.)*
