### PR TITLE
Fix nvcc CUDA 12.0/12.1 C++20 ranges parse error (#3907)

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -237,10 +237,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # matrix to empirically pin down which nvcc/CUDA versions reproduce #3907
-        # (a c++20 parse error in iteration_proxy.hpp's enable_borrowed_range) before
-        # attempting a source-level fix; 11.8 predates CUDA's C++20 support entirely.
-        cuda: ['11.8.0', '12.0.1', '12.1.1', '12.2.2', '12.3.2', '12.4.1', '12.5.1', '12.6.3']
+        # 11.8.0: newest pre-C++20 CUDA release, exercises the C++17 fallback
+        # path (tests/cuda_example/CMakeLists.txt picks the standard per nvcc
+        # version); 12.1.1: permanent regression guard for #3907 (nvcc 12.0/12.1
+        # choke on enable_borrowed_range at C++20, fixed in 12.2); 12.6.3: recent
+        # CUDA/C++20 coverage.
+        cuda: ['11.8.0', '12.1.1', '12.6.3']
     container: nvidia/cuda:${{ matrix.cuda }}-devel-ubuntu22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -234,11 +234,20 @@ jobs:
 
   ci_cuda_example:
     runs-on: ubuntu-latest
-    container: ghcr.io/nlohmann/json-ci:v2.4.0
+    strategy:
+      fail-fast: false
+      matrix:
+        # matrix to empirically pin down which nvcc/CUDA versions reproduce #3907
+        # (a c++20 parse error in iteration_proxy.hpp's enable_borrowed_range) before
+        # attempting a source-level fix; 11.8 predates CUDA's C++20 support entirely.
+        cuda: ['11.8.0', '12.0.1', '12.1.1', '12.2.2', '12.3.2', '12.4.1', '12.5.1', '12.6.3']
+    container: nvidia/cuda:${{ matrix.cuda }}-devel-ubuntu22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Get latest CMake and ninja
+        uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
       - name: Run CMake
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -669,7 +669,6 @@ add_custom_target(ci_test_compiler_default
 add_custom_target(ci_cuda_example
     COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
-        -DCMAKE_CUDA_HOST_COMPILER=g++-8
         -S${PROJECT_SOURCE_DIR}/tests/cuda_example -B${PROJECT_BINARY_DIR}/build_cuda_example
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_cuda_example
 )

--- a/docs/mkdocs/docs/community/quality_assurance.md
+++ b/docs/mkdocs/docs/community/quality_assurance.md
@@ -62,7 +62,9 @@ violations will result in a failed build.
         | Clang 20.1.1                                 | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
         | Clang 20.1.8 with GNU-like command-line      | x86_64       | Windows Server 2022 (Build 20348) | GitHub    |
         | Clang 21.1.8                                 | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
-        | CUDA 11.0.221 (nvcc)                         | x86_64       | Ubuntu 20.04 LTS                  | GitHub    |
+        | CUDA 11.8.0 (nvcc)                           | x86_64       | Ubuntu 22.04 LTS                  | GitHub    |
+        | CUDA 12.1.1 (nvcc)                           | x86_64       | Ubuntu 22.04 LTS                  | GitHub    |
+        | CUDA 12.6.3 (nvcc)                           | x86_64       | Ubuntu 22.04 LTS                  | GitHub    |
         | Emscripten 4.0.6                             | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
         | GNU 4.8.5                                    | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
         | GNU 4.9.3                                    | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |

--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -146,6 +146,11 @@
         #define JSON_HAS_RANGES 0
     #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
         #define JSON_HAS_RANGES 0
+        // nvcc CUDA 12.0/12.1 chokes on the enable_borrowed_range variable-template
+        // syntax when compiling as CUDA source; fixed in CUDA 12.2 (issue #3907)
+    #elif defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ == 12 \
+        && defined(__CUDACC_VER_MINOR__) && (__CUDACC_VER_MINOR__ == 0 || __CUDACC_VER_MINOR__ == 1)
+        #define JSON_HAS_RANGES 0
     #elif defined(__cpp_lib_ranges)
         #define JSON_HAS_RANGES 1
     #else

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2520,6 +2520,11 @@ JSON_HEDLEY_DIAGNOSTIC_POP
         #define JSON_HAS_RANGES 0
     #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
         #define JSON_HAS_RANGES 0
+        // nvcc CUDA 12.0/12.1 chokes on the enable_borrowed_range variable-template
+        // syntax when compiling as CUDA source; fixed in CUDA 12.2 (issue #3907)
+    #elif defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ == 12 \
+        && defined(__CUDACC_VER_MINOR__) && (__CUDACC_VER_MINOR__ == 0 || __CUDACC_VER_MINOR__ == 1)
+        #define JSON_HAS_RANGES 0
     #elif defined(__cpp_lib_ranges)
         #define JSON_HAS_RANGES 1
     #else

--- a/tests/cuda_example/CMakeLists.txt
+++ b/tests/cuda_example/CMakeLists.txt
@@ -3,7 +3,18 @@ project(json_cuda LANGUAGES CUDA)
 
 add_executable(json_cuda json_cuda.cu)
 target_include_directories(json_cuda PRIVATE ../../include)
-target_compile_features(json_cuda PUBLIC cuda_std_20)
+
+# nvcc added C++20 support in CUDA 12.0 and C++17 in CUDA 11.0; pick the
+# newest standard the detected compiler actually supports (see #3907)
+# instead of hard-requiring one standard for every CUDA version.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+    set(json_cuda_std 20)
+elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0)
+    set(json_cuda_std 17)
+else()
+    set(json_cuda_std 11)
+endif()
+target_compile_features(json_cuda PUBLIC cuda_std_${json_cuda_std})
 set_target_properties(json_cuda PROPERTIES
     CUDA_EXTENSIONS OFF
     CUDA_STANDARD_REQUIRED ON

--- a/tests/cuda_example/CMakeLists.txt
+++ b/tests/cuda_example/CMakeLists.txt
@@ -3,7 +3,7 @@ project(json_cuda LANGUAGES CUDA)
 
 add_executable(json_cuda json_cuda.cu)
 target_include_directories(json_cuda PRIVATE ../../include)
-target_compile_features(json_cuda PUBLIC cuda_std_11)
+target_compile_features(json_cuda PUBLIC cuda_std_20)
 set_target_properties(json_cuda PROPERTIES
     CUDA_EXTENSIONS OFF
     CUDA_STANDARD_REQUIRED ON

--- a/tests/cuda_example/json_cuda.cu
+++ b/tests/cuda_example/json_cuda.cu
@@ -24,8 +24,10 @@ int main()
     nlohmann::json a = {1, 2, 3};
     nlohmann::json b = {1, 2, 3};
     static_cast<void>(a == b);
+#if JSON_HAS_THREE_WAY_COMPARISON
     static_cast<void>(a <=> b); // *NOPAD*
     static_cast<void>(a <=> 1); // *NOPAD*
+#endif
     for (const auto& element : a)
     {
         static_cast<void>(element);

--- a/tests/cuda_example/json_cuda.cu
+++ b/tests/cuda_example/json_cuda.cu
@@ -16,4 +16,18 @@ int main()
     // regression for #3013 (ordered_json::reset() compile error with nvcc)
     nlohmann::ordered_json metadata;
     metadata.erase("key");
+
+    // exercise comparisons (operator==/operator<=>, gated by
+    // JSON_HAS_THREE_WAY_COMPARISON, independent of JSON_HAS_RANGES) and
+    // range-based iteration (exercises iteration_proxy/ranges machinery
+    // beyond just the enable_borrowed_range specialization) — see #3907
+    nlohmann::json a = {1, 2, 3};
+    nlohmann::json b = {1, 2, 3};
+    static_cast<void>(a == b);
+    static_cast<void>(a <=> b); // *NOPAD*
+    static_cast<void>(a <=> 1); // *NOPAD*
+    for (const auto& element : a)
+    {
+        static_cast<void>(element);
+    }
 }


### PR DESCRIPTION
- [x] The changes are described in detail, both the what and why.
- [x] An existing issue is referenced: #3907.
- [ ] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

## What and why

#3907 reports that `nlohmann/json.hpp` fails to compile under `nvcc` at `-std=c++20`
(`error: expected initializer before '<' token` in `iteration_proxy.hpp`'s
`enable_borrowed_range` specialization), but compiles fine at C++17. The issue was
previously closed as "un-reproducible in CI": the existing `ci_cuda_example` job built
against the `json-ci` image's CUDA 11.0 toolkit at `cuda_std_11`, and CUDA 11 has no
C++20 support at all, so the job could never hit this code path. A separate job
(`ci_nvhpc`) and a previously closed PR (#4796) both use CUDA 12.9, a version where the
bug is already fixed — so neither of those could catch it either.

This PR was done in two stages, both on this branch:

**1. Diagnose first.** Turned `ci_cuda_example` into a matrix pulling official
`nvidia/cuda:*-devel-ubuntu22.04` images directly (same pattern as `ci_nvhpc`) across 8
CUDA versions (11.8.0 through 12.6.3) at `cuda_std_20`, to empirically confirm which
versions are actually affected instead of trusting an unverified issue-thread comment.
Result, reproduced against real nvcc:

| CUDA (nvcc) | Result |
|---|---|
| 11.8.0 | fails at CMake configure — no C++20 support in CUDA 11, unrelated to #3907 |
| **12.0.1** | fails with the exact #3907 error |
| **12.1.1** | fails with the exact #3907 error |
| 12.2.2 – 12.6.3 | all pass |

So the affected range is exactly nvcc 12.0.x/12.1.x, fixed by NVIDIA from 12.2 onward —
nothing broader or narrower.

**2. Fix it.** Added a targeted guard to the `JSON_HAS_RANGES` detection chain in
`include/nlohmann/detail/macro_scope.hpp`, disabling ranges support specifically for
nvcc 12.0/12.1 (detected via `__CUDACC_VER_MAJOR__`/`__CUDACC_VER_MINOR__`), matching the
style of the neighboring GCC-11/libstdc++ carve-outs already in that file. This is the
part that protects real client code — any project compiling this header with nvcc
12.0/12.1 at C++20 gets `JSON_HAS_RANGES` disabled automatically, regardless of their own
build system. Regenerated `single_include/nlohmann/json.hpp` accordingly.

Also broadened `tests/cuda_example/json_cuda.cu` (previously only called `dump()`/
`erase()`) to exercise `operator==`/`operator<=>` (three-way comparison, gated
independently by `JSON_HAS_THREE_WAY_COMPARISON`) and range-based iteration, so the CI
matrix gives real evidence about the fix's scope rather than a guess. This *did* catch a
real issue: once `11.8.0` started building at C++17 (see below), its use of `<=>`
unconditionally broke, since that operator isn't valid pre-C++20 syntax — fixed by
gating those two lines behind `JSON_HAS_THREE_WAY_COMPARISON`, the same way the library
itself does internally.

`tests/cuda_example/CMakeLists.txt` no longer hard-requires `cuda_std_20` (which failed
outright on anything older than CUDA 12.0). It now picks the newest C++ standard the
detected nvcc version actually supports — 20 for CUDA ≥ 12.0, 17 for CUDA ≥ 11.0, else
11 — so older toolkits still build the smoke test at whatever standard they support
instead of erroring. This is local to our own test project only (a header can't control
its own `-std=` invocation); the actual protection for downstream users is the
`macro_scope.hpp` guard above.

With the fix in place, every CUDA version can build successfully at its own standard, so
the matrix no longer needs the full 8-version diagnostic sweep to avoid a permanently red
leg. Right-sized `ci_cuda_example` down to 3 legs, each testing something distinct:
- `11.8.0` — exercises the new C++17 fallback path end-to-end
- `12.1.1` — the permanent regression guard for #3907
- `12.6.3` — recent CUDA/C++20 coverage

Also updated the CUDA row in `docs/mkdocs/docs/community/quality_assurance.md`'s compiler
table to match (previously listed a stale `CUDA 11.0.221` / Ubuntu 20.04 entry).

Final CI on this branch: all three `ci_cuda_example` legs (`11.8.0`, `12.1.1`, `12.6.3`)
pass.

## Changes

- `include/nlohmann/detail/macro_scope.hpp` / `single_include/nlohmann/json.hpp`: nvcc
  12.0/12.1 `JSON_HAS_RANGES` guard (the actual fix for #3907).
- `tests/cuda_example/json_cuda.cu`: broadened smoke test (comparisons + range-based
  iteration), `<=>` usage gated by `JSON_HAS_THREE_WAY_COMPARISON`.
- `tests/cuda_example/CMakeLists.txt`: graceful per-nvcc-version C++ standard selection
  instead of hard-requiring `cuda_std_20`.
- `cmake/ci.cmake`: dropped the stale `-DCMAKE_CUDA_HOST_COMPILER=g++-8` pin on the
  `ci_cuda_example` target so it falls back to the stock host compiler in each image.
- `.github/workflows/ubuntu.yml`: `ci_cuda_example` now matrices over
  `nvidia/cuda:{11.8.0,12.1.1,12.6.3}-devel-ubuntu22.04` directly instead of the pinned
  `ghcr.io/nlohmann/json-ci` image, with a `lukka/get-cmake` step added.
- `docs/mkdocs/docs/community/quality_assurance.md`: updated the CUDA compiler-version
  table row(s) to match.
