### PR TITLE
reject unpaired UTF-16 surrogates in wide-string input

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -403,7 +403,7 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
                 // UTF-8 decoder rejects it, matching how \uXXXX surrogate escapes
                 // are handled in the lexer.
                 bool valid_pair = false;
-                if (wc <= 0xDBFF && !input.empty())
+                if (wc <= 0xDBFF && JSON_HEDLEY_UNLIKELY(!input.empty()))
                 {
                     const auto wc2 = static_cast<unsigned int>(input.get_character());
                     if (0xDC00 <= wc2 && wc2 <= 0xDFFF)

--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -395,17 +395,30 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
             }
             else
             {
-                if (JSON_HEDLEY_UNLIKELY(!input.empty()))
+                // A supplementary code point is a high surrogate (0xD800..0xDBFF)
+                // followed by a low surrogate (0xDC00..0xDFFF). A lone low
+                // surrogate, a high surrogate at the end of the input, or a high
+                // surrogate followed by any other unit is malformed UTF-16. In
+                // that case the offending unit is passed through unchanged so the
+                // UTF-8 decoder rejects it, matching how \uXXXX surrogate escapes
+                // are handled in the lexer.
+                bool valid_pair = false;
+                if (wc <= 0xDBFF && !input.empty())
                 {
                     const auto wc2 = static_cast<unsigned int>(input.get_character());
-                    const auto charcode = 0x10000u + (((static_cast<unsigned int>(wc) & 0x3FFu) << 10u) | (wc2 & 0x3FFu));
-                    utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xF0u | (charcode >> 18u));
-                    utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 12u) & 0x3Fu));
-                    utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 6u) & 0x3Fu));
-                    utf8_bytes[3] = static_cast<std::char_traits<char>::int_type>(0x80u | (charcode & 0x3Fu));
-                    utf8_bytes_filled = 4;
+                    if (0xDC00 <= wc2 && wc2 <= 0xDFFF)
+                    {
+                        const auto charcode = 0x10000u + (((static_cast<unsigned int>(wc) & 0x3FFu) << 10u) | (wc2 & 0x3FFu));
+                        utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xF0u | (charcode >> 18u));
+                        utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 12u) & 0x3Fu));
+                        utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 6u) & 0x3Fu));
+                        utf8_bytes[3] = static_cast<std::char_traits<char>::int_type>(0x80u | (charcode & 0x3Fu));
+                        utf8_bytes_filled = 4;
+                        valid_pair = true;
+                    }
                 }
-                else
+
+                if (!valid_pair)
                 {
                     utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(wc);
                     utf8_bytes_filled = 1;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7390,7 +7390,7 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
                 // UTF-8 decoder rejects it, matching how \uXXXX surrogate escapes
                 // are handled in the lexer.
                 bool valid_pair = false;
-                if (wc <= 0xDBFF && !input.empty())
+                if (wc <= 0xDBFF && JSON_HEDLEY_UNLIKELY(!input.empty()))
                 {
                     const auto wc2 = static_cast<unsigned int>(input.get_character());
                     if (0xDC00 <= wc2 && wc2 <= 0xDFFF)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -7382,17 +7382,30 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
             }
             else
             {
-                if (JSON_HEDLEY_UNLIKELY(!input.empty()))
+                // A supplementary code point is a high surrogate (0xD800..0xDBFF)
+                // followed by a low surrogate (0xDC00..0xDFFF). A lone low
+                // surrogate, a high surrogate at the end of the input, or a high
+                // surrogate followed by any other unit is malformed UTF-16. In
+                // that case the offending unit is passed through unchanged so the
+                // UTF-8 decoder rejects it, matching how \uXXXX surrogate escapes
+                // are handled in the lexer.
+                bool valid_pair = false;
+                if (wc <= 0xDBFF && !input.empty())
                 {
                     const auto wc2 = static_cast<unsigned int>(input.get_character());
-                    const auto charcode = 0x10000u + (((static_cast<unsigned int>(wc) & 0x3FFu) << 10u) | (wc2 & 0x3FFu));
-                    utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xF0u | (charcode >> 18u));
-                    utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 12u) & 0x3Fu));
-                    utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 6u) & 0x3Fu));
-                    utf8_bytes[3] = static_cast<std::char_traits<char>::int_type>(0x80u | (charcode & 0x3Fu));
-                    utf8_bytes_filled = 4;
+                    if (0xDC00 <= wc2 && wc2 <= 0xDFFF)
+                    {
+                        const auto charcode = 0x10000u + (((static_cast<unsigned int>(wc) & 0x3FFu) << 10u) | (wc2 & 0x3FFu));
+                        utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xF0u | (charcode >> 18u));
+                        utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 12u) & 0x3Fu));
+                        utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 6u) & 0x3Fu));
+                        utf8_bytes[3] = static_cast<std::char_traits<char>::int_type>(0x80u | (charcode & 0x3Fu));
+                        utf8_bytes_filled = 4;
+                        valid_pair = true;
+                    }
                 }
