### PR TITLE
Speed up dump(), and keep it from overflowing the stack

### DIFF
--- a/include/nlohmann/detail/input/string_scan.hpp
+++ b/include/nlohmann/detail/input/string_scan.hpp
@@ -87,6 +87,58 @@ inline std::size_t find_string_special(const unsigned char* data, std::size_t n)
     return n;
 }
 
+// classify a byte as one the serializer must NOT copy verbatim when
+// ensure_ascii is requested: the closing quote, an escape, a control character
+// (< 0x20), DEL (0x7F), or any non-ASCII byte (>= 0x80). Everything else -
+// printable ASCII except '"' and '\\' - is emitted unchanged. Note this differs
+// from is_string_special() only in that 0x7F is also a stop (it is escaped as
+// \u007f under ensure_ascii).
+inline bool is_ascii_copyable(unsigned char c) noexcept
+{
+    return c >= 0x20u && c < 0x7Fu && c != '\"' && c != '\\';
+}
+
+// return the index of the first byte in [data, data+n) that is NOT
+// is_ascii_copyable(), or n if every byte can be copied verbatim; scans 8 bytes
+// at a time. Used by the serializer's ensure_ascii fast path.
+inline std::size_t find_ascii_copyable_run(const unsigned char* data, std::size_t n) noexcept
+{
+    constexpr std::uint64_t ones = 0x0101010101010101ull;
+    constexpr std::uint64_t high = 0x8080808080808080ull;
+    std::size_t i = 0;
+    for (; i + 8 <= n; i += 8)
+    {
+        std::uint64_t v = 0;
+        std::memcpy(&v, data + i, sizeof(v));
+        const std::uint64_t q = v ^ 0x2222222222222222ull; // '"'  (0x22)
+        const std::uint64_t b = v ^ 0x5C5C5C5C5C5C5C5Cull; // '\\' (0x5C)
+        const std::uint64_t d = v ^ 0x7F7F7F7F7F7F7F7Full; // DEL  (0x7F)
+        const std::uint64_t stop = ((q - ones) & ~q & high)   // == '"'
+                                   | ((b - ones) & ~b & high)  // == '\\'
+                                   | ((d - ones) & ~d & high)  // == 0x7F
+                                   | ((v - 0x2020202020202020ull) & ~v & high) // < 0x20
+                                   | (v & high);               // >= 0x80
+        if (stop != 0)
+        {
+            for (std::size_t j = 0; j < 8; ++j)
+            {
+                if (!is_ascii_copyable(data[i + j]))
+                {
+                    return i + j;
+                }
+            }
+        }
+    }
+    for (; i < n; ++i)
+    {
+        if (!is_ascii_copyable(data[i]))
+        {
+            return i;
+        }
+    }
+    return n;
+}
+
 // Validate one UTF-8 sequence at the front of [data, data+avail). Returns its
 // length (2..4) only when the bytes form a *well-formed* sequence using exactly
 // the same ranges as scan_string()'s per-byte switch, so the bulk path accepts

--- a/include/nlohmann/detail/input/string_scan.hpp
+++ b/include/nlohmann/detail/input/string_scan.hpp
@@ -93,6 +93,58 @@ inline std::size_t find_string_special(const unsigned char* data, std::size_t n)
     return n;
 }
 
+// classify a byte as one the serializer must NOT copy verbatim when
+// ensure_ascii is requested: the closing quote, an escape, a control character
+// (< 0x20), DEL (0x7F), or any non-ASCII byte (>= 0x80). Everything else -
+// printable ASCII except '"' and '\\' - is emitted unchanged. Note this differs
+// from is_string_special() only in that 0x7F is also a stop (it is escaped as
+// \u007f under ensure_ascii).
+inline bool is_ascii_copyable(unsigned char c) noexcept
+{
+    return c >= 0x20u && c < 0x7Fu && c != '\"' && c != '\\';
+}
+
+// return the index of the first byte in [data, data+n) that is NOT
+// is_ascii_copyable(), or n if every byte can be copied verbatim; scans 8 bytes
+// at a time. Used by the serializer's ensure_ascii fast path.
+inline std::size_t find_ascii_copyable_run(const unsigned char* data, std::size_t n) noexcept
+{
+    constexpr std::uint64_t ones = 0x0101010101010101ull;
+    constexpr std::uint64_t high = 0x8080808080808080ull;
+    std::size_t i = 0;
+    for (; i + 8 <= n; i += 8)
+    {
+        std::uint64_t v = 0;
+        std::memcpy(&v, data + i, sizeof(v));
+        const std::uint64_t q = v ^ 0x2222222222222222ull; // '"'  (0x22)
+        const std::uint64_t b = v ^ 0x5C5C5C5C5C5C5C5Cull; // '\\' (0x5C)
+        const std::uint64_t d = v ^ 0x7F7F7F7F7F7F7F7Full; // DEL  (0x7F)
+        const std::uint64_t stop = ((q - ones) & ~q & high)   // == '"'
+                                   | ((b - ones) & ~b & high)  // == '\\'
+                                   | ((d - ones) & ~d & high)  // == 0x7F
+                                   | ((v - 0x2020202020202020ull) & ~v & high) // < 0x20
+                                   | (v & high);               // >= 0x80
+        if (stop != 0)
+        {
+            for (std::size_t j = 0; j < 8; ++j)
+            {
+                if (!is_ascii_copyable(data[i + j]))
+                {
+                    return i + j;
+                }
+            }
+        }
+    }
+    for (; i < n; ++i)
+    {
+        if (!is_ascii_copyable(data[i]))
+        {
+            return i;
+        }
+    }
+    return n;
+}
+
 // Validate one UTF-8 sequence at the front of [data, data+avail). Returns its
 // length (2..4) only when the bytes form a *well-formed* sequence using exactly
 // the same ranges as scan_string()'s per-byte switch, so the bulk path accepts

--- a/include/nlohmann/detail/input/string_scan.hpp
+++ b/include/nlohmann/detail/input/string_scan.hpp
@@ -101,7 +101,7 @@ inline std::size_t find_string_special(const unsigned char* data, std::size_t n)
 // \u007f under ensure_ascii).
 inline bool is_ascii_copyable(unsigned char c) noexcept
 {
-    return c >= 0x20u && c < 0x7Fu && c != '\"' && c != '\\';
+    return c >= 0x20u && c < 0x7Fu && c != '"' && c != '\\';
 }
 
 // return the index of the first byte in [data, data+n) that is NOT
@@ -126,13 +126,7 @@ inline std::size_t find_ascii_copyable_run(const unsigned char* data, std::size_
                                    | (v & high);               // >= 0x80
         if (stop != 0)
         {
-            for (std::size_t j = 0; j < 8; ++j)
-            {
-                if (!is_ascii_copyable(data[i + j]))
-                {
-                    return i + j;
-                }
-            }
+            break;
         }
     }
     for (; i < n; ++i)

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -16,6 +16,7 @@
 #include <cstddef> // size_t, ptrdiff_t
 #include <cstdint> // uint8_t
 #include <cstdio> // snprintf
+#include <cstring> // memcpy
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
 #include <iomanip> // setfill, setw
@@ -111,19 +112,38 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
+        dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
+        flush();
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief recursive worker for @ref dump
+
+    Identical in behavior to the historical @ref dump, but writes into the
+    serializer's internal @ref write_buffer instead of issuing a virtual call
+    per token. The public @ref dump wraps this and flushes the buffer once the
+    top-level value has been serialized.
+    */
+    void dump_internal(const BasicJsonType& val,
+                       const bool pretty_print,
+                       const bool ensure_ascii,
+                       const unsigned int indent_step,
+                       const unsigned int current_indent = 0)
+    {
         switch (val.m_data.m_type)
         {
             case value_t::object:
             {
                 if (val.m_data.m_value.object->empty())
                 {
-                    o->write_characters("{}", 2);
+                    put_chars("{}", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -136,51 +156,51 @@ class serializer
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        o->write_character('\"');
+                        put_chars(indent_string.c_str(), new_indent);
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars("\": ", 3);
+                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    o->write_character('\"');
+                    put_chars(indent_string.c_str(), new_indent);
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                    put_chars("\": ", 3);
+                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_character('{');
+                    put_char('{');
 
                     // first n-1 elements
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_character('\"');
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\":", 2);
-                        dump(i->second, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        put_chars("\":", 2);
+                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_character('\"');
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\":", 2);
-                    dump(i->second, false, ensure_ascii, indent_step, current_indent);
+                    put_chars("\":", 2);
+                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character('}');
+                    put_char('}');
                 }
 
                 return;
@@ -190,13 +210,13 @@ class serializer
             {
                 if (val.m_data.m_value.array->empty())
                 {
-                    o->write_characters("[]", 2);
+                    put_chars("[]", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("[\n", 2);
+                    put_chars("[\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -209,37 +229,37 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars(indent_string.c_str(), new_indent);
+                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
+                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character(']');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char(']');
                 }
                 else
                 {
-                    o->write_character('[');
+                    put_char('[');
 
                     // first n-1 elements
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump(*i, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character(']');
+                    put_char(']');
                 }
 
                 return;
@@ -247,9 +267,9 @@ class serializer
 
             case value_t::string:
             {
-                o->write_character('\"');
+                put_char('\"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                o->write_character('\"');
+                put_char('\"');
                 return;
             }
 
@@ -257,7 +277,7 @@ class serializer
             {
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -266,9 +286,9 @@ class serializer
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
 
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"bytes\": [", 10);
+                    put_chars("\"bytes\": [", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -276,30 +296,30 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_characters(", ", 2);
+                            put_chars(", ", 2);
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\n", 3);
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars("],\n", 3);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"subtype\": ", 11);
+                    put_chars("\"subtype\": ", 11);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
-                        o->write_characters("null", 4);
+                        put_chars("null", 4);
                     }
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_characters("{\"bytes\":[", 10);
+                    put_chars("{\"bytes\":[", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -307,20 +327,20 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_character(',');
+                            put_char(',');
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\"subtype\":", 12);
+                    put_chars("],\"subtype\":", 12);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
-                        o->write_character('}');
+                        put_char('}');
                     }
                     else
                     {
-                        o->write_characters("null}", 5);
+                        put_chars("null}", 5);
                     }
                 }
                 return;
@@ -330,11 +350,11 @@ class serializer
             {
                 if (val.m_data.m_value.boolean)
                 {
-                    o->write_characters("true", 4);
+                    put_chars("true", 4);
                 }
                 else
                 {
-                    o->write_characters("false", 5);
+                    put_chars("false", 5);
                 }
                 return;
             }
@@ -359,13 +379,13 @@ class serializer
 
             case value_t::discarded:
             {
-                o->write_characters("<discarded>", 11);
+                put_chars("<discarded>", 11);
                 return;
             }
 
             case value_t::null:
             {
-                o->write_characters("null", 4);
+                put_chars("null", 4);
                 return;
             }
 
@@ -401,28 +421,35 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
-            // Fast path: when not escaping non-ASCII characters and sitting on a
-            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
-            // run of bytes that need no escaping. string_bulk_run() (shared with
-            // the lexer's contiguous scanner) stops exactly at the first byte
-            // that dump_escaped would handle individually - a quote, a backslash,
-            // a control character (< 0x20), or an ill-formed/truncated UTF-8
-            // sequence - so that byte is left to the byte-at-a-time path below,
-            // keeping error handling and diagnostics unchanged.
-            if (!ensure_ascii && state == UTF8_ACCEPT)
+            // Fast path: at a character boundary (state == UTF8_ACCEPT),
+            // bulk-copy the longest run of bytes that need no escaping using a
+            // SWAR scanner shared with the lexer's contiguous path. The scanner
+            // stops exactly at the first byte dump_escaped would handle
+            // individually, so that byte is left to the byte-at-a-time path
+            // below, keeping escaping output and error diagnostics unchanged.
+            //
+            // - ensure_ascii == false: string_bulk_run() copies ordinary bytes
+            //   and complete well-formed UTF-8, stopping at a quote, backslash,
+            //   control character (< 0x20), or ill-formed/truncated sequence.
+            // - ensure_ascii == true: only printable ASCII may be copied
+            //   verbatim; find_ascii_copyable_run() additionally stops at 0x7F
+            //   and every non-ASCII byte (>= 0x80), which must be \u-escaped.
+            if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                const std::size_t run = ensure_ascii
+                                        ? find_ascii_copyable_run(data + i, s.size() - i)
+                                        : string_bulk_run(data + i, s.size() - i);
                 if (run != 0)
                 {
                     // emit any bytes still pending in string_buffer first to
                     // preserve output order, then write the run directly
                     if (bytes != 0)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
-                    o->write_characters(s.data() + i, run);
+                    put_chars(s.data() + i, run);
                     bytes_after_last_accept = 0;
                     undumped_chars = 0;
                     i += run;
@@ -521,7 +548,7 @@ class serializer
                     // written ("\uxxxx\uxxxx\0") for one code point
                     if (string_buffer.size() - bytes < 13)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
 
@@ -580,7 +607,7 @@ class serializer
                                 // written ("\uxxxx\uxxxx\0") for one code point
                                 if (string_buffer.size() - bytes < 13)
                                 {
-                                    o->write_characters(string_buffer.data(), bytes);
+                                    put_chars(string_buffer.data(), bytes);
                                     bytes = 0;
                                 }
 
@@ -619,7 +646,7 @@ class serializer
             // write buffer
             if (bytes > 0)
             {
-                o->write_characters(string_buffer.data(), bytes);
+                put_chars(string_buffer.data(), bytes);
             }
         }
         else
@@ -635,22 +662,22 @@ class serializer
                 case error_handler_t::ignore:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     break;
                 }
 
                 case error_handler_t::replace:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     // add a replacement character
                     if (ensure_ascii)
                     {
-                        o->write_characters("\\ufffd", 6);
+                        put_chars("\\ufffd", 6);
                     }
                     else
                     {
-                        o->write_characters("\xEF\xBF\xBD", 3);
+                        put_chars("\xEF\xBF\xBD", 3);
                     }
                     break;
                 }
@@ -662,6 +689,60 @@ class serializer
     }
 
   private:
+    /*!
+    @brief append a single character to the write buffer
+
+    Structural characters ('{', '"', ',', ...) previously went straight to the
+    output adapter, one virtual call each. Buffering them and flushing in bulk
+    turns those many indirect calls into a single memcpy plus an occasional
+    flush, which dominates the cost of serializing object/array-heavy values.
+    */
+    void put_char(char c)
+    {
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
+        {
+            flush();
+        }
+        write_buffer[write_buffer_pos++] = c;
+    }
+
+    /*!
+    @brief append @a length characters to the write buffer
+
+    Runs that do not fit the buffer are written straight through the output
+    adapter (after flushing what is pending), so large string/number payloads
+    are not copied an extra time.
+    */
+    JSON_HEDLEY_NON_NULL(2)
+    void put_chars(const char* s, std::size_t length)
+    {
+        if (JSON_HEDLEY_UNLIKELY(length >= write_buffer.size()))
+        {
+            flush();
+            o->write_characters(s, length);
+            return;
+        }
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + length > write_buffer.size()))
+        {
+            flush();
+        }
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
+        write_buffer_pos += length;
+    }
+
+    /*!
+    @brief flush the write buffer to the output adapter
+
+    Writing zero characters is a well-defined no-op for every output adapter, so
+    the buffered length is passed through unconditionally (no empty-guard branch
+    to leave uncovered).
+    */
+    void flush()
+    {
+        o->write_characters(write_buffer.data(), write_buffer_pos);
+        write_buffer_pos = 0;
+    }
+
     /*!
     @brief count digits
 
@@ -785,7 +866,7 @@ class serializer
         // special case for "0"
         if (x == 0)
         {
-            o->write_character('0');
+            put_char('0');
             return;
         }
 
@@ -838,7 +919,7 @@ class serializer
             *(--buffer_ptr) = static_cast<char>('0' + abs_value);
         }
 
-        o->write_characters(number_buffer.data(), n_chars);
+        put_chars(number_buffer.data(), n_chars);
     }
 
     /*!
@@ -854,7 +935,7 @@ class serializer
         // NaN / inf
         if (!std::isfinite(x))
         {
-            o->write_characters("null", 4);
+            put_chars("null", 4);
             return;
         }
 
@@ -875,7 +956,7 @@ class serializer
         auto* begin = number_buffer.data();
         auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
 
-        o->write_characters(begin, static_cast<size_t>(end - begin));
+        put_chars(begin, static_cast<size_t>(end - begin));
     }
 
     JSON_HEDLEY_NON_NULL(1)
@@ -926,7 +1007,7 @@ class serializer
             }
         }
 
-        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+        put_chars(number_buffer.data(), static_cast<std::size_t>(len));
 
         // determine if we need to append ".0"
         const bool value_is_int_like =
@@ -938,7 +1019,7 @@ class serializer
 
         if (value_is_int_like)
         {
-            o->write_characters(".0", 2);
+            put_chars(".0", 2);
         }
     }
 
@@ -1048,6 +1129,12 @@ class serializer
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
+
+    /// buffer collecting output before it is flushed to the output adapter, so
+    /// that the many small structural writes become few bulk writes
+    std::array<char, 1024> write_buffer{{}};
+    /// number of valid bytes currently held in @ref write_buffer
+    std::size_t write_buffer_pos = 0;
 };
 
 }  // namespace detail

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -24,6 +24,7 @@
 
 #include <nlohmann/detail/conversions/to_chars.hpp>
 #include <nlohmann/detail/exceptions.hpp>
+#include <nlohmann/detail/input/string_scan.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
 #include <nlohmann/detail/output/binary_writer.hpp>
@@ -400,6 +401,38 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
+            // Fast path: when not escaping non-ASCII characters and sitting on a
+            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
+            // run of bytes that need no escaping. string_bulk_run() (shared with
+            // the lexer's contiguous scanner) stops exactly at the first byte
+            // that dump_escaped would handle individually - a quote, a backslash,
+            // a control character (< 0x20), or an ill-formed/truncated UTF-8
+            // sequence - so that byte is left to the byte-at-a-time path below,
+            // keeping error handling and diagnostics unchanged.
+            if (!ensure_ascii && state == UTF8_ACCEPT)
+            {
+                const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
+                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                if (run != 0)
+                {
+                    // emit any bytes still pending in string_buffer first to
+                    // preserve output order, then write the run directly
+                    if (bytes != 0)
+                    {
+                        o->write_characters(string_buffer.data(), bytes);
+                        bytes = 0;
+                    }
+                    o->write_characters(s.data() + i, run);
+                    bytes_after_last_accept = 0;
+                    undumped_chars = 0;
+                    i += run;
+                    if (i >= s.size())
+                    {
+                        break;
+                    }
+                }
+            }
+
             const auto byte = static_cast<std::uint8_t>(s[i]);
 
             switch (decode(state, codepoint, byte))

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -730,12 +730,17 @@ class serializer
         write_buffer_pos += length;
     }
 
+  JSON_PRIVATE_UNLESS_TESTED:
     /*!
     @brief flush the write buffer to the output adapter
 
     Writing zero characters is a well-defined no-op for every output adapter, so
     the buffered length is passed through unconditionally (no empty-guard branch
     to leave uncovered).
+
+    @note dump_escaped() and dump_integer()/dump_float() write into the internal
+    write buffer; callers that invoke them directly (rather than through the
+    public dump()) must call flush() before inspecting the output.
     */
     void flush()
     {
@@ -743,6 +748,7 @@ class serializer
         write_buffer_pos = 0;
     }
 
+  private:
     /*!
     @brief count digits
 

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -843,9 +843,20 @@ class serializer
             if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = EnsureAscii
-                                        ? find_ascii_copyable_run(data + i, s.size() - i)
-                                        : string_bulk_run(data + i, s.size() - i);
+                // A run can only be non-empty when the very first byte is one
+                // the scanner may copy, so test that single byte before paying
+                // for the scan. Without it, text whose characters all have to be
+                // escaped - CJK under ensure_ascii, where every byte is >= 0x80 -
+                // runs the scanner once per character only to be told zero.
+                std::size_t run = 0;
+                if (!EnsureAscii)
+                {
+                    run = string_bulk_run(data + i, s.size() - i);
+                }
+                else if (is_ascii_copyable(data[i]))
+                {
+                    run = find_ascii_copyable_run(data + i, s.size() - i);
+                }
                 if (run != 0)
                 {
                     // emit any bytes still pending in string_buffer first to

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -1383,21 +1383,21 @@ class serializer
         }
 
         const auto byte = static_cast<unsigned>(value);
-        char* out = write_buffer.data() + write_buffer_pos;
+        std::size_t pos = write_buffer_pos;
 
         if (byte >= 100)
         {
-            *out++ = static_cast<char>('0' + (byte / 100));
-            *out++ = static_cast<char>('0' + ((byte / 10) % 10));
+            write_buffer[pos++] = static_cast<char>('0' + (byte / 100));
+            write_buffer[pos++] = static_cast<char>('0' + ((byte / 10) % 10));
         }
         else if (byte >= 10)
         {
-            *out++ = static_cast<char>('0' + (byte / 10));
+            write_buffer[pos++] = static_cast<char>('0' + (byte / 10));
         }
 
-        *out++ = static_cast<char>('0' + (byte % 10));
+        write_buffer[pos++] = static_cast<char>('0' + (byte % 10));
 
-        write_buffer_pos = static_cast<std::size_t>(out - write_buffer.data());
+        write_buffer_pos = pos;
     }
 
     /*!

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -107,8 +107,8 @@ class serializer
     void dump(const BasicJsonType& val,
               const bool pretty_print,
               const bool ensure_ascii,
-              const unsigned int indent_step,
-              const unsigned int current_indent = 0)
+              const std::size_t indent_step,
+              const std::size_t current_indent = 0)
     {
         dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
         flush();
@@ -126,8 +126,8 @@ class serializer
     void dump_internal(const BasicJsonType& val,
                        const bool pretty_print,
                        const bool ensure_ascii,
-                       const unsigned int indent_step,
-                       const unsigned int current_indent = 0)
+                       const std::size_t indent_step,
+                       const std::size_t current_indent = 0)
     {
         switch (val.m_data.m_type)
         {
@@ -384,11 +384,13 @@ class serializer
     @brief the indentation level to use for the children of the current value
 
     A very large @a indent_step can wrap the unsigned accumulation on deep
-    nesting, which would silently truncate the indentation.
+    nesting, which would silently truncate the indentation. Far harder to reach
+    now that the accumulator is a std::size_t, but still reachable where that is
+    32 bits wide.
     */
-    static unsigned int next_indent(const unsigned int current_indent, const unsigned int indent_step)
+    static std::size_t next_indent(const std::size_t current_indent, const std::size_t indent_step)
     {
-        const unsigned int new_indent = current_indent + indent_step;
+        const std::size_t new_indent = current_indent + indent_step;
         JSON_ASSERT(new_indent >= current_indent);
         return new_indent;
     }
@@ -448,7 +450,7 @@ class serializer
                         put_buffer(string_buffer, bytes);
                         bytes = 0;
                     }
-                    put_chars(s.data() + i, run);
+                    put_string(s, i, i + run);
                     bytes_after_last_accept = 0;
                     undumped_chars = 0;
                     i += run;
@@ -706,13 +708,6 @@ class serializer
     }
 
     /*!
-    @brief append @a length characters to the write buffer
-
-    Runs that do not fit the buffer are written straight through the output
-    adapter (after flushing what is pending), so large string/number payloads
-    are not copied an extra time.
-    */
-    /*!
     @brief append @a indent indentation characters to the write buffer
 
     Writes the indentation straight into the buffer instead of copying it out of
@@ -724,7 +719,7 @@ class serializer
     flushing does not disturb what the buffer holds, so re-filling it between
     flushes would be redundant work.
     */
-    void put_indent(unsigned int indent)
+    void put_indent(std::size_t indent)
     {
         // closing braces at the outermost level ask for no indentation at all
         if (indent == 0)
@@ -737,10 +732,10 @@ class serializer
         // fill whatever room is left in the buffer; this is the whole job
         // whenever the indentation is narrower than the buffer, which is the
         // case for every sane indent_step
-        const std::size_t head = (std::min)(static_cast<std::size_t>(indent), capacity - write_buffer_pos);
+        const std::size_t head = (std::min)(indent, capacity - write_buffer_pos);
         std::memset(write_buffer.data() + write_buffer_pos, indent_char, head);
         write_buffer_pos += head;
-        indent -= static_cast<unsigned int>(head);
+        indent -= head;
 
         if (JSON_HEDLEY_LIKELY(indent == 0))
         {
@@ -757,7 +752,7 @@ class serializer
         {
             write_buffer_pos = capacity;
             flush();
-            indent -= static_cast<unsigned int>(capacity);
+            indent -= capacity;
         }
 
         // the buffer still holds indentation characters throughout, so the tail
@@ -777,14 +772,30 @@ class serializer
     void put_literal(const char (&s)[N])
     {
         static_assert(N >= 2, "put_literal expects a non-empty string literal");
-        static_assert(N - 1 < write_buffer_size, "string literal must fit into the write buffer");
+        // the array bound counts the terminating NUL, which is not written
+        constexpr std::size_t length = N - 1;
+        static_assert(length < write_buffer_size, "string literal must fit into the write buffer");
 
-        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + (N - 1) > write_buffer.size()))
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + length > write_buffer.size()))
         {
             flush();
         }
