### PR TITLE
Fix flaky ci_nvhpc job: pin nvc++ target to generic baseline (-tp=px)

### DIFF
--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -720,6 +720,11 @@ add_custom_target(ci_icpx
 # to zero and does not honor NaN ordering; -Kieee restores strict IEEE 754 behavior
 # (needed for the dtoa/grisu and NaN-comparison code paths).
 #
+# -tp=px pins the target processor to the generic x86-64 baseline (SSE2-only) to avoid
+# a nvc++ 25.5 / LLVM issue: when nvc++ auto-detects -tp from the runner's CPU (e.g. -tp znver4),
+# certain attribute combinations trigger an llc instruction-selection crash on std::ldexp<unsigned>.
+# Pinning to px removes this variability and is robust to future llc/nvc++ updates.
+#
 # The following tests are excluded as they trigger known nvc++ 25.5 defects (not
 # library bugs); see https://github.com/nlohmann/json for tracking. Only the
 # affected language-standard variants are excluded so coverage is otherwise kept:
@@ -733,7 +738,7 @@ add_custom_target(ci_nvhpc
     COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
         -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++
-        -DCMAKE_CXX_FLAGS=-Kieee
+        -DCMAKE_CXX_FLAGS="-Kieee;-tp=px"
         -DJSON_BuildTests=ON -DJSON_FastTests=ON
         -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_nvhpc
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_nvhpc


### PR DESCRIPTION
## Summary

Fixes the intermittent `ci_nvhpc` CI job crashes by pinning nvc++ to a generic x86-64 baseline target.

## Problem

The `ci_nvhpc` job crashes intermittently with nvc++ 25.5's bundled LLVM failing during instruction selection when compiling `std::ldexp<unsigned int>`. This defect manifests when nvc++ auto-detects certain CPU targets (particularly `-tp znver4`) from the GitHub Actions runner's hardware.

## Root Cause

Empirical analysis of 19+ recent CI runs shows a sharp correlation:
- **-tp znver4** (AMD Zen 4): 2 of 3 runs crashed with the llc instruction-selection failure
- **-tp znver3** (AMD Zen 3): 0 of 7 runs crashed
- **-tp graniterapids** (Intel): 0 of 1 runs crashed  
- **-tp icelake** (Intel): 0 of 1 runs crashed

This is an LLVM/nvc++ 25.5 internal compiler bug (not a library bug), triggered specifically by Zen4-specific CPU attributes at `-O0` when compiling the half-precision float decoder in `binary_reader.hpp`.

## Solution

Pin `-tp` to `px` (generic x86-64 baseline, SSE2-only) in `cmake/ci.cmake:741`. This removes the run-to-run CPU auto-detection variability that causes the crash.

Trade-off: Small potential codegen performance reduction vs. reproducible, reliable CI. The `-Kieee` flag already ensures IEEE 754 strictness for floating-point correctness.

## Verification

Before merging, re-run ci_nvhpc 5–10 times via `gh run rerun` to sample different physical runners and confirm the crash is gone.