### PR TITLE
reject CBOR array/map length equal to the indefinite-length marker

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -1114,10 +1114,11 @@ class binary_reader
     /*!
     @brief narrow a definite CBOR array/map length to std::size_t
 
-    detail::unknown_size() is reserved to mark an indefinite-length container,
-    so a definite length that equals it would be read as indefinite instead of
-    as the (impossible) size it claims. Reject that value here; it also exceeds
-    any container's max_size(), so no representable input is affected.
+    A definite length is rejected if it does not fit in std::size_t or if it
+    equals detail::unknown_size(), which is reserved to mark an indefinite-
+    length container and would otherwise make the length read as indefinite.
+    Both cases exceed any container's max_size(), so no representable input
+    is affected.
 
     @param[in]  len      the declared length
     @param[out] result   the length narrowed to std::size_t
@@ -1126,12 +1127,12 @@ class binary_reader
     */
     bool get_cbor_container_size(const std::uint64_t len, std::size_t& result, const char* context)
     {
-        result = conditional_static_cast<std::size_t>(len);
-        if (JSON_HEDLEY_UNLIKELY(result == detail::unknown_size()))
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::size_t>(len) || len == detail::unknown_size()))
         {
             return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
-                                    exception_message(input_format_t::cbor, concat("excessive ", context, " size"), "value"), nullptr));
+                                    exception_message(input_format_t::cbor, concat("excessive ", context, " size"), "size"), nullptr));
         }
+        result = conditional_static_cast<std::size_t>(len);
         return true;
     }
 

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -656,13 +656,15 @@ class binary_reader
             case 0x9A: // array (four-byte uint32_t for n follow)
             {
                 std::uint32_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_array(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "array") && get_cbor_array(size, tag_handler);
             }
 
             case 0x9B: // array (eight-byte uint64_t for n follow)
             {
                 std::uint64_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_array(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "array") && get_cbor_array(size, tag_handler);
             }
 
             case 0x9F: // array (indefinite length)
@@ -710,13 +712,15 @@ class binary_reader
             case 0xBA: // map (four-byte uint32_t for n follow)
             {
                 std::uint32_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_object(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "map") && get_cbor_object(size, tag_handler);
             }
 
             case 0xBB: // map (eight-byte uint64_t for n follow)
             {
                 std::uint64_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_object(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "map") && get_cbor_object(size, tag_handler);
             }
 
             case 0xBF: // map (indefinite length)
@@ -1105,6 +1109,30 @@ class binary_reader
                                         exception_message(input_format_t::cbor, concat("expected length specification (0x40-0x5B) or indefinite binary array type (0x5F); last byte: 0x", last_token), "binary"), nullptr));
             }
         }
+    }
+
+    /*!
+    @brief narrow a definite CBOR array/map length to std::size_t
+
+    detail::unknown_size() is reserved to mark an indefinite-length container,
+    so a definite length that equals it would be read as indefinite instead of
+    as the (impossible) size it claims. Reject that value here; it also exceeds
+    any container's max_size(), so no representable input is affected.
+
+    @param[in]  len      the declared length
+    @param[out] result   the length narrowed to std::size_t
+    @param[in]  context  "array" or "map", for the error message
+    @return whether the length is usable
+    */
+    bool get_cbor_container_size(const std::uint64_t len, std::size_t& result, const char* context)
+    {
+        result = conditional_static_cast<std::size_t>(len);
+        if (JSON_HEDLEY_UNLIKELY(result == detail::unknown_size()))
+        {
+            return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
+                                    exception_message(input_format_t::cbor, concat("excessive ", context, " size"), "value"), nullptr));
+        }
+        return true;
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11192,13 +11192,15 @@ class binary_reader
             case 0x9A: // array (four-byte uint32_t for n follow)
             {
                 std::uint32_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_array(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "array") && get_cbor_array(size, tag_handler);
             }
 
             case 0x9B: // array (eight-byte uint64_t for n follow)
             {
                 std::uint64_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_array(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "array") && get_cbor_array(size, tag_handler);
             }
 
             case 0x9F: // array (indefinite length)
@@ -11246,13 +11248,15 @@ class binary_reader
             case 0xBA: // map (four-byte uint32_t for n follow)
             {
                 std::uint32_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_object(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "map") && get_cbor_object(size, tag_handler);
             }
 
             case 0xBB: // map (eight-byte uint64_t for n follow)
             {
                 std::uint64_t len{};
-                return get_number(input_format_t::cbor, len) && get_cbor_object(conditional_static_cast<std::size_t>(len), tag_handler);
+                std::size_t size{};
+                return get_number(input_format_t::cbor, len) && get_cbor_container_size(len, size, "map") && get_cbor_object(size, tag_handler);
             }
 
             case 0xBF: // map (indefinite length)