-        std::memcpy(write_buffer.data() + write_buffer_pos, s, N - 1);
-        write_buffer_pos += N - 1;
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
+        write_buffer_pos += length;
+    }
+
+    /*!
+    @brief append the characters of @a str in [@a start, @a end)
+
+    Keeps the pointer arithmetic and the bounds checking inside the function
+    rather than at the call site, which is all @ref put_chars could offer.
+    */
+    template<typename StringType>
+    void put_string(const StringType& str, std::size_t start, std::size_t end)
+    {
+        JSON_ASSERT(start <= end);
+        JSON_ASSERT(end <= str.size());
+        put_chars(str.data() + start, end - start);
     }
 
     /*!
@@ -800,6 +811,16 @@ class serializer
         put_chars(buffer.data(), length);
     }
 
+    /*!
+    @brief append @a length characters to the write buffer
+
+    Runs that do not fit the buffer are written straight through the output
+    adapter (after flushing what is pending), so large string/number payloads
+    are not copied an extra time.
+
+    The callers all reach this through @ref put_literal, @ref put_buffer or
+    @ref put_string, which each derive the length from something that knows it.
+    */
     JSON_HEDLEY_NON_NULL(2)
     void put_chars(const char* s, std::size_t length)
     {
@@ -1049,7 +1070,7 @@ class serializer
         auto* begin = number_buffer.data();
         auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
 
-        put_chars(begin, static_cast<size_t>(end - begin));
+        put_buffer(number_buffer, static_cast<std::size_t>(end - begin));
     }
 
     JSON_HEDLEY_NON_NULL(1)

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -64,15 +64,31 @@ class serializer
     /*!
     @param[in] s  output stream to serialize to
     @param[in] ichar  indentation character to use
+    @param[in] pretty_print_  whether the output shall be pretty-printed
+    @param[in] ensure_ascii_ If @a ensure_ascii_ is true, all non-ASCII
+    characters in the output are escaped with `\uXXXX` sequences, and the
+    result consists of ASCII characters only.
+    @param[in] indent_step_  the indent level
     @param[in] error_handler_  how to react on decoding errors
+
+    None of @a pretty_print_, @a ensure_ascii_ and @a indent_step_ change over
+    the life of the serializer, so they are captured once here instead of
+    being threaded through every call to @ref dump, @ref dump_internal and
+    @ref dump_iteratively.
     */
     serializer(output_adapter_t<char> s, const char ichar,
+               const bool pretty_print_ = false,
+               const bool ensure_ascii_ = false,
+               const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
         : o(std::move(s))
         , loc(std::localeconv())
         , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
         , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
+        , pretty_print(pretty_print_)
+        , ensure_ascii(ensure_ascii_)
+        , indent_step(indent_step_)
         , error_handler(error_handler_)
     {}
 
@@ -98,20 +114,12 @@ class serializer
       byte array
 
     @param[in] val               value to serialize
-    @param[in] pretty_print      whether the output shall be pretty-printed
-    @param[in] ensure_ascii If @a ensure_ascii is true, all non-ASCII characters
-    in the output are escaped with `\uXXXX` sequences, and the result consists
-    of ASCII characters only.
-    @param[in] indent_step       the indent level
     @param[in] current_indent    the current indent level (only used internally)
     */
     void dump(const BasicJsonType& val,
-              const bool pretty_print,
-              const bool ensure_ascii,
-              const std::size_t indent_step,
               const std::size_t current_indent = 0)
     {
-        dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
+        dump_internal(val, current_indent);
         flush();
     }
 
@@ -134,9 +142,6 @@ class serializer
     @sa https://github.com/nlohmann/json/issues/5387
     */
     void dump_internal(const BasicJsonType& val,
-                       const bool pretty_print,
-                       const bool ensure_ascii,
-                       const std::size_t indent_step,
                        const std::size_t current_indent = 0,
                        const std::size_t depth = 0)
     {
@@ -146,7 +151,7 @@ class serializer
             {
                 if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
                 {
-                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    dump_iteratively(val, current_indent);
                     return;
                 }
 
@@ -169,9 +174,9 @@ class serializer
                     {
                         put_indent(new_indent);
                         put_char('"');
-                        dump_escaped(i->first, ensure_ascii);
+                        dump_escaped(i->first);
                         put_literal("\": ");
-                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
+                        dump_internal(i->second, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
@@ -180,9 +185,9 @@ class serializer
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_indent(new_indent);
                     put_char('"');
-                    dump_escaped(i->first, ensure_ascii);
+                    dump_escaped(i->first);
                     put_literal("\": ");
-                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
+                    dump_internal(i->second, new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -197,9 +202,9 @@ class serializer
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         put_char('"');
-                        dump_escaped(i->first, ensure_ascii);
+                        dump_escaped(i->first);
                         put_literal("\":");
-                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
+                        dump_internal(i->second, current_indent, depth + 1);
                         put_char(',');
                     }
 
@@ -207,9 +212,9 @@ class serializer
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_char('"');
-                    dump_escaped(i->first, ensure_ascii);
+                    dump_escaped(i->first);
                     put_literal("\":");
-                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
+                    dump_internal(i->second, current_indent, depth + 1);
 
                     put_char('}');
                 }
@@ -221,7 +226,7 @@ class serializer
             {
                 if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
                 {
-                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    dump_iteratively(val, current_indent);
                     return;
                 }
 
@@ -243,14 +248,14 @@ class serializer
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
                         put_indent(new_indent);
-                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent, depth + 1);
+                        dump_internal(*i, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
                     put_indent(new_indent);
-                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent, depth + 1);
+                    dump_internal(val.m_data.m_value.array->back(), new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -264,13 +269,13 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent, depth + 1);
+                        dump_internal(*i, current_indent, depth + 1);
                         put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent, depth + 1);
+                    dump_internal(val.m_data.m_value.array->back(), current_indent, depth + 1);
 
                     put_char(']');
                 }
@@ -281,7 +286,7 @@ class serializer
             case value_t::string:
             {
                 put_char('"');
-                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                dump_escaped(*val.m_data.m_value.string);
                 put_char('"');
                 return;
             }
@@ -421,9 +426,6 @@ class serializer
     object-heavy documents than letting the compiler drive the descent.
     */
     void dump_iteratively(const BasicJsonType& val,
-                          const bool pretty_print,
-                          const bool ensure_ascii,
-                          const std::size_t indent_step,
                           const std::size_t current_indent = 0)
     {
         // Scalars, empty containers and binary values are written by dump_value
@@ -431,7 +433,7 @@ class serializer
         // elements is ever pushed.
         std::vector<dump_frame> stack;
 
-        dump_value(val, pretty_print, ensure_ascii, indent_step, current_indent, stack);
+        dump_value(val, current_indent, stack);
 
         while (!stack.empty())
         {
@@ -474,7 +476,7 @@ class serializer
                 }
 
                 put_char('"');
-                dump_escaped(frame.object_it->first, ensure_ascii);
+                dump_escaped(frame.object_it->first);
 
                 if (pretty_print)
                 {
@@ -491,7 +493,7 @@ class serializer
                 // read everything needed from the frame before this: entering a
                 // container pushes another one and can move them all
                 const std::size_t element_indent = frame.child_indent;
-                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+                dump_value(element, element_indent, stack);
             }
             else
             {
@@ -532,7 +534,7 @@ class serializer
 
                 // see above
                 const std::size_t element_indent = frame.child_indent;
-                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+                dump_value(element, element_indent, stack);
             }
         }
     }
@@ -571,9 +573,6 @@ class serializer
     out here in full.
     */
     void dump_value(const BasicJsonType& val,
-                    const bool pretty_print,
-                    const bool ensure_ascii,
-                    const std::size_t indent_step,
                     const std::size_t current_indent,
                     std::vector<dump_frame>& stack)
     {
@@ -632,7 +631,7 @@ class serializer
             case value_t::string:
             {
                 put_char('"');
-                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                dump_escaped(*val.m_data.m_value.string);
                 put_char('"');
                 return;
             }
@@ -780,12 +779,10 @@ class serializer
     representation. The escaped string is written to output stream @a o.
 
     @param[in] s  the string to escape
-    @param[in] ensure_ascii  whether to escape non-ASCII characters with
-                             \uXXXX sequences
 
     @complexity Linear in the length of string @a s.
     */
-    void dump_escaped(const string_t& s, const bool ensure_ascii)
+    void dump_escaped(const string_t& s)
     {
         // dispatch once here rather than test the flag inside the loop: it does
         // not change while a string is written, and folding it lets each of the
@@ -1689,6 +1686,15 @@ class serializer
 
     /// the indentation character
     const char indent_char;
+
+    /// whether to pretty-print the output
+    const bool pretty_print;
+
+    /// whether to escape non-ASCII characters with \uXXXX sequences
+    const bool ensure_ascii;
+
+    /// the indent level
+    const std::size_t indent_step;
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include <algorithm> // reverse, remove, fill, find, none_of
+#include <algorithm> // reverse, remove, fill, find, none_of, min
 #include <array> // array
 #include <clocale> // localeconv, lconv
 #include <cmath> // labs, isfinite, isnan, signbit
 #include <cstddef> // size_t, ptrdiff_t
 #include <cstdint> // uint8_t
 #include <cstdio> // snprintf
-#include <cstring> // memcpy
+#include <cstring> // memcpy, memset
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
 #include <type_traits> // is_same
@@ -72,7 +72,6 @@ class serializer
         , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
         , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
-        , indent_string(512, indent_char)
         , error_handler(error_handler_)
     {}
 
@@ -136,44 +135,40 @@ class serializer
             {
                 if (val.m_data.m_value.object->empty())
                 {
-                    put_chars("{}", 2);
+                    put_literal("{}");
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    put_chars("{\n", 2);
+                    put_literal("{\n");
 
                     // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
+                    const auto new_indent = next_indent(current_indent, indent_step);
 
                     // first n-1 elements
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        put_chars(indent_string.c_str(), new_indent);
+                        put_indent(new_indent);
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        put_chars("\": ", 3);
+                        put_literal("\": ");
                         dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
-                        put_chars(",\n", 2);
+                        put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_indent(new_indent);
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    put_chars("\": ", 3);
+                    put_literal("\": ");
                     dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
 
                     put_char('\n');
-                    put_chars(indent_string.c_str(), current_indent);
+                    put_indent(current_indent);
                     put_char('}');
                 }
                 else
@@ -186,7 +181,7 @@ class serializer
                     {
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        put_chars("\":", 2);
+                        put_literal("\":");
                         dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
                         put_char(',');
                     }
@@ -196,7 +191,7 @@ class serializer
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    put_chars("\":", 2);
+                    put_literal("\":");
                     dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
 
                     put_char('}');
@@ -209,37 +204,33 @@ class serializer
             {
                 if (val.m_data.m_value.array->empty())
                 {
-                    put_chars("[]", 2);
+                    put_literal("[]");
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    put_chars("[\n", 2);
+                    put_literal("[\n");
 
                     // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
+                    const auto new_indent = next_indent(current_indent, indent_step);
 
                     // first n-1 elements
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        put_chars(indent_string.c_str(), new_indent);
+                        put_indent(new_indent);
                         dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
-                        put_chars(",\n", 2);
+                        put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_indent(new_indent);
                     dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
                     put_char('\n');
-                    put_chars(indent_string.c_str(), current_indent);
+                    put_indent(current_indent);
                     put_char(']');
                 }
                 else
@@ -276,18 +267,14 @@ class serializer
             {
                 if (pretty_print)
                 {
-                    put_chars("{\n", 2);
+                    put_literal("{\n");
 
                     // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
+                    const auto new_indent = next_indent(current_indent, indent_step);
 
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_indent(new_indent);
 
-                    put_chars("\"bytes\": [", 10);
+                    put_literal("\"bytes\": [");
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -295,30 +282,30 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            put_chars(", ", 2);
+                            put_literal(", ");
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    put_chars("],\n", 3);
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_literal("],\n");
+                    put_indent(new_indent);
 
-                    put_chars("\"subtype\": ", 11);
+                    put_literal("\"subtype\": ");
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
-                        put_chars("null", 4);
+                        put_literal("null");
                     }
                     put_char('\n');
-                    put_chars(indent_string.c_str(), current_indent);
+                    put_indent(current_indent);
                     put_char('}');
                 }
                 else
                 {
-                    put_chars("{\"bytes\":[", 10);
+                    put_literal("{\"bytes\":[");
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -331,7 +318,7 @@ class serializer
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    put_chars("],\"subtype\":", 12);
+                    put_literal("],\"subtype\":");
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
@@ -339,7 +326,7 @@ class serializer
                     }
                     else
                     {
-                        put_chars("null}", 5);
+                        put_literal("null}");
                     }
                 }
                 return;
@@ -349,11 +336,11 @@ class serializer
             {
                 if (val.m_data.m_value.boolean)
                 {
-                    put_chars("true", 4);
+                    put_literal("true");
                 }
                 else
                 {
-                    put_chars("false", 5);
+                    put_literal("false");
                 }
                 return;
             }
@@ -378,19 +365,32 @@ class serializer
 
             case value_t::discarded:
             {
-                put_chars("<discarded>", 11);
+                put_literal("<discarded>");
                 return;
             }
 
             case value_t::null:
             {
-                put_chars("null", 4);
+                put_literal("null");
                 return;
             }
 
             default:            // LCOV_EXCL_LINE
                 JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
         }
+    }
+
+    /*!
+    @brief the indentation level to use for the children of the current value
+
+    A very large @a indent_step can wrap the unsigned accumulation on deep
+    nesting, which would silently truncate the indentation.
+    */
+    static unsigned int next_indent(const unsigned int current_indent, const unsigned int indent_step)
+    {
+        const unsigned int new_indent = current_indent + indent_step;
+        JSON_ASSERT(new_indent >= current_indent);
+        return new_indent;
     }
 
   JSON_PRIVATE_UNLESS_TESTED:
@@ -445,7 +445,7 @@ class serializer
                     // preserve output order, then write the run directly
                     if (bytes != 0)
                     {
-                        put_chars(string_buffer.data(), bytes);
+                        put_buffer(string_buffer, bytes);
                         bytes = 0;
                     }
                     put_chars(s.data() + i, run);
@@ -547,7 +547,7 @@ class serializer
                     // written ("\uxxxx\uxxxx\0") for one code point
                     if (string_buffer.size() - bytes < 13)
                     {
-                        put_chars(string_buffer.data(), bytes);
+                        put_buffer(string_buffer, bytes);
                         bytes = 0;
                     }
 
@@ -606,7 +606,7 @@ class serializer
                                 // written ("\uxxxx\uxxxx\0") for one code point
                                 if (string_buffer.size() - bytes < 13)
                                 {
-                                    put_chars(string_buffer.data(), bytes);
+                                    put_buffer(string_buffer, bytes);
                                     bytes = 0;
                                 }
 
@@ -645,7 +645,7 @@ class serializer
             // write buffer
             if (bytes > 0)
             {
-                put_chars(string_buffer.data(), bytes);
+                put_buffer(string_buffer, bytes);
             }
         }
         else
@@ -661,22 +661,22 @@ class serializer
                 case error_handler_t::ignore:
                 {
                     // write all accepted bytes
-                    put_chars(string_buffer.data(), bytes_after_last_accept);
+                    put_buffer(string_buffer, bytes_after_last_accept);
                     break;
                 }
 
                 case error_handler_t::replace:
                 {
                     // write all accepted bytes
-                    put_chars(string_buffer.data(), bytes_after_last_accept);
+                    put_buffer(string_buffer, bytes_after_last_accept);
                     // add a replacement character
                     if (ensure_ascii)
                     {
-                        put_chars("\\ufffd", 6);
+                        put_literal("\\ufffd");
                     }
                     else
                     {
-                        put_chars("\xEF\xBF\xBD", 3);
+                        put_literal("\xEF\xBF\xBD");
                     }
                     break;
                 }
@@ -712,6 +712,66 @@ class serializer
     adapter (after flushing what is pending), so large string/number payloads
     are not copied an extra time.
     */
+    /*!
+    @brief append @a indent indentation characters to the write buffer
+
+    Writes the indentation straight into the buffer instead of copying it out of
+    a pre-grown indentation string, so no auxiliary string has to be sized,
+    resized, or kept in sync with the deepest nesting level reached. An
+    indentation wider than the buffer simply fills and flushes it repeatedly.
+    */
+    void put_indent(unsigned int indent)
+    {
+        while (indent > 0)
+        {
+            if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
+            {
+                flush();
+            }
+
+            const std::size_t chunk = (std::min)(static_cast<std::size_t>(indent),
+                                                 write_buffer.size() - write_buffer_pos);
+            std::memset(write_buffer.data() + write_buffer_pos, indent_char, chunk);
+            write_buffer_pos += chunk;
+            indent -= static_cast<unsigned int>(chunk);
+        }
+    }
+
+    /*!
+    @brief append a string literal to the write buffer
+
+    The length comes from the array bound rather than a hand-written count, so
+    it cannot drift out of sync with the literal. A literal always fits into the
+    buffer (checked at compile time), so unlike @ref put_chars this needs no
+    write-through path for oversized runs.
+    */
+    template<std::size_t N>
+    void put_literal(const char (&s)[N])
+    {
+        static_assert(N >= 2, "put_literal expects a non-empty string literal");
+        static_assert(N - 1 < write_buffer_size, "string literal must fit into the write buffer");
+
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + (N - 1) > write_buffer.size()))
+        {
+            flush();
+        }
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, N - 1);
+        write_buffer_pos += N - 1;
+    }
+
+    /*!
+    @brief append the first @a length characters of a fixed-size buffer
+
+    Same as @ref put_chars, but the buffer carries its own bound, so the length
+    can be checked against it - which a bare pointer plus count cannot do.
+    */
+    template<std::size_t N>
+    void put_buffer(const std::array<char, N>& buffer, std::size_t length)
+    {
+        JSON_ASSERT(length <= N);
+        put_chars(buffer.data(), length);
+    }
+
     JSON_HEDLEY_NON_NULL(2)
     void put_chars(const char* s, std::size_t length)
     {
@@ -924,7 +984,7 @@ class serializer
             *(--buffer_ptr) = static_cast<char>('0' + abs_value);
         }
 
-        put_chars(number_buffer.data(), n_chars);
+        put_buffer(number_buffer, n_chars);
     }
 
     /*!
@@ -940,7 +1000,7 @@ class serializer
         // NaN / inf
         if (!std::isfinite(x))
         {
-            put_chars("null", 4);
+            put_literal("null");
             return;
         }
 
@@ -1012,7 +1072,7 @@ class serializer
             }
         }
 
-        put_chars(number_buffer.data(), static_cast<std::size_t>(len));
+        put_buffer(number_buffer, static_cast<std::size_t>(len));
 
         // determine if we need to append ".0"
         const bool value_is_int_like =
@@ -1024,7 +1084,7 @@ class serializer
 
         if (value_is_int_like)
         {
-            put_chars(".0", 2);
+            put_literal(".0");
         }
     }
 
@@ -1129,15 +1189,14 @@ class serializer
 
     /// the indentation character
     const char indent_char;
-    /// the indentation string
-    string_t indent_string;
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
 
     /// buffer collecting output before it is flushed to the output adapter, so
     /// that the many small structural writes become few bulk writes
-    std::array<char, 1024> write_buffer{{}};
+    static constexpr std::size_t write_buffer_size = 1024;
+    std::array<char, write_buffer_size> write_buffer{{}};
     /// number of valid bytes currently held in @ref write_buffer
     std::size_t write_buffer_pos = 0;
 };

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -23,6 +23,7 @@
 
 #include <nlohmann/detail/conversions/to_chars.hpp>
 #include <nlohmann/detail/exceptions.hpp>
+#include <nlohmann/detail/input/string_scan.hpp>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/detail/meta/cpp_future.hpp>
 #include <nlohmann/detail/output/binary_writer.hpp>
@@ -399,6 +400,38 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
+            // Fast path: when not escaping non-ASCII characters and sitting on a
+            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
+            // run of bytes that need no escaping. string_bulk_run() (shared with
+            // the lexer's contiguous scanner) stops exactly at the first byte
+            // that dump_escaped would handle individually - a quote, a backslash,
+            // a control character (< 0x20), or an ill-formed/truncated UTF-8
+            // sequence - so that byte is left to the byte-at-a-time path below,
+            // keeping error handling and diagnostics unchanged.
+            if (!ensure_ascii && state == UTF8_ACCEPT)
+            {
+                const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
+                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                if (run != 0)
+                {
+                    // emit any bytes still pending in string_buffer first to
+                    // preserve output order, then write the run directly
+                    if (bytes != 0)
+                    {
+                        o->write_characters(string_buffer.data(), bytes);
+                        bytes = 0;
+                    }
+                    o->write_characters(s.data() + i, run);
+                    bytes_after_last_accept = 0;
+                    undumped_chars = 0;
+                    i += run;
+                    if (i >= s.size())
+                    {
+                        break;
+                    }
+                }
+            }
+
             const auto byte = static_cast<std::uint8_t>(s[i]);
 
             switch (decode(state, codepoint, byte))

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -785,20 +785,6 @@ class serializer
 
     @complexity Linear in the length of string @a s.
     */
-    /*!
-    @brief dump escaped string
-
-    Escape a string by replacing certain special characters by a sequence of an
-    escape character (backslash) and another character and other control
-    characters by a sequence of "\u" followed by a four-digit hex
-    representation. The escaped string is written to output stream @a o.
-
-    @param[in] s  the string to escape
-    @param[in] ensure_ascii  whether to escape non-ASCII characters with
-                             \uXXXX sequences
-
-    @complexity Linear in the length of string @a s.
-    */
     void dump_escaped(const string_t& s, const bool ensure_ascii)
     {
         // dispatch once here rather than test the flag inside the loop: it does
@@ -814,6 +800,12 @@ class serializer
         }
     }
 
+    /*!
+    @brief worker for @ref dump_escaped
+
+    @a ensure_ascii is a template parameter here so that the branch on it is
+    resolved once, outside the loop; see @ref dump_escaped.
+    */
     template<bool EnsureAscii>
     void dump_escaped_impl(const string_t& s)
     {
@@ -1181,7 +1173,7 @@ class serializer
 
     The length comes from the array bound rather than a hand-written count, so
     it cannot drift out of sync with the literal. A literal always fits into the
-    buffer (checked at compile time), so unlike @ref put_chars this needs no
+    buffer (checked at compile time), so unlike @ref put_string this needs no
     write-through path for oversized runs.
     */
     template<std::size_t N>
@@ -1203,43 +1195,21 @@ class serializer
     /*!
     @brief append the characters of @a str in [@a start, @a end)
 
-    Keeps the pointer arithmetic and the bounds checking inside the function
-    rather than at the call site, which is all @ref put_chars could offer.
+    The only way to append a run of characters: @a str carries its own bound,
+    so the range can be checked against it, which a bare pointer plus a count
+    could not do. Runs that do not fit the buffer are written straight through
+    the output adapter (after flushing what is pending), so large string and
+    number payloads are not copied an extra time.
     */
     template<typename StringType>
     void put_string(const StringType& str, std::size_t start, std::size_t end)
     {
         JSON_ASSERT(start <= end);
         JSON_ASSERT(end <= str.size());
-        put_chars(str.data() + start, end - start);
-    }
 
-    /*!
-    @brief append the first @a length characters of a fixed-size buffer
+        const char* const s = str.data() + start;
+        const std::size_t length = end - start;
 
-    Same as @ref put_chars, but the buffer carries its own bound, so the length
-    can be checked against it - which a bare pointer plus count cannot do.
-    */
-    template<std::size_t N>
-    void put_buffer(const std::array<char, N>& buffer, std::size_t length)
-    {
-        JSON_ASSERT(length <= N);
-        put_chars(buffer.data(), length);
-    }
-
-    /*!
-    @brief append @a length characters to the write buffer
-
-    Runs that do not fit the buffer are written straight through the output
-    adapter (after flushing what is pending), so large string/number payloads
-    are not copied an extra time.
-
-    The callers all reach this through @ref put_literal, @ref put_buffer or
-    @ref put_string, which each derive the length from something that knows it.
-    */
-    JSON_HEDLEY_NON_NULL(2)
-    void put_chars(const char* s, std::size_t length)
-    {
         if (JSON_HEDLEY_UNLIKELY(length >= write_buffer.size()))
         {
             flush();
@@ -1252,6 +1222,15 @@ class serializer
         }
         std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
         write_buffer_pos += length;
+    }
+
+    /*!
+    @brief append the first @a length characters of a fixed-size buffer
+    */
+    template<std::size_t N>
+    void put_buffer(const std::array<char, N>& buffer, std::size_t length)
+    {
+        put_string(buffer, 0, length);
     }
 
   JSON_PRIVATE_UNLESS_TESTED:
@@ -1394,6 +1373,11 @@ class serializer
         }
 
         const auto byte = static_cast<unsigned>(value);
+        // Accumulate the offset in a local and store it back once. Writing
+        // through write_buffer[] is a char write, which may alias any object,
+        // so with the member updated in place the compiler has to reload and
+        // store it around every digit - measured 2.4x slower on a dump of a
+        // multi-megabyte binary value.
         std::size_t pos = write_buffer_pos;
 
         if (byte >= 100)

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -717,24 +717,52 @@ class serializer
 
     Writes the indentation straight into the buffer instead of copying it out of
     a pre-grown indentation string, so no auxiliary string has to be sized,
