### PR TITLE
Documentation review: fix stale version-history placeholder in operator_ne.md

### DIFF
--- a/docs/docset/docset.json
+++ b/docs/docset/docset.json
@@ -4,7 +4,7 @@
   "archive": "JSON_for_Modern_C++.tgz",
   "author": {
     "name": "Niels Lohmann",
-    "link": "https://twitter.com/nlohmann"
+    "link": "https://nlohmann.me"
   },
   "aliases": ["nlohmann/json"]
 }

--- a/docs/mkdocs/docs/api/basic_json/operator_ne.md
+++ b/docs/mkdocs/docs/api/basic_json/operator_ne.md
@@ -91,7 +91,7 @@ Linear.
 
 ## Version history
 
-1. Added in version 1.0.0. Added C++20 member functions in version 3.11.0. Changed in version 3.12.x to remove 
+1. Added in version 1.0.0. Added C++20 member functions in version 3.11.0. Changed in version 3.13.0 to remove 
    special-casing for `NaN` and `discarded` values; `operator!=` now consistently means `!(a == b)`.
-2. Added in version 1.0.0. Added C++20 member functions in version 3.11.0. Changed in version 3.12.x to remove
+2. Added in version 1.0.0. Added C++20 member functions in version 3.11.0. Changed in version 3.13.0 to remove
    special-casing for `NaN` and `discarded` values; `operator!=` now consistently means `!(a == b)`.


### PR DESCRIPTION
## Summary

Follow-up documentation pass after #5257/#5258, checking activity merged into `develop` since then.

- **`operator_ne.md`**: #5253 (fixing #3868 — removing the hand-written `operator!=` so the compiler synthesizes it as `!(a==b)`, restoring C++20 P2468R2 rewritten-candidate synthesis) added new version-history entries, but merged *after* the earlier global `3.12.x` → `3.13.0` placeholder sweep, so its entries used the stale placeholder. Fixed to `3.13.0`.
- **`docset.json`**: fixed a long-stale `"link"` field pointing at `https://twitter.com/nlohmann` instead of `https://nlohmann.me` (todo 152) — the rest of the docs tree and README already use the current URL.

No other documentation gaps found in this pass — checked all doc pages referencing `operator!=` (`operator_eq.md`, `operator_spaceship.md`, `migration_guide.md`, etc.) for stale content describing the old NaN/discarded special-casing; none found beyond the placeholder above.

## Test plan

- [x] Confirmed no remaining `3.12.x` placeholders anywhere in `docs/mkdocs/docs/` (`grep -rl '3\.12\.x' docs/mkdocs/docs/` → empty).
- [x] Manually reviewed `operator_ne.md`'s prose/notes sections (already correct as shipped in #5253) against the actual code change for accuracy.
- [x] Confirmed no remaining `twitter.com/nlohmann` references anywhere in `docs/` or `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)