### PR TITLE
Document std::optional<T> direct construction limitation

### DIFF
--- a/docs/mkdocs/docs/features/conversions.md
+++ b/docs/mkdocs/docs/features/conversions.md
@@ -66,6 +66,24 @@ which forces the explicit `get` form and can catch unintended conversions at com
     floating-point value as an integer truncates it, and narrowing conversions may overflow. See
     [number conversion](types/number_handling.md#number-conversion) for details and how to guard against it.
 
+!!! warning "std::optional direct construction from JSON null throws"
+
+    Constructing or assigning `std::optional<T>` directly from a JSON value does not correctly produce
+    `std::nullopt` for a JSON `null`:
+
+    ```cpp
+    json j_null;
+    std::optional<std::string> opt = j_null;  // ❌ throws type_error 302
+    ```
+
+    This is due to C++ language rules: `std::optional<T>` has its own converting constructor that is chosen over
+    `basic_json::operator T()` when both are viable. Use `get<std::optional<T>>()` or `get_to()` instead:
+
+    ```cpp
+    auto opt = j_null.get<std::optional<std::string>>();  // ✅ std::nullopt
+    j_null.get_to(opt);                                     // ✅ std::nullopt
+    ```
+
 ## Putting values in
 
 The reverse direction works the same way: assigning or constructing a `json` from a C++ value converts it to JSON.

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1779,8 +1779,10 @@ TEST_CASE("std::optional")
         // operator); there is no SFINAE path that distinguishes "call from inside
         // std::optional's constructor" from "direct call". Use get<std::optional<T>>()
         // or get_to() instead for correct null handling. See #4864 and #5246.
-        CHECK_THROWS_AS(std::optional<std::string>(j_null), json::type_error);
-        CHECK_THROWS_AS(std::optional<int>(j_null), json::type_error);
+        CHECK_THROWS_AS_WITH(std::optional<std::string>(j_null), json::type_error,
+                             "type must be string, but is null");
+        CHECK_THROWS_AS_WITH(std::optional<int>(j_null), json::type_error,
+                             "type must be number, but is null");
     }
 
     SECTION("string")

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1779,10 +1779,10 @@ TEST_CASE("std::optional")
         // operator); there is no SFINAE path that distinguishes "call from inside
         // std::optional's constructor" from "direct call". Use get<std::optional<T>>()
         // or get_to() instead for correct null handling. See #4864 and #5246.
-        CHECK_THROWS_AS_WITH(std::optional<std::string>(j_null), json::type_error,
-                             "type must be string, but is null");
-        CHECK_THROWS_AS_WITH(std::optional<int>(j_null), json::type_error,
-                             "type must be number, but is null");
+        CHECK_THROWS_WITH_AS(std::optional<std::string>(j_null),
+                             "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
+        CHECK_THROWS_WITH_AS(std::optional<int>(j_null),
+                             "[json.exception.type_error.302] type must be number, but is null", json::type_error&);
     }
 
     SECTION("string")

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1761,7 +1761,6 @@ TEST_CASE("std::filesystem::path")
 }
 #endif
 
-#if !JSON_USE_IMPLICIT_CONVERSIONS
 TEST_CASE("std::optional")
 {
     SECTION("null")
@@ -1830,7 +1829,6 @@ TEST_CASE("std::optional")
         CHECK(std::map<std::string, std::optional<int>>(j_object) == opt_object);
     }
 }
-#endif
 #endif
 
 #ifdef JSON_HAS_CPP_17

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1765,8 +1765,8 @@ TEST_CASE("std::optional")
 {
     SECTION("null")
     {
-        json j_null;
-        std::optional<std::string> opt_null;
+        const json j_null;
+        const std::optional<std::string> opt_null;
 
         CHECK(json(opt_null) == j_null);
         CHECK(j_null.get<std::optional<std::string>>() == std::nullopt);

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1778,7 +1778,7 @@ TEST_CASE("std::optional")
         // constructible from T, and T is constructible from basic_json via the
         // operator); there is no SFINAE path that distinguishes "call from inside
         // std::optional's constructor" from "direct call". Use get<std::optional<T>>()
-        // or get_to() instead for correct null handling. See json#4864 and #XXXX.
+        // or get_to() instead for correct null handling. See #4864 and #5246.
         CHECK_THROWS_AS(std::optional<std::string>(j_null), json::type_error);
         CHECK_THROWS_AS(std::optional<int>(j_null), json::type_error);
     }

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1771,6 +1771,16 @@ TEST_CASE("std::optional")
 
         CHECK(json(opt_null) == j_null);
         CHECK(j_null.get<std::optional<std::string>>() == std::nullopt);
+
+        // Constructing std::optional<T> directly from JSON null throws because
+        // std::optional's own converting constructor is chosen over basic_json's
+        // operator T(). This is a language-level limitation (std::optional<T> is
+        // constructible from T, and T is constructible from basic_json via the
+        // operator); there is no SFINAE path that distinguishes "call from inside
+        // std::optional's constructor" from "direct call". Use get<std::optional<T>>()
+        // or get_to() instead for correct null handling. See json#4864 and #XXXX.
+        CHECK_THROWS_AS(std::optional<std::string>(j_null), json::type_error);
+        CHECK_THROWS_AS(std::optional<int>(j_null), json::type_error);
     }
 
     SECTION("string")


### PR DESCRIPTION
## Summary

Documents and tests a known limitation with `std::optional<T>` direct construction/assignment from JSON `null` values.

When constructing `std::optional<T>` directly from a JSON `null`, the library throws `type_error 302` instead of yielding `std::nullopt`. Only the explicit `get<std::optional<T>>()` form works correctly.

**Related to:** #4864 (original `std::optional` support issue, which is fixed on `develop` pending release)

**New tracking issue:** #5246 (documents this direct-init/copy-init limitation separately)

## Changes

1. **Test regression** (`tests/src/unit-conversions.cpp`):
   - Added `CHECK_THROWS_AS_WITH` assertions in the `null` section of `TEST_CASE("std::optional")`
   - Verifies both exception type and error message for `std::optional<std::string>(j_null)` and `std::optional<int>(j_null)`
   - Includes detailed comment explaining the C++ language-level root cause

2. **Documentation** (`docs/mkdocs/docs/features/conversions.md`):
   - Added warning callout in the "Implicit conversions" section
   - Clearly states the limitation and provides the correct workaround (`get<std::optional<T>>()` / `get_to()`)

## Why this limitation exists

This is a C++ language-level constraint, not a library bug:
- `std::optional<T>` has its own converting constructor that accepts any type constructible from `T`
- `T` is constructible from `basic_json` via `basic_json::operator T()`
- When both constructors are viable, std::optional's own constructor wins overload resolution
- There is no SFINAE path to distinguish "called from inside std::optional's own constructor" from "direct call"

A proper fix would require restricting/redesigning `basic_json::operator ValueType()`, which would be a breaking change to the core conversion API and belongs in a 4.0 major-version redesign (see #3453).

## Workaround

Users should use explicit conversion:
```cpp
auto opt = j_null.get<std::optional<std::string>>();  // ✓ std::nullopt
j_null.get_to(opt);                                     // ✓ std::nullopt
```

---

🤖 Generated with Claude Code