-    resized, or kept in sync with the deepest nesting level reached. An
-    indentation wider than the buffer simply fills and flushes it repeatedly.
+    resized, or kept in sync with the deepest nesting level reached.
+
+    An indentation wider than the buffer is emitted by filling the buffer with
+    the indentation character once and flushing that same content repeatedly:
+    flushing does not disturb what the buffer holds, so re-filling it between
+    flushes would be redundant work.
     */
     void put_indent(unsigned int indent)
     {
-        while (indent > 0)
+        // closing braces at the outermost level ask for no indentation at all
+        if (indent == 0)
         {
-            if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
-            {
-                flush();
-            }
-
-            const std::size_t chunk = (std::min)(static_cast<std::size_t>(indent),
-                                                 write_buffer.size() - write_buffer_pos);
-            std::memset(write_buffer.data() + write_buffer_pos, indent_char, chunk);
-            write_buffer_pos += chunk;
-            indent -= static_cast<unsigned int>(chunk);
+            return;
         }
+
+        const std::size_t capacity = write_buffer.size();
+
+        // fill whatever room is left in the buffer; this is the whole job
+        // whenever the indentation is narrower than the buffer, which is the
+        // case for every sane indent_step
+        const std::size_t head = (std::min)(static_cast<std::size_t>(indent), capacity - write_buffer_pos);
+        std::memset(write_buffer.data() + write_buffer_pos, indent_char, head);
+        write_buffer_pos += head;
+        indent -= static_cast<unsigned int>(head);
+
+        if (JSON_HEDLEY_LIKELY(indent == 0))
+        {
+            return;
+        }
+
+        // the buffer is full and the remainder spans whole buffer-fulls: flush
+        // what is pending, then fill the buffer with the indentation character
+        // exactly once and hand the same bytes to the adapter as often as needed
+        flush();
+        std::memset(write_buffer.data(), indent_char, capacity);
+
+        while (indent >= capacity)
+        {
+            write_buffer_pos = capacity;
+            flush();
+            indent -= static_cast<unsigned int>(capacity);
+        }
+
+        // the buffer still holds indentation characters throughout, so the tail
+        // only has to be claimed, not written again
+        write_buffer_pos = indent;
     }
 
     /*!

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -21,6 +21,7 @@
 #include <string> // string, char_traits
 #include <type_traits> // is_same
 #include <utility> // move
+#include <vector> // vector
 
 #include <nlohmann/detail/conversions/to_chars.hpp>
 #include <nlohmann/detail/exceptions.hpp>
@@ -87,8 +88,8 @@ class serializer
 
     This function is called by the public member function dump and organizes
     the serialization internally. The indentation level is propagated as
-    additional parameter. In case of arrays and objects, the function is
-    called recursively.
+    additional parameter. Arrays and objects are serialized without recursion,
+    however deeply they are nested.
 
     - strings and object keys are escaped using `escape_string()`
     - integer numbers are converted implicitly via `operator<<`
@@ -116,23 +117,39 @@ class serializer
 
   JSON_PRIVATE_UNLESS_TESTED:
     /*!
-    @brief recursive worker for @ref dump
+    @brief worker for @ref dump
 
     Identical in behavior to the historical @ref dump, but writes into the
     serializer's internal @ref write_buffer instead of issuing a virtual call
     per token. The public @ref dump wraps this and flushes the buffer once the
     top-level value has been serialized.
+
+    Serializing a container descends into its elements, so a value nested deeply
+    enough used to exhaust the call stack and terminate the process with no
+    exception to catch. The descent is bounded here: once @ref dump_depth_limit
+    levels have been entered, @ref dump_iteratively writes out what is left
+    without the call stack. A value nested less deeply than that - all but a
+    vanishing minority - is written by exactly the code that always wrote it.
+
+    @sa https://github.com/nlohmann/json/issues/5387
     */
     void dump_internal(const BasicJsonType& val,
                        const bool pretty_print,
                        const bool ensure_ascii,
                        const std::size_t indent_step,
-                       const std::size_t current_indent = 0)
+                       const std::size_t current_indent = 0,
+                       const std::size_t depth = 0)
     {
         switch (val.m_data.m_type)
         {
             case value_t::object:
             {
+                if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
+                {
+                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    return;
+                }
+
                 if (val.m_data.m_value.object->empty())
                 {
                     put_literal("{}");
@@ -154,7 +171,7 @@ class serializer
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\": ");
-                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
@@ -165,7 +182,7 @@ class serializer
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\": ");
-                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -182,7 +199,7 @@ class serializer
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\":");
-                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
                         put_char(',');
                     }
 
@@ -192,7 +209,7 @@ class serializer
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\":");
-                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
 
                     put_char('}');
                 }
@@ -202,6 +219,12 @@ class serializer
 
             case value_t::array:
             {
+                if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
+                {
+                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    return;
+                }
+
                 if (val.m_data.m_value.array->empty())
                 {
                     put_literal("[]");
@@ -220,14 +243,14 @@ class serializer
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
                         put_indent(new_indent);
-                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
+                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
                     put_indent(new_indent);
-                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -241,13 +264,13 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent);
+                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent, depth + 1);
                         put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent, depth + 1);
 
                     put_char(']');
                 }
@@ -379,6 +402,358 @@ class serializer
                 JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
         }
     }
