### PR TITLE
Documentation review: fix stale compiler-exclusion list

### DIFF
--- a/docs/mkdocs/docs/api/macros/json_has_ranges.md
+++ b/docs/mkdocs/docs/api/macros/json_has_ranges.md
@@ -22,6 +22,7 @@ When the macro is not defined, the library will define it to its default value.
     - **libstdc++ < 11** — disabled (incomplete C++20 ranges support; [issue #4440](https://github.com/nlohmann/json/issues/4440))
     - **Clang < 16 with libstdc++** — disabled (incomplete ranges support; [issue #4440](https://github.com/nlohmann/json/issues/4440))
     - **libc++ < 160000** — disabled (incomplete C++20 ranges support; [issue #4440](https://github.com/nlohmann/json/issues/4440))
+    - **nvcc (CUDA) 12.0.x and 12.1.x** — disabled (the `enable_borrowed_range` variable-template syntax triggers a parse error under these two toolkit versions; fixed in CUDA 12.2; [issue #3907](https://github.com/nlohmann/json/issues/3907))
     
     If `JSON_HAS_RANGES` is `0` despite `__cpp_lib_ranges` being defined, one of the exclusions above likely applies to your toolchain.
 


### PR DESCRIPTION
## Summary

Follow-up documentation pass after #5257, checking activity merged into `develop` since then.

- **`json_has_ranges.md`**: #5252 added a "Known compiler/stdlib exclusions" list for `JSON_HAS_RANGES` (4 entries), but #5248 — merged less than 2 hours later — added a 5th exclusion branch to `macro_scope.hpp` (nvcc CUDA 12.0.x/12.1.x, fixed in CUDA 12.2, issue #3907) as part of unrelated work fixing the underlying nvcc parse error. The doc page never caught up. This restores parity: verified via `macro_scope.hpp` that there are exactly 5 `#elif`-chained `JSON_HAS_RANGES` exclusion branches in code, now exactly 5 documented.

## Test plan

- [x] Confirmed exact branch count in `include/nlohmann/detail/macro_scope.hpp` matches the bullet count in the doc page.
- [x] Manually reviewed the new bullet for accuracy against the PR #5248 diff (exact CUDA version range, fixed-in version, issue number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)