### PR TITLE
Fix out-of-bounds read in dump() for large indentation widths

### DIFF
--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -126,9 +126,9 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
-                        indent_string.resize(indent_string.size() * 2, ' ');
+                        indent_string.resize((std::max)(indent_string.size() * 2, static_cast<typename string_t::size_type>(new_indent)), ' ');
                     }
 
                     // first n-1 elements
@@ -199,9 +199,9 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
-                        indent_string.resize(indent_string.size() * 2, ' ');
+                        indent_string.resize((std::max)(indent_string.size() * 2, static_cast<typename string_t::size_type>(new_indent)), ' ');
                     }
 
                     // first n-1 elements
@@ -260,9 +260,9 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
-                        indent_string.resize(indent_string.size() * 2, ' ');
+                        indent_string.resize((std::max)(indent_string.size() * 2, static_cast<typename string_t::size_type>(new_indent)), ' ');
                     }
 
                     o->write_characters(indent_string.c_str(), new_indent);

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -126,7 +126,7 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
@@ -199,7 +199,7 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
@@ -260,7 +260,7 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19833,9 +19833,9 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
-                        indent_string.resize(indent_string.size() * 2, ' ');
+                        indent_string.resize((std::max)(indent_string.size() * 2, static_cast<typename string_t::size_type>(new_indent)), ' ');
                     }
 
                     // first n-1 elements
@@ -19906,9 +19906,9 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
-                        indent_string.resize(indent_string.size() * 2, ' ');
+                        indent_string.resize((std::max)(indent_string.size() * 2, static_cast<typename string_t::size_type>(new_indent)), ' ');
                     }
 
                     // first n-1 elements
@@ -19967,9 +19967,9 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
-                        indent_string.resize(indent_string.size() * 2, ' ');
+                        indent_string.resize((std::max)(indent_string.size() * 2, static_cast<typename string_t::size_type>(new_indent)), ' ');
                     }
 
                     o->write_characters(indent_string.c_str(), new_indent);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -19833,7 +19833,7 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
@@ -19906,7 +19906,7 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
@@ -19967,7 +19967,7 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    while (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -150,6 +150,36 @@ TEST_CASE("serialization")
         }
     }
 
+    SECTION("dump with large indentation")
+    {
+        // the indentation buffer starts at 512 characters and grows on demand;
+        // a width that needs more room than a single doubling provides must keep
+        // growing the buffer rather than emit past its end
+        const unsigned int width = 1100;
+
+        SECTION("object")
+        {
+            const json j = {{"outer", {{"inner", 1}}}};
+            const std::string s = j.dump(static_cast<int>(width));
+            CHECK(s.find('\n' + std::string(width, ' ') + "\"outer\"") != std::string::npos);
+            CHECK(s.find('\n' + std::string(2 * width, ' ') + "\"inner\"") != std::string::npos);
+        }
+
+        SECTION("array")
+        {
+            const json j = json::array({json::array({1})});
+            const std::string s = j.dump(static_cast<int>(width));
+            CHECK(s.find('\n' + std::string(2 * width, ' ') + '1') != std::string::npos);
+        }
+
+        SECTION("binary")
+        {
+            const json j = json::binary({1, 2, 3});
+            const std::string s = j.dump(static_cast<int>(width));
+            CHECK(s.find('\n' + std::string(width, ' ') + "\"bytes\"") != std::string::npos);
+        }
+    }
+
     SECTION("to_string")
     {
         auto test = [&](std::string const & input, std::string const & expected)


### PR DESCRIPTION
When pretty-printing, the serializer keeps one reusable `indent_string` buffer and widens it on demand before writing a run of indentation. The width it needs is `current_indent + indent_step`, which grows with nesting depth and with the indent argument given to `dump()`. The buffer only doubled once behind an `if`, so when the required width was more than twice the current size the buffer stayed too short and the following `write_characters(indent_string.c_str(), new_indent)` ran off its end, copying whatever heap bytes followed into the output. It reproduces under AddressSanitizer with `json j = {{"a", 1}}; j.dump(1100);`, which reads 1100 bytes out of a 1040-byte allocation. Looping the doubling until the buffer actually holds `new_indent` closes it while keeping the same amortized growth. I applied it to the three pretty-print branches (object, array, binary) that share the pattern, and added a serialization test that checks the emitted indentation is the expected run of spaces at a width past the first doubling.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.