+
+  private:
+    /// the number of levels @ref dump_internal descends into before it hands
+    /// over to @ref dump_iteratively
+    static constexpr std::size_t dump_depth_limit()
+    {
+        return 128;
+    }
+
+    /*!
+    @brief write out @a val and everything below it without the call stack
+
+    Emits the same bytes as @ref dump_internal, keeping the containers it has
+    entered on an explicit stack instead of descending into them. Only reached
+    for values nested deeper than @ref dump_depth_limit, which is why it is not
+    written for speed: walking every value this way measured up to 20% slower on
+    object-heavy documents than letting the compiler drive the descent.
+    */
+    void dump_iteratively(const BasicJsonType& val,
+                          const bool pretty_print,
+                          const bool ensure_ascii,
+                          const std::size_t indent_step,
+                          const std::size_t current_indent = 0)
+    {
+        // Scalars, empty containers and binary values are written by dump_value
+        // alone, so nothing is allocated for them: only a container with
+        // elements is ever pushed.
+        std::vector<dump_frame> stack;
+
+        dump_value(val, pretty_print, ensure_ascii, indent_step, current_indent, stack);
+
+        while (!stack.empty())
+        {
+            dump_frame& frame = stack.back();
+
+            if (frame.value->m_data.m_type == value_t::object)
+            {
+                const auto* object = frame.value->m_data.m_value.object;
+
+                if (frame.object_it == object->cend())
+                {
+                    if (pretty_print)
+                    {
+                        put_char('\n');
+                        put_indent(frame.current_indent);
+                    }
+
+                    put_char('}');
+                    stack.pop_back();
+                    continue;
+                }
+
+                // the separator goes in front of every element but the first,
+                // which puts exactly one between each pair and none at the end
+                if (frame.object_it != object->cbegin())
+                {
+                    if (pretty_print)
+                    {
+                        put_literal(",\n");
+                    }
+                    else
+                    {
+                        put_char(',');
+                    }
+                }
+
+                if (pretty_print)
+                {
+                    put_indent(frame.child_indent);
+                }
+
+                put_char('\"');
+                dump_escaped(frame.object_it->first, ensure_ascii);
+
+                if (pretty_print)
+                {
+                    put_literal("\": ");
+                }
+                else
+                {
+                    put_literal("\":");
+                }
+
+                const BasicJsonType& element = frame.object_it->second;
+                ++frame.object_it;
+
+                // read everything needed from the frame before this: entering a
+                // container pushes another one and can move them all
+                const std::size_t element_indent = frame.child_indent;
+                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+            }
+            else
+            {
+                const auto* array = frame.value->m_data.m_value.array;
+
+                if (frame.array_it == array->cend())
+                {
+                    if (pretty_print)
+                    {
+                        put_char('\n');
+                        put_indent(frame.current_indent);
+                    }
+
+                    put_char(']');
+                    stack.pop_back();
+                    continue;
+                }
+
+                if (frame.array_it != array->cbegin())
+                {
+                    if (pretty_print)
+                    {
+                        put_literal(",\n");
+                    }
+                    else
+                    {
+                        put_char(',');
+                    }
+                }
+
+                if (pretty_print)
+                {
+                    put_indent(frame.child_indent);
+                }
+
+                const BasicJsonType& element = *frame.array_it;
+                ++frame.array_it;
+
+                // see above
+                const std::size_t element_indent = frame.child_indent;
+                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+            }
+        }
+    }
+
+  private:
+    /// @brief a container that has been opened but not closed yet
+    struct dump_frame
+    {
+        dump_frame(const BasicJsonType* value_, const std::size_t current_indent_,
+                   const std::size_t child_indent_) noexcept
+            : value(value_)
+            , current_indent(current_indent_)
+            , child_indent(child_indent_)
+        {}
+
+        /// the object or array being serialized
+        const BasicJsonType* value;
+        /// the element to serialize next; which of the two is live follows from
+        /// the type of @a value. They are kept side by side rather than in a
+        /// union, which would need its special members written out by hand, see
+        /// detail/iterators/internal_iterator.hpp
+        typename BasicJsonType::object_t::const_iterator object_it{};
+        typename BasicJsonType::array_t::const_iterator array_it{};
+        /// the indentation of the container itself, used by its closing bracket
+        std::size_t current_indent;
+        /// the indentation of the container's elements
+        std::size_t child_indent;
+    };
+
+    /*!
+    @brief serialize the value @a val, but not the elements of a container
+
+    An object or array with elements is opened and pushed onto @a stack for
+    @ref dump_internal to walk; everything else - including a binary value,
+    which looks like an object but has no elements to descend into - is written
+    out here in full.
+    */
+    void dump_value(const BasicJsonType& val,
+                    const bool pretty_print,
+                    const bool ensure_ascii,
+                    const std::size_t indent_step,
+                    const std::size_t current_indent,
+                    std::vector<dump_frame>& stack)
+    {
+        switch (val.m_data.m_type)
+        {
+            case value_t::object:
+            {
+                if (val.m_data.m_value.object->empty())
+                {
+                    put_literal("{}");
+                    return;
+                }
+
+                std::size_t child_indent = current_indent;
+
+                if (pretty_print)
+                {
+                    put_literal("{\n");
+                    child_indent = next_indent(current_indent, indent_step);
+                }
+                else
+                {
+                    put_char('{');
+                }
+
+                stack.emplace_back(&val, current_indent, child_indent);
+                stack.back().object_it = val.m_data.m_value.object->cbegin();
+                return;
+            }
+
+            case value_t::array:
+            {
+                if (val.m_data.m_value.array->empty())
+                {
+                    put_literal("[]");
+                    return;
+                }
+
+                std::size_t child_indent = current_indent;
+
+                if (pretty_print)
+                {
+                    put_literal("[\n");
+                    child_indent = next_indent(current_indent, indent_step);
+                }
+                else
+                {
+                    put_char('[');
+                }
+
+                stack.emplace_back(&val, current_indent, child_indent);
+                stack.back().array_it = val.m_data.m_value.array->cbegin();
+                return;
+            }
+
+            case value_t::string:
+            {
+                put_char('\"');
+                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                put_char('\"');
+                return;
+            }
+
+            case value_t::binary:
+            {
+                if (pretty_print)
+                {
+                    put_literal("{\n");
+
+                    // variable to hold indentation for the bytes
+                    const auto new_indent = next_indent(current_indent, indent_step);
+
+                    put_indent(new_indent);
+
+                    put_literal("\"bytes\": [");
+
+                    if (!val.m_data.m_value.binary->empty())
+                    {
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
+                        {
+                            dump_integer(*i);
+                            put_literal(", ");
+                        }
+                        dump_integer(val.m_data.m_value.binary->back());
+                    }
+
+                    put_literal("],\n");
+                    put_indent(new_indent);
+
+                    put_literal("\"subtype\": ");
+                    if (val.m_data.m_value.binary->has_subtype())
+                    {
+                        dump_integer(val.m_data.m_value.binary->subtype());
+                    }
+                    else
+                    {
+                        put_literal("null");
+                    }
+                    put_char('\n');
+                    put_indent(current_indent);
+                    put_char('}');
+                }
+                else
+                {
+                    put_literal("{\"bytes\":[");
+
+                    if (!val.m_data.m_value.binary->empty())
+                    {
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
+                        {
+                            dump_integer(*i);
+                            put_char(',');
+                        }
+                        dump_integer(val.m_data.m_value.binary->back());
+                    }
+
+                    put_literal("],\"subtype\":");
+                    if (val.m_data.m_value.binary->has_subtype())
+                    {
+                        dump_integer(val.m_data.m_value.binary->subtype());
+                        put_char('}');
+                    }
+                    else
+                    {
+                        put_literal("null}");
+                    }
+                }
+                return;
+            }
+
+            case value_t::boolean:
+            {
+                if (val.m_data.m_value.boolean)
+                {
+                    put_literal("true");
+                }
+                else
+                {
+                    put_literal("false");
+                }
+                return;
+            }
+
+            case value_t::number_integer:
+            {
+                dump_integer(val.m_data.m_value.number_integer);
+                return;
+            }
+
+            case value_t::number_unsigned:
+            {
+                dump_integer(val.m_data.m_value.number_unsigned);
+                return;
+            }
+
+            case value_t::number_float:
+            {
+                dump_float(val.m_data.m_value.number_float);
+                return;
+            }
+
+            case value_t::discarded:
+            {
+                put_literal("<discarded>");
+                return;
+            }
+
+            case value_t::null:
+            {
+                put_literal("null");
+                return;
+            }
+
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+    }
+
 
     /*!
     @brief the indentation level to use for the children of the current value

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -304,10 +304,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_literal(", ");
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\n");
@@ -335,10 +335,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_char(',');
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\"subtype\":");
@@ -655,10 +655,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_literal(", ");
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\n");
@@ -686,10 +686,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_char(',');
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\"subtype\":");
@@ -785,7 +785,37 @@ class serializer
 
     @complexity Linear in the length of string @a s.
     */
+    /*!
+    @brief dump escaped string
+
+    Escape a string by replacing certain special characters by a sequence of an
+    escape character (backslash) and another character and other control
+    characters by a sequence of "\u" followed by a four-digit hex
+    representation. The escaped string is written to output stream @a o.
+
+    @param[in] s  the string to escape
+    @param[in] ensure_ascii  whether to escape non-ASCII characters with
+                             \uXXXX sequences
+
+    @complexity Linear in the length of string @a s.
+    */
     void dump_escaped(const string_t& s, const bool ensure_ascii)
+    {
+        // dispatch once here rather than test the flag inside the loop: it does
+        // not change while a string is written, and folding it lets each of the
+        // two scanners be inlined into a loop of its own
+        if (ensure_ascii)
+        {
+            dump_escaped_impl<true>(s);
+        }
+        else
+        {
+            dump_escaped_impl<false>(s);
+        }
+    }
+
+    template<bool EnsureAscii>
+    void dump_escaped_impl(const string_t& s)
     {
         std::uint32_t codepoint{};
         std::uint8_t state = UTF8_ACCEPT;
@@ -804,16 +834,16 @@ class serializer
             // individually, so that byte is left to the byte-at-a-time path
             // below, keeping escaping output and error diagnostics unchanged.
             //
-            // - ensure_ascii == false: string_bulk_run() copies ordinary bytes
+            // - EnsureAscii == false: string_bulk_run() copies ordinary bytes
             //   and complete well-formed UTF-8, stopping at a quote, backslash,
             //   control character (< 0x20), or ill-formed/truncated sequence.
-            // - ensure_ascii == true: only printable ASCII may be copied
+            // - EnsureAscii == true: only printable ASCII may be copied
             //   verbatim; find_ascii_copyable_run() additionally stops at 0x7F
             //   and every non-ASCII byte (>= 0x80), which must be \u-escaped.
             if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = ensure_ascii
+                const std::size_t run = EnsureAscii
                                         ? find_ascii_copyable_run(data + i, s.size() - i)
                                         : string_bulk_run(data + i, s.size() - i);
                 if (run != 0)
@@ -896,8 +926,8 @@ class serializer
                         default:
                         {
                             // escape control characters (0x00..0x1F) or, if
-                            // ensure_ascii parameter is used, non-ASCII characters
-                            if ((codepoint <= 0x1F) || (ensure_ascii && (codepoint >= 0x7F)))
+                            // EnsureAscii parameter is used, non-ASCII characters
+                            if ((codepoint <= 0x1F) || (EnsureAscii && (codepoint >= 0x7F)))
                             {
                                 if (codepoint <= 0xFFFF)
                                 {
@@ -962,7 +992,7 @@ class serializer
                             if (error_handler == error_handler_t::replace)
                             {
                                 // add a replacement character
-                                if (ensure_ascii)
+                                if (EnsureAscii)
                                 {
                                     string_buffer[bytes++] = '\\';
                                     string_buffer[bytes++] = 'u';
@@ -1005,7 +1035,7 @@ class serializer
 
                 default:  // decode found yet incomplete multibyte code point
                 {
-                    if (!ensure_ascii)
+                    if (!EnsureAscii)
                     {
                         // code point will not be escaped - copy byte to buffer
                         string_buffer[bytes++] = s[i];
@@ -1047,7 +1077,7 @@ class serializer
                     // write all accepted bytes
                     put_buffer(string_buffer, bytes_after_last_accept);
                     // add a replacement character
-                    if (ensure_ascii)
+                    if (EnsureAscii)
                     {
                         put_literal("\\ufffd");
                     }
@@ -1317,6 +1347,57 @@ class serializer
     bool is_negative_number(NumberType /*unused*/)
     {
         return false;
+    }
+
+    /*!
+    @brief write the decimal representation of the byte @a value
+
+    A binary value's bytes are always in [0, 255], so writing one needs neither
+    the digit counting nor the 64-bit arithmetic that @ref dump_integer does for
+    an arbitrary number, and the three digits it takes at most are written
+    straight into the write buffer.
+
+    Any byte type that is not a plain unsigned byte is left to @ref dump_integer,
+    whose representation of it may differ.
+    */
+    template<typename ByteType>
+    void dump_byte(const ByteType value)
+    {
+        dump_byte(value, std::integral_constant < bool,
+                  std::is_unsigned<ByteType>::value && sizeof(ByteType) == 1
+                  && !std::is_same<ByteType, bool>::value > {});
+    }
+
+    template<typename ByteType>
+    void dump_byte(const ByteType value, std::false_type /*is_plain_byte*/)
+    {
+        dump_integer(value);
+    }
+
+    template<typename ByteType>
+    void dump_byte(const ByteType value, std::true_type /*is_plain_byte*/)
+    {
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + 3 > write_buffer.size()))
+        {
+            flush();
+        }
+
+        const auto byte = static_cast<unsigned>(value);
+        char* out = write_buffer.data() + write_buffer_pos;
+
+        if (byte >= 100)
+        {
+            *out++ = static_cast<char>('0' + (byte / 100));
+            *out++ = static_cast<char>('0' + ((byte / 10) % 10));
+        }
+        else if (byte >= 10)
+        {
+            *out++ = static_cast<char>('0' + (byte / 10));
+        }
+
+        *out++ = static_cast<char>('0' + (byte % 10));
+
+        write_buffer_pos = static_cast<std::size_t>(out - write_buffer.data());
     }
 
     /*!

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -82,15 +82,18 @@ class serializer
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
         : o(std::move(s))
-        , loc(std::localeconv())
-        , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
-        , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
         , pretty_print(pretty_print_)
         , ensure_ascii(ensure_ascii_)
         , indent_step(indent_step_)
         , error_handler(error_handler_)
-    {}
+    {
+        // only used here to seed thousands_sep/decimal_point, so a local
+        // suffices and the serializer does not need to hold onto it
+        const auto* loc = std::localeconv();
+        thousands_sep = loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep));
+        decimal_point = loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point));
+    }
 
     // deleted because of pointer members
     serializer(const serializer&) = delete;
@@ -1674,12 +1677,10 @@ class serializer
     /// a (hopefully) large enough character buffer
     std::array<char, 64> number_buffer{{}};
 
-    /// the locale
-    const std::lconv* loc = nullptr;
     /// the locale's thousand separator character
-    const char thousands_sep = '\0';
+    char thousands_sep = '\0';
     /// the locale's decimal point character
-    const char decimal_point = '\0';
+    char decimal_point = '\0';
 
     /// string buffer
     std::array<char, 512> string_buffer{{}};

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -168,7 +168,7 @@ class serializer
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         put_indent(new_indent);
-                        put_char('\"');
+                        put_char('"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\": ");
                         dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
@@ -179,7 +179,7 @@ class serializer
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_indent(new_indent);
-                    put_char('\"');
+                    put_char('"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\": ");
                     dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
@@ -196,7 +196,7 @@ class serializer
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        put_char('\"');
+                        put_char('"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\":");
                         dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
@@ -206,7 +206,7 @@ class serializer
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    put_char('\"');
+                    put_char('"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\":");
                     dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
@@ -280,9 +280,9 @@ class serializer
 
             case value_t::string:
             {
-                put_char('\"');
+                put_char('"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                put_char('\"');
+                put_char('"');
                 return;
             }
 
@@ -473,7 +473,7 @@ class serializer
                     put_indent(frame.child_indent);
                 }
 
-                put_char('\"');
+                put_char('"');
                 dump_escaped(frame.object_it->first, ensure_ascii);
 
                 if (pretty_print)
@@ -631,9 +631,9 @@ class serializer
 
             case value_t::string:
             {
-                put_char('\"');
+                put_char('"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                put_char('\"');
+                put_char('"');
                 return;
             }
 
@@ -915,7 +915,7 @@ class serializer
                         case 0x22: // quotation mark
                         {
                             string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = '\"';
+                            string_buffer[bytes++] = '"';
                             break;
                         }
 

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -16,6 +16,7 @@
 #include <cstddef> // size_t, ptrdiff_t
 #include <cstdint> // uint8_t
 #include <cstdio> // snprintf
+#include <cstring> // memcpy
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
 #include <type_traits> // is_same
@@ -110,19 +111,38 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
+        dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
+        flush();
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief recursive worker for @ref dump
+
+    Identical in behavior to the historical @ref dump, but writes into the
+    serializer's internal @ref write_buffer instead of issuing a virtual call
+    per token. The public @ref dump wraps this and flushes the buffer once the
+    top-level value has been serialized.
+    */
+    void dump_internal(const BasicJsonType& val,
+                       const bool pretty_print,
+                       const bool ensure_ascii,
+                       const unsigned int indent_step,
+                       const unsigned int current_indent = 0)
+    {
         switch (val.m_data.m_type)
         {
             case value_t::object:
             {
                 if (val.m_data.m_value.object->empty())
                 {
-                    o->write_characters("{}", 2);
+                    put_chars("{}", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -135,51 +155,51 @@ class serializer
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        o->write_character('\"');
+                        put_chars(indent_string.c_str(), new_indent);
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars("\": ", 3);
+                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    o->write_character('\"');
+                    put_chars(indent_string.c_str(), new_indent);
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                    put_chars("\": ", 3);
+                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_character('{');
+                    put_char('{');
 
                     // first n-1 elements
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_character('\"');
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\":", 2);
-                        dump(i->second, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        put_chars("\":", 2);
+                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_character('\"');
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\":", 2);
-                    dump(i->second, false, ensure_ascii, indent_step, current_indent);
+                    put_chars("\":", 2);
+                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character('}');
+                    put_char('}');
                 }
 
                 return;
@@ -189,13 +209,13 @@ class serializer
             {
                 if (val.m_data.m_value.array->empty())
                 {
-                    o->write_characters("[]", 2);
+                    put_chars("[]", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("[\n", 2);
+                    put_chars("[\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -208,37 +228,37 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars(indent_string.c_str(), new_indent);
+                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
+                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character(']');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char(']');
                 }
                 else
                 {
-                    o->write_character('[');
+                    put_char('[');
 
                     // first n-1 elements
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump(*i, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character(']');
+                    put_char(']');
                 }
 
                 return;
@@ -246,9 +266,9 @@ class serializer
 
             case value_t::string:
             {
-                o->write_character('\"');
+                put_char('\"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                o->write_character('\"');
+                put_char('\"');
                 return;
             }
 
@@ -256,7 +276,7 @@ class serializer
             {
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -265,9 +285,9 @@ class serializer
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
 
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"bytes\": [", 10);
+                    put_chars("\"bytes\": [", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -275,30 +295,30 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_characters(", ", 2);
+                            put_chars(", ", 2);
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\n", 3);
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars("],\n", 3);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"subtype\": ", 11);
+                    put_chars("\"subtype\": ", 11);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
-                        o->write_characters("null", 4);
+                        put_chars("null", 4);
                     }
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_characters("{\"bytes\":[", 10);
+                    put_chars("{\"bytes\":[", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -306,20 +326,20 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_character(',');
+                            put_char(',');
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\"subtype\":", 12);
+                    put_chars("],\"subtype\":", 12);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
-                        o->write_character('}');
+                        put_char('}');
                     }
                     else
                     {
-                        o->write_characters("null}", 5);
+                        put_chars("null}", 5);
                     }
                 }
                 return;
@@ -329,11 +349,11 @@ class serializer
             {
                 if (val.m_data.m_value.boolean)
                 {
-                    o->write_characters("true", 4);
+                    put_chars("true", 4);
                 }
                 else
                 {
-                    o->write_characters("false", 5);
+                    put_chars("false", 5);
                 }
                 return;
             }
@@ -358,13 +378,13 @@ class serializer
 
             case value_t::discarded:
             {
-                o->write_characters("<discarded>", 11);
+                put_chars("<discarded>", 11);
                 return;
             }
 
             case value_t::null:
             {
-                o->write_characters("null", 4);
+                put_chars("null", 4);
                 return;
             }
 
@@ -400,28 +420,35 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
-            // Fast path: when not escaping non-ASCII characters and sitting on a
-            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
-            // run of bytes that need no escaping. string_bulk_run() (shared with
-            // the lexer's contiguous scanner) stops exactly at the first byte
-            // that dump_escaped would handle individually - a quote, a backslash,
-            // a control character (< 0x20), or an ill-formed/truncated UTF-8
-            // sequence - so that byte is left to the byte-at-a-time path below,
-            // keeping error handling and diagnostics unchanged.
-            if (!ensure_ascii && state == UTF8_ACCEPT)
+            // Fast path: at a character boundary (state == UTF8_ACCEPT),
+            // bulk-copy the longest run of bytes that need no escaping using a
+            // SWAR scanner shared with the lexer's contiguous path. The scanner
+            // stops exactly at the first byte dump_escaped would handle
+            // individually, so that byte is left to the byte-at-a-time path
+            // below, keeping escaping output and error diagnostics unchanged.
+            //
+            // - ensure_ascii == false: string_bulk_run() copies ordinary bytes
+            //   and complete well-formed UTF-8, stopping at a quote, backslash,
+            //   control character (< 0x20), or ill-formed/truncated sequence.
+            // - ensure_ascii == true: only printable ASCII may be copied
+            //   verbatim; find_ascii_copyable_run() additionally stops at 0x7F
+            //   and every non-ASCII byte (>= 0x80), which must be \u-escaped.
+            if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                const std::size_t run = ensure_ascii
+                                        ? find_ascii_copyable_run(data + i, s.size() - i)
+                                        : string_bulk_run(data + i, s.size() - i);
                 if (run != 0)
                 {
                     // emit any bytes still pending in string_buffer first to
                     // preserve output order, then write the run directly
                     if (bytes != 0)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
-                    o->write_characters(s.data() + i, run);
+                    put_chars(s.data() + i, run);
                     bytes_after_last_accept = 0;
                     undumped_chars = 0;
                     i += run;
@@ -520,7 +547,7 @@ class serializer
                     // written ("\uxxxx\uxxxx\0") for one code point
                     if (string_buffer.size() - bytes < 13)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
 
@@ -579,7 +606,7 @@ class serializer
                                 // written ("\uxxxx\uxxxx\0") for one code point
                                 if (string_buffer.size() - bytes < 13)
                                 {
-                                    o->write_characters(string_buffer.data(), bytes);
+                                    put_chars(string_buffer.data(), bytes);
                                     bytes = 0;
                                 }
 
@@ -618,7 +645,7 @@ class serializer
             // write buffer
             if (bytes > 0)
             {
-                o->write_characters(string_buffer.data(), bytes);
+                put_chars(string_buffer.data(), bytes);
             }
         }
         else
@@ -634,22 +661,22 @@ class serializer
                 case error_handler_t::ignore:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     break;
                 }
 
                 case error_handler_t::replace:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     // add a replacement character
                     if (ensure_ascii)
                     {
-                        o->write_characters("\\ufffd", 6);
+                        put_chars("\\ufffd", 6);
                     }
                     else
                     {
-                        o->write_characters("\xEF\xBF\xBD", 3);
+                        put_chars("\xEF\xBF\xBD", 3);
                     }
                     break;
                 }
@@ -661,6 +688,60 @@ class serializer
     }
 
   private:
+    /*!
+    @brief append a single character to the write buffer
+
+    Structural characters ('{', '"', ',', ...) previously went straight to the
+    output adapter, one virtual call each. Buffering them and flushing in bulk
+    turns those many indirect calls into a single memcpy plus an occasional
+    flush, which dominates the cost of serializing object/array-heavy values.
+    */
+    void put_char(char c)
+    {
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
+        {
+            flush();
+        }
+        write_buffer[write_buffer_pos++] = c;
+    }
+
+    /*!
+    @brief append @a length characters to the write buffer
+
+    Runs that do not fit the buffer are written straight through the output
+    adapter (after flushing what is pending), so large string/number payloads
+    are not copied an extra time.
+    */
+    JSON_HEDLEY_NON_NULL(2)
+    void put_chars(const char* s, std::size_t length)
+    {
+        if (JSON_HEDLEY_UNLIKELY(length >= write_buffer.size()))
+        {
+            flush();
+            o->write_characters(s, length);
+            return;
+        }
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + length > write_buffer.size()))
+        {
+            flush();
+        }
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
+        write_buffer_pos += length;
+    }
+
+    /*!
+    @brief flush the write buffer to the output adapter
+
+    Writing zero characters is a well-defined no-op for every output adapter, so
+    the buffered length is passed through unconditionally (no empty-guard branch
+    to leave uncovered).
+    */
+    void flush()
+    {
+        o->write_characters(write_buffer.data(), write_buffer_pos);
+        write_buffer_pos = 0;
+    }
+
     /*!
     @brief count digits
 
@@ -784,7 +865,7 @@ class serializer
         // special case for "0"
         if (x == 0)
         {
-            o->write_character('0');
+            put_char('0');
             return;
         }
 
@@ -837,7 +918,7 @@ class serializer
             *(--buffer_ptr) = static_cast<char>('0' + abs_value);
         }
 
-        o->write_characters(number_buffer.data(), n_chars);
+        put_chars(number_buffer.data(), n_chars);
     }
 
     /*!
@@ -853,7 +934,7 @@ class serializer
         // NaN / inf
         if (!std::isfinite(x))
         {
-            o->write_characters("null", 4);
+            put_chars("null", 4);
             return;
         }
 
@@ -874,7 +955,7 @@ class serializer
         auto* begin = number_buffer.data();
         auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
 
-        o->write_characters(begin, static_cast<size_t>(end - begin));
+        put_chars(begin, static_cast<size_t>(end - begin));
     }
 
     JSON_HEDLEY_NON_NULL(1)
@@ -925,7 +1006,7 @@ class serializer
             }
         }
 
-        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+        put_chars(number_buffer.data(), static_cast<std::size_t>(len));
 
         // determine if we need to append ".0"
         const bool value_is_int_like =
@@ -937,7 +1018,7 @@ class serializer
 
         if (value_is_int_like)
         {
-            o->write_characters(".0", 2);
+            put_chars(".0", 2);
         }
     }
 
@@ -1047,6 +1128,12 @@ class serializer
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
+
+    /// buffer collecting output before it is flushed to the output adapter, so
+    /// that the many small structural writes become few bulk writes
+    std::array<char, 1024> write_buffer{{}};
+    /// number of valid bytes currently held in @ref write_buffer
+    std::size_t write_buffer_pos = 0;
 };
 
 }  // namespace detail

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -82,18 +82,13 @@ class serializer
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
         : o(std::move(s))
+        , locale(std::localeconv())
         , indent_char(ichar)
         , pretty_print(pretty_print_)
         , ensure_ascii(ensure_ascii_)
         , indent_step(indent_step_)
         , error_handler(error_handler_)
-    {
-        // only used here to seed thousands_sep/decimal_point, so a local
-        // suffices and the serializer does not need to hold onto it
-        const auto* loc = std::localeconv();
-        thousands_sep = loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep));
-        decimal_point = loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point));
-    }
+    {}
 
     // deleted because of pointer members
     serializer(const serializer&) = delete;
@@ -1552,20 +1547,20 @@ class serializer
         JSON_ASSERT(static_cast<std::size_t>(len) < number_buffer.size());
 
         // erase thousands separators
-        if (thousands_sep != '\0')
+        if (locale.thousands_sep != '\0')
         {
             // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::remove returns an iterator, see https://github.com/nlohmann/json/issues/3081
-            const auto end = std::remove(number_buffer.begin(), number_buffer.begin() + len, thousands_sep);
+            const auto end = std::remove(number_buffer.begin(), number_buffer.begin() + len, locale.thousands_sep);
             std::fill(end, number_buffer.end(), '\0');
             JSON_ASSERT((end - number_buffer.begin()) <= len);
             len = (end - number_buffer.begin());
         }
 
         // convert decimal point to '.'
-        if (decimal_point != '\0' && decimal_point != '.')
+        if (locale.decimal_point != '\0' && locale.decimal_point != '.')
         {
             // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::find returns an iterator, see https://github.com/nlohmann/json/issues/3081
-            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), decimal_point);
+            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), locale.decimal_point);
             if (dec_pos != number_buffer.end())
             {
                 *dec_pos = '.';
@@ -1671,16 +1666,28 @@ class serializer
     }
 
   private:
+    /// the locale's thousand separator and decimal point characters
+    struct locale_chars
+    {
+        explicit locale_chars(const std::lconv* loc) noexcept
+            : thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
+            , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
+        {}
+
+        const char thousands_sep;
+        const char decimal_point;
+    };
+
     /// the output of the serializer
     output_adapter_t<char> o = nullptr;
 
     /// a (hopefully) large enough character buffer
     std::array<char, 64> number_buffer{{}};
 
-    /// the locale's thousand separator character
-    char thousands_sep = '\0';
-    /// the locale's decimal point character
-    char decimal_point = '\0';
+    /// computed once from std::localeconv() at construction; @ref
+    /// locale_chars keeps std::localeconv()'s pointer from having to be held
+    /// past the constructor, while still letting these stay const
+    const locale_chars locale;
 
     /// string buffer
     std::array<char, 512> string_buffer{{}};

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -769,7 +769,7 @@ class serializer
     write-through path for oversized runs.
     */
     template<std::size_t N>
-    void put_literal(const char (&s)[N])
+    void put_literal(const char (&s)[N]) // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
     {
         static_assert(N >= 2, "put_literal expects a non-empty string literal");
         // the array bound counts the terminating NUL, which is not written

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -729,12 +729,17 @@ class serializer
         write_buffer_pos += length;
     }
 
+  JSON_PRIVATE_UNLESS_TESTED:
     /*!
     @brief flush the write buffer to the output adapter
 
     Writing zero characters is a well-defined no-op for every output adapter, so
     the buffered length is passed through unconditionally (no empty-guard branch
     to leave uncovered).
+
+    @note dump_escaped() and dump_integer()/dump_float() write into the internal
+    write buffer; callers that invoke them directly (rather than through the
+    public dump()) must call flush() before inspecting the output.
     */
     void flush()
     {
@@ -742,6 +747,7 @@ class serializer
         write_buffer_pos = 0;
     }
 
+  private:
     /*!
     @brief count digits
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1343,15 +1343,18 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
         string_t result;
-        serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
 
         if (indent >= 0)
         {
-            s.dump(*this, true, ensure_ascii, static_cast<std::size_t>(indent));
+            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+                         true, ensure_ascii, static_cast<std::size_t>(indent), error_handler);
+            s.dump(*this);
         }
         else
         {
-            s.dump(*this, false, ensure_ascii, 0);
+            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+                         false, ensure_ascii, 0, error_handler);
+            s.dump(*this);
         }
 
         return result;
@@ -4080,8 +4083,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         o.width(0);
 
         // do the actual serialization
-        serializer s(detail::output_adapter<char>(o), o.fill());
-        s.dump(j, pretty_print, false, static_cast<unsigned int>(indentation));
+        serializer s(detail::output_adapter<char>(o), o.fill(),
+                     pretty_print, false, static_cast<std::size_t>(indentation));
+        s.dump(j);
         return o;
     }
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1347,7 +1347,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (indent >= 0)
         {
-            s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
+            s.dump(*this, true, ensure_ascii, static_cast<std::size_t>(indent));
         }
         else
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21313,12 +21313,17 @@ class serializer
         write_buffer_pos += length;
     }
 
+  JSON_PRIVATE_UNLESS_TESTED:
     /*!
     @brief flush the write buffer to the output adapter
 
     Writing zero characters is a well-defined no-op for every output adapter, so
     the buffered length is passed through unconditionally (no empty-guard branch
     to leave uncovered).
+
+    @note dump_escaped() and dump_integer()/dump_float() write into the internal
+    write buffer; callers that invoke them directly (rather than through the
+    public dump()) must call flush() before inspecting the output.
     */
     void flush()
     {
@@ -21326,6 +21331,7 @@ class serializer
         write_buffer_pos = 0;
     }
 
+  private:
     /*!
     @brief count digits
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8177,6 +8177,58 @@ inline std::size_t find_string_special(const unsigned char* data, std::size_t n)
     return n;
 }
 
+// classify a byte as one the serializer must NOT copy verbatim when
+// ensure_ascii is requested: the closing quote, an escape, a control character
+// (< 0x20), DEL (0x7F), or any non-ASCII byte (>= 0x80). Everything else -
+// printable ASCII except '"' and '\\' - is emitted unchanged. Note this differs
+// from is_string_special() only in that 0x7F is also a stop (it is escaped as
+// \u007f under ensure_ascii).
+inline bool is_ascii_copyable(unsigned char c) noexcept
+{
+    return c >= 0x20u && c < 0x7Fu && c != '\"' && c != '\\';
+}
+
+// return the index of the first byte in [data, data+n) that is NOT
+// is_ascii_copyable(), or n if every byte can be copied verbatim; scans 8 bytes
+// at a time. Used by the serializer's ensure_ascii fast path.
+inline std::size_t find_ascii_copyable_run(const unsigned char* data, std::size_t n) noexcept
+{
+    constexpr std::uint64_t ones = 0x0101010101010101ull;
+    constexpr std::uint64_t high = 0x8080808080808080ull;
+    std::size_t i = 0;
+    for (; i + 8 <= n; i += 8)
+    {
+        std::uint64_t v = 0;
+        std::memcpy(&v, data + i, sizeof(v));
+        const std::uint64_t q = v ^ 0x2222222222222222ull; // '"'  (0x22)
+        const std::uint64_t b = v ^ 0x5C5C5C5C5C5C5C5Cull; // '\\' (0x5C)
+        const std::uint64_t d = v ^ 0x7F7F7F7F7F7F7F7Full; // DEL  (0x7F)
+        const std::uint64_t stop = ((q - ones) & ~q & high)   // == '"'
+                                   | ((b - ones) & ~b & high)  // == '\\'
+                                   | ((d - ones) & ~d & high)  // == 0x7F
+                                   | ((v - 0x2020202020202020ull) & ~v & high) // < 0x20
+                                   | (v & high);               // >= 0x80
+        if (stop != 0)
+        {
+            for (std::size_t j = 0; j < 8; ++j)
+            {
+                if (!is_ascii_copyable(data[i + j]))
+                {
+                    return i + j;
+                }
+            }
+        }
+    }
+    for (; i < n; ++i)
+    {
+        if (!is_ascii_copyable(data[i]))
+        {
+            return i;
+        }
+    }
+    return n;
+}
+
 // Validate one UTF-8 sequence at the front of [data, data+avail). Returns its
 // length (2..4) only when the bytes form a *well-formed* sequence using exactly
 // the same ranges as scan_string()'s per-byte switch, so the bulk path accepts
@@ -19419,6 +19471,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <cstddef> // size_t, ptrdiff_t
 #include <cstdint> // uint8_t
 #include <cstdio> // snprintf
+#include <cstring> // memcpy
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
 #include <iomanip> // setfill, setw
@@ -20642,19 +20695,38 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
+        dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
+        flush();
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief recursive worker for @ref dump
+
+    Identical in behavior to the historical @ref dump, but writes into the
+    serializer's internal @ref write_buffer instead of issuing a virtual call
+    per token. The public @ref dump wraps this and flushes the buffer once the
+    top-level value has been serialized.
+    */
+    void dump_internal(const BasicJsonType& val,
+                       const bool pretty_print,
+                       const bool ensure_ascii,
+                       const unsigned int indent_step,
+                       const unsigned int current_indent = 0)
+    {
         switch (val.m_data.m_type)
         {
             case value_t::object:
             {
                 if (val.m_data.m_value.object->empty())
                 {
-                    o->write_characters("{}", 2);
+                    put_chars("{}", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -20667,51 +20739,51 @@ class serializer
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        o->write_character('\"');
+                        put_chars(indent_string.c_str(), new_indent);
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars("\": ", 3);
+                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    o->write_character('\"');
+                    put_chars(indent_string.c_str(), new_indent);
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                    put_chars("\": ", 3);
+                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_character('{');
+                    put_char('{');
 
                     // first n-1 elements
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_character('\"');
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\":", 2);
-                        dump(i->second, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        put_chars("\":", 2);
+                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_character('\"');
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\":", 2);
-                    dump(i->second, false, ensure_ascii, indent_step, current_indent);
+                    put_chars("\":", 2);
+                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character('}');
+                    put_char('}');
                 }
 
                 return;
@@ -20721,13 +20793,13 @@ class serializer
             {
                 if (val.m_data.m_value.array->empty())
                 {
-                    o->write_characters("[]", 2);
+                    put_chars("[]", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("[\n", 2);
+                    put_chars("[\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -20740,37 +20812,37 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars(indent_string.c_str(), new_indent);
+                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
+                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character(']');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char(']');
                 }
                 else
                 {
-                    o->write_character('[');
+                    put_char('[');
 
                     // first n-1 elements
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump(*i, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character(']');
+                    put_char(']');
                 }
 
                 return;
@@ -20778,9 +20850,9 @@ class serializer
 
             case value_t::string:
             {
-                o->write_character('\"');
+                put_char('\"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                o->write_character('\"');
+                put_char('\"');
                 return;
             }
 
@@ -20788,7 +20860,7 @@ class serializer
             {
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -20797,9 +20869,9 @@ class serializer
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
 
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"bytes\": [", 10);
+                    put_chars("\"bytes\": [", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -20807,30 +20879,30 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_characters(", ", 2);
+                            put_chars(", ", 2);
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\n", 3);
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars("],\n", 3);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"subtype\": ", 11);
+                    put_chars("\"subtype\": ", 11);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
-                        o->write_characters("null", 4);
+                        put_chars("null", 4);
                     }
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_characters("{\"bytes\":[", 10);
+                    put_chars("{\"bytes\":[", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -20838,20 +20910,20 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_character(',');
+                            put_char(',');
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\"subtype\":", 12);
+                    put_chars("],\"subtype\":", 12);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
-                        o->write_character('}');
+                        put_char('}');
                     }
                     else
                     {
-                        o->write_characters("null}", 5);
+                        put_chars("null}", 5);
                     }
                 }
                 return;
@@ -20861,11 +20933,11 @@ class serializer
             {
                 if (val.m_data.m_value.boolean)
                 {
-                    o->write_characters("true", 4);
+                    put_chars("true", 4);
                 }
                 else
                 {
-                    o->write_characters("false", 5);
+                    put_chars("false", 5);
                 }
                 return;
             }
@@ -20890,13 +20962,13 @@ class serializer
 
             case value_t::discarded:
             {
-                o->write_characters("<discarded>", 11);
+                put_chars("<discarded>", 11);
                 return;
             }
 
             case value_t::null:
             {
-                o->write_characters("null", 4);
+                put_chars("null", 4);
                 return;
             }
 
@@ -20932,28 +21004,35 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
-            // Fast path: when not escaping non-ASCII characters and sitting on a
-            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
-            // run of bytes that need no escaping. string_bulk_run() (shared with
-            // the lexer's contiguous scanner) stops exactly at the first byte
-            // that dump_escaped would handle individually - a quote, a backslash,
-            // a control character (< 0x20), or an ill-formed/truncated UTF-8
-            // sequence - so that byte is left to the byte-at-a-time path below,
-            // keeping error handling and diagnostics unchanged.
-            if (!ensure_ascii && state == UTF8_ACCEPT)
+            // Fast path: at a character boundary (state == UTF8_ACCEPT),
+            // bulk-copy the longest run of bytes that need no escaping using a
+            // SWAR scanner shared with the lexer's contiguous path. The scanner
+            // stops exactly at the first byte dump_escaped would handle
+            // individually, so that byte is left to the byte-at-a-time path
+            // below, keeping escaping output and error diagnostics unchanged.
+            //
+            // - ensure_ascii == false: string_bulk_run() copies ordinary bytes
+            //   and complete well-formed UTF-8, stopping at a quote, backslash,
+            //   control character (< 0x20), or ill-formed/truncated sequence.
+            // - ensure_ascii == true: only printable ASCII may be copied
+            //   verbatim; find_ascii_copyable_run() additionally stops at 0x7F
+            //   and every non-ASCII byte (>= 0x80), which must be \u-escaped.
+            if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                const std::size_t run = ensure_ascii
+                                        ? find_ascii_copyable_run(data + i, s.size() - i)
+                                        : string_bulk_run(data + i, s.size() - i);
                 if (run != 0)
                 {
                     // emit any bytes still pending in string_buffer first to
                     // preserve output order, then write the run directly
                     if (bytes != 0)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
-                    o->write_characters(s.data() + i, run);
+                    put_chars(s.data() + i, run);
                     bytes_after_last_accept = 0;
                     undumped_chars = 0;
                     i += run;
@@ -21052,7 +21131,7 @@ class serializer
                     // written ("\uxxxx\uxxxx\0") for one code point
                     if (string_buffer.size() - bytes < 13)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
 
@@ -21111,7 +21190,7 @@ class serializer
                                 // written ("\uxxxx\uxxxx\0") for one code point
                                 if (string_buffer.size() - bytes < 13)
                                 {
-                                    o->write_characters(string_buffer.data(), bytes);
+                                    put_chars(string_buffer.data(), bytes);
                                     bytes = 0;
                                 }
 
@@ -21150,7 +21229,7 @@ class serializer
             // write buffer
             if (bytes > 0)
             {
-                o->write_characters(string_buffer.data(), bytes);
+                put_chars(string_buffer.data(), bytes);
             }
         }
         else
@@ -21166,22 +21245,22 @@ class serializer
                 case error_handler_t::ignore:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     break;
                 }
 
                 case error_handler_t::replace:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     // add a replacement character
                     if (ensure_ascii)
                     {
-                        o->write_characters("\\ufffd", 6);
+                        put_chars("\\ufffd", 6);
                     }
                     else
                     {
-                        o->write_characters("\xEF\xBF\xBD", 3);
+                        put_chars("\xEF\xBF\xBD", 3);
                     }
                     break;
                 }
@@ -21193,6 +21272,60 @@ class serializer
     }
 
   private:
+    /*!
+    @brief append a single character to the write buffer
+
+    Structural characters ('{', '"', ',', ...) previously went straight to the
+    output adapter, one virtual call each. Buffering them and flushing in bulk
+    turns those many indirect calls into a single memcpy plus an occasional
+    flush, which dominates the cost of serializing object/array-heavy values.
+    */
+    void put_char(char c)
+    {
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
+        {
+            flush();
+        }
+        write_buffer[write_buffer_pos++] = c;
+    }
+
+    /*!
+    @brief append @a length characters to the write buffer
+
+    Runs that do not fit the buffer are written straight through the output
+    adapter (after flushing what is pending), so large string/number payloads
+    are not copied an extra time.
+    */
+    JSON_HEDLEY_NON_NULL(2)
+    void put_chars(const char* s, std::size_t length)
+    {
+        if (JSON_HEDLEY_UNLIKELY(length >= write_buffer.size()))
+        {
+            flush();
+            o->write_characters(s, length);
+            return;
+        }
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + length > write_buffer.size()))
+        {
+            flush();
+        }
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
+        write_buffer_pos += length;
+    }
+
+    /*!
+    @brief flush the write buffer to the output adapter
+
+    Writing zero characters is a well-defined no-op for every output adapter, so
+    the buffered length is passed through unconditionally (no empty-guard branch
+    to leave uncovered).
+    */
+    void flush()
+    {
+        o->write_characters(write_buffer.data(), write_buffer_pos);
+        write_buffer_pos = 0;
+    }
+
     /*!
     @brief count digits
 
@@ -21316,7 +21449,7 @@ class serializer
         // special case for "0"
         if (x == 0)
         {
-            o->write_character('0');
+            put_char('0');
             return;
         }
 
@@ -21369,7 +21502,7 @@ class serializer
             *(--buffer_ptr) = static_cast<char>('0' + abs_value);
         }
 
-        o->write_characters(number_buffer.data(), n_chars);
+        put_chars(number_buffer.data(), n_chars);
     }
 
     /*!
@@ -21385,7 +21518,7 @@ class serializer
         // NaN / inf
         if (!std::isfinite(x))
         {
-            o->write_characters("null", 4);
+            put_chars("null", 4);
             return;
         }
 
@@ -21406,7 +21539,7 @@ class serializer
         auto* begin = number_buffer.data();
         auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
 
-        o->write_characters(begin, static_cast<size_t>(end - begin));
+        put_chars(begin, static_cast<size_t>(end - begin));
     }
 
     JSON_HEDLEY_NON_NULL(1)
@@ -21457,7 +21590,7 @@ class serializer
             }
         }
 
-        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+        put_chars(number_buffer.data(), static_cast<std::size_t>(len));
 
         // determine if we need to append ".0"
         const bool value_is_int_like =
@@ -21469,7 +21602,7 @@ class serializer
 
         if (value_is_int_like)
         {
-            o->write_characters(".0", 2);
+            put_chars(".0", 2);
         }
     }
 
@@ -21579,6 +21712,12 @@ class serializer
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
+
+    /// buffer collecting output before it is flushed to the output adapter, so
+    /// that the many small structural writes become few bulk writes
+    std::array<char, 1024> write_buffer{{}};
+    /// number of valid bytes currently held in @ref write_buffer
+    std::size_t write_buffer_pos = 0;
 };
 
 }  // namespace detail

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20548,6 +20548,8 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/exceptions.hpp>
 
+// #include <nlohmann/detail/input/string_scan.hpp>
+
 // #include <nlohmann/detail/macro_scope.hpp>
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
@@ -20930,6 +20932,38 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
+            // Fast path: when not escaping non-ASCII characters and sitting on a
+            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
+            // run of bytes that need no escaping. string_bulk_run() (shared with
+            // the lexer's contiguous scanner) stops exactly at the first byte
+            // that dump_escaped would handle individually - a quote, a backslash,
+            // a control character (< 0x20), or an ill-formed/truncated UTF-8
+            // sequence - so that byte is left to the byte-at-a-time path below,
+            // keeping error handling and diagnostics unchanged.
+            if (!ensure_ascii && state == UTF8_ACCEPT)
+            {
+                const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
+                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                if (run != 0)
+                {
+                    // emit any bytes still pending in string_buffer first to
+                    // preserve output order, then write the run directly
+                    if (bytes != 0)
+                    {
+                        o->write_characters(string_buffer.data(), bytes);
+                        bytes = 0;
+                    }
+                    o->write_characters(s.data() + i, run);
+                    bytes_after_last_accept = 0;
+                    undumped_chars = 0;
+                    i += run;
+                    if (i >= s.size())
+                    {
+                        break;
+                    }
+                }
+            }
+
             const auto byte = static_cast<std::uint8_t>(s[i]);
 
             switch (decode(state, codepoint, byte))

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21461,8 +21461,8 @@ class serializer
     void dump(const BasicJsonType& val,
               const bool pretty_print,
               const bool ensure_ascii,
-              const unsigned int indent_step,
-              const unsigned int current_indent = 0)
+              const std::size_t indent_step,
+              const std::size_t current_indent = 0)
     {
         dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
         flush();
@@ -21480,8 +21480,8 @@ class serializer
     void dump_internal(const BasicJsonType& val,
                        const bool pretty_print,
                        const bool ensure_ascii,
-                       const unsigned int indent_step,
-                       const unsigned int current_indent = 0)
+                       const std::size_t indent_step,
+                       const std::size_t current_indent = 0)
     {
         switch (val.m_data.m_type)
         {
@@ -21738,11 +21738,13 @@ class serializer
     @brief the indentation level to use for the children of the current value
 
     A very large @a indent_step can wrap the unsigned accumulation on deep
-    nesting, which would silently truncate the indentation.
+    nesting, which would silently truncate the indentation. Far harder to reach
+    now that the accumulator is a std::size_t, but still reachable where that is
+    32 bits wide.
     */
-    static unsigned int next_indent(const unsigned int current_indent, const unsigned int indent_step)
+    static std::size_t next_indent(const std::size_t current_indent, const std::size_t indent_step)
     {
-        const unsigned int new_indent = current_indent + indent_step;
+        const std::size_t new_indent = current_indent + indent_step;
         JSON_ASSERT(new_indent >= current_indent);
         return new_indent;
     }
@@ -21802,7 +21804,7 @@ class serializer
                         put_buffer(string_buffer, bytes);
                         bytes = 0;
                     }
-                    put_chars(s.data() + i, run);
+                    put_string(s, i, i + run);
                     bytes_after_last_accept = 0;
                     undumped_chars = 0;
                     i += run;
@@ -22060,13 +22062,6 @@ class serializer
     }
 
     /*!
-    @brief append @a length characters to the write buffer
-
-    Runs that do not fit the buffer are written straight through the output
-    adapter (after flushing what is pending), so large string/number payloads
-    are not copied an extra time.
-    */
-    /*!
     @brief append @a indent indentation characters to the write buffer
 
     Writes the indentation straight into the buffer instead of copying it out of
@@ -22078,7 +22073,7 @@ class serializer
     flushing does not disturb what the buffer holds, so re-filling it between
     flushes would be redundant work.
     */
-    void put_indent(unsigned int indent)
+    void put_indent(std::size_t indent)
     {
         // closing braces at the outermost level ask for no indentation at all
         if (indent == 0)
@@ -22091,10 +22086,10 @@ class serializer
         // fill whatever room is left in the buffer; this is the whole job
         // whenever the indentation is narrower than the buffer, which is the
         // case for every sane indent_step
-        const std::size_t head = (std::min)(static_cast<std::size_t>(indent), capacity - write_buffer_pos);
+        const std::size_t head = (std::min)(indent, capacity - write_buffer_pos);
         std::memset(write_buffer.data() + write_buffer_pos, indent_char, head);
         write_buffer_pos += head;
-        indent -= static_cast<unsigned int>(head);
+        indent -= head;
 
         if (JSON_HEDLEY_LIKELY(indent == 0))
         {
@@ -22111,7 +22106,7 @@ class serializer
         {
             write_buffer_pos = capacity;
             flush();
-            indent -= static_cast<unsigned int>(capacity);
+            indent -= capacity;
         }
 
         // the buffer still holds indentation characters throughout, so the tail
@@ -22131,14 +22126,30 @@ class serializer
     void put_literal(const char (&s)[N])
     {
         static_assert(N >= 2, "put_literal expects a non-empty string literal");
-        static_assert(N - 1 < write_buffer_size, "string literal must fit into the write buffer");
+        // the array bound counts the terminating NUL, which is not written
+        constexpr std::size_t length = N - 1;
+        static_assert(length < write_buffer_size, "string literal must fit into the write buffer");
 
-        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + (N - 1) > write_buffer.size()))
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + length > write_buffer.size()))
         {
             flush();
         }
-        std::memcpy(write_buffer.data() + write_buffer_pos, s, N - 1);
-        write_buffer_pos += N - 1;
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
+        write_buffer_pos += length;
+    }
+
+    /*!
+    @brief append the characters of @a str in [@a start, @a end)
+
+    Keeps the pointer arithmetic and the bounds checking inside the function
+    rather than at the call site, which is all @ref put_chars could offer.
+    */
+    template<typename StringType>
+    void put_string(const StringType& str, std::size_t start, std::size_t end)
+    {
+        JSON_ASSERT(start <= end);
+        JSON_ASSERT(end <= str.size());
+        put_chars(str.data() + start, end - start);
     }
 
     /*!
@@ -22154,6 +22165,16 @@ class serializer
         put_chars(buffer.data(), length);
     }
 
+    /*!
+    @brief append @a length characters to the write buffer
+
+    Runs that do not fit the buffer are written straight through the output
+    adapter (after flushing what is pending), so large string/number payloads
+    are not copied an extra time.
+
+    The callers all reach this through @ref put_literal, @ref put_buffer or
+    @ref put_string, which each derive the length from something that knows it.
+    */
     JSON_HEDLEY_NON_NULL(2)
     void put_chars(const char* s, std::size_t length)
     {
@@ -22403,7 +22424,7 @@ class serializer
         auto* begin = number_buffer.data();
         auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
 
-        put_chars(begin, static_cast<size_t>(end - begin));
+        put_buffer(number_buffer, static_cast<std::size_t>(end - begin));
     }
 
     JSON_HEDLEY_NON_NULL(1)
@@ -24262,7 +24283,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (indent >= 0)
         {
-            s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
+            s.dump(*this, true, ensure_ascii, static_cast<std::size_t>(indent));
         }
         else
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22071,24 +22071,52 @@ class serializer
 
     Writes the indentation straight into the buffer instead of copying it out of
     a pre-grown indentation string, so no auxiliary string has to be sized,
-    resized, or kept in sync with the deepest nesting level reached. An
-    indentation wider than the buffer simply fills and flushes it repeatedly.
+    resized, or kept in sync with the deepest nesting level reached.
+
+    An indentation wider than the buffer is emitted by filling the buffer with
+    the indentation character once and flushing that same content repeatedly:
+    flushing does not disturb what the buffer holds, so re-filling it between
+    flushes would be redundant work.
     */
     void put_indent(unsigned int indent)
     {
-        while (indent > 0)
+        // closing braces at the outermost level ask for no indentation at all
+        if (indent == 0)
         {
-            if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
-            {
-                flush();
-            }
-
-            const std::size_t chunk = (std::min)(static_cast<std::size_t>(indent),
-                                                 write_buffer.size() - write_buffer_pos);
-            std::memset(write_buffer.data() + write_buffer_pos, indent_char, chunk);
-            write_buffer_pos += chunk;
-            indent -= static_cast<unsigned int>(chunk);
+            return;
         }
+
+        const std::size_t capacity = write_buffer.size();
+
+        // fill whatever room is left in the buffer; this is the whole job
+        // whenever the indentation is narrower than the buffer, which is the
+        // case for every sane indent_step
+        const std::size_t head = (std::min)(static_cast<std::size_t>(indent), capacity - write_buffer_pos);
+        std::memset(write_buffer.data() + write_buffer_pos, indent_char, head);
+        write_buffer_pos += head;
+        indent -= static_cast<unsigned int>(head);
+
+        if (JSON_HEDLEY_LIKELY(indent == 0))
+        {
+            return;
+        }
+
+        // the buffer is full and the remainder spans whole buffer-fulls: flush
+        // what is pending, then fill the buffer with the indentation character
+        // exactly once and hand the same bytes to the adapter as often as needed
+        flush();
+        std::memset(write_buffer.data(), indent_char, capacity);
+
+        while (indent >= capacity)
+        {
+            write_buffer_pos = capacity;
+            flush();
+            indent -= static_cast<unsigned int>(capacity);
+        }
+
+        // the buffer still holds indentation characters throughout, so the tail
+        // only has to be claimed, not written again
+        write_buffer_pos = indent;
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8327,6 +8327,58 @@ inline std::size_t find_string_special(const unsigned char* data, std::size_t n)
     return n;
 }
 
+// classify a byte as one the serializer must NOT copy verbatim when
+// ensure_ascii is requested: the closing quote, an escape, a control character
+// (< 0x20), DEL (0x7F), or any non-ASCII byte (>= 0x80). Everything else -
+// printable ASCII except '"' and '\\' - is emitted unchanged. Note this differs
+// from is_string_special() only in that 0x7F is also a stop (it is escaped as
+// \u007f under ensure_ascii).
+inline bool is_ascii_copyable(unsigned char c) noexcept
+{
+    return c >= 0x20u && c < 0x7Fu && c != '\"' && c != '\\';
+}
+
+// return the index of the first byte in [data, data+n) that is NOT
+// is_ascii_copyable(), or n if every byte can be copied verbatim; scans 8 bytes
+// at a time. Used by the serializer's ensure_ascii fast path.
+inline std::size_t find_ascii_copyable_run(const unsigned char* data, std::size_t n) noexcept
+{
+    constexpr std::uint64_t ones = 0x0101010101010101ull;
+    constexpr std::uint64_t high = 0x8080808080808080ull;
+    std::size_t i = 0;
+    for (; i + 8 <= n; i += 8)
+    {
+        std::uint64_t v = 0;
+        std::memcpy(&v, data + i, sizeof(v));
+        const std::uint64_t q = v ^ 0x2222222222222222ull; // '"'  (0x22)
+        const std::uint64_t b = v ^ 0x5C5C5C5C5C5C5C5Cull; // '\\' (0x5C)
+        const std::uint64_t d = v ^ 0x7F7F7F7F7F7F7F7Full; // DEL  (0x7F)
+        const std::uint64_t stop = ((q - ones) & ~q & high)   // == '"'
+                                   | ((b - ones) & ~b & high)  // == '\\'
+                                   | ((d - ones) & ~d & high)  // == 0x7F
+                                   | ((v - 0x2020202020202020ull) & ~v & high) // < 0x20
+                                   | (v & high);               // >= 0x80
+        if (stop != 0)
+        {
+            for (std::size_t j = 0; j < 8; ++j)
+            {
+                if (!is_ascii_copyable(data[i + j]))
+                {
+                    return i + j;
+                }
+            }
+        }
+    }
+    for (; i < n; ++i)
+    {
+        if (!is_ascii_copyable(data[i]))
+        {
+            return i;
+        }
+    }
+    return n;
+}
+
 // Validate one UTF-8 sequence at the front of [data, data+avail). Returns its
 // length (2..4) only when the bytes form a *well-formed* sequence using exactly
 // the same ranges as scan_string()'s per-byte switch, so the bulk path accepts
@@ -20190,6 +20242,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <cstddef> // size_t, ptrdiff_t
 #include <cstdint> // uint8_t
 #include <cstdio> // snprintf
+#include <cstring> // memcpy
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
 #include <type_traits> // is_same
@@ -21412,19 +21465,38 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
+        dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
+        flush();
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief recursive worker for @ref dump
+
+    Identical in behavior to the historical @ref dump, but writes into the
+    serializer's internal @ref write_buffer instead of issuing a virtual call
+    per token. The public @ref dump wraps this and flushes the buffer once the
+    top-level value has been serialized.
+    */
+    void dump_internal(const BasicJsonType& val,
+                       const bool pretty_print,
+                       const bool ensure_ascii,
+                       const unsigned int indent_step,
+                       const unsigned int current_indent = 0)
+    {
         switch (val.m_data.m_type)
         {
             case value_t::object:
             {
                 if (val.m_data.m_value.object->empty())
                 {
-                    o->write_characters("{}", 2);
+                    put_chars("{}", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -21437,51 +21509,51 @@ class serializer
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        o->write_character('\"');
+                        put_chars(indent_string.c_str(), new_indent);
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars("\": ", 3);
+                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    o->write_character('\"');
+                    put_chars(indent_string.c_str(), new_indent);
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                    put_chars("\": ", 3);
+                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_character('{');
+                    put_char('{');
 
                     // first n-1 elements
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        o->write_character('\"');
+                        put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\":", 2);
-                        dump(i->second, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        put_chars("\":", 2);
+                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    o->write_character('\"');
+                    put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\":", 2);
-                    dump(i->second, false, ensure_ascii, indent_step, current_indent);
+                    put_chars("\":", 2);
+                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character('}');
+                    put_char('}');
                 }
 
                 return;
@@ -21491,13 +21563,13 @@ class serializer
             {
                 if (val.m_data.m_value.array->empty())
                 {
-                    o->write_characters("[]", 2);
+                    put_chars("[]", 2);
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    o->write_characters("[\n", 2);
+                    put_chars("[\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -21510,37 +21582,37 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
+                        put_chars(indent_string.c_str(), new_indent);
+                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
+                        put_chars(",\n", 2);
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
+                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character(']');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char(']');
                 }
                 else
                 {
-                    o->write_character('[');
+                    put_char('[');
 
                     // first n-1 elements
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump(*i, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
+                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent);
+                        put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
 
-                    o->write_character(']');
+                    put_char(']');
                 }
 
                 return;
@@ -21548,9 +21620,9 @@ class serializer
 
             case value_t::string:
             {
-                o->write_character('\"');
+                put_char('\"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                o->write_character('\"');
+                put_char('\"');
                 return;
             }
 
@@ -21558,7 +21630,7 @@ class serializer
             {
                 if (pretty_print)
                 {
-                    o->write_characters("{\n", 2);
+                    put_chars("{\n", 2);
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
@@ -21567,9 +21639,9 @@ class serializer
                         indent_string.resize(indent_string.size() * 2, ' ');
                     }
 
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"bytes\": [", 10);
+                    put_chars("\"bytes\": [", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -21577,30 +21649,30 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_characters(", ", 2);
+                            put_chars(", ", 2);
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\n", 3);
-                    o->write_characters(indent_string.c_str(), new_indent);
+                    put_chars("],\n", 3);
+                    put_chars(indent_string.c_str(), new_indent);
 
-                    o->write_characters("\"subtype\": ", 11);
+                    put_chars("\"subtype\": ", 11);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
-                        o->write_characters("null", 4);
+                        put_chars("null", 4);
                     }
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
+                    put_char('\n');
+                    put_chars(indent_string.c_str(), current_indent);
+                    put_char('}');
                 }
                 else
                 {
-                    o->write_characters("{\"bytes\":[", 10);
+                    put_chars("{\"bytes\":[", 10);
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -21608,20 +21680,20 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            o->write_character(',');
+                            put_char(',');
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    o->write_characters("],\"subtype\":", 12);
+                    put_chars("],\"subtype\":", 12);
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
-                        o->write_character('}');
+                        put_char('}');
                     }
                     else
                     {
-                        o->write_characters("null}", 5);
+                        put_chars("null}", 5);
                     }
                 }
                 return;
@@ -21631,11 +21703,11 @@ class serializer
             {
                 if (val.m_data.m_value.boolean)
                 {
-                    o->write_characters("true", 4);
+                    put_chars("true", 4);
                 }
                 else
                 {
-                    o->write_characters("false", 5);
+                    put_chars("false", 5);
                 }
                 return;
             }
@@ -21660,13 +21732,13 @@ class serializer
 
             case value_t::discarded:
             {
-                o->write_characters("<discarded>", 11);
+                put_chars("<discarded>", 11);
                 return;
             }
 
             case value_t::null:
             {
-                o->write_characters("null", 4);
+                put_chars("null", 4);
                 return;
             }
 
@@ -21702,28 +21774,35 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
-            // Fast path: when not escaping non-ASCII characters and sitting on a
-            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
-            // run of bytes that need no escaping. string_bulk_run() (shared with
-            // the lexer's contiguous scanner) stops exactly at the first byte
-            // that dump_escaped would handle individually - a quote, a backslash,
-            // a control character (< 0x20), or an ill-formed/truncated UTF-8
-            // sequence - so that byte is left to the byte-at-a-time path below,
-            // keeping error handling and diagnostics unchanged.
-            if (!ensure_ascii && state == UTF8_ACCEPT)
+            // Fast path: at a character boundary (state == UTF8_ACCEPT),
+            // bulk-copy the longest run of bytes that need no escaping using a
+            // SWAR scanner shared with the lexer's contiguous path. The scanner
+            // stops exactly at the first byte dump_escaped would handle
+            // individually, so that byte is left to the byte-at-a-time path
+            // below, keeping escaping output and error diagnostics unchanged.
+            //
+            // - ensure_ascii == false: string_bulk_run() copies ordinary bytes
+            //   and complete well-formed UTF-8, stopping at a quote, backslash,
+            //   control character (< 0x20), or ill-formed/truncated sequence.
+            // - ensure_ascii == true: only printable ASCII may be copied
+            //   verbatim; find_ascii_copyable_run() additionally stops at 0x7F
+            //   and every non-ASCII byte (>= 0x80), which must be \u-escaped.
+            if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                const std::size_t run = ensure_ascii
+                                        ? find_ascii_copyable_run(data + i, s.size() - i)
+                                        : string_bulk_run(data + i, s.size() - i);
                 if (run != 0)
                 {
                     // emit any bytes still pending in string_buffer first to
                     // preserve output order, then write the run directly
                     if (bytes != 0)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
-                    o->write_characters(s.data() + i, run);
+                    put_chars(s.data() + i, run);
                     bytes_after_last_accept = 0;
                     undumped_chars = 0;
                     i += run;
@@ -21822,7 +21901,7 @@ class serializer
                     // written ("\uxxxx\uxxxx\0") for one code point
                     if (string_buffer.size() - bytes < 13)
                     {
-                        o->write_characters(string_buffer.data(), bytes);
+                        put_chars(string_buffer.data(), bytes);
                         bytes = 0;
                     }
 
@@ -21881,7 +21960,7 @@ class serializer
                                 // written ("\uxxxx\uxxxx\0") for one code point
                                 if (string_buffer.size() - bytes < 13)
                                 {
-                                    o->write_characters(string_buffer.data(), bytes);
+                                    put_chars(string_buffer.data(), bytes);
                                     bytes = 0;
                                 }
 
@@ -21920,7 +21999,7 @@ class serializer
             // write buffer
             if (bytes > 0)
             {
-                o->write_characters(string_buffer.data(), bytes);
+                put_chars(string_buffer.data(), bytes);
             }
         }
         else
@@ -21936,22 +22015,22 @@ class serializer
                 case error_handler_t::ignore:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     break;
                 }
 
                 case error_handler_t::replace:
                 {
                     // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    put_chars(string_buffer.data(), bytes_after_last_accept);
                     // add a replacement character
                     if (ensure_ascii)
                     {
-                        o->write_characters("\\ufffd", 6);
+                        put_chars("\\ufffd", 6);
                     }
                     else
                     {
-                        o->write_characters("\xEF\xBF\xBD", 3);
+                        put_chars("\xEF\xBF\xBD", 3);
                     }
                     break;
                 }
@@ -21963,6 +22042,60 @@ class serializer
     }
 
   private:
+    /*!
+    @brief append a single character to the write buffer
+
+    Structural characters ('{', '"', ',', ...) previously went straight to the
+    output adapter, one virtual call each. Buffering them and flushing in bulk
+    turns those many indirect calls into a single memcpy plus an occasional
+    flush, which dominates the cost of serializing object/array-heavy values.
+    */
+    void put_char(char c)
+    {
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
+        {
+            flush();
+        }
+        write_buffer[write_buffer_pos++] = c;
+    }
+
+    /*!
+    @brief append @a length characters to the write buffer
+
+    Runs that do not fit the buffer are written straight through the output
+    adapter (after flushing what is pending), so large string/number payloads
+    are not copied an extra time.
+    */
+    JSON_HEDLEY_NON_NULL(2)
+    void put_chars(const char* s, std::size_t length)
+    {
+        if (JSON_HEDLEY_UNLIKELY(length >= write_buffer.size()))
+        {
+            flush();
+            o->write_characters(s, length);
+            return;
+        }
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + length > write_buffer.size()))
+        {
+            flush();
+        }
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
+        write_buffer_pos += length;
+    }
+
+    /*!
+    @brief flush the write buffer to the output adapter
+
+    Writing zero characters is a well-defined no-op for every output adapter, so
+    the buffered length is passed through unconditionally (no empty-guard branch
+    to leave uncovered).
+    */
+    void flush()
+    {
+        o->write_characters(write_buffer.data(), write_buffer_pos);
+        write_buffer_pos = 0;
+    }
+
     /*!
     @brief count digits
 
@@ -22086,7 +22219,7 @@ class serializer
         // special case for "0"
         if (x == 0)
         {
-            o->write_character('0');
+            put_char('0');
             return;
         }
 
@@ -22139,7 +22272,7 @@ class serializer
             *(--buffer_ptr) = static_cast<char>('0' + abs_value);
         }
 
-        o->write_characters(number_buffer.data(), n_chars);
+        put_chars(number_buffer.data(), n_chars);
     }
 
     /*!
@@ -22155,7 +22288,7 @@ class serializer
         // NaN / inf
         if (!std::isfinite(x))
         {
-            o->write_characters("null", 4);
+            put_chars("null", 4);
             return;
         }
 
@@ -22176,7 +22309,7 @@ class serializer
         auto* begin = number_buffer.data();
         auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
 
-        o->write_characters(begin, static_cast<size_t>(end - begin));
+        put_chars(begin, static_cast<size_t>(end - begin));
     }
 
     JSON_HEDLEY_NON_NULL(1)
@@ -22227,7 +22360,7 @@ class serializer
             }
         }
 
-        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+        put_chars(number_buffer.data(), static_cast<std::size_t>(len));
 
         // determine if we need to append ".0"
         const bool value_is_int_like =
@@ -22239,7 +22372,7 @@ class serializer
 
         if (value_is_int_like)
         {
-            o->write_characters(".0", 2);
+            put_chars(".0", 2);
         }
     }
 
@@ -22349,6 +22482,12 @@ class serializer
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
+
+    /// buffer collecting output before it is flushed to the output adapter, so
+    /// that the many small structural writes become few bulk writes
+    std::array<char, 1024> write_buffer{{}};
+    /// number of valid bytes currently held in @ref write_buffer
+    std::size_t write_buffer_pos = 0;
 };
 
 }  // namespace detail

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -8335,7 +8335,7 @@ inline std::size_t find_string_special(const unsigned char* data, std::size_t n)
 // \u007f under ensure_ascii).
 inline bool is_ascii_copyable(unsigned char c) noexcept
 {
-    return c >= 0x20u && c < 0x7Fu && c != '\"' && c != '\\';
+    return c >= 0x20u && c < 0x7Fu && c != '"' && c != '\\';
 }
 
 // return the index of the first byte in [data, data+n) that is NOT
@@ -8360,13 +8360,7 @@ inline std::size_t find_ascii_copyable_run(const unsigned char* data, std::size_
                                    | (v & high);               // >= 0x80
         if (stop != 0)
         {
-            for (std::size_t j = 0; j < 8; ++j)
-            {
-                if (!is_ascii_copyable(data[i + j]))
-                {
-                    return i + j;
-                }
-            }
+            break;
         }
     }
     for (; i < n; ++i)
@@ -21522,7 +21516,7 @@ class serializer
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         put_indent(new_indent);
-                        put_char('\"');
+                        put_char('"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\": ");
                         dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
@@ -21533,7 +21527,7 @@ class serializer
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_indent(new_indent);
-                    put_char('\"');
+                    put_char('"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\": ");
                     dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
@@ -21550,7 +21544,7 @@ class serializer
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        put_char('\"');
+                        put_char('"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\":");
                         dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
@@ -21560,7 +21554,7 @@ class serializer
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    put_char('\"');
+                    put_char('"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\":");
                     dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
@@ -21634,9 +21628,9 @@ class serializer
 
             case value_t::string:
             {
-                put_char('\"');
+                put_char('"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                put_char('\"');
+                put_char('"');
                 return;
             }
 
@@ -21827,7 +21821,7 @@ class serializer
                     put_indent(frame.child_indent);
                 }
 
-                put_char('\"');
+                put_char('"');
                 dump_escaped(frame.object_it->first, ensure_ascii);
 
                 if (pretty_print)
@@ -21985,9 +21979,9 @@ class serializer
 
             case value_t::string:
             {
-                put_char('\"');
+                put_char('"');
                 dump_escaped(*val.m_data.m_value.string, ensure_ascii);
-                put_char('\"');
+                put_char('"');
                 return;
             }
 
@@ -22269,7 +22263,7 @@ class serializer
                         case 0x22: // quotation mark
                         {
                             string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = '\"';
+                            string_buffer[bytes++] = '"';
                             break;
                         }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21412,15 +21412,31 @@ class serializer
     /*!
     @param[in] s  output stream to serialize to
     @param[in] ichar  indentation character to use
+    @param[in] pretty_print_  whether the output shall be pretty-printed
+    @param[in] ensure_ascii_ If @a ensure_ascii_ is true, all non-ASCII
+    characters in the output are escaped with `\uXXXX` sequences, and the
+    result consists of ASCII characters only.
+    @param[in] indent_step_  the indent level
     @param[in] error_handler_  how to react on decoding errors
+
+    None of @a pretty_print_, @a ensure_ascii_ and @a indent_step_ change over
+    the life of the serializer, so they are captured once here instead of
+    being threaded through every call to @ref dump, @ref dump_internal and
+    @ref dump_iteratively.
     */
     serializer(output_adapter_t<char> s, const char ichar,
+               const bool pretty_print_ = false,
+               const bool ensure_ascii_ = false,
+               const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
         : o(std::move(s))
         , loc(std::localeconv())
         , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
         , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
+        , pretty_print(pretty_print_)
+        , ensure_ascii(ensure_ascii_)
+        , indent_step(indent_step_)
         , error_handler(error_handler_)
     {}
 
@@ -21446,20 +21462,12 @@ class serializer
       byte array
 
     @param[in] val               value to serialize
-    @param[in] pretty_print      whether the output shall be pretty-printed
-    @param[in] ensure_ascii If @a ensure_ascii is true, all non-ASCII characters
-    in the output are escaped with `\uXXXX` sequences, and the result consists
-    of ASCII characters only.
-    @param[in] indent_step       the indent level
     @param[in] current_indent    the current indent level (only used internally)
     */
     void dump(const BasicJsonType& val,
-              const bool pretty_print,
-              const bool ensure_ascii,
-              const std::size_t indent_step,
               const std::size_t current_indent = 0)
     {
-        dump_internal(val, pretty_print, ensure_ascii, indent_step, current_indent);
+        dump_internal(val, current_indent);
         flush();
     }
 
@@ -21482,9 +21490,6 @@ class serializer
     @sa https://github.com/nlohmann/json/issues/5387
     */
     void dump_internal(const BasicJsonType& val,
-                       const bool pretty_print,
-                       const bool ensure_ascii,
-                       const std::size_t indent_step,
                        const std::size_t current_indent = 0,
                        const std::size_t depth = 0)
     {
@@ -21494,7 +21499,7 @@ class serializer
             {
                 if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
                 {
-                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    dump_iteratively(val, current_indent);
                     return;
                 }
 
@@ -21517,9 +21522,9 @@ class serializer
                     {
                         put_indent(new_indent);
                         put_char('"');
-                        dump_escaped(i->first, ensure_ascii);
+                        dump_escaped(i->first);
                         put_literal("\": ");
-                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
+                        dump_internal(i->second, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
@@ -21528,9 +21533,9 @@ class serializer
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_indent(new_indent);
                     put_char('"');
-                    dump_escaped(i->first, ensure_ascii);
+                    dump_escaped(i->first);
                     put_literal("\": ");
-                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
+                    dump_internal(i->second, new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -21545,9 +21550,9 @@ class serializer
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         put_char('"');
-                        dump_escaped(i->first, ensure_ascii);
+                        dump_escaped(i->first);
                         put_literal("\":");
-                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
+                        dump_internal(i->second, current_indent, depth + 1);
                         put_char(',');
                     }
 
@@ -21555,9 +21560,9 @@ class serializer
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_char('"');
-                    dump_escaped(i->first, ensure_ascii);
+                    dump_escaped(i->first);
                     put_literal("\":");
-                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
+                    dump_internal(i->second, current_indent, depth + 1);
 
                     put_char('}');
                 }
@@ -21569,7 +21574,7 @@ class serializer
             {
                 if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
                 {
-                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    dump_iteratively(val, current_indent);
                     return;
                 }
 
@@ -21591,14 +21596,14 @@ class serializer
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
                         put_indent(new_indent);
-                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent, depth + 1);
+                        dump_internal(*i, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
                     put_indent(new_indent);
-                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent, depth + 1);
+                    dump_internal(val.m_data.m_value.array->back(), new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -21612,13 +21617,13 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent, depth + 1);
+                        dump_internal(*i, current_indent, depth + 1);
                         put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent, depth + 1);
+                    dump_internal(val.m_data.m_value.array->back(), current_indent, depth + 1);
 
                     put_char(']');
                 }
@@ -21629,7 +21634,7 @@ class serializer
             case value_t::string:
             {
                 put_char('"');
-                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                dump_escaped(*val.m_data.m_value.string);
                 put_char('"');
                 return;
             }
@@ -21769,9 +21774,6 @@ class serializer
     object-heavy documents than letting the compiler drive the descent.
     */
     void dump_iteratively(const BasicJsonType& val,
-                          const bool pretty_print,
-                          const bool ensure_ascii,
-                          const std::size_t indent_step,
                           const std::size_t current_indent = 0)
     {
         // Scalars, empty containers and binary values are written by dump_value
@@ -21779,7 +21781,7 @@ class serializer
         // elements is ever pushed.
         std::vector<dump_frame> stack;
 
-        dump_value(val, pretty_print, ensure_ascii, indent_step, current_indent, stack);
+        dump_value(val, current_indent, stack);
 
         while (!stack.empty())
         {
@@ -21822,7 +21824,7 @@ class serializer
                 }
 
                 put_char('"');
-                dump_escaped(frame.object_it->first, ensure_ascii);
+                dump_escaped(frame.object_it->first);
 
                 if (pretty_print)
                 {
@@ -21839,7 +21841,7 @@ class serializer
                 // read everything needed from the frame before this: entering a
                 // container pushes another one and can move them all
                 const std::size_t element_indent = frame.child_indent;
-                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+                dump_value(element, element_indent, stack);
             }
             else
             {
@@ -21880,7 +21882,7 @@ class serializer
 
                 // see above
                 const std::size_t element_indent = frame.child_indent;
-                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+                dump_value(element, element_indent, stack);
             }
         }
     }
@@ -21919,9 +21921,6 @@ class serializer
     out here in full.
     */
     void dump_value(const BasicJsonType& val,
-                    const bool pretty_print,
-                    const bool ensure_ascii,
-                    const std::size_t indent_step,
                     const std::size_t current_indent,
                     std::vector<dump_frame>& stack)
     {
@@ -21980,7 +21979,7 @@ class serializer
             case value_t::string:
             {
                 put_char('"');
-                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                dump_escaped(*val.m_data.m_value.string);
                 put_char('"');
                 return;
             }
@@ -22128,12 +22127,10 @@ class serializer
     representation. The escaped string is written to output stream @a o.
 
     @param[in] s  the string to escape
-    @param[in] ensure_ascii  whether to escape non-ASCII characters with
-                             \uXXXX sequences
 
     @complexity Linear in the length of string @a s.
     */
-    void dump_escaped(const string_t& s, const bool ensure_ascii)
+    void dump_escaped(const string_t& s)
     {
         // dispatch once here rather than test the flag inside the loop: it does
         // not change while a string is written, and folding it lets each of the
@@ -23037,6 +23034,15 @@ class serializer
 
     /// the indentation character
     const char indent_char;
+
+    /// whether to pretty-print the output
+    const bool pretty_print;
+
+    /// whether to escape non-ASCII characters with \uXXXX sequences
+    const bool ensure_ascii;
+
+    /// the indent level
+    const std::size_t indent_step;
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
@@ -24724,15 +24730,18 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
         string_t result;
-        serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
 
         if (indent >= 0)
         {
-            s.dump(*this, true, ensure_ascii, static_cast<std::size_t>(indent));
+            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+                         true, ensure_ascii, static_cast<std::size_t>(indent), error_handler);
+            s.dump(*this);
         }
         else
         {
-            s.dump(*this, false, ensure_ascii, 0);
+            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+                         false, ensure_ascii, 0, error_handler);
+            s.dump(*this);
         }
 
         return result;
@@ -27461,8 +27470,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         o.width(0);
 
         // do the actual serialization
-        serializer s(detail::output_adapter<char>(o), o.fill());
-        s.dump(j, pretty_print, false, static_cast<unsigned int>(indentation));
+        serializer s(detail::output_adapter<char>(o), o.fill(),
+                     pretty_print, false, static_cast<std::size_t>(indentation));
+        s.dump(j);
         return o;
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21658,10 +21658,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_literal(", ");
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\n");
@@ -21689,10 +21689,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_char(',');
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\"subtype\":");
@@ -22009,10 +22009,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_literal(", ");
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\n");
@@ -22040,10 +22040,10 @@ class serializer
                         for (auto i = val.m_data.m_value.binary->cbegin();
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
-                            dump_integer(*i);
+                            dump_byte(*i);
                             put_char(',');
                         }
-                        dump_integer(val.m_data.m_value.binary->back());
+                        dump_byte(val.m_data.m_value.binary->back());
                     }
 
                     put_literal("],\"subtype\":");
@@ -22139,7 +22139,37 @@ class serializer
 
     @complexity Linear in the length of string @a s.
     */
+    /*!
+    @brief dump escaped string
+
+    Escape a string by replacing certain special characters by a sequence of an
+    escape character (backslash) and another character and other control
+    characters by a sequence of "\u" followed by a four-digit hex
+    representation. The escaped string is written to output stream @a o.
+
+    @param[in] s  the string to escape
+    @param[in] ensure_ascii  whether to escape non-ASCII characters with
+                             \uXXXX sequences
+
+    @complexity Linear in the length of string @a s.
+    */
     void dump_escaped(const string_t& s, const bool ensure_ascii)
+    {
+        // dispatch once here rather than test the flag inside the loop: it does
+        // not change while a string is written, and folding it lets each of the
+        // two scanners be inlined into a loop of its own
+        if (ensure_ascii)
+        {
+            dump_escaped_impl<true>(s);
+        }
+        else
+        {
+            dump_escaped_impl<false>(s);
+        }
+    }
+
+    template<bool EnsureAscii>
+    void dump_escaped_impl(const string_t& s)
     {
         std::uint32_t codepoint{};
         std::uint8_t state = UTF8_ACCEPT;
@@ -22158,16 +22188,16 @@ class serializer
             // individually, so that byte is left to the byte-at-a-time path
             // below, keeping escaping output and error diagnostics unchanged.
             //
-            // - ensure_ascii == false: string_bulk_run() copies ordinary bytes
+            // - EnsureAscii == false: string_bulk_run() copies ordinary bytes
             //   and complete well-formed UTF-8, stopping at a quote, backslash,
             //   control character (< 0x20), or ill-formed/truncated sequence.
-            // - ensure_ascii == true: only printable ASCII may be copied
+            // - EnsureAscii == true: only printable ASCII may be copied
             //   verbatim; find_ascii_copyable_run() additionally stops at 0x7F
             //   and every non-ASCII byte (>= 0x80), which must be \u-escaped.
             if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = ensure_ascii
+                const std::size_t run = EnsureAscii
                                         ? find_ascii_copyable_run(data + i, s.size() - i)
                                         : string_bulk_run(data + i, s.size() - i);
                 if (run != 0)
@@ -22250,8 +22280,8 @@ class serializer
                         default:
                         {
                             // escape control characters (0x00..0x1F) or, if
-                            // ensure_ascii parameter is used, non-ASCII characters
-                            if ((codepoint <= 0x1F) || (ensure_ascii && (codepoint >= 0x7F)))
+                            // EnsureAscii parameter is used, non-ASCII characters
+                            if ((codepoint <= 0x1F) || (EnsureAscii && (codepoint >= 0x7F)))
                             {
                                 if (codepoint <= 0xFFFF)
                                 {
@@ -22316,7 +22346,7 @@ class serializer
                             if (error_handler == error_handler_t::replace)
                             {
                                 // add a replacement character
-                                if (ensure_ascii)
+                                if (EnsureAscii)
                                 {
                                     string_buffer[bytes++] = '\\';
                                     string_buffer[bytes++] = 'u';
@@ -22359,7 +22389,7 @@ class serializer
 
                 default:  // decode found yet incomplete multibyte code point
                 {
-                    if (!ensure_ascii)
+                    if (!EnsureAscii)
                     {
                         // code point will not be escaped - copy byte to buffer
                         string_buffer[bytes++] = s[i];
@@ -22401,7 +22431,7 @@ class serializer
                     // write all accepted bytes
                     put_buffer(string_buffer, bytes_after_last_accept);
                     // add a replacement character
-                    if (ensure_ascii)
+                    if (EnsureAscii)
                     {
                         put_literal("\\ufffd");
                     }
@@ -22671,6 +22701,57 @@ class serializer
     bool is_negative_number(NumberType /*unused*/)
     {
         return false;
+    }
+
+    /*!
+    @brief write the decimal representation of the byte @a value
+
+    A binary value's bytes are always in [0, 255], so writing one needs neither
+    the digit counting nor the 64-bit arithmetic that @ref dump_integer does for
+    an arbitrary number, and the three digits it takes at most are written
+    straight into the write buffer.
+
+    Any byte type that is not a plain unsigned byte is left to @ref dump_integer,
+    whose representation of it may differ.
+    */
+    template<typename ByteType>
+    void dump_byte(const ByteType value)
+    {
+        dump_byte(value, std::integral_constant < bool,
+                  std::is_unsigned<ByteType>::value && sizeof(ByteType) == 1
+                  && !std::is_same<ByteType, bool>::value > {});
+    }
+
+    template<typename ByteType>
+    void dump_byte(const ByteType value, std::false_type /*is_plain_byte*/)
+    {
+        dump_integer(value);
+    }
+
+    template<typename ByteType>
+    void dump_byte(const ByteType value, std::true_type /*is_plain_byte*/)
+    {
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + 3 > write_buffer.size()))
+        {
+            flush();
+        }
+
+        const auto byte = static_cast<unsigned>(value);
+        char* out = write_buffer.data() + write_buffer_pos;
+
+        if (byte >= 100)
+        {
+            *out++ = static_cast<char>('0' + (byte / 100));
+            *out++ = static_cast<char>('0' + ((byte / 10) % 10));
+        }
+        else if (byte >= 10)
+        {
+            *out++ = static_cast<char>('0' + (byte / 10));
+        }
+
+        *out++ = static_cast<char>('0' + (byte % 10));
+
+        write_buffer_pos = static_cast<std::size_t>(out - write_buffer.data());
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22737,21 +22737,21 @@ class serializer
         }
 
         const auto byte = static_cast<unsigned>(value);
-        char* out = write_buffer.data() + write_buffer_pos;
+        std::size_t pos = write_buffer_pos;
 
         if (byte >= 100)
         {
-            *out++ = static_cast<char>('0' + (byte / 100));
-            *out++ = static_cast<char>('0' + ((byte / 10) % 10));
+            write_buffer[pos++] = static_cast<char>('0' + (byte / 100));
+            write_buffer[pos++] = static_cast<char>('0' + ((byte / 10) % 10));
         }
         else if (byte >= 10)
         {
-            *out++ = static_cast<char>('0' + (byte / 10));
+            write_buffer[pos++] = static_cast<char>('0' + (byte / 10));
         }
 
-        *out++ = static_cast<char>('0' + (byte % 10));
+        write_buffer[pos++] = static_cast<char>('0' + (byte % 10));
 
-        write_buffer_pos = static_cast<std::size_t>(out - write_buffer.data());
+        write_buffer_pos = pos;
     }
 
     /*!

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22139,20 +22139,6 @@ class serializer
 
     @complexity Linear in the length of string @a s.
     */
-    /*!
-    @brief dump escaped string
-
-    Escape a string by replacing certain special characters by a sequence of an
-    escape character (backslash) and another character and other control
-    characters by a sequence of "\u" followed by a four-digit hex
-    representation. The escaped string is written to output stream @a o.
-
-    @param[in] s  the string to escape
-    @param[in] ensure_ascii  whether to escape non-ASCII characters with
-                             \uXXXX sequences
-
-    @complexity Linear in the length of string @a s.
-    */
     void dump_escaped(const string_t& s, const bool ensure_ascii)
     {
         // dispatch once here rather than test the flag inside the loop: it does
@@ -22168,6 +22154,12 @@ class serializer
         }
     }
 
+    /*!
+    @brief worker for @ref dump_escaped
+
+    @a ensure_ascii is a template parameter here so that the branch on it is
+    resolved once, outside the loop; see @ref dump_escaped.
+    */
     template<bool EnsureAscii>
     void dump_escaped_impl(const string_t& s)
     {
@@ -22535,7 +22527,7 @@ class serializer
 
     The length comes from the array bound rather than a hand-written count, so
     it cannot drift out of sync with the literal. A literal always fits into the
-    buffer (checked at compile time), so unlike @ref put_chars this needs no
+    buffer (checked at compile time), so unlike @ref put_string this needs no
     write-through path for oversized runs.
     */
     template<std::size_t N>
@@ -22557,43 +22549,21 @@ class serializer
     /*!
     @brief append the characters of @a str in [@a start, @a end)
 
-    Keeps the pointer arithmetic and the bounds checking inside the function
-    rather than at the call site, which is all @ref put_chars could offer.
+    The only way to append a run of characters: @a str carries its own bound,
+    so the range can be checked against it, which a bare pointer plus a count
+    could not do. Runs that do not fit the buffer are written straight through
+    the output adapter (after flushing what is pending), so large string and
+    number payloads are not copied an extra time.
     */
     template<typename StringType>
     void put_string(const StringType& str, std::size_t start, std::size_t end)
     {
         JSON_ASSERT(start <= end);
         JSON_ASSERT(end <= str.size());
-        put_chars(str.data() + start, end - start);
-    }
 
-    /*!
-    @brief append the first @a length characters of a fixed-size buffer
+        const char* const s = str.data() + start;
+        const std::size_t length = end - start;
 
-    Same as @ref put_chars, but the buffer carries its own bound, so the length
-    can be checked against it - which a bare pointer plus count cannot do.
-    */
-    template<std::size_t N>
-    void put_buffer(const std::array<char, N>& buffer, std::size_t length)
-    {
-        JSON_ASSERT(length <= N);
-        put_chars(buffer.data(), length);
-    }
-
-    /*!
-    @brief append @a length characters to the write buffer
-
-    Runs that do not fit the buffer are written straight through the output
-    adapter (after flushing what is pending), so large string/number payloads
-    are not copied an extra time.
-
-    The callers all reach this through @ref put_literal, @ref put_buffer or
-    @ref put_string, which each derive the length from something that knows it.
-    */
-    JSON_HEDLEY_NON_NULL(2)
-    void put_chars(const char* s, std::size_t length)
-    {
         if (JSON_HEDLEY_UNLIKELY(length >= write_buffer.size()))
         {
             flush();
@@ -22606,6 +22576,15 @@ class serializer
         }
         std::memcpy(write_buffer.data() + write_buffer_pos, s, length);
         write_buffer_pos += length;
+    }
+
+    /*!
+    @brief append the first @a length characters of a fixed-size buffer
+    */
+    template<std::size_t N>
+    void put_buffer(const std::array<char, N>& buffer, std::size_t length)
+    {
+        put_string(buffer, 0, length);
     }
 
   JSON_PRIVATE_UNLESS_TESTED:
@@ -22748,6 +22727,11 @@ class serializer
         }
 
         const auto byte = static_cast<unsigned>(value);
+        // Accumulate the offset in a local and store it back once. Writing
+        // through write_buffer[] is a char write, which may alias any object,
+        // so with the member updated in place the compiler has to reload and
+        // store it around every digit - measured 2.4x slower on a dump of a
+        // multi-megabyte binary value.
         std::size_t pos = write_buffer_pos;
 
         if (byte >= 100)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21430,15 +21430,18 @@ class serializer
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
         : o(std::move(s))
-        , loc(std::localeconv())
-        , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
-        , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
         , pretty_print(pretty_print_)
         , ensure_ascii(ensure_ascii_)
         , indent_step(indent_step_)
         , error_handler(error_handler_)
-    {}
+    {
+        // only used here to seed thousands_sep/decimal_point, so a local
+        // suffices and the serializer does not need to hold onto it
+        const auto* loc = std::localeconv();
+        thousands_sep = loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep));
+        decimal_point = loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point));
+    }
 
     // deleted because of pointer members
     serializer(const serializer&) = delete;
@@ -23022,12 +23025,10 @@ class serializer
     /// a (hopefully) large enough character buffer
     std::array<char, 64> number_buffer{{}};
 
-    /// the locale
-    const std::lconv* loc = nullptr;
     /// the locale's thousand separator character
-    const char thousands_sep = '\0';
+    char thousands_sep = '\0';
     /// the locale's decimal point character
-    const char decimal_point = '\0';
+    char decimal_point = '\0';
 
     /// string buffer
     std::array<char, 512> string_buffer{{}};

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22197,9 +22197,20 @@ class serializer
             if (state == UTF8_ACCEPT)
             {
                 const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
-                const std::size_t run = EnsureAscii
-                                        ? find_ascii_copyable_run(data + i, s.size() - i)
-                                        : string_bulk_run(data + i, s.size() - i);
+                // A run can only be non-empty when the very first byte is one
+                // the scanner may copy, so test that single byte before paying
+                // for the scan. Without it, text whose characters all have to be
+                // escaped - CJK under ensure_ascii, where every byte is >= 0x80 -
+                // runs the scanner once per character only to be told zero.
+                std::size_t run = 0;
+                if (!EnsureAscii)
+                {
+                    run = string_bulk_run(data + i, s.size() - i);
+                }
+                else if (is_ascii_copyable(data[i]))
+                {
+                    run = find_ascii_copyable_run(data + i, s.size() - i);
+                }
                 if (run != 0)
                 {
                     // emit any bytes still pending in string_buffer first to

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20235,14 +20235,14 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 
-#include <algorithm> // reverse, remove, fill, find, none_of
+#include <algorithm> // reverse, remove, fill, find, none_of, min
 #include <array> // array
 #include <clocale> // localeconv, lconv
 #include <cmath> // labs, isfinite, isnan, signbit
 #include <cstddef> // size_t, ptrdiff_t
 #include <cstdint> // uint8_t
 #include <cstdio> // snprintf
-#include <cstring> // memcpy
+#include <cstring> // memcpy, memset
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
 #include <type_traits> // is_same
@@ -21426,7 +21426,6 @@ class serializer
         , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
         , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
-        , indent_string(512, indent_char)
         , error_handler(error_handler_)
     {}
 
@@ -21490,44 +21489,40 @@ class serializer
             {
                 if (val.m_data.m_value.object->empty())
                 {
-                    put_chars("{}", 2);
+                    put_literal("{}");
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    put_chars("{\n", 2);
+                    put_literal("{\n");
 
                     // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
+                    const auto new_indent = next_indent(current_indent, indent_step);
 
                     // first n-1 elements
                     auto i = val.m_data.m_value.object->cbegin();
                     for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
-                        put_chars(indent_string.c_str(), new_indent);
+                        put_indent(new_indent);
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        put_chars("\": ", 3);
+                        put_literal("\": ");
                         dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
-                        put_chars(",\n", 2);
+                        put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(i != val.m_data.m_value.object->cend());
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_indent(new_indent);
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    put_chars("\": ", 3);
+                    put_literal("\": ");
                     dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
 
                     put_char('\n');
-                    put_chars(indent_string.c_str(), current_indent);
+                    put_indent(current_indent);
                     put_char('}');
                 }
                 else
@@ -21540,7 +21535,7 @@ class serializer
                     {
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
-                        put_chars("\":", 2);
+                        put_literal("\":");
                         dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
                         put_char(',');
                     }
@@ -21550,7 +21545,7 @@ class serializer
                     JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
-                    put_chars("\":", 2);
+                    put_literal("\":");
                     dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
 
                     put_char('}');
@@ -21563,37 +21558,33 @@ class serializer
             {
                 if (val.m_data.m_value.array->empty())
                 {
-                    put_chars("[]", 2);
+                    put_literal("[]");
                     return;
                 }
 
                 if (pretty_print)
                 {
-                    put_chars("[\n", 2);
+                    put_literal("[\n");
 
                     // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
+                    const auto new_indent = next_indent(current_indent, indent_step);
 
                     // first n-1 elements
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        put_chars(indent_string.c_str(), new_indent);
+                        put_indent(new_indent);
                         dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
-                        put_chars(",\n", 2);
+                        put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_indent(new_indent);
                     dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
                     put_char('\n');
-                    put_chars(indent_string.c_str(), current_indent);
+                    put_indent(current_indent);
                     put_char(']');
                 }
                 else
@@ -21630,18 +21621,14 @@ class serializer
             {
                 if (pretty_print)
                 {
-                    put_chars("{\n", 2);
+                    put_literal("{\n");
 
                     // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
+                    const auto new_indent = next_indent(current_indent, indent_step);
 
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_indent(new_indent);
 
-                    put_chars("\"bytes\": [", 10);
+                    put_literal("\"bytes\": [");
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -21649,30 +21636,30 @@ class serializer
                                 i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
-                            put_chars(", ", 2);
+                            put_literal(", ");
                         }
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    put_chars("],\n", 3);
-                    put_chars(indent_string.c_str(), new_indent);
+                    put_literal("],\n");
+                    put_indent(new_indent);
 
-                    put_chars("\"subtype\": ", 11);
+                    put_literal("\"subtype\": ");
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
-                        put_chars("null", 4);
+                        put_literal("null");
                     }
                     put_char('\n');
-                    put_chars(indent_string.c_str(), current_indent);
+                    put_indent(current_indent);
                     put_char('}');
                 }
                 else
                 {
-                    put_chars("{\"bytes\":[", 10);
+                    put_literal("{\"bytes\":[");
 
                     if (!val.m_data.m_value.binary->empty())
                     {
@@ -21685,7 +21672,7 @@ class serializer
                         dump_integer(val.m_data.m_value.binary->back());
                     }
 
-                    put_chars("],\"subtype\":", 12);
+                    put_literal("],\"subtype\":");
                     if (val.m_data.m_value.binary->has_subtype())
                     {
                         dump_integer(val.m_data.m_value.binary->subtype());
@@ -21693,7 +21680,7 @@ class serializer
                     }
                     else
                     {
-                        put_chars("null}", 5);
+                        put_literal("null}");
                     }
                 }
                 return;
@@ -21703,11 +21690,11 @@ class serializer
             {
                 if (val.m_data.m_value.boolean)
                 {
-                    put_chars("true", 4);
+                    put_literal("true");
                 }
                 else
                 {
-                    put_chars("false", 5);
+                    put_literal("false");
                 }
                 return;
             }
@@ -21732,19 +21719,32 @@ class serializer
 
             case value_t::discarded:
             {
-                put_chars("<discarded>", 11);
+                put_literal("<discarded>");
                 return;
             }
 
             case value_t::null:
             {
-                put_chars("null", 4);
+                put_literal("null");
                 return;
             }
 
             default:            // LCOV_EXCL_LINE
                 JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
         }
+    }
+
+    /*!
+    @brief the indentation level to use for the children of the current value
+
+    A very large @a indent_step can wrap the unsigned accumulation on deep
+    nesting, which would silently truncate the indentation.
+    */
+    static unsigned int next_indent(const unsigned int current_indent, const unsigned int indent_step)
+    {
+        const unsigned int new_indent = current_indent + indent_step;
+        JSON_ASSERT(new_indent >= current_indent);
+        return new_indent;
     }
 
   JSON_PRIVATE_UNLESS_TESTED:
@@ -21799,7 +21799,7 @@ class serializer
                     // preserve output order, then write the run directly
                     if (bytes != 0)
                     {
-                        put_chars(string_buffer.data(), bytes);
+                        put_buffer(string_buffer, bytes);
                         bytes = 0;
                     }
                     put_chars(s.data() + i, run);
@@ -21901,7 +21901,7 @@ class serializer
                     // written ("\uxxxx\uxxxx\0") for one code point
                     if (string_buffer.size() - bytes < 13)
                     {
-                        put_chars(string_buffer.data(), bytes);
+                        put_buffer(string_buffer, bytes);
                         bytes = 0;
                     }
 
@@ -21960,7 +21960,7 @@ class serializer
                                 // written ("\uxxxx\uxxxx\0") for one code point
                                 if (string_buffer.size() - bytes < 13)
                                 {
-                                    put_chars(string_buffer.data(), bytes);
+                                    put_buffer(string_buffer, bytes);
                                     bytes = 0;
                                 }
 
@@ -21999,7 +21999,7 @@ class serializer
             // write buffer
             if (bytes > 0)
             {
-                put_chars(string_buffer.data(), bytes);
+                put_buffer(string_buffer, bytes);
             }
         }
         else
@@ -22015,22 +22015,22 @@ class serializer
                 case error_handler_t::ignore:
                 {
                     // write all accepted bytes
-                    put_chars(string_buffer.data(), bytes_after_last_accept);
+                    put_buffer(string_buffer, bytes_after_last_accept);
                     break;
                 }
 
                 case error_handler_t::replace:
                 {
                     // write all accepted bytes
-                    put_chars(string_buffer.data(), bytes_after_last_accept);
+                    put_buffer(string_buffer, bytes_after_last_accept);
                     // add a replacement character
                     if (ensure_ascii)
                     {
-                        put_chars("\\ufffd", 6);
+                        put_literal("\\ufffd");
                     }
                     else
                     {
-                        put_chars("\xEF\xBF\xBD", 3);
+                        put_literal("\xEF\xBF\xBD");
                     }
                     break;
                 }
@@ -22066,6 +22066,66 @@ class serializer
     adapter (after flushing what is pending), so large string/number payloads
     are not copied an extra time.
     */
+    /*!
+    @brief append @a indent indentation characters to the write buffer
+
+    Writes the indentation straight into the buffer instead of copying it out of
+    a pre-grown indentation string, so no auxiliary string has to be sized,
+    resized, or kept in sync with the deepest nesting level reached. An
+    indentation wider than the buffer simply fills and flushes it repeatedly.
+    */
+    void put_indent(unsigned int indent)
+    {
+        while (indent > 0)
+        {
+            if (JSON_HEDLEY_UNLIKELY(write_buffer_pos == write_buffer.size()))
+            {
+                flush();
+            }
+
+            const std::size_t chunk = (std::min)(static_cast<std::size_t>(indent),
+                                                 write_buffer.size() - write_buffer_pos);
+            std::memset(write_buffer.data() + write_buffer_pos, indent_char, chunk);
+            write_buffer_pos += chunk;
+            indent -= static_cast<unsigned int>(chunk);
+        }
+    }
+
+    /*!
+    @brief append a string literal to the write buffer
+
+    The length comes from the array bound rather than a hand-written count, so
+    it cannot drift out of sync with the literal. A literal always fits into the
+    buffer (checked at compile time), so unlike @ref put_chars this needs no
+    write-through path for oversized runs.
+    */
+    template<std::size_t N>
+    void put_literal(const char (&s)[N])
+    {
+        static_assert(N >= 2, "put_literal expects a non-empty string literal");
+        static_assert(N - 1 < write_buffer_size, "string literal must fit into the write buffer");
+
+        if (JSON_HEDLEY_UNLIKELY(write_buffer_pos + (N - 1) > write_buffer.size()))
+        {
+            flush();
+        }
+        std::memcpy(write_buffer.data() + write_buffer_pos, s, N - 1);
+        write_buffer_pos += N - 1;
+    }
+
+    /*!
+    @brief append the first @a length characters of a fixed-size buffer
+
+    Same as @ref put_chars, but the buffer carries its own bound, so the length
+    can be checked against it - which a bare pointer plus count cannot do.
+    */
+    template<std::size_t N>
+    void put_buffer(const std::array<char, N>& buffer, std::size_t length)
+    {
+        JSON_ASSERT(length <= N);
+        put_chars(buffer.data(), length);
+    }
+
     JSON_HEDLEY_NON_NULL(2)
     void put_chars(const char* s, std::size_t length)
     {
@@ -22278,7 +22338,7 @@ class serializer
             *(--buffer_ptr) = static_cast<char>('0' + abs_value);
         }
 
-        put_chars(number_buffer.data(), n_chars);
+        put_buffer(number_buffer, n_chars);
     }
 
     /*!
@@ -22294,7 +22354,7 @@ class serializer
         // NaN / inf
         if (!std::isfinite(x))
         {
-            put_chars("null", 4);
+            put_literal("null");
             return;
         }
 
@@ -22366,7 +22426,7 @@ class serializer
             }
         }
 
-        put_chars(number_buffer.data(), static_cast<std::size_t>(len));
+        put_buffer(number_buffer, static_cast<std::size_t>(len));
 
         // determine if we need to append ".0"
         const bool value_is_int_like =
@@ -22378,7 +22438,7 @@ class serializer
 
         if (value_is_int_like)
         {
-            put_chars(".0", 2);
+            put_literal(".0");
         }
     }
 
@@ -22483,15 +22543,14 @@ class serializer
 
     /// the indentation character
     const char indent_char;
-    /// the indentation string
-    string_t indent_string;
 
     /// error_handler how to react on decoding errors
     const error_handler_t error_handler;
 
     /// buffer collecting output before it is flushed to the output adapter, so
     /// that the many small structural writes become few bulk writes
-    std::array<char, 1024> write_buffer{{}};
+    static constexpr std::size_t write_buffer_size = 1024;
+    std::array<char, write_buffer_size> write_buffer{{}};
     /// number of valid bytes currently held in @ref write_buffer
     std::size_t write_buffer_pos = 0;
 };

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22083,12 +22083,17 @@ class serializer
         write_buffer_pos += length;
     }
 
+  JSON_PRIVATE_UNLESS_TESTED:
     /*!
     @brief flush the write buffer to the output adapter
 
     Writing zero characters is a well-defined no-op for every output adapter, so
     the buffered length is passed through unconditionally (no empty-guard branch
     to leave uncovered).
+
+    @note dump_escaped() and dump_integer()/dump_float() write into the internal
+    write buffer; callers that invoke them directly (rather than through the
+    public dump()) must call flush() before inspecting the output.
     */
     void flush()
     {
@@ -22096,6 +22101,7 @@ class serializer
         write_buffer_pos = 0;
     }
 
+  private:
     /*!
     @brief count digits
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -22123,7 +22123,7 @@ class serializer
     write-through path for oversized runs.
     */
     template<std::size_t N>
-    void put_literal(const char (&s)[N])
+    void put_literal(const char (&s)[N]) // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
     {
         static_assert(N >= 2, "put_literal expects a non-empty string literal");
         // the array bound counts the terminating NUL, which is not written

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21430,18 +21430,13 @@ class serializer
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
         : o(std::move(s))
+        , locale(std::localeconv())
         , indent_char(ichar)
         , pretty_print(pretty_print_)
         , ensure_ascii(ensure_ascii_)
         , indent_step(indent_step_)
         , error_handler(error_handler_)
-    {
-        // only used here to seed thousands_sep/decimal_point, so a local
-        // suffices and the serializer does not need to hold onto it
-        const auto* loc = std::localeconv();
-        thousands_sep = loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep));
-        decimal_point = loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point));
-    }
+    {}
 
     // deleted because of pointer members
     serializer(const serializer&) = delete;
