### PR TITLE
Extend std::optional null regression coverage (assignment, get_to)

### DIFF
--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1784,10 +1784,14 @@ TEST_CASE("std::optional")
                              "[json.exception.type_error.302] type must be number, but is null", json::type_error&);
 
         // Assignment goes through the same overload resolution as direct
-        // construction, so it throws for the same reason.
+        // construction, so it throws for the same reason. This relies on
+        // basic_json's implicit conversion operator, so it only applies
+        // when JSON_USE_IMPLICIT_CONVERSIONS is enabled (the default).
+#if JSON_USE_IMPLICIT_CONVERSIONS
         std::optional<std::string> opt_assign;
         CHECK_THROWS_WITH_AS(opt_assign = j_null,
                              "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
+#endif
 
         // get_to() is the correct way to obtain std::nullopt from a JSON null.
         std::optional<std::string> opt_get_to = "placeholder";

--- a/tests/src/unit-conversions.cpp
+++ b/tests/src/unit-conversions.cpp
@@ -1782,6 +1782,17 @@ TEST_CASE("std::optional")
                              "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
         CHECK_THROWS_WITH_AS(std::optional<int>(j_null),
                              "[json.exception.type_error.302] type must be number, but is null", json::type_error&);
+
+        // Assignment goes through the same overload resolution as direct
+        // construction, so it throws for the same reason.
+        std::optional<std::string> opt_assign;
+        CHECK_THROWS_WITH_AS(opt_assign = j_null,
+                             "[json.exception.type_error.302] type must be string, but is null", json::type_error&);
+
+        // get_to() is the correct way to obtain std::nullopt from a JSON null.
+        std::optional<std::string> opt_get_to = "placeholder";
+        j_null.get_to(opt_get_to);
+        CHECK(opt_get_to == std::nullopt);
     }
 
     SECTION("string")


### PR DESCRIPTION
## Summary

Extends the `std::optional<T>` null-handling regression test with two cases that weren't previously covered:

- **Assignment**: `opt = json_null` throws `type_error 302`, for the same overload-resolution reason as direct construction (`std::optional<std::string>(json_null)`, already covered).
- **`get_to()`**: confirms `json_null.get_to(opt)` correctly yields `std::nullopt`, which was previously only asserted in documentation prose, not exercised by a test.

## Context

Prompted by a [review comment](https://github.com/nlohmann/json/issues/5246#issuecomment-4943659240) on #5246 suggesting a fuller regression matrix (null / valid / invalid-non-null / assignment / `get_to`) to pin down the intended semantics. Construction and `get<std::optional<T>>()` were already covered by #5247; this PR fills in the two remaining gaps. The "invalid non-null value" case was left out since it's ordinary `type_error` propagation with no special behavior tied to this issue.

## Test plan

- [x] Built and ran `test-conversions_cpp17` locally — all 287 assertions pass, including the two new checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)