### PR TITLE
Documentation review: document std::tuple/std::pair conversion and C++20 range-view construction

### DIFF
--- a/docs/mkdocs/docs/features/conversions.md
+++ b/docs/mkdocs/docs/features/conversions.md
@@ -47,6 +47,28 @@ json j = {{"one", 1}, {"two", 2}};
 auto m = j.get<std::map<std::string, int>>();  // {{"one", 1}, {"two", 2}}
 ```
 
+`#!cpp std::pair` and `#!cpp std::tuple` are also supported, converting positionally to and from a JSON array:
+
+```cpp
+json j = {1.0, "hello", 42};
+auto t = j.get<std::tuple<double, std::string, int>>();  // {1.0, "hello", 42}
+```
+
+!!! info "Extracting references into a tuple"
+
+    A tuple type may also hold references (e.g. `#!cpp std::tuple<double&, std::string&>`) to avoid copying: `get`
+    then returns a tuple of references pointing directly at the elements stored inside the `basic_json` array,
+    rather than a tuple of copies:
+
+    ```cpp
+    json j = {1.0, "hello"};
+    auto refs = j.get<std::tuple<double&, std::string&>>();
+    std::get<1>(refs) = "world";  // modifies j[1] in place
+    ```
+
+    A referenced type must be one the library actually stores (or an arithmetic type it can convert to/from);
+    otherwise this is a compile error.
+
 ## Implicit conversions
 
 By default, a JSON value implicitly converts to a compatible C++ type, so the explicit `get` call can often be omitted:
@@ -135,6 +157,20 @@ The reverse direction works the same way: assigning or constructing a `json` fro
 std::vector<int> numbers = {1, 2, 3};
 json j = numbers;   // [1,2,3]
 ```
+
+!!! info "Constructing from a C++20 range view"
+
+    A `json` array can also be constructed directly from a C++20 range view (`std::ranges::view`), such as the result
+    of `std::views::filter` or `std::views::transform` -- no intermediate container is needed:
+
+    ```cpp
+    std::vector<int> nums{1, 2, 37, 42, 21};
+    auto filtered = nums | std::views::filter([](int i) { return i > 10; });
+    json j(filtered);   // [37,42,21]
+    ```
+
+    This requires [`JSON_HAS_RANGES`](../api/macros/json_has_ranges.md) to be enabled and is unavailable on MinGW due
+    to incomplete C++20 ranges support there.
 
 ## Your own types
 


### PR DESCRIPTION
## Summary

Follow-up documentation pass after #5261, checking activity merged into `develop` since then.

- **C++20 range-view construction (#5205, closes #4916):** adds a new `to_json`/constructor overload so `json` can be built directly from a `std::ranges::view` (e.g. `nums | std::views::filter(...)`). The PR touches zero files under `docs/mkdocs/`. Added an example to `conversions.md`.
- **`std::pair`/`std::tuple` conversion (long-standing gap):** while checking #5205's neighbor feature, found that basic `std::tuple`/`std::pair` <-> JSON array conversion has **never** been documented anywhere — not just #5016's reference-extraction addition, but the underlying feature itself. This was actually first noticed in the very first git-log audit pass but only mentioned in passing in a tracking note, never turned into an actionable item, so it slipped through four subsequent passes uncaught. Fixed now: added both the basic conversion and the reference-extraction capability (`get<std::tuple<T&, T&>>()` returning references into the stored array, enabling in-place mutation) to `conversions.md`.

Spot-checked #5266 (custom `BinaryType` direct assignment) and #5265 (iterator+sentinel support for `parse`/`accept`/`sax_parse` and all 5 binary deserializers) — both already ship accurate, complete documentation as part of their own PRs. No gaps found there.

## Test plan

- [x] Manually reviewed both new `conversions.md` additions against the actual PR diffs (`to_json.hpp`, `from_json.hpp`) and their regression tests for accuracy.
- [x] Confirmed no other doc pages reference tuple/pair conversion with stale or missing content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)