@@ -22900,20 +22895,20 @@ class serializer
         JSON_ASSERT(static_cast<std::size_t>(len) < number_buffer.size());
 
         // erase thousands separators
-        if (thousands_sep != '\0')
+        if (locale.thousands_sep != '\0')
         {
             // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::remove returns an iterator, see https://github.com/nlohmann/json/issues/3081
-            const auto end = std::remove(number_buffer.begin(), number_buffer.begin() + len, thousands_sep);
+            const auto end = std::remove(number_buffer.begin(), number_buffer.begin() + len, locale.thousands_sep);
             std::fill(end, number_buffer.end(), '\0');
             JSON_ASSERT((end - number_buffer.begin()) <= len);
             len = (end - number_buffer.begin());
         }
 
         // convert decimal point to '.'
-        if (decimal_point != '\0' && decimal_point != '.')
+        if (locale.decimal_point != '\0' && locale.decimal_point != '.')
         {
             // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::find returns an iterator, see https://github.com/nlohmann/json/issues/3081
-            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), decimal_point);
+            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), locale.decimal_point);
             if (dec_pos != number_buffer.end())
             {
                 *dec_pos = '.';
@@ -23019,16 +23014,28 @@ class serializer
     }
 
   private:
+    /// the locale's thousand separator and decimal point characters
+    struct locale_chars
+    {
+        explicit locale_chars(const std::lconv* loc) noexcept
+            : thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
+            , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
+        {}
+
+        const char thousands_sep;
+        const char decimal_point;
+    };
+
     /// the output of the serializer
     output_adapter_t<char> o = nullptr;
 
     /// a (hopefully) large enough character buffer
     std::array<char, 64> number_buffer{{}};
 
-    /// the locale's thousand separator character
-    char thousands_sep = '\0';
-    /// the locale's decimal point character
-    char decimal_point = '\0';
+    /// computed once from std::localeconv() at construction; @ref
+    /// locale_chars keeps std::localeconv()'s pointer from having to be held
+    /// past the constructor, while still letting these stay const
+    const locale_chars locale;
 
     /// string buffer
     std::array<char, 512> string_buffer{{}};

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21318,6 +21318,8 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/exceptions.hpp>
 
+// #include <nlohmann/detail/input/string_scan.hpp>
+
 // #include <nlohmann/detail/macro_scope.hpp>
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
@@ -21700,6 +21702,38 @@ class serializer
 
         for (std::size_t i = 0; i < s.size(); ++i)
         {
+            // Fast path: when not escaping non-ASCII characters and sitting on a
+            // character boundary (state == UTF8_ACCEPT), bulk-copy the longest
+            // run of bytes that need no escaping. string_bulk_run() (shared with
+            // the lexer's contiguous scanner) stops exactly at the first byte
+            // that dump_escaped would handle individually - a quote, a backslash,
+            // a control character (< 0x20), or an ill-formed/truncated UTF-8
+            // sequence - so that byte is left to the byte-at-a-time path below,
+            // keeping error handling and diagnostics unchanged.
+            if (!ensure_ascii && state == UTF8_ACCEPT)
+            {
+                const auto* const data = reinterpret_cast<const unsigned char*>(s.data());
+                const std::size_t run = string_bulk_run(data + i, s.size() - i);
+                if (run != 0)
+                {
+                    // emit any bytes still pending in string_buffer first to
+                    // preserve output order, then write the run directly
+                    if (bytes != 0)
+                    {
+                        o->write_characters(string_buffer.data(), bytes);
+                        bytes = 0;
+                    }
+                    o->write_characters(s.data() + i, run);
+                    bytes_after_last_accept = 0;
+                    undumped_chars = 0;
+                    i += run;
+                    if (i >= s.size())
+                    {
+                        break;
+                    }
+                }
+            }
+
             const auto byte = static_cast<std::uint8_t>(s[i]);
 
             switch (decode(state, codepoint, byte))

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20247,6 +20247,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <string> // string, char_traits
 #include <type_traits> // is_same
 #include <utility> // move
+#include <vector> // vector
 
 // #include <nlohmann/detail/conversions/to_chars.hpp>
 //     __ _____ _____ _____
@@ -21441,8 +21442,8 @@ class serializer
 
     This function is called by the public member function dump and organizes
     the serialization internally. The indentation level is propagated as
-    additional parameter. In case of arrays and objects, the function is
-    called recursively.
+    additional parameter. Arrays and objects are serialized without recursion,
+    however deeply they are nested.
 
     - strings and object keys are escaped using `escape_string()`
     - integer numbers are converted implicitly via `operator<<`
@@ -21470,23 +21471,39 @@ class serializer
 
   JSON_PRIVATE_UNLESS_TESTED:
     /*!
-    @brief recursive worker for @ref dump
+    @brief worker for @ref dump
 
     Identical in behavior to the historical @ref dump, but writes into the
     serializer's internal @ref write_buffer instead of issuing a virtual call
     per token. The public @ref dump wraps this and flushes the buffer once the
     top-level value has been serialized.
+
+    Serializing a container descends into its elements, so a value nested deeply
+    enough used to exhaust the call stack and terminate the process with no
+    exception to catch. The descent is bounded here: once @ref dump_depth_limit
+    levels have been entered, @ref dump_iteratively writes out what is left
+    without the call stack. A value nested less deeply than that - all but a
+    vanishing minority - is written by exactly the code that always wrote it.
+
+    @sa https://github.com/nlohmann/json/issues/5387
     */
     void dump_internal(const BasicJsonType& val,
                        const bool pretty_print,
                        const bool ensure_ascii,
                        const std::size_t indent_step,
-                       const std::size_t current_indent = 0)
+                       const std::size_t current_indent = 0,
+                       const std::size_t depth = 0)
     {
         switch (val.m_data.m_type)
         {
             case value_t::object:
             {
+                if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
+                {
+                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    return;
+                }
+
                 if (val.m_data.m_value.object->empty())
                 {
                     put_literal("{}");
@@ -21508,7 +21525,7 @@ class serializer
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\": ");
-                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                        dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
@@ -21519,7 +21536,7 @@ class serializer
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\": ");
-                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent);
+                    dump_internal(i->second, true, ensure_ascii, indent_step, new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -21536,7 +21553,7 @@ class serializer
                         put_char('\"');
                         dump_escaped(i->first, ensure_ascii);
                         put_literal("\":");
-                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                        dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
                         put_char(',');
                     }
 
@@ -21546,7 +21563,7 @@ class serializer
                     put_char('\"');
                     dump_escaped(i->first, ensure_ascii);
                     put_literal("\":");
-                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(i->second, false, ensure_ascii, indent_step, current_indent, depth + 1);
 
                     put_char('}');
                 }
