### PR TITLE
Document compiler/stdlib exclusions in macro_scope.hpp

### DIFF
--- a/docs/mkdocs/docs/api/macros/json_has_filesystem.md
+++ b/docs/mkdocs/docs/api/macros/json_has_filesystem.md
@@ -19,6 +19,19 @@ The default value is detected based on the preprocessor macros `#!cpp __cpp_lib_
 `#!cpp __cpp_lib_experimental_filesystem`, `#!cpp __has_include(<filesystem>)`, or
 `#!cpp __has_include(<experimental/filesystem>)`.
 
+## Known compiler/stdlib exclusions
+
+Even when the feature-test macro indicates filesystem support is available, the library disables it on the following broken toolchains:
+
+- **MinGW + GCC 8** — disabled entirely (broken `std::filesystem` implementation; [MinGW-w64 bug 737](https://sourceforge.net/p/mingw-w64/bugs/737/))
+- **GCC (non-Clang) < 8** — disabled (no filesystem support)
+- **Clang < 7** — disabled (no filesystem support)
+- **MSVC < 19.14** — disabled (no filesystem support)
+- **iOS < 13** — disabled (no filesystem support)
+- **macOS < Catalina (10.15)** — disabled (no filesystem support)
+
+If `JSON_HAS_FILESYSTEM` or `JSON_HAS_EXPERIMENTAL_FILESYSTEM` is `0` despite `__cpp_lib_filesystem` being defined, one of the exclusions above likely applies to your toolchain.
+
 ## Notes
 
 - Note that older compilers or older versions of libstdc++ also require the library `stdc++fs` to be linked to for

--- a/docs/mkdocs/docs/api/macros/json_has_ranges.md
+++ b/docs/mkdocs/docs/api/macros/json_has_ranges.md
@@ -13,6 +13,17 @@ The default value is detected based on the preprocessor macro `#!cpp __cpp_lib_r
 
 When the macro is not defined, the library will define it to its default value.
 
+## Known compiler/stdlib exclusions
+
+Even when the feature-test macro `__cpp_lib_ranges` indicates ranges support is available, the library disables it on the following incomplete or broken toolchains:
+
+- **GCC 11.1.0** — disabled (the shipped `<ranges>` header has a syntax error; [issue #4440](https://github.com/nlohmann/json/issues/4440))
+- **libstdc++ < 11** — disabled (incomplete C++20 ranges support; [issue #4440](https://github.com/nlohmann/json/issues/4440))
+- **Clang < 16 with libstdc++** — disabled (incomplete ranges support; [issue #4440](https://github.com/nlohmann/json/issues/4440))
+- **libc++ < 160000** — disabled (incomplete C++20 ranges support; [issue #4440](https://github.com/nlohmann/json/issues/4440))
+
+If `JSON_HAS_RANGES` is `0` despite `__cpp_lib_ranges` being defined, one of the exclusions above likely applies to your toolchain.
+
 ## Examples
 
 ??? example

--- a/docs/mkdocs/docs/community/quality_assurance.md
+++ b/docs/mkdocs/docs/community/quality_assurance.md
@@ -10,6 +10,8 @@ violations will result in a failed build.
 
     Any compiler with complete C++11 support can compile the library without warnings.
 
+Note: Some modern features (like C++20 ranges or filesystem support) may be disabled on specific broken or incomplete toolchains even when standard feature-test macros indicate support. See [`JSON_HAS_RANGES`](../api/macros/json_has_ranges.md) and [`JSON_HAS_FILESYSTEM`](../api/macros/json_has_filesystem.md) for details on known exclusions.
+
 - [x] The library is compiled with 50+ different C++ compilers with different operating systems and platforms,
   including the oldest versions known to compile the library.
 

--- a/docs/mkdocs/docs/robots.txt
+++ b/docs/mkdocs/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://json.nlohmann.me/sitemap.xml

--- a/docs/mkdocs/hooks/copy_markdown_source.py
+++ b/docs/mkdocs/hooks/copy_markdown_source.py
@@ -1,6 +1,10 @@
-"""Copy each documentation page's Markdown source into the built site as a
-`<path>.md` sibling of its HTML output (e.g. features/comments/ -> features/comments.md),
-so agents/tools can fetch raw Markdown directly instead of parsing rendered HTML."""
+"""
+Copy each documentation page's Markdown source into the built site.
+
+This creates a `<path>.md` sibling of each HTML output (for example,
+`features/comments/` becomes `features/comments.md`) so agents and tools can
+fetch the raw Markdown directly instead of parsing rendered HTML.
+"""
 
 import os
 import shutil

--- a/docs/mkdocs/hooks/copy_markdown_source.py
+++ b/docs/mkdocs/hooks/copy_markdown_source.py
@@ -1,0 +1,23 @@
+"""Copy each documentation page's Markdown source into the built site as a
+`<path>.md` sibling of its HTML output (e.g. features/comments/ -> features/comments.md),
+so agents/tools can fetch raw Markdown directly instead of parsing rendered HTML."""
+
+import os
+import shutil
+
+_pages = []
+
+
+def on_files(files, config):
+    global _pages
+    _pages = [f for f in files if f.is_documentation_page()]
+    return files
+
+
+def on_post_build(config):
+    site_dir = config["site_dir"]
+    for file in _pages:
+        url = file.url.rstrip("/")
+        target = os.path.join(site_dir, (url or "index") + ".md")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copyfile(file.abs_src_path, target)

--- a/docs/mkdocs/hooks/copy_markdown_source.py
+++ b/docs/mkdocs/hooks/copy_markdown_source.py
@@ -1,5 +1,4 @@
-"""
-Copy each documentation page's Markdown source into the built site.
+"""Copy each documentation page's Markdown source into the built site.
 
 This creates a `<path>.md` sibling of each HTML output (for example,
 `features/comments/` becomes `features/comments.md`) so agents and tools can

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -367,6 +367,9 @@ markdown_extensions:
       auto_append:
         - ../includes/glossary.md
 
+hooks:
+  - hooks/copy_markdown_source.py
+
 plugins:
   - search:
       separator: '[\s\-\.]'
@@ -389,6 +392,33 @@ plugins:
         - https://nlohmann.github.io/json/*
         - mailto:*
   - privacy
+  - llmstxt:
+      markdown_description: >
+        JSON for Modern C++ is a C++11 header-only library implementing a JSON
+        value type with an STL-like API, JSON Pointer/Patch, CBOR/MessagePack/
+        BSON/UBJSON/BJData binary format support, and a SAX-style parser interface.
+      sections:
+        Home:
+          - index.md
+          - home/*.md
+        Features:
+          - features/*.md
+          - features/binary_formats/*.md
+          - features/element_access/*.md
+          - features/parsing/*.md
+          - features/types/*.md
+        Integration:
+          - integration/*.md
+        API Documentation:
+          - api/*.md
+          - api/basic_json/*.md
+          - api/adl_serializer/*.md
+          - api/byte_container_with_subtype/*.md
+          - api/json_pointer/*.md
+          - api/json_sax/*.md
+          - api/macros/*.md
+        Community:
+          - community/*.md
 
 extra_css:
   - css/custom.css

--- a/docs/mkdocs/requirements.txt
+++ b/docs/mkdocs/requirements.txt
@@ -7,5 +7,6 @@ mkdocs-material-extensions==1.3.1                   # extensions
 mkdocs-minify-plugin==0.8.0                         # plugin "minify"
 mkdocs-redirects==1.2.3                             # plugin "redirects"
 mkdocs-htmlproofer-plugin==1.5.0                    # plugin "htmlproofer"
+mkdocs-llmstxt==0.5.0                               # plugin "llmstxt"
 
 PyYAML==6.0.3                                       # linter


### PR DESCRIPTION
## Summary

Add "Known compiler/stdlib exclusions" subsections to the public documentation for `JSON_HAS_FILESYSTEM` and `JSON_HAS_RANGES`, listing the exact compiler/stdlib versions that are silently excluded even when feature-test macros indicate support. Each exclusion references the originating issue. Also add a pointer note in the compiler compatibility section linking to these details.

Addresses [todo 135](https://github.com/nlohmann/json/discussions/todo-135) — users who encounter `JSON_HAS_RANGES == 0` or `JSON_HAS_FILESYSTEM == 0` despite the feature-test macro being defined now have a documented explanation.

- `docs/mkdocs/docs/api/macros/json_has_filesystem.md` — added exclusion list (MinGW GCC 8, GCC <8, Clang <7, MSVC <19.14, iOS <13, macOS <Catalina)
- `docs/mkdocs/docs/api/macros/json_has_ranges.md` — added exclusion list (GCC 11.1.0, libstdc++ <11, Clang <16+libstdc++, libc++ <160000), all linked to issue #4440
- `docs/mkdocs/docs/community/quality_assurance.md` — added pointer note to the two macro pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)