@@ -11641,6 +11645,30 @@ class binary_reader
                                         exception_message(input_format_t::cbor, concat("expected length specification (0x40-0x5B) or indefinite binary array type (0x5F); last byte: 0x", last_token), "binary"), nullptr));
             }
         }
+    }
+
+    /*!
+    @brief narrow a definite CBOR array/map length to std::size_t
+
+    detail::unknown_size() is reserved to mark an indefinite-length container,
+    so a definite length that equals it would be read as indefinite instead of
+    as the (impossible) size it claims. Reject that value here; it also exceeds
+    any container's max_size(), so no representable input is affected.
+
+    @param[in]  len      the declared length
+    @param[out] result   the length narrowed to std::size_t
+    @param[in]  context  "array" or "map", for the error message
+    @return whether the length is usable
+    */
+    bool get_cbor_container_size(const std::uint64_t len, std::size_t& result, const char* context)
+    {
+        result = conditional_static_cast<std::size_t>(len);
+        if (JSON_HEDLEY_UNLIKELY(result == detail::unknown_size()))
+        {
+            return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
+                                    exception_message(input_format_t::cbor, concat("excessive ", context, " size"), "value"), nullptr));
+        }
+        return true;
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11650,10 +11650,11 @@ class binary_reader
     /*!
     @brief narrow a definite CBOR array/map length to std::size_t
 
-    detail::unknown_size() is reserved to mark an indefinite-length container,
-    so a definite length that equals it would be read as indefinite instead of
-    as the (impossible) size it claims. Reject that value here; it also exceeds
-    any container's max_size(), so no representable input is affected.
+    A definite length is rejected if it does not fit in std::size_t or if it
+    equals detail::unknown_size(), which is reserved to mark an indefinite-
+    length container and would otherwise make the length read as indefinite.
+    Both cases exceed any container's max_size(), so no representable input
+    is affected.
 
     @param[in]  len      the declared length
     @param[out] result   the length narrowed to std::size_t
@@ -11662,12 +11663,12 @@ class binary_reader
     */
     bool get_cbor_container_size(const std::uint64_t len, std::size_t& result, const char* context)
     {
-        result = conditional_static_cast<std::size_t>(len);
-        if (JSON_HEDLEY_UNLIKELY(result == detail::unknown_size()))
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::size_t>(len) || len == detail::unknown_size()))
         {
             return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
-                                    exception_message(input_format_t::cbor, concat("excessive ", context, " size"), "value"), nullptr));
+                                    exception_message(input_format_t::cbor, concat("excessive ", context, " size"), "size"), nullptr));
         }
+        result = conditional_static_cast<std::size_t>(len);
         return true;
     }
 

--- a/tests/src/unit-32bit.cpp
+++ b/tests/src/unit-32bit.cpp
@@ -132,3 +132,37 @@ TEST_CASE("BJData")
         }
     }
 }
+
+TEST_CASE("CBOR")
+{
+    SECTION("parse errors")
+    {
+        SECTION("array/map size larger than std::size_t")
+        {
+            // declared lengths do not fit in a 32-bit std::size_t and must not be truncated
+            std::vector<uint8_t> const varr = {0x9B, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05};
+            std::vector<uint8_t> const vmap = {0xBB, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05};
+
+            json _;
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(varr), "[json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive array size", json::out_of_range&);
+            CHECK(json::from_cbor(varr, true, false).is_discarded());
+
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(vmap), "[json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive map size", json::out_of_range&);
+            CHECK(json::from_cbor(vmap, true, false).is_discarded());
+        }
+
+        SECTION("array/map size equal to the indefinite-length sentinel")
+        {
+            // on 32-bit platforms a four-byte length of 0xFFFFFFFF aliases unknown_size()
+            std::vector<uint8_t> const varr = {0x9A, 0xFF, 0xFF, 0xFF, 0xFF};
+            std::vector<uint8_t> const vmap = {0xBA, 0xFF, 0xFF, 0xFF, 0xFF};
+
+            json _;
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(varr), "[json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive array size", json::out_of_range&);
+            CHECK(json::from_cbor(varr, true, false).is_discarded());
+
+            CHECK_THROWS_WITH_AS(_ = json::from_cbor(vmap), "[json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive map size", json::out_of_range&);
+            CHECK(json::from_cbor(vmap, true, false).is_discarded());
+        }
+    }
+}

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -1999,6 +1999,42 @@ TEST_CASE("CBOR regressions")
 }
 #endif
 
