### PR TITLE
Extend memcpy fast path to sized sentinels (e.g. std::counted_iterator)

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/accept.md
+++ b/docs/mkdocs/docs/api/basic_json/accept.md
@@ -49,7 +49,7 @@ Unlike the [`parse()`](parse.md) function, this function neither throws an excep
 :   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
 
     - a custom sentinel type for C++20 ranges
-    - `std::counted_iterator` with a different sentinel type
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/from_bjdata.md
+++ b/docs/mkdocs/docs/api/basic_json/from_bjdata.md
@@ -36,8 +36,10 @@ The exact mapping and its limitations are described on a [dedicated page](../../
 :   a compatible iterator type
 
 `SentinelType`
-:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance a
-    custom sentinel type for C++20 ranges
+:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
+
+    - a custom sentinel type for C++20 ranges
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/from_bson.md
+++ b/docs/mkdocs/docs/api/basic_json/from_bson.md
@@ -36,8 +36,10 @@ The exact mapping and its limitations are described on a [dedicated page](../../
 :   a compatible iterator type
 
 `SentinelType`
-:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance a
-    custom sentinel type for C++20 ranges
+:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
+
+    - a custom sentinel type for C++20 ranges
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/from_cbor.md
+++ b/docs/mkdocs/docs/api/basic_json/from_cbor.md
@@ -39,8 +39,10 @@ The exact mapping and its limitations are described on a [dedicated page](../../
 :   a compatible iterator type
 
 `SentinelType`
-:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance a
-    custom sentinel type for C++20 ranges
+:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
+
+    - a custom sentinel type for C++20 ranges
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/from_msgpack.md
+++ b/docs/mkdocs/docs/api/basic_json/from_msgpack.md
@@ -36,8 +36,10 @@ The exact mapping and its limitations are described on a [dedicated page](../../
 :   a compatible iterator type
 
 `SentinelType`
-:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance a
-    custom sentinel type for C++20 ranges
+:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
+
+    - a custom sentinel type for C++20 ranges
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/from_ubjson.md
+++ b/docs/mkdocs/docs/api/basic_json/from_ubjson.md
@@ -36,8 +36,10 @@ The exact mapping and its limitations are described on a [dedicated page](../../
 :   a compatible iterator type
 
 `SentinelType`
-:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance a
-    custom sentinel type for C++20 ranges
+:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
+
+    - a custom sentinel type for C++20 ranges
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/parse.md
+++ b/docs/mkdocs/docs/api/basic_json/parse.md
@@ -48,7 +48,7 @@ static basic_json parse(IteratorType first, SentinelType last,
 :   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for instance.
 
     - a custom sentinel type for C++20 ranges
-    - `std::counted_iterator` with a different sentinel type
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 ## Parameters
 

--- a/docs/mkdocs/docs/api/basic_json/sax_parse.md
+++ b/docs/mkdocs/docs/api/basic_json/sax_parse.md
@@ -48,7 +48,10 @@ The SAX event lister must follow the interface of [`json_sax`](../json_sax/index
     with a size of 1, 2, or 4 bytes (interpreted respectively as UTF-8, UTF-16, and UTF-32)
 
 `SentinelType`
-:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for overload (2)
+:   defaults to `IteratorType`; may be a different type comparable to `IteratorType` via `operator!=`, for overload (2), for instance.
+
+    - a custom sentinel type for C++20 ranges
+    - `std::default_sentinel_t`, when `IteratorType` is `std::counted_iterator`
 
 `SAX`
 :   a class fulfilling the SAX event listener interface; see [`json_sax`](../json_sax/index.md)

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -220,20 +220,29 @@ class iterator_input_adapter
     // whether IteratorType refers to a contiguous range and therefore supports
     // a std::memcpy fast path (pointers always do; in C++20 we can also detect
     // library iterators such as those of std::vector and std::string).
-    // The fast path also requires SentinelType == IteratorType so std::distance works.
+    // Computing the available element count needs either same-type iterators
+    // (plain std::distance) or, in C++20, a sized sentinel (std::ranges::distance),
+    // e.g. std::counted_iterator paired with std::default_sentinel_t.
     static constexpr bool iterator_is_contiguous =
-        std::is_same<IteratorType, SentinelType>::value && (
 #if defined(__cpp_lib_concepts) && defined(JSON_HAS_CPP_20)
-            std::contiguous_iterator<IteratorType> ||
+        (std::is_same<IteratorType, SentinelType>::value || std::sized_sentinel_for<SentinelType, IteratorType>)
+        && (std::contiguous_iterator<IteratorType> || std::is_pointer<IteratorType>::value);
+#else
+        std::is_same<IteratorType, SentinelType>::value && std::is_pointer<IteratorType>::value;
 #endif
-            std::is_pointer<IteratorType>::value);
 
     // contiguous fast path: bulk copy the remaining range with std::memcpy
     template<class T>
     std::size_t get_elements_impl(T* dest, std::size_t count, std::true_type /*contiguous*/)
     {
         const std::size_t wanted = count * sizeof(T);
+#if defined(__cpp_lib_concepts) && defined(JSON_HAS_CPP_20)
+        // std::ranges::distance also supports sized sentinels of a different
+        // type (e.g. std::counted_iterator + std::default_sentinel_t)
+        const std::size_t available = static_cast<std::size_t>(std::ranges::distance(current, end)) * sizeof(char_type);
+#else
         const std::size_t available = static_cast<std::size_t>(std::distance(current, end)) * sizeof(char_type);
+#endif
         const std::size_t copied = (std::min)(wanted, available);
         if (JSON_HEDLEY_LIKELY(copied != 0))
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7207,20 +7207,29 @@ class iterator_input_adapter
     // whether IteratorType refers to a contiguous range and therefore supports
     // a std::memcpy fast path (pointers always do; in C++20 we can also detect
     // library iterators such as those of std::vector and std::string).
-    // The fast path also requires SentinelType == IteratorType so std::distance works.
+    // Computing the available element count needs either same-type iterators
+    // (plain std::distance) or, in C++20, a sized sentinel (std::ranges::distance),
+    // e.g. std::counted_iterator paired with std::default_sentinel_t.
     static constexpr bool iterator_is_contiguous =
-        std::is_same<IteratorType, SentinelType>::value && (
 #if defined(__cpp_lib_concepts) && defined(JSON_HAS_CPP_20)
-            std::contiguous_iterator<IteratorType> ||
+        (std::is_same<IteratorType, SentinelType>::value || std::sized_sentinel_for<SentinelType, IteratorType>)
+        && (std::contiguous_iterator<IteratorType> || std::is_pointer<IteratorType>::value);
+#else
+        std::is_same<IteratorType, SentinelType>::value && std::is_pointer<IteratorType>::value;
 #endif
-            std::is_pointer<IteratorType>::value);
 
     // contiguous fast path: bulk copy the remaining range with std::memcpy
     template<class T>
     std::size_t get_elements_impl(T* dest, std::size_t count, std::true_type /*contiguous*/)
     {
         const std::size_t wanted = count * sizeof(T);
+#if defined(__cpp_lib_concepts) && defined(JSON_HAS_CPP_20)
+        // std::ranges::distance also supports sized sentinels of a different
+        // type (e.g. std::counted_iterator + std::default_sentinel_t)
+        const std::size_t available = static_cast<std::size_t>(std::ranges::distance(current, end)) * sizeof(char_type);
+#else
         const std::size_t available = static_cast<std::size_t>(std::distance(current, end)) * sizeof(char_type);
+#endif
         const std::size_t copied = (std::min)(wanted, available);
         if (JSON_HEDLEY_LIKELY(copied != 0))
         {

--- a/tests/src/unit-user_defined_input.cpp
+++ b/tests/src/unit-user_defined_input.cpp
@@ -220,12 +220,12 @@ TEST_CASE("Parse with std::counted_iterator and std::default_sentinel_t")
     const std::string json_str = R"({"key":"value","array":[1,2,3]})";
     const auto len = static_cast<std::iter_difference_t<iterator_type>>(json_str.size());
 
-    std::counted_iterator<iterator_type> first(json_str.begin(), len);
+    const std::counted_iterator<iterator_type> first(json_str.begin(), len);
     const json j = json::parse(first, std::default_sentinel);
     CHECK(j["key"] == "value");
     CHECK(j["array"].size() == 3);
 
-    std::counted_iterator<iterator_type> first2(json_str.begin(), len);
+    const std::counted_iterator<iterator_type> first2(json_str.begin(), len);
     CHECK(json::accept(first2, std::default_sentinel));
 }
 #endif

--- a/tests/src/unit-user_defined_input.cpp
+++ b/tests/src/unit-user_defined_input.cpp
@@ -6,12 +6,23 @@
 // SPDX-FileCopyrightText: 2013-2026 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
+// cmake/test.cmake selects the C++ standard versions with which to build a
+// unit test based on the presence of JSON_HAS_CPP_<VERSION> macros.
+// When using macros that are only defined for particular versions of the standard
+// (e.g., JSON_HAS_FILESYSTEM for C++17 and up), please mention the corresponding
+// version macro in a comment close by, like this:
+// JSON_HAS_CPP_<VERSION> (do not remove; see note at top of file)
+
 #include "doctest_compatibility.h"
 
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
 #include <list>
+
+#if defined(__cpp_lib_concepts) && defined(JSON_HAS_CPP_20)
+    #include <iterator>
+#endif
 
 namespace
 {
@@ -200,5 +211,22 @@ TEST_CASE("Parse with heterogeneous iterator and sentinel types")
     json j2 = json::parse(data.begin(), data.end());
     CHECK(j2.at(0) == 1);
 }
+
+#if defined(__cpp_lib_concepts) && defined(JSON_HAS_CPP_20)
+// JSON_HAS_CPP_20 (do not remove; see note at top of file)
+TEST_CASE("Parse with std::counted_iterator and std::default_sentinel_t")
+{
+    const std::string json_str = R"({"key":"value","array":[1,2,3]})";
+    const auto len = static_cast<std::iter_difference_t<std::string::const_iterator>>(json_str.size());
+
+    std::counted_iterator first(json_str.begin(), len);
+    const json j = json::parse(first, std::default_sentinel);
+    CHECK(j["key"] == "value");
+    CHECK(j["array"].size() == 3);
+
+    std::counted_iterator first2(json_str.begin(), len);
+    CHECK(json::accept(first2, std::default_sentinel));
+}
+#endif
 
 } // namespace

--- a/tests/src/unit-user_defined_input.cpp
+++ b/tests/src/unit-user_defined_input.cpp
@@ -216,15 +216,16 @@ TEST_CASE("Parse with heterogeneous iterator and sentinel types")
 // JSON_HAS_CPP_20 (do not remove; see note at top of file)
 TEST_CASE("Parse with std::counted_iterator and std::default_sentinel_t")
 {
+    using iterator_type = std::string::const_iterator;
     const std::string json_str = R"({"key":"value","array":[1,2,3]})";
-    const auto len = static_cast<std::iter_difference_t<std::string::const_iterator>>(json_str.size());
+    const auto len = static_cast<std::iter_difference_t<iterator_type>>(json_str.size());
 
-    std::counted_iterator first(json_str.begin(), len);
+    std::counted_iterator<iterator_type> first(json_str.begin(), len);
     const json j = json::parse(first, std::default_sentinel);
     CHECK(j["key"] == "value");
     CHECK(j["array"].size() == 3);
 
-    std::counted_iterator first2(json_str.begin(), len);
+    std::counted_iterator<iterator_type> first2(json_str.begin(), len);
     CHECK(json::accept(first2, std::default_sentinel));
 }
 #endif


### PR DESCRIPTION
## Summary

Follow-up to #5265's review discussion: https://github.com/nlohmann/json/pull/5265#discussion_r3564237584 (@gregmarr asked whether the fast path should support `std::counted_iterator` + `std::default_sentinel_t`).

`std::counted_iterator` over a contiguous iterator already satisfies `std::contiguous_iterator`, and `std::default_sentinel_t` is a `std::sized_sentinel_for` it — verified this compiles and behaves correctly (`std::ranges::distance` returns the right count, `&*it` gives a valid contiguous address). This generalizes beyond just `counted_iterator` to any C++20 sized-sentinel pair, without needing a custom count-based member function as originally suggested.

- `iterator_input_adapter::iterator_is_contiguous` now also allows `std::sized_sentinel_for<SentinelType, IteratorType>` under C++20 (previously required `IteratorType == SentinelType`).
- The memcpy fast path computes the available element count with `std::ranges::distance` under C++20 (works for both same-type and sized-sentinel pairs), falling back to `std::distance` pre-C++20 where `SentinelType` is always `IteratorType`.
- Added a C++20-only test exercising `json::parse`/`accept` with `std::counted_iterator` + `std::default_sentinel_t`.
- Documented `std::default_sentinel_t` + `std::counted_iterator` as a `SentinelType` example across `parse.md`, `accept.md`, `sax_parse.md`, and the five `from_*.md` pages, replacing an earlier ambiguously-worded bullet.

Before this combination correctly fell back to the byte-by-byte path (functionally correct, just not optimized); this lets it reach the `memcpy` fast path.

## Test plan

- [x] New C++20-gated test case (`test-user_defined_input_cpp20`) covering `json::parse`/`accept` with `std::counted_iterator` + `std::default_sentinel_t`
- [x] Full local test suite: 109/109 passing across C++11/14/17/20/23
- [x] Verified `iterator_is_contiguous` evaluates true for the new combination and false-path (pre-C++20, byte-by-byte) still compiles/works unchanged
- [x] `make check-amalgamation` clean

🤖 Generated with Claude Code