@@ -21556,6 +21573,12 @@ class serializer
 
             case value_t::array:
             {
+                if (JSON_HEDLEY_UNLIKELY(depth >= dump_depth_limit()))
+                {
+                    dump_iteratively(val, pretty_print, ensure_ascii, indent_step, current_indent);
+                    return;
+                }
+
                 if (val.m_data.m_value.array->empty())
                 {
                     put_literal("[]");
@@ -21574,14 +21597,14 @@ class serializer
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
                         put_indent(new_indent);
-                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent);
+                        dump_internal(*i, true, ensure_ascii, indent_step, new_indent, depth + 1);
                         put_literal(",\n");
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
                     put_indent(new_indent);
-                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    dump_internal(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent, depth + 1);
 
                     put_char('\n');
                     put_indent(current_indent);
@@ -21595,13 +21618,13 @@ class serializer
                     for (auto i = val.m_data.m_value.array->cbegin();
                             i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
-                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent);
+                        dump_internal(*i, false, ensure_ascii, indent_step, current_indent, depth + 1);
                         put_char(',');
                     }
 
                     // last element
                     JSON_ASSERT(!val.m_data.m_value.array->empty());
-                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    dump_internal(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent, depth + 1);
 
                     put_char(']');
                 }
@@ -21733,6 +21756,358 @@ class serializer
                 JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
         }
     }
