### PR TITLE
Document that JSON_Diagnostics CMake option doesn't apply to pre-installed packages

### DIFF
--- a/docs/mkdocs/docs/api/macros/json_diagnostics.md
+++ b/docs/mkdocs/docs/api/macros/json_diagnostics.md
@@ -38,7 +38,8 @@ When the macro is not defined, the library will define it to its default value.
 
     Diagnostic messages can also be controlled with the CMake option
     [`JSON_Diagnostics`](../../integration/cmake.md#json_diagnostics) (`OFF` by default)
-    which defines `JSON_DIAGNOSTICS` accordingly.
+    which defines `JSON_DIAGNOSTICS` accordingly. Note this only applies when building the
+    library from source — see the pre-installed-package caveat on that page.
 
 ## Examples
 

--- a/docs/mkdocs/docs/integration/cmake.md
+++ b/docs/mkdocs/docs/integration/cmake.md
@@ -135,6 +135,31 @@ Enable CI build targets. The exact targets are used during the several CI steps 
 
 Enable [extended diagnostic messages](../home/exceptions.md#extended-diagnostic-messages) by defining macro [`JSON_DIAGNOSTICS`](../api/macros/json_diagnostics.md). This option is `OFF` by default.
 
+!!! warning "Does not apply to a pre-installed package"
+
+    This option only takes effect when building nlohmann/json from source as part of your own
+    CMake project (e.g. via [`FetchContent`](#fetchcontent) or [`add_subdirectory`](#external)).
+    It has **no effect** on a package that was already built and installed elsewhere (Homebrew,
+    vcpkg, a system package, etc.) — the resulting compile definition is baked into the exported
+    `nlohmann_jsonTargets.cmake` at install time, and `set(JSON_Diagnostics ON)` before
+    `find_package()` does not change it (verified against the Homebrew-installed package: the
+    exported target still carries a fixed `$<$<BOOL:OFF>:JSON_DIAGNOSTICS=1>`, regardless of any
+    variable set in the consuming project).
+
+    To enable extended diagnostics for a pre-installed package, override the imported target's
+    property directly after `find_package()`:
+
+    ```cmake
+    find_package(nlohmann_json REQUIRED)
+    set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "JSON_DIAGNOSTICS=1")
+    ```
+
+    This only works cleanly when your project is the sole consumer of that imported target. If
+    nlohmann_json is pulled in from more than one place in your dependency graph with different
+    `JSON_DIAGNOSTICS` values, you may see a `"JSON_DIAGNOSTICS" redefined` compiler error, since
+    conflicting `-D` flags can end up on the same compile command line.
+
 ### `JSON_Diagnostic_Positions`
 
 Enable position diagnostics by defining macro [`JSON_DIAGNOSTIC_POSITIONS`](../api/macros/json_diagnostic_positions.md). This option is `OFF` by default.


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line and make sure you follow the checklist.]

Closes #3106.

`set(JSON_Diagnostics ON)` before `find_package(nlohmann_json)` was reported to work "even if the package is installed via homebrew" (see the closing comment on #3106). That turned out to be incorrect for the actual scenario the issue is about, and this PR corrects the record.

**What's wrong:** The `JSON_Diagnostics` CMake option (`CMakeLists.txt`) is consumed only by this project's own `target_compile_definitions(...)` at *this* library's own configure time. `cmake/config.cmake.in` (the template for the installed `nlohmann_jsonConfig.cmake`) never reads a `JSON_Diagnostics` variable — it just `include()`s the pre-generated `nlohmann_jsonTargets.cmake`, whose `INTERFACE_COMPILE_DEFINITIONS` were baked in permanently at `install(EXPORT ...)` time, at whatever value the packager used.

**Verified empirically**, not just by reading the code: built a throwaway CMake project against the real Homebrew-installed 3.12.0 package with the exact `set(JSON_Diagnostics ON); find_package(nlohmann_json REQUIRED)` snippet from the issue. The installed `nlohmann_jsonTargets.cmake` literally contains `$<$<BOOL:OFF>:JSON_DIAGNOSTICS=1>` (the `OFF` baked in from Homebrew's build, which never passes `-DJSON_Diagnostics=ON`), and the resulting exception message had no JSON Pointer in it, confirming diagnostics stayed off regardless of the consumer's variable.

Then verified the actual working fix — overriding the imported target's property directly after `find_package()` — which does work: the same test program's exception message became `(/address/housenumber) type must be number, but is string`.

**What changed:**
- `docs/mkdocs/docs/integration/cmake.md`: new warning admonition under `### JSON_Diagnostics` explaining the pre-installed-package limitation, the verified working `set_target_properties` override, and the multi-target `"JSON_DIAGNOSTICS" redefined` pitfall reported earlier in the issue thread.
- `docs/mkdocs/docs/api/macros/json_diagnostics.md`: one-sentence pointer from the existing "CMake option" hint to the new caveat.

Docs-only change; no header/source changes. Locally built the mkdocs site (`make install_venv && make build`) and confirmed both edits render correctly, including the escaped generator-expression code sample.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code. (docs-only, N/A)
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`. (no `include/`/`single_include/` changes in this PR)

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.