### PR TITLE
Fix container input_adapter SFINAE for lvalue-only ADL begin/end

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/accept.md
+++ b/docs/mkdocs/docs/api/basic_json/accept.md
@@ -35,7 +35,8 @@ Unlike the [`parse()`](parse.md) function, this function neither throws an excep
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters (throws if null)
     - a `std::string`
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type, for instance.
@@ -110,6 +111,7 @@ A UTF-8 byte order mark is silently ignored.
 - Ignoring comments via `ignore_comments` added in version 3.9.0.
 - Changed [runtime assertion](../../features/assertions.md) in case of `FILE*` null pointers to exception in version 3.12.0.
 - Added `ignore_trailing_commas` in version 3.13.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/api/basic_json/from_bjdata.md
+++ b/docs/mkdocs/docs/api/basic_json/from_bjdata.md
@@ -29,7 +29,8 @@ The exact mapping and its limitations are described on a [dedicated page](../../
     - a `FILE` pointer
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type
@@ -101,3 +102,4 @@ Linear in the size of the input.
 ## Version history
 
 - Added in version 3.11.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.

--- a/docs/mkdocs/docs/api/basic_json/from_bson.md
+++ b/docs/mkdocs/docs/api/basic_json/from_bson.md
@@ -29,7 +29,8 @@ The exact mapping and its limitations are described on a [dedicated page](../../
     - a `FILE` pointer
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type
@@ -101,6 +102,7 @@ Linear in the size of the input.
 ## Version history
 
 - Added in version 3.4.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/api/basic_json/from_cbor.md
+++ b/docs/mkdocs/docs/api/basic_json/from_cbor.md
@@ -32,7 +32,8 @@ The exact mapping and its limitations are described on a [dedicated page](../../
     - a `FILE` pointer
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type
@@ -111,6 +112,7 @@ Linear in the size of the input.
 - Changed to consume input adapters, removed `start_index` parameter, and added `strict` parameter in version 3.0.0.
 - Added `allow_exceptions` parameter in version 3.2.0.
 - Added `tag_handler` parameter in version 3.9.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/api/basic_json/from_msgpack.md
+++ b/docs/mkdocs/docs/api/basic_json/from_msgpack.md
@@ -29,7 +29,8 @@ The exact mapping and its limitations are described on a [dedicated page](../../
     - a `FILE` pointer
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type
@@ -103,6 +104,7 @@ Linear in the size of the input.
 - Parameter `start_index` since version 2.1.1.
 - Changed to consume input adapters, removed `start_index` parameter, and added `strict` parameter in version 3.0.0.
 - Added `allow_exceptions` parameter in version 3.2.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/api/basic_json/from_ubjson.md
+++ b/docs/mkdocs/docs/api/basic_json/from_ubjson.md
@@ -29,7 +29,8 @@ The exact mapping and its limitations are described on a [dedicated page](../../
     - a `FILE` pointer
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type
@@ -102,6 +103,7 @@ Linear in the size of the input.
 
 - Added in version 3.1.0.
 - Added `allow_exceptions` parameter in version 3.2.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/api/basic_json/parse.md
+++ b/docs/mkdocs/docs/api/basic_json/parse.md
@@ -34,7 +34,8 @@ static basic_json parse(IteratorType first, IteratorType last,
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters (throws if null)
     - a `std::string`
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type, for instance.
@@ -236,6 +237,7 @@ Invalid Unicode escapes and unpaired surrogates in the input are reported as
 - Ignoring comments via `ignore_comments` added in version 3.9.0.
 - Changed [runtime assertion](../../features/assertions.md) in case of `FILE*` null pointers to exception in version 3.12.0.
 - Added `ignore_trailing_commas` in version 3.13.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/api/basic_json/sax_parse.md
+++ b/docs/mkdocs/docs/api/basic_json/sax_parse.md
@@ -39,8 +39,8 @@ The SAX event lister must follow the interface of [`json_sax`](../json_sax/index
     - a `FILE` pointer
     - a C-style array of characters
     - a pointer to a null-terminated string of single byte characters
-    - an object `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of
-      iterators.
+    - a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators
+      (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)
 
 `IteratorType`
 :   a compatible iterator type for overload (2); a pair of character iterators whose `value_type` is an integral type
@@ -127,6 +127,7 @@ A UTF-8 byte order mark is silently ignored.
 - Added in version 3.2.0.
 - Ignoring comments via `ignore_comments` added in version 3.9.0.
 - Added `ignore_trailing_commas` in version 3.13.0.
+- Extended container support (1) to include types with lvalue-only ADL `begin`/`end` (matching `std::begin`/`std::end` semantics) in version 3.13.0.
 
 !!! warning "Deprecation"
 

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -526,8 +526,7 @@ struct container_input_adapter_factory< ContainerType,
 }  // namespace container_input_adapter_factory_impl
 
 template<typename ContainerType>
-auto input_adapter(ContainerType&& container)
--> typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
+typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type input_adapter(ContainerType&& container)
 {
     return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(std::forward<ContainerType>(container));
 }

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -517,18 +517,19 @@ struct container_input_adapter_factory< ContainerType,
        {
            using adapter_type = decltype(input_adapter(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>())));
 
-           static adapter_type create(const ContainerType& container)
+           static adapter_type create(ContainerType&& container)
 {
-    return input_adapter(begin(container), end(container));
+    return input_adapter(begin(std::forward<ContainerType>(container)), end(std::forward<ContainerType>(container)));
 }
        };
 
 }  // namespace container_input_adapter_factory_impl
 
 template<typename ContainerType>
-typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type input_adapter(const ContainerType& container)
+auto input_adapter(ContainerType&& container)
+-> typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
 {
-    return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(container);
+    return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(std::forward<ContainerType>(container));
 }
 
 // specialization for std::string

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7354,18 +7354,19 @@ struct container_input_adapter_factory< ContainerType,
        {
            using adapter_type = decltype(input_adapter(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>())));
 
-           static adapter_type create(const ContainerType& container)
+           static adapter_type create(ContainerType&& container)
 {
-    return input_adapter(begin(container), end(container));
+    return input_adapter(begin(std::forward<ContainerType>(container)), end(std::forward<ContainerType>(container)));
 }
        };
 
 }  // namespace container_input_adapter_factory_impl
 
 template<typename ContainerType>
-typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type input_adapter(const ContainerType& container)
+auto input_adapter(ContainerType&& container)
+-> typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
 {
-    return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(container);
+    return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(std::forward<ContainerType>(container));
 }
 
 // specialization for std::string

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7363,8 +7363,7 @@ struct container_input_adapter_factory< ContainerType,
 }  // namespace container_input_adapter_factory_impl
 
 template<typename ContainerType>
-auto input_adapter(ContainerType&& container)
--> typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
+typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type input_adapter(ContainerType&& container)
 {
     return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(std::forward<ContainerType>(container));
 }

--- a/tests/src/unit-user_defined_input.cpp
+++ b/tests/src/unit-user_defined_input.cpp
@@ -73,8 +73,8 @@ char* end(MyContainerNonConstADL& c)
 TEST_CASE("Custom container non-member non-const begin/end")
 {
     // Container with lvalue-only non-const ADL begin/end (bug reproduction)
-    char raw_data[] = "[1,2,3,4]";
-    MyContainerNonConstADL data{raw_data, sizeof(raw_data) - 1};
+    std::string raw_data = "[1,2,3,4]";
+    MyContainerNonConstADL data{&raw_data[0], raw_data.size()}; // NOLINT(readability-container-data-pointer)
     const json as_json = json::parse(data);
     CHECK(as_json.at(0) == 1);
     CHECK(as_json.at(1) == 2);

--- a/tests/src/unit-user_defined_input.cpp
+++ b/tests/src/unit-user_defined_input.cpp
@@ -54,6 +54,47 @@ TEST_CASE("Custom container non-member begin/end")
 
 }
 
+struct MyContainerNonConstADL
+{
+    char* data;
+    std::size_t size;
+};
+
+char* begin(MyContainerNonConstADL& c)
+{
+    return c.data;
+}
+
+char* end(MyContainerNonConstADL& c)
+{
+    return c.data + c.size; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+}
+
+TEST_CASE("Custom container non-member non-const begin/end")
+{
+    // Container with lvalue-only non-const ADL begin/end (bug reproduction)
+    char raw_data[] = "[1,2,3,4]";
+    MyContainerNonConstADL data{raw_data, sizeof(raw_data) - 1};
+    const json as_json = json::parse(data);
+    CHECK(as_json.at(0) == 1);
+    CHECK(as_json.at(1) == 2);
+    CHECK(as_json.at(2) == 3);
+    CHECK(as_json.at(3) == 4);
+
+    // Same container with accept()
+    CHECK(json::accept(data));
+}
+
+TEST_CASE("Custom container non-member begin/end, rvalue")
+{
+    // Regression check: rvalue container parsing should still work
+    const json as_json = json::parse(MyContainer{"[1,2,3,4]"});
+    CHECK(as_json.at(0) == 1);
+    CHECK(as_json.at(1) == 2);
+    CHECK(as_json.at(2) == 3);
+    CHECK(as_json.at(3) == 4);
+}
+
 TEST_CASE("Custom container member begin/end")
 {
     struct MyContainer2


### PR DESCRIPTION
## Summary

The container overload of `json::parse(c)` / `json::accept(c)` / `json::sax_parse(c, ...)` was silently dropped from overload resolution for user container types whose ADL `begin(T&)` / `end(T&)` accepted **only non-const lvalue references** (a legitimate pattern matching `std::begin`/`std::end` semantics).

**Root cause**: The SFINAE detection used `std::declval<ContainerType>()` which synthesized an rvalue. Rvalues couldn't bind to lvalue-only ADL functions, so the whole specialization disappeared from overload resolution, forcing users to write `json::parse(begin(c), end(c))` instead of `json::parse(c)`.

**Fix**: Make both the outer `input_adapter(ContainerType&&)` entry point and the factory's `create(ContainerType&&)` use forwarding references, preserving the caller's actual value category and constness via reference collapsing. This ensures detection (`std::declval`) and actual use (`std::forward`) always match — no mismatch possible.

## Changes

- **include/nlohmann/detail/input/input_adapters.hpp** (~lines 505-532): Rewrite container overload with forwarding references
  - `create()` now takes `ContainerType&&` and forwards with `std::forward<ContainerType>()`
  - Outer `input_adapter()` now takes `ContainerType&&` with trailing return type (C++11 compatible)
  - Primary template unchanged; no `decay`/`remove_reference` needed

- **tests/src/unit-user_defined_input.cpp**: Add two new test cases
  - "Custom container non-member non-const begin/end" — reproduces the bug with lvalue-only ADL `begin`/`end`
  - "Custom container non-member begin/end, rvalue" — regression test for rvalue containers (no breakage)
  - Both use `const json` declarations for improved const-correctness

- **Documentation** (8 API files): Clarify container requirements
  - `parse.md`, `accept.md`, `sax_parse.md`: Updated InputType description
  - `from_cbor.md`, `from_msgpack.md`, `from_bson.md`, `from_ubjson.md`, `from_bjdata.md`: Updated InputType description
  - All now explicitly state: "a container `obj` for which `begin(obj)` and `end(obj)` produce a valid pair of iterators (as found via ADL or member functions, with semantics compatible to `std::begin` and `std::end`)"
  - Added version history notes indicating feature added in 3.13.0

- **single_include/nlohmann/json.hpp**: Regenerated amalgamation via `make amalgamate`

## Verification

✅ Tested with C++11, C++17, C++20 — all pass  
✅ Compiled with `-Wall -Wextra` — no warnings  
✅ 6 test cases in unit-user_defined_input.cpp pass (30 assertions)  
✅ unit-class_parser.cpp passes (2 test cases, 10,295 assertions)  
✅ unit-deserialization.cpp passes (10 test cases, 446 assertions)  

## Second-Order Effect

`include/nlohmann/detail/input/binary_reader.hpp:2736` calls `detail::input_adapter(number_vector)` on a local non-const `std::vector<char>&`. Under the new forwarding-reference code, this now deduces a non-const iterator instead of const_iterator. Functionally harmless — `iterator_input_adapter` and `lexer` are iterator-type-agnostic — verified via existing UBJSON/BJData high-precision-number tests.

## Related Issues

- Closes remaining limitation from #4354 / PR #5218 (todo 106)
- Fixes todo #111 from `~/Desktop/json_todos.md`

## Notes for Reviewers

This is a **non-breaking API change**: the public signatures of `parse()`, `accept()`, and `sax_parse()` are unchanged. The fix makes the library **more permissive** (accepts a superset of previously-accepted inputs) — specifically, it now supports containers with lvalue-only ADL `begin`/`end`, matching the behavior of `std::begin`/`std::end`.

The change is **strictly additive** at the public API layer (`detail::input_adapter` is an implementation detail; its signature is internal). No existing code will break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)