-                else
+
+                if (!valid_pair)
                 {
                     utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(wc);
                     utf8_bytes_filled = 1;

--- a/tests/src/unit-wstring.cpp
+++ b/tests/src/unit-wstring.cpp
@@ -54,14 +54,26 @@ TEST_CASE("wide strings")
             json _;
             CHECK_THROWS_AS(_ = json::parse(w), json::parse_error&);
 
+            // the exact message depends on the width of wchar_t: a 16-bit
+            // wchar_t passes the lone surrogate to the UTF-8 decoder unchanged
+            // (rejected as a single ill-formed byte at column 2), while a
+            // 32-bit wchar_t first encodes it as an ill-formed three-byte
+            // sequence (rejected one byte later, at column 3)
+            const char* const error_low_surrogate = sizeof(wchar_t) == 2
+                    ? "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'"
+                    : "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\xED\xB0'";
+            const char* const error_high_surrogate = sizeof(wchar_t) == 2
+                    ? "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'"
+                    : "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\xED\xA0'";
+
             // a lone low surrogate cannot start a pair
-            CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'"'}), json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'"'}), error_low_surrogate, json::parse_error&);
             // a high surrogate followed by a non-low-surrogate unit is invalid
-            CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xD800), L'a', L'"'}), json::parse_error&);
-            // a lone low surrogate must not swallow the following unit; the
-            // exact-message check lives in the u16string section below, since
-            // the message here depends on sizeof(wchar_t)
-            CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'a', L'"'}), json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xD800), L'a', L'"'}), error_high_surrogate, json::parse_error&);
+            // a lone low surrogate must not swallow the following unit: pairing
+            // it with any second unit would produce valid UTF-8, so the error
+            // has to report an ill-formed byte at the surrogate's own position
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'a', L'"'}), error_low_surrogate, json::parse_error&);
         }
     }
 
@@ -84,9 +96,9 @@ TEST_CASE("wide strings")
             CHECK_THROWS_AS(_ = json::parse(w), json::parse_error&);
 
             // a lone low surrogate cannot start a pair
-            CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'"'}), json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'"'}), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'", json::parse_error&);
             // a high surrogate followed by a non-low-surrogate unit is invalid
-            CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xD800, u'a', u'"'}), json::parse_error&);
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::u16string{u'"', 0xD800, u'a', u'"'}), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'", json::parse_error&);
             // a lone low surrogate must not swallow the following unit: pairing
             // it with any second unit would produce valid UTF-8, so the error
             // has to report an ill-formed byte at the surrogate's own position

--- a/tests/src/unit-wstring.cpp
+++ b/tests/src/unit-wstring.cpp
@@ -58,7 +58,9 @@ TEST_CASE("wide strings")
             CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'"'}), json::parse_error&);
             // a high surrogate followed by a non-low-surrogate unit is invalid
             CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xD800), L'a', L'"'}), json::parse_error&);
-            // a lone low surrogate must not swallow the following unit
+            // a lone low surrogate must not swallow the following unit; the
+            // exact-message check lives in the u16string section below, since
+            // the message here depends on sizeof(wchar_t)
             CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'a', L'"'}), json::parse_error&);
         }
     }
@@ -85,8 +87,10 @@ TEST_CASE("wide strings")
             CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'"'}), json::parse_error&);
             // a high surrogate followed by a non-low-surrogate unit is invalid
             CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xD800, u'a', u'"'}), json::parse_error&);
-            // a lone low surrogate must not swallow the following unit
-            CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'a', u'"'}), json::parse_error&);
+            // a lone low surrogate must not swallow the following unit: pairing
+            // it with any second unit would produce valid UTF-8, so the error
+            // has to report an ill-formed byte at the surrogate's own position
+            CHECK_THROWS_WITH_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'a', u'"'}), "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'", json::parse_error&);
             // a valid surrogate pair is still decoded (U+1F600)
             CHECK(json::parse(std::u16string{u'"', 0xD83D, 0xDE00, u'"'}).get<std::string>() == "\xF0\x9F\x98\x80");
         }

--- a/tests/src/unit-wstring.cpp
+++ b/tests/src/unit-wstring.cpp
@@ -53,6 +53,13 @@ TEST_CASE("wide strings")
             std::wstring const w = L"\"\xDBFF";
             json _;
             CHECK_THROWS_AS(_ = json::parse(w), json::parse_error&);
+
+            // a lone low surrogate cannot start a pair
+            CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'"'}), json::parse_error&);
+            // a high surrogate followed by a non-low-surrogate unit is invalid
+            CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xD800), L'a', L'"'}), json::parse_error&);
+            // a lone low surrogate must not swallow the following unit
+            CHECK_THROWS_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'a', L'"'}), json::parse_error&);
         }
     }
 
@@ -68,11 +75,20 @@ TEST_CASE("wide strings")
 
     SECTION("invalid std::u16string")
     {
-        if (wstring_is_utf16())
+        if (u16string_is_utf16())
         {
             std::u16string const w = u"\"\xDBFF";
             json _;
             CHECK_THROWS_AS(_ = json::parse(w), json::parse_error&);
+
+            // a lone low surrogate cannot start a pair
+            CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'"'}), json::parse_error&);
+            // a high surrogate followed by a non-low-surrogate unit is invalid
+            CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xD800, u'a', u'"'}), json::parse_error&);
+            // a lone low surrogate must not swallow the following unit
+            CHECK_THROWS_AS(_ = json::parse(std::u16string{u'"', 0xDC00, u'a', u'"'}), json::parse_error&);
+            // a valid surrogate pair is still decoded (U+1F600)
+            CHECK(json::parse(std::u16string{u'"', 0xD83D, 0xDE00, u'"'}).get<std::string>() == "\xF0\x9F\x98\x80");
         }
     }
 

--- a/tests/src/unit-wstring.cpp
+++ b/tests/src/unit-wstring.cpp
@@ -60,11 +60,11 @@ TEST_CASE("wide strings")
             // 32-bit wchar_t first encodes it as an ill-formed three-byte
             // sequence (rejected one byte later, at column 3)
             const char* const error_low_surrogate = sizeof(wchar_t) == 2
-                    ? "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'"
-                    : "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\xED\xB0'";
+                                                    ? "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'"
+                                                    : "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\xED\xB0'";
             const char* const error_high_surrogate = sizeof(wchar_t) == 2
-                    ? "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'"
-                    : "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\xED\xA0'";
+                ? "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"<U+0000>'"
+                : "[json.exception.parse_error.101] parse error at line 1, column 3: syntax error while parsing value - invalid string: ill-formed UTF-8 byte; last read: '\"\xED\xA0'";
 
             // a lone low surrogate cannot start a pair
             CHECK_THROWS_WITH_AS(_ = json::parse(std::wstring{L'"', static_cast<wchar_t>(0xDC00), L'"'}), error_low_surrogate, json::parse_error&);


### PR DESCRIPTION
The wide-string input path in `wide_string_input_helper::fill_buffer` converts UTF-16 code units to UTF-8 one unit at a time. When it reaches a value in the surrogate range it assumes a high surrogate and reads the next unit to build a pair, without checking that the first unit is actually a high surrogate or that the second is a low surrogate. So a lone low surrogate, or a high surrogate followed by an ordinary character, is silently combined into a different code point, and the trailing unit is consumed even when it is the closing quote, which throws the rest of the parse off. I noticed it while comparing this path against the `\uXXXX` surrogate handling in the lexer, which already rejects these same malformed sequences with a parse error. The fix forms a pair only when a high surrogate is followed by a low surrogate and otherwise passes the offending unit through unchanged, so the UTF-8 decoder reports it the same way the escape path does. Valid input and the existing lone-high-surrogate-at-end case are unchanged.

Separately, this PR also fixes a pre-existing bug in the test suite itself: the `"invalid std::u16string"` section in `tests/src/unit-wstring.cpp` was gated on `wstring_is_utf16()` instead of `u16string_is_utf16()`. That is independent of the surrogate fix, but correcting it was necessary so the new `std::u16string` cases run under the intended guard.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.