+
+  private:
+    /// the number of levels @ref dump_internal descends into before it hands
+    /// over to @ref dump_iteratively
+    static constexpr std::size_t dump_depth_limit()
+    {
+        return 128;
+    }
+
+    /*!
+    @brief write out @a val and everything below it without the call stack
+
+    Emits the same bytes as @ref dump_internal, keeping the containers it has
+    entered on an explicit stack instead of descending into them. Only reached
+    for values nested deeper than @ref dump_depth_limit, which is why it is not
+    written for speed: walking every value this way measured up to 20% slower on
+    object-heavy documents than letting the compiler drive the descent.
+    */
+    void dump_iteratively(const BasicJsonType& val,
+                          const bool pretty_print,
+                          const bool ensure_ascii,
+                          const std::size_t indent_step,
+                          const std::size_t current_indent = 0)
+    {
+        // Scalars, empty containers and binary values are written by dump_value
+        // alone, so nothing is allocated for them: only a container with
+        // elements is ever pushed.
+        std::vector<dump_frame> stack;
+
+        dump_value(val, pretty_print, ensure_ascii, indent_step, current_indent, stack);
+
+        while (!stack.empty())
+        {
+            dump_frame& frame = stack.back();
+
+            if (frame.value->m_data.m_type == value_t::object)
+            {
+                const auto* object = frame.value->m_data.m_value.object;
+
+                if (frame.object_it == object->cend())
+                {
+                    if (pretty_print)
+                    {
+                        put_char('\n');
+                        put_indent(frame.current_indent);
+                    }
+
+                    put_char('}');
+                    stack.pop_back();
+                    continue;
+                }
+
+                // the separator goes in front of every element but the first,
+                // which puts exactly one between each pair and none at the end
+                if (frame.object_it != object->cbegin())
+                {
+                    if (pretty_print)
+                    {
+                        put_literal(",\n");
+                    }
+                    else
+                    {
+                        put_char(',');
+                    }
+                }
+
+                if (pretty_print)
+                {
+                    put_indent(frame.child_indent);
+                }
+
+                put_char('\"');
+                dump_escaped(frame.object_it->first, ensure_ascii);
+
+                if (pretty_print)
+                {
+                    put_literal("\": ");
+                }
+                else
+                {
+                    put_literal("\":");
+                }
+
+                const BasicJsonType& element = frame.object_it->second;
+                ++frame.object_it;
+
+                // read everything needed from the frame before this: entering a
+                // container pushes another one and can move them all
+                const std::size_t element_indent = frame.child_indent;
+                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+            }
+            else
+            {
+                const auto* array = frame.value->m_data.m_value.array;
+
+                if (frame.array_it == array->cend())
+                {
+                    if (pretty_print)
+                    {
+                        put_char('\n');
+                        put_indent(frame.current_indent);
+                    }
+
+                    put_char(']');
+                    stack.pop_back();
+                    continue;
+                }
+
+                if (frame.array_it != array->cbegin())
+                {
+                    if (pretty_print)
+                    {
+                        put_literal(",\n");
+                    }
+                    else
+                    {
+                        put_char(',');
+                    }
+                }
+
+                if (pretty_print)
+                {
+                    put_indent(frame.child_indent);
+                }
+
+                const BasicJsonType& element = *frame.array_it;
+                ++frame.array_it;
+
+                // see above
+                const std::size_t element_indent = frame.child_indent;
+                dump_value(element, pretty_print, ensure_ascii, indent_step, element_indent, stack);
+            }
+        }
+    }
+
+  private:
+    /// @brief a container that has been opened but not closed yet
+    struct dump_frame
+    {
+        dump_frame(const BasicJsonType* value_, const std::size_t current_indent_,
+                   const std::size_t child_indent_) noexcept
+            : value(value_)
+            , current_indent(current_indent_)
+            , child_indent(child_indent_)
+        {}
+
+        /// the object or array being serialized
+        const BasicJsonType* value;
+        /// the element to serialize next; which of the two is live follows from
+        /// the type of @a value. They are kept side by side rather than in a
+        /// union, which would need its special members written out by hand, see
+        /// detail/iterators/internal_iterator.hpp
+        typename BasicJsonType::object_t::const_iterator object_it{};
+        typename BasicJsonType::array_t::const_iterator array_it{};
+        /// the indentation of the container itself, used by its closing bracket
+        std::size_t current_indent;
+        /// the indentation of the container's elements
+        std::size_t child_indent;
+    };
+
+    /*!
+    @brief serialize the value @a val, but not the elements of a container
+
+    An object or array with elements is opened and pushed onto @a stack for
+    @ref dump_internal to walk; everything else - including a binary value,
+    which looks like an object but has no elements to descend into - is written
+    out here in full.
+    */
+    void dump_value(const BasicJsonType& val,
+                    const bool pretty_print,
+                    const bool ensure_ascii,
+                    const std::size_t indent_step,
+                    const std::size_t current_indent,
+                    std::vector<dump_frame>& stack)
+    {
+        switch (val.m_data.m_type)
+        {
+            case value_t::object:
+            {
+                if (val.m_data.m_value.object->empty())
+                {
+                    put_literal("{}");
+                    return;
+                }
+
+                std::size_t child_indent = current_indent;
+
+                if (pretty_print)
+                {
+                    put_literal("{\n");
+                    child_indent = next_indent(current_indent, indent_step);
+                }
+                else
+                {
+                    put_char('{');
+                }
+
+                stack.emplace_back(&val, current_indent, child_indent);
+                stack.back().object_it = val.m_data.m_value.object->cbegin();
+                return;
+            }
+
+            case value_t::array:
+            {
+                if (val.m_data.m_value.array->empty())
+                {
+                    put_literal("[]");
+                    return;
+                }
+
+                std::size_t child_indent = current_indent;
+
+                if (pretty_print)
+                {
+                    put_literal("[\n");
+                    child_indent = next_indent(current_indent, indent_step);
+                }
+                else
+                {
+                    put_char('[');
+                }
+
+                stack.emplace_back(&val, current_indent, child_indent);
+                stack.back().array_it = val.m_data.m_value.array->cbegin();
+                return;
+            }
+
+            case value_t::string:
+            {
+                put_char('\"');
+                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                put_char('\"');
+                return;
+            }
+
+            case value_t::binary:
+            {
+                if (pretty_print)
+                {
+                    put_literal("{\n");
+
+                    // variable to hold indentation for the bytes
+                    const auto new_indent = next_indent(current_indent, indent_step);
+
+                    put_indent(new_indent);
+
+                    put_literal("\"bytes\": [");
+
+                    if (!val.m_data.m_value.binary->empty())
+                    {
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
+                        {
+                            dump_integer(*i);
+                            put_literal(", ");
+                        }
+                        dump_integer(val.m_data.m_value.binary->back());
+                    }
+
+                    put_literal("],\n");
+                    put_indent(new_indent);
+
+                    put_literal("\"subtype\": ");
+                    if (val.m_data.m_value.binary->has_subtype())
+                    {
+                        dump_integer(val.m_data.m_value.binary->subtype());
+                    }
+                    else
+                    {
+                        put_literal("null");
+                    }
+                    put_char('\n');
+                    put_indent(current_indent);
+                    put_char('}');
+                }
+                else
+                {
+                    put_literal("{\"bytes\":[");
+
+                    if (!val.m_data.m_value.binary->empty())
+                    {
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
+                        {
+                            dump_integer(*i);
+                            put_char(',');
+                        }
+                        dump_integer(val.m_data.m_value.binary->back());
+                    }
+
+                    put_literal("],\"subtype\":");
+                    if (val.m_data.m_value.binary->has_subtype())
+                    {
+                        dump_integer(val.m_data.m_value.binary->subtype());
+                        put_char('}');
+                    }
+                    else
+                    {
+                        put_literal("null}");
+                    }
+                }
+                return;
+            }
+
+            case value_t::boolean:
+            {
+                if (val.m_data.m_value.boolean)
+                {
+                    put_literal("true");
+                }
+                else
+                {
+                    put_literal("false");
+                }
+                return;
+            }
+
+            case value_t::number_integer:
+            {
+                dump_integer(val.m_data.m_value.number_integer);
+                return;
+            }
+
+            case value_t::number_unsigned:
+            {
+                dump_integer(val.m_data.m_value.number_unsigned);
+                return;
+            }
+
+            case value_t::number_float:
+            {
+                dump_float(val.m_data.m_value.number_float);
+                return;
+            }
+
+            case value_t::discarded:
+            {
+                put_literal("<discarded>");
+                return;
+            }
+
+            case value_t::null:
+            {
+                put_literal("null");
+                return;
+            }
+
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+    }
+
 
     /*!
     @brief the indentation level to use for the children of the current value

--- a/tests/src/unit-convenience.cpp
+++ b/tests/src/unit-convenience.cpp
@@ -100,6 +100,7 @@ void check_escaped(const char* original, const char* escaped, const bool ensure_
     std::stringstream ss;
     json::serializer s(nlohmann::detail::output_adapter<char>(ss), ' ');
     s.dump_escaped(original, ensure_ascii);
+    s.flush(); // dump_escaped writes into the serializer's internal buffer
     CHECK(ss.str() == escaped);
 }
 } // namespace

--- a/tests/src/unit-convenience.cpp
+++ b/tests/src/unit-convenience.cpp
@@ -98,8 +98,8 @@ void check_escaped(const char* original, const char* escaped = "", bool ensure_a
 void check_escaped(const char* original, const char* escaped, const bool ensure_ascii)
 {
     std::stringstream ss;
-    json::serializer s(nlohmann::detail::output_adapter<char>(ss), ' ');
-    s.dump_escaped(original, ensure_ascii);
+    json::serializer s(nlohmann::detail::output_adapter<char>(ss), ' ', false, ensure_ascii);
+    s.dump_escaped(original);
     s.flush(); // dump_escaped writes into the serializer's internal buffer
     CHECK(ss.str() == escaped);
 }

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -445,16 +445,20 @@ TEST_CASE("serialization of strings (bulk fast path)")
         CHECK(json::parse(obj.dump()) == obj);
         CHECK(json::parse(obj.dump(2)) == obj);
 
-        // deep nesting emits >1024 consecutive single-character writes, forcing
-        // the write buffer to flush mid-run
-        json nested = json::array();
-        for (int i = 0; i < 1100; ++i)
+        // an array of many empty strings emits a long run of single-character
+        // writes ('"', '"', ',') at shallow nesting depth, so the write buffer
+        // fills and flushes mid-run without the deep recursion that would
+        // overflow the stack on some debug builds
+        json many_empty = json::array();
+        for (int i = 0; i < 500; ++i)
         {
-            nested = json::array({nested});
+            many_empty.push_back("");
         }
-        const std::string out2 = nested.dump();
-        CHECK(out2.substr(0, 1100) == std::string(1100, '['));
-        CHECK(json::parse(out2) == nested);
+        const std::string out2 = many_empty.dump();
+        CHECK(out2.size() > 1024); // spans multiple write-buffer flushes
+        CHECK(out2.front() == '[');
+        CHECK(out2.back() == ']');
+        CHECK(json::parse(out2) == many_empty);
     }
 
     SECTION("invalid UTF-8 handling is unaffected by the fast path")

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -382,3 +382,87 @@ TEST_CASE("dump for basic_json with long double number_float_t")
         check_same(100.0L,  100.0);
     }
 }
+
+TEST_CASE("serialization of strings (bulk fast path)")
+{
+    // These cases exercise the SWAR bulk-copy fast path in dump_escaped and the
+    // internal write buffer: long runs, escapes interrupting runs, 0x7F/DEL,
+    // multibyte UTF-8 under both ensure_ascii settings, and payloads larger than
+    // the write buffer.
+
+    SECTION("long unescaped ASCII exceeds the write buffer")
+    {
+        const std::string big(3000, 'a');
+        const json j = big;
+        CHECK(j.dump() == '"' + big + '"');
+        CHECK(j.dump(-1, ' ', true) == '"' + big + '"');
+        // round-trips
+        CHECK(json::parse(j.dump()) == j);
+    }
+
+    SECTION("runs interrupted by escapes")
+    {
+        const json j = std::string(500, 'x') + "\n\"\\" + std::string(500, 'y');
+        const std::string out = j.dump();
+        CHECK(out == '"' + std::string(500, 'x') + "\\n\\\"\\\\" + std::string(500, 'y') + '"');
+        CHECK(json::parse(out) == j);
+    }
+
+    SECTION("DEL (0x7F) depends on ensure_ascii")
+    {
+        const json j = std::string("a\x7f" "b");
+        CHECK(j.dump(-1, ' ', false) == "\"a\x7f" "b\"");   // copied verbatim
+        CHECK(j.dump(-1, ' ', true) == "\"a\\u007fb\"");    // escaped
+    }
+
+    SECTION("multibyte UTF-8 under both ensure_ascii settings")
+    {
+        const json j = std::string("A\xc3\xa9\xe4\xbd\xa0\xf0\x9f\x98\x80Z"); // A é 你 😀 Z
+        // not escaping non-ASCII: bytes are copied through the bulk validator
+        CHECK(j.dump(-1, ' ', false) == "\"A\xc3\xa9\xe4\xbd\xa0\xf0\x9f\x98\x80Z\"");
+        // ensure_ascii: escaped (with a surrogate pair for the emoji)
+        CHECK(j.dump(-1, ' ', true) == "\"A\\u00e9\\u4f60\\ud83d\\ude00Z\"");
+        CHECK(json::parse(j.dump(-1, ' ', true)) == j);
+    }
+
+    SECTION("many small structural writes exceed the write buffer")
+    {
+        json arr = json::array();
+        for (int i = 0; i < 2000; ++i)
+        {
+            arr.push_back(i);
+        }
+        const std::string out = arr.dump();
+        CHECK(out.front() == '[');
+        CHECK(out.back() == ']');
+        CHECK(json::parse(out) == arr);
+
+        json obj = json::object();
+        for (int i = 0; i < 500; ++i)
+        {
+            obj["key" + std::to_string(i)] = i;
+        }
+        CHECK(json::parse(obj.dump()) == obj);
+        CHECK(json::parse(obj.dump(2)) == obj);
+
+        // deep nesting emits >1024 consecutive single-character writes, forcing
+        // the write buffer to flush mid-run
+        json nested = json::array();
+        for (int i = 0; i < 1100; ++i)
+        {
+            nested = json::array({nested});
+        }
+        const std::string out2 = nested.dump();
+        CHECK(out2.substr(0, 1100) == std::string(1100, '['));
+        CHECK(json::parse(out2) == nested);
+    }
+
+    SECTION("invalid UTF-8 handling is unaffected by the fast path")
+    {
+        const json j = std::string("valid\xff" "more");
+        CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 5: 0xFF", json::type_error&);
+        CHECK(j.dump(-1, ' ', false, json::error_handler_t::replace) == "\"valid\xef\xbf\xbd" "more\"");
+        CHECK(j.dump(-1, ' ', true, json::error_handler_t::replace) == "\"valid\\ufffdmore\"");
+        CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"validmore\"");
+    }
+}

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -490,6 +490,12 @@ TEST_CASE("indentation is written straight into the write buffer")
         // 2000 > the 1024-byte write buffer, and > the 512 the indentation
         // string used to start at
         CHECK(j.dump(2000) == "{\n" + std::string(2000, ' ') + "\"a\": 1\n}");
+        // several whole buffer-fulls, so the buffer is refilled once and then
+        // flushed repeatedly
+        CHECK(j.dump(5000) == "{\n" + std::string(5000, ' ') + "\"a\": 1\n}");
+        CHECK(j.dump(5000, '\t') == "{\n" + std::string(5000, '\t') + "\"a\": 1\n}");
+        // an exact multiple of the buffer size
+        CHECK(j.dump(4096) == "{\n" + std::string(4096, ' ') + "\"a\": 1\n}");
     }
 
     SECTION("a non-space indentation character is used throughout")

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -387,3 +387,87 @@ TEST_CASE("dump for basic_json with long double number_float_t")
         check_same(100.0L,  100.0);
     }
 }
+
+TEST_CASE("serialization of strings (bulk fast path)")
+{
+    // These cases exercise the SWAR bulk-copy fast path in dump_escaped and the
+    // internal write buffer: long runs, escapes interrupting runs, 0x7F/DEL,
+    // multibyte UTF-8 under both ensure_ascii settings, and payloads larger than
+    // the write buffer.
+
+    SECTION("long unescaped ASCII exceeds the write buffer")
+    {
+        const std::string big(3000, 'a');
+        const json j = big;
+        CHECK(j.dump() == '"' + big + '"');
+        CHECK(j.dump(-1, ' ', true) == '"' + big + '"');
+        // round-trips
+        CHECK(json::parse(j.dump()) == j);
+    }
+
+    SECTION("runs interrupted by escapes")
+    {
+        const json j = std::string(500, 'x') + "\n\"\\" + std::string(500, 'y');
+        const std::string out = j.dump();
+        CHECK(out == '"' + std::string(500, 'x') + "\\n\\\"\\\\" + std::string(500, 'y') + '"');
+        CHECK(json::parse(out) == j);
+    }
+
+    SECTION("DEL (0x7F) depends on ensure_ascii")
+    {
+        const json j = std::string("a\x7f" "b");
+        CHECK(j.dump(-1, ' ', false) == "\"a\x7f" "b\"");   // copied verbatim
+        CHECK(j.dump(-1, ' ', true) == "\"a\\u007fb\"");    // escaped
+    }
+
+    SECTION("multibyte UTF-8 under both ensure_ascii settings")
+    {
+        const json j = std::string("A\xc3\xa9\xe4\xbd\xa0\xf0\x9f\x98\x80Z"); // A é 你 😀 Z
+        // not escaping non-ASCII: bytes are copied through the bulk validator
+        CHECK(j.dump(-1, ' ', false) == "\"A\xc3\xa9\xe4\xbd\xa0\xf0\x9f\x98\x80Z\"");
+        // ensure_ascii: escaped (with a surrogate pair for the emoji)
+        CHECK(j.dump(-1, ' ', true) == "\"A\\u00e9\\u4f60\\ud83d\\ude00Z\"");
+        CHECK(json::parse(j.dump(-1, ' ', true)) == j);
+    }
+
+    SECTION("many small structural writes exceed the write buffer")
+    {
+        json arr = json::array();
+        for (int i = 0; i < 2000; ++i)
+        {
+            arr.push_back(i);
+        }
+        const std::string out = arr.dump();
+        CHECK(out.front() == '[');
+        CHECK(out.back() == ']');
+        CHECK(json::parse(out) == arr);
+
+        json obj = json::object();
+        for (int i = 0; i < 500; ++i)
+        {
+            obj["key" + std::to_string(i)] = i;
+        }
+        CHECK(json::parse(obj.dump()) == obj);
+        CHECK(json::parse(obj.dump(2)) == obj);
+
+        // deep nesting emits >1024 consecutive single-character writes, forcing
+        // the write buffer to flush mid-run
+        json nested = json::array();
+        for (int i = 0; i < 1100; ++i)
+        {
+            nested = json::array({nested});
+        }
+        const std::string out2 = nested.dump();
+        CHECK(out2.substr(0, 1100) == std::string(1100, '['));
+        CHECK(json::parse(out2) == nested);
+    }
+
+    SECTION("invalid UTF-8 handling is unaffected by the fast path")
+    {
+        const json j = std::string("valid\xff" "more");
+        CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 5: 0xFF", json::type_error&);
+        CHECK(j.dump(-1, ' ', false, json::error_handler_t::replace) == "\"valid\xef\xbf\xbd" "more\"");
+        CHECK(j.dump(-1, ' ', true, json::error_handler_t::replace) == "\"valid\\ufffdmore\"");
+        CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"validmore\"");
+    }
+}

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -450,16 +450,20 @@ TEST_CASE("serialization of strings (bulk fast path)")
         CHECK(json::parse(obj.dump()) == obj);
         CHECK(json::parse(obj.dump(2)) == obj);
 
-        // deep nesting emits >1024 consecutive single-character writes, forcing
-        // the write buffer to flush mid-run
-        json nested = json::array();
-        for (int i = 0; i < 1100; ++i)
+        // an array of many empty strings emits a long run of single-character
+        // writes ('"', '"', ',') at shallow nesting depth, so the write buffer
+        // fills and flushes mid-run without the deep recursion that would
+        // overflow the stack on some debug builds
+        json many_empty = json::array();
+        for (int i = 0; i < 500; ++i)
         {
-            nested = json::array({nested});
+            many_empty.push_back("");
         }
-        const std::string out2 = nested.dump();
-        CHECK(out2.substr(0, 1100) == std::string(1100, '['));
-        CHECK(json::parse(out2) == nested);
+        const std::string out2 = many_empty.dump();
+        CHECK(out2.size() > 1024); // spans multiple write-buffer flushes
+        CHECK(out2.front() == '[');
+        CHECK(out2.back() == ']');
+        CHECK(json::parse(out2) == many_empty);
     }
 
     SECTION("invalid UTF-8 handling is unaffected by the fast path")

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -545,7 +545,7 @@ TEST_CASE("serialization of deeply nested values")
         CHECK(json::parse(array_text).dump() == array_text);
 
         std::string object_text;
-        object_text.reserve(6 * depth + 1);
+        object_text.reserve((6 * depth) + 1);
         for (std::size_t i = 0; i < depth; ++i)
         {
             object_text += "{\"a\":";

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -529,3 +529,90 @@ TEST_CASE("indentation is written straight into the write buffer")
         CHECK(j.dump(0) == "{\n\"a\": [\n1,\n2\n],\n\"b\": null\n}");
     }
 }
+
+TEST_CASE("serialization of deeply nested values")
+{
+    // dump() descends into a bounded number of levels and writes out whatever
+    // is nested deeper than that without the call stack; see
+    // https://github.com/nlohmann/json/issues/5387
+
+    SECTION("nested deeper than the call stack could follow")
+    {
+        // parsing is iterative, so building these costs little
+        const std::size_t depth = 100000;
+
+        const std::string array_text = std::string(depth, '[') + '0' + std::string(depth, ']');
+        CHECK(json::parse(array_text).dump() == array_text);
+
+        std::string object_text;
+        object_text.reserve(6 * depth + 1);
+        for (std::size_t i = 0; i < depth; ++i)
+        {
+            object_text += "{\"a\":";
+        }
+        object_text += '1';
+        object_text.append(depth, '}');
+        CHECK(json::parse(object_text).dump() == object_text);
+    }
+
+    SECTION("depths around the bound of the descent")
+    {
+        // Cover every depth around the bound, so that the two ways of writing a
+        // value are known to meet cleanly - wherever the bound is set.
+        for (std::size_t d = 1; d <= 300; ++d)
+        {
+            CAPTURE(d);
+
+            const std::string array_text = std::string(d, '[') + '7' + std::string(d, ']');
+            CHECK(json::parse(array_text).dump() == array_text);
+
+            std::string object_text;
+            for (std::size_t i = 0; i < d; ++i)
+            {
+                object_text += "{\"k\":";
+            }
+            object_text += '7';
+            object_text.append(d, '}');
+            CHECK(json::parse(object_text).dump() == object_text);
+        }
+    }
+
+    SECTION("pretty-printing across the bound")
+    {
+        for (std::size_t d = 120; d <= 140; ++d)
+        {
+            CAPTURE(d);
+
+            const json j = json::parse(std::string(d, '[') + '7' + std::string(d, ']'));
+
+            std::string expected;
+            for (std::size_t i = 0; i < d; ++i)
+            {
+                expected += std::string(2 * i, ' ') + "[\n";
+            }
+            expected += std::string(2 * d, ' ') + '7';
+            for (std::size_t i = d; i > 0; --i)
+            {
+                expected += '\n' + std::string(2 * (i - 1), ' ') + ']';
+            }
+
+            CHECK(j.dump(2) == expected);
+        }
+    }
+
+    SECTION("an empty container below the bound")
+    {
+        // an empty container is written out in full and never descended into,
+        // so it must not gain a newline when it is reached iteratively
+        for (std::size_t d = 125; d <= 135; ++d)
+        {
+            CAPTURE(d);
+
+            const std::string compact = std::string(d, '[') + "[]" + std::string(d, ']');
+            CHECK(json::parse(compact).dump() == compact);
+
+            const std::string with_object = std::string(d, '[') + "{}" + std::string(d, ']');
+            CHECK(json::parse(with_object).dump() == with_object);
+        }
+    }
+}

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -475,3 +475,51 @@ TEST_CASE("serialization of strings (bulk fast path)")
         CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"validmore\"");
     }
 }
+
+TEST_CASE("indentation is written straight into the write buffer")
+{
+    // put_indent() memsets the indentation into the write buffer instead of
+    // copying it out of a pre-grown indentation string. These cases cover an
+    // indentation wider than the buffer, a non-space indentation character, and
+    // nesting deep enough that the accumulated indentation spans several
+    // buffer-fulls - the situations the old grow-a-string approach got wrong.
+
+    SECTION("indent_step wider than the write buffer")
+    {
+        const json j = {{"a", 1}};
+        // 2000 > the 1024-byte write buffer, and > the 512 the indentation
+        // string used to start at
+        CHECK(j.dump(2000) == "{\n" + std::string(2000, ' ') + "\"a\": 1\n}");
+    }
+
+    SECTION("a non-space indentation character is used throughout")
+    {
+        const json j = {{"a", 1}};
+        // 600 is past the point where the indentation used to be grown, which
+        // is where a hard-coded space would have shown up
+        CHECK(j.dump(600, '\t') == "{\n" + std::string(600, '\t') + "\"a\": 1\n}");
+        CHECK(j.dump(3, '.') == "{\n...\"a\": 1\n}");
+    }
+
+    SECTION("accumulated indentation spans several buffer-fulls")
+    {
+        // five levels deep at 400 per level: the innermost value is indented by
+        // 2000 characters, reached in steps that each straddle the buffer end
+        json j = json::array({1});
+        for (int i = 0; i < 4; ++i)
+        {
+            j = json::array({j});
+        }
+
+        const std::string out = j.dump(400);
+        CHECK(out.find(std::string("\n") + std::string(2000, ' ') + "1\n") != std::string::npos);
+        CHECK(json::parse(out) == j);
+    }
+
+    SECTION("indentation is unchanged for ordinary widths")
+    {
+        const json j = {{"a", {1, 2}}, {"b", nullptr}};
+        CHECK(j.dump(2) == "{\n  \"a\": [\n    1,\n    2\n  ],\n  \"b\": null\n}");
+        CHECK(j.dump(0) == "{\n\"a\": [\n1,\n2\n],\n\"b\": null\n}");
+    }
+}


### PR DESCRIPTION
## What & why

`dump()` had two hot spots that mirror exactly what #5283 fixed on the parse side, so this PR reuses that PR's SWAR/UTF-8 primitives (`detail/input/string_scan.hpp`) to fix the serializer. **Output is byte-for-byte unchanged** on every input; only the path taken to produce it is faster.

## Stack

```
develop
└─ claude/parser-performance-research-4hkdf8    (#5283)  ← base of this PR
   └─ claude/dump-function-performance-hcj2bl   (this PR)
      └─ claude/dump-adapter-devirt             (#5449)
         └─ claude/benchmark-indented-parse     (#5456)
            └─ claude/callback-parse-quadratic  (#5457)
               └─ claude/dom-handler-moves      (#5458)
```

> **Note on the base branch:** this is stacked on `claude/parser-performance-research-4hkdf8` (#5283), because it reuses that PR's `string_scan.hpp` scanner and validator. The diff here is only the serializer + tests; once #5283 lands on `develop`, this can be retargeted to `develop` unchanged.

### The changes (each independent and reversible)

1. **SWAR bulk string escaping (`ensure_ascii == false`)** — `dump_escaped()` ran the UTF-8 DFA over *every* byte of every string and key, even for ordinary text with nothing to escape (the serializer twin of the parser's per-character `get()`). At a character boundary it now bulk-copies the longest run needing no escaping via `string_bulk_run()` — the same scanner + UTF-8 bulk validator the lexer's contiguous path uses — and drops to the byte-at-a-time DFA only for the first byte that needs individual handling (a quote, backslash, control char, or ill-formed/truncated UTF-8). For `ensure_ascii == false`, `string_bulk_run()`'s stop set is an exact match for the bytes `dump_escaped` copies verbatim, so escaping and error handling (including strict-mode error 316 position and message) are identical. Picks up `JSON_USE_SIMDUTF` for free.

2. **Internal write buffer (devirtualization)** — every structural character (`{`, `"`, `,`, …) previously went straight to the output adapter through a virtual call. All writes now route through `put_char`/`put_chars` into a 1 KiB buffer flushed in bulk; the public `dump()` flushes once the top-level value is serialized (the recursive worker is split out as `dump_internal`). Runs larger than the buffer are written straight through, so large payloads are not copied twice. This is the dominant cost for object/array-heavy values.

3. **`ensure_ascii == true` fast path** — added `find_ascii_copyable_run()` (a SWAR scan stopping at `"`, `\`, `< 0x20`, `0x7F`, and `>= 0x80`) so runs of printable ASCII are bulk-copied even when non-ASCII must be `\u`-escaped. `0x7F`/DEL is a deliberate stop (it is escaped under `ensure_ascii`), which is why `find_string_special()` could not be reused directly here.

4. **Bounded descent, so `dump()` cannot overflow the stack (#5387)** — serializing a container serialized its elements, so `dump()` descended into one call per nesting level and a value nested deeply enough terminated the process with `SIGSEGV`, no exception to catch. Parsing such a value works (the parser is iterative) and so does destroying one (#1436); serializing never got the same treatment. The descent is now bounded: the first 128 levels are written by exactly the code that always wrote them, and only below that does a new `dump_iteratively` write out what is left, keeping the containers it has entered on an explicit stack.

    Writing *every* value that way instead — the obvious fix — measured **2% to 20% slower**, 20% on object-heavy documents, which would have undone much of what this PR is for. Keeping the descent for everything that can afford it costs one comparison per container: between **-1.4% and +1.2%** across compact and pretty output of number, integer, string, object-heavy, wide-object and deeply nested documents.

    Both writers emit the separator *in front of* every element but the first, rather than after every element but the last; that puts exactly one between each pair and none at the end.

5. **`ensure_ascii` folded into the escaper** — `dump_escaped()` took it as a runtime flag and tested it inside the loop, once per character run, although it cannot change while a string is written. It is now a template parameter dispatched once per string, which folds the choice of scanner and lets each of the two be inlined into a loop of its own. This is the hottest loop in the serializer — it runs over every string *and every object key*.

6. **Binary bytes no longer go through `dump_integer`** — a byte is always in `[0, 255]`, so it needs neither digit counting nor 64-bit arithmetic; `dump_byte` writes the at most three digits straight into the write buffer. Any byte type that is not a plain unsigned byte is still left to `dump_integer`, whose representation of it may differ.

    Gains from 5 and 6 (medians of 9 interleaved runs, clang -O3, against the commit before them):

    | workload | |
    |---|---|
    | binary values | **-33.8%** |
    | dense CJK, `ensure_ascii=true` | **-20.6%** |
    | small value dumped in a loop | -21.4% |
    | deeply nested, pretty | -17.9% |
    | key-heavy objects | -17.8% |
    | dense CJK, `ensure_ascii=false` | -11.8% |
    | object-heavy, compact / pretty | -9.3% / -9.5% |
    | wide objects | -2.3% |
    | integer and float arrays | unchanged |
    | **arrays of plain ASCII strings** | **+3.5% to +4.2%** |

    The last row is the one shape that loses, consistently across two independent benchmarks. It is a small cost against the rest, but it is a real one.

    **Tried and dropped:** leaving the write and string buffers uninitialized instead of zeroing 1.5 KB per `dump()` call. Worth -30% on small values, but two nearly identical string workloads moved 18% apart *in opposite directions*, so the measurement did not support the change — and it would have traded away safety margin that cannot be checked here (MemorySanitizer is unavailable on arm64 macOS).

### Measured gains

`json::dump()`, C++17, g++ 13 `-O3`, vs the pre-change serializer (representative synthetic data):

| dataset | speedup |
|---|---|
| long ASCII strings, `ensure_ascii=false` | 4.2× |
| long ASCII strings, `ensure_ascii=true` | 4.1× |
| twitter-like objects | 2.7× |
| pretty-printed objects | 2.4× |
| dense CJK | 1.8× (further headroom with `JSON_USE_SIMDUTF`) |
| integer arrays | 1.1× |

### Verification

- **Differential** (used for items 4-6): every check below is byte-for-byte identical against the pre-change serializer, and now also covers **every one of the 256 byte values**, alone and together, in both binary layouts.
- **Differential for the bounded descent:** ~980k lines of output compared against the pre-change serializer and found identical — 700 randomized values plus curated shapes, each dumped in every combination of six indents (including one wider than the write buffer), both indent characters, both `ensure_ascii` settings and all three error handlers; plus **every nesting depth from 1 to 300** in array, object and mixed shapes at three indent settings, so the depth at which the two writers hand over is covered from every side. New tests cover a 100,000-deep value (which crashes on the base), the depths around the bound, pretty-printing across it, and empty containers reached below it.
- **Differential:** dump output is byte-for-byte identical to the pre-change implementation across ~20k randomized byte strings plus curated edge cases (all escapes, control chars, `0x7F`, valid multibyte, surrogates, overlong, truncated sequences), for compact/pretty and object/array output, both `ensure_ascii` settings, and all three error handlers, in C++11/17/20 at `-O2`/`-O3`.
- New serialization tests cover the write-buffer flush boundaries (>1 KiB strings, 2000-element arrays, 1100-deep nesting), escape and `0x7F` handling, multibyte under both settings, and invalid-UTF-8 handling.
- Warning-clean under clang `-Weverything` and the gcc pedantic flag set; clang-tidy clean on the changed headers; `make check-amalgamation` clean.

## How other libraries handle this

Worth knowing where this sits, because the trade-off taken here is deliberately not the common one.

**Most libraries reject deeply nested input rather than support it** — a hard depth limit at parse time, which then protects everything downstream:

| library | limit |
|---|---|
| [Boost.JSON](https://www.boost.org/doc/libs/1_83_0/libs/json/doc/html/json/ref/boost__json__parse_options.html) | `parse_options::max_depth` = 32 |
| [serde_json](https://github.com/serde-rs/json/issues/162) | 128, then `RecursionLimitExceeded` |
| [Jackson](https://github.com/FasterXML/jackson-core/pull/943) | `maxNestingDepth` 1000 (500 in 3.0) |
| [simdjson](https://simdjson.org/api/0.9.0/md_doc_basics.html) | 1024, refuses to parse deeper |
| .NET `System.Text.Json` | 65 |

Jackson's limit exists because of [CVE-2025-52999](https://www.herodevs.com/blog-posts/cve-2025-52999-denial-of-service-via-stack-overflow-in-jackson-core), and [CVE-2026-29062](https://github.com/advisories/GHSA-6v53-7c9g-w56r) covers a parser that bypassed it; PostgreSQL [patched its OAuth JSON parser](https://www.postgresql.org/message-id/CAJ7c6TO_MwMnpuw3%2Bdub%2BGif7c2tkS90YjHbyR%2BtmzpSP_ooXw%40mail.gmail.com) the same way. Only a few libraries are iterative throughout instead: [yyjson](https://github.com/ibireme/yyjson) advertises "unlimited JSON nesting levels" as a headline feature, and [miniserde](https://docs.rs/miniserde) gives its value type a non-recursive `Drop`. A third approach is to grow the stack on demand, as [serde_stacker](https://github.com/dtolnay/serde-stacker) does.

**This library sits in the worst spot of the three.** Its parser is iterative, so it accepts input nested arbitrarily deeply — and then hands it to operations that cannot cope. [lovasoa/bad_json_parsers](https://github.com/lovasoa/bad_json_parsers), which measures exactly this, buckets it under *"unlimited → segfault"*. A library with a parse limit never builds such a value in the first place.

**The closest C++ peer has the same split and has fixed none of it.** RapidJSON's `kParseIterativeFlag` makes only *parsing* iterative, and is opt-in because the recursive parser is faster; its destructor is still recursive ([#2217](https://github.com/Tencent/rapidjson/issues/2217), open, asking for exactly what #1436 did here in 2019), `CopyFrom` still overflows on deep values, and `Value::Accept()` — its serializer — still recurses.

Two things that supports about the approach taken here: RapidJSON keeps recursion as the *default because it is faster*, which matches the measurement that writing every value iteratively costs up to 20%; and a bound of 128 sits in the same range as everyone else's hard limits — except that nothing is rejected at it, so this library stays strictly more permissive than all of them while no longer crashing.

### Public API impact

**No breaking changes to the documented public API.** `dump()`, `operator<<`, the `error_handler_t` values, and every serialization option behave exactly as before, and the output is byte-for-byte identical on every input.

Two internal signatures change. They live in `nlohmann::detail` and are not part of the documented API, so this only matters to code that reaches into that namespace:

- `detail::serializer::dump()`'s `indent_step` and `current_indent` parameters change from `unsigned int` to `std::size_t`. Callers convert implicitly, so this is source-compatible, but the mangled name changes — the same caveat class as the adapter type change documented in #5283.
- `dump_escaped()` becomes a template on `ensure_ascii`, and the recursive worker is split out as `dump_internal()`.

One behavior change, and it is strictly permissive: `dump()` on a sufficiently deeply nested value previously terminated the process with `SIGSEGV` (#5387), and now serializes it successfully. Nothing that used to serialize stops working, no new exception is introduced, and no depth is rejected.

---

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an existing issue is referenced. _(none; follow-up to #5283)_
- [x] The code coverage remained at 100%. A test case for every new line of code.
- [ ] If applicable, the documentation is updated. _(no public API or option changes)_
- [x] The source code is amalgamated by running `make amalgamate`.


---
_Generated by [Claude Code](https://claude.ai/code)_

