### PR TITLE
Add missing copyright notices to SBOM

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -11,6 +11,10 @@ Files: include/nlohmann/thirdparty/hedley.hpp
 Copyright: 2016-2021 Evan Nemerson <evan@nemerson.com>
 License: CC0
 
+Files: include/nlohmann/detail/meta/cpp_future.hpp
+Copyright: 2013-2026 Niels Lohmann <https://nlohmann.me> and 2018 The Abseil Authors
+License: MIT AND Apache-2.0
+
 Files: tests/thirdparty/doctest/*
 Copyright: 2016-2023 Viktor Kirilov
 License: MIT

--- a/include/nlohmann/detail/meta/cpp_future.hpp
+++ b/include/nlohmann/detail/meta/cpp_future.hpp
@@ -5,7 +5,7 @@
 //
 // SPDX-FileCopyrightText: 2013-2026 Niels Lohmann <https://nlohmann.me>
 // SPDX-FileCopyrightText: 2018 The Abseil Authors
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND Apache-2.0
 
 #pragma once
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3405,7 +3405,7 @@ NLOHMANN_JSON_NAMESPACE_END
 //
 // SPDX-FileCopyrightText: 2013-2026 Niels Lohmann <https://nlohmann.me>
 // SPDX-FileCopyrightText: 2018 The Abseil Authors
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND Apache-2.0
 
 
 


### PR DESCRIPTION
According to the README file and the git history, code from the Apache 2.0 library "Abseil" was copy-pasted into the cpp_future.hpp file. Despite this, their license was not specified in the SPDX specification causing it to be missing in the SBOM. They were however already noted as co-authors of the file.

This commit adds them to correct the generated SBOM.

No README update is needed since it already explains this.

[Describe your pull request here. Please read the text below the line and make sure you follow the checklist.]

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [ ] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.