+TEST_CASE("CBOR definite length equal to the indefinite-length sentinel")
+{
+    // A definite-length array or map whose declared element count equals the
+    // reserved unknown_size() sentinel (SIZE_MAX) must be rejected. Otherwise
+    // it is read as an indefinite-length container and the following bytes are
+    // silently accepted instead of the (impossible) count being reported.
+    json _;
+
+    SECTION("array")
+    {
+        // 0x9B: array with eight-byte length; length = 0xFFFFFFFFFFFFFFFF
+        const std::vector<uint8_t> input = {0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x02, 0xFF};
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(input), "[json.exception.out_of_range.408] syntax error while parsing CBOR value: excessive array size", json::out_of_range&);
+    }
+
+    SECTION("map")
+    {
+        // 0xBB: map with eight-byte length; length = 0xFFFFFFFFFFFFFFFF
+        const std::vector<uint8_t> input = {0xBB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x61, 0x61, 0x01, 0xFF};
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(input), "[json.exception.out_of_range.408] syntax error while parsing CBOR value: excessive map size", json::out_of_range&);
+    }
+
+    SECTION("indefinite-length containers are unaffected")
+    {
+        CHECK(json::from_cbor(std::vector<uint8_t>({0x9F, 0x01, 0x02, 0xFF})) == json({1, 2}));
+        CHECK(json::from_cbor(std::vector<uint8_t>({0xBF, 0x61, 0x61, 0x01, 0xFF})) == json({{"a", 1}}));
+    }
+
+    SECTION("ordinary four-byte length containers are unaffected")
+    {
+        // 0x9A/0xBA carry a four-byte length; a normal count still parses
+        CHECK(json::from_cbor(std::vector<uint8_t>({0x9A, 0x00, 0x00, 0x00, 0x02, 0x01, 0x02})) == json({1, 2}));
+        CHECK(json::from_cbor(std::vector<uint8_t>({0xBA, 0x00, 0x00, 0x00, 0x01, 0x61, 0x61, 0x01})) == json({{"a", 1}}));
+    }
+}
+
 TEST_CASE("CBOR roundtrips" * doctest::skip())
 {
     SECTION("input from flynn")

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -2011,14 +2011,14 @@ TEST_CASE("CBOR definite length equal to the indefinite-length sentinel")
     {
         // 0x9B: array with eight-byte length; length = 0xFFFFFFFFFFFFFFFF
         const std::vector<uint8_t> input = {0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x02, 0xFF};
-        CHECK_THROWS_WITH_AS(_ = json::from_cbor(input), "[json.exception.out_of_range.408] syntax error while parsing CBOR value: excessive array size", json::out_of_range&);
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(input), "[json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive array size", json::out_of_range&);
     }
 
     SECTION("map")
     {
         // 0xBB: map with eight-byte length; length = 0xFFFFFFFFFFFFFFFF
         const std::vector<uint8_t> input = {0xBB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x61, 0x61, 0x01, 0xFF};
-        CHECK_THROWS_WITH_AS(_ = json::from_cbor(input), "[json.exception.out_of_range.408] syntax error while parsing CBOR value: excessive map size", json::out_of_range&);
+        CHECK_THROWS_WITH_AS(_ = json::from_cbor(input), "[json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive map size", json::out_of_range&);
     }
 
     SECTION("indefinite-length containers are unaffected")


### PR DESCRIPTION
CBOR arrays and maps can prefix their element count with a full eight-byte integer, and the reader tells a definite-length container from an indefinite one by comparing that count against `detail::unknown_size()`, which is `SIZE_MAX`. Nothing stops a definite count from being exactly `SIZE_MAX`, so on a 64-bit build a stream that declares `0xFFFFFFFFFFFFFFFF` elements narrows straight onto the sentinel and `get_cbor_array`/`get_cbor_object` read the container as indefinite rather than rejecting it. The effect is that bytes like `9B FF FF FF FF FF FF FF FF 01 02 FF` come back as `[1, 2]`, read up to the next `0xFF` break, even though the neighboring count `0xFFFFFFFFFFFFFFFE` is correctly turned away as excessive. I noticed the gap while checking how the eight-byte length path lines up with the indefinite marker. The fix adds a small `get_cbor_container_size` helper that narrows the length and rejects the one value that aliases the sentinel; such a count is larger than any container's `max_size()` anyway, so no representable input changes behavior. The four-byte and eight-byte array and map cases route through it, and the indefinite forms stay as they were.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.
