### PR TITLE
Docs: clarify there is no official npm package (impersonation/typosquat awareness)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -17,8 +17,9 @@ For vulnerabilities in third-party dependencies or modules, please report them d
 
 ## Unofficial packages
 
-This project does not publish an official npm package. Any npm package named `nlohmann-json` (or similar) is not
-maintained or endorsed by this project. See the
+This project does not publish an official npm package. The npm package
+[`nlohmann-json`](https://www.npmjs.com/package/nlohmann-json) (or similarly named packages) is not maintained or
+endorsed by this project. See the
 [package managers documentation](https://json.nlohmann.me/integration/package_managers/#npm) for supported
 integration options.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,6 +15,13 @@ guidance.
 
 For vulnerabilities in third-party dependencies or modules, please report them directly to the respective maintainers.
 
+## Unofficial packages
+
+This project does not publish an official npm package. Any npm package named `nlohmann-json` (or similar) is not
+maintained or endorsed by this project. See the
+[package managers documentation](https://json.nlohmann.me/integration/package_managers/#npm) for supported
+integration options.
+
 ## Additional Resources
 
 - Explore security-related topics and contribute to tools and projects through

--- a/docs/mkdocs/docs/home/faq.md
+++ b/docs/mkdocs/docs/home/faq.md
@@ -131,6 +131,16 @@ As described [above](#parse-errors-reading-non-ascii-characters), the library as
 
 ## Usage
 
+### Official npm package
+
+!!! question
+
+    Is there an official npm package for this library?
+
+No. This project does not publish an official npm package. Any npm package named `nlohmann-json` (or similar) is not
+maintained or endorsed by this project. See [Package Managers](../integration/package_managers.md#npm) for supported
+integration options.
+
 ### Thread safety
 
 !!! question

--- a/docs/mkdocs/docs/home/faq.md
+++ b/docs/mkdocs/docs/home/faq.md
@@ -131,16 +131,6 @@ As described [above](#parse-errors-reading-non-ascii-characters), the library as
 
 ## Usage
 
-### Official npm package
-
-!!! question
-
-    Is there an official npm package for this library?
-
-No. This project does not publish an official npm package. Any npm package named `nlohmann-json` (or similar) is not
-maintained or endorsed by this project. See [Package Managers](../integration/package_managers.md#npm) for supported
-integration options.
-
 ### Thread safety
 
 !!! question

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -930,6 +930,12 @@ If you are using [CocoaPods](https://cocoapods.org), you can use the library by 
 to your podfile (see [an example](https://bitbucket.org/benman/nlohmann_json-cocoapod/src/master/)). Please file issues
 [here](https://bitbucket.org/benman/nlohmann_json-cocoapod/issues?status=new&status=open).
 
+## npm
+
+This project does not publish an official [npm](https://www.npmjs.com) package. Any npm package named `nlohmann-json`
+(or similar) is not maintained or endorsed by this project. Use one of the package managers listed above, or integrate
+the single header directly.
+
 ## ESP-IDF and PlatformIO
 
 There is no official package published to the [ESP-IDF Component Registry](https://components.espressif.com) or the

--- a/docs/mkdocs/docs/integration/package_managers.md
+++ b/docs/mkdocs/docs/integration/package_managers.md
@@ -932,9 +932,9 @@ to your podfile (see [an example](https://bitbucket.org/benman/nlohmann_json-coc
 
 ## npm
 
-This project does not publish an official [npm](https://www.npmjs.com) package. Any npm package named `nlohmann-json`
-(or similar) is not maintained or endorsed by this project. Use one of the package managers listed above, or integrate
-the single header directly.
+This project does not publish an official [npm](https://www.npmjs.com) package. The npm package
+[`nlohmann-json`](https://www.npmjs.com/package/nlohmann-json) (or similarly named packages) is not maintained or
+endorsed by this project. Use one of the package managers listed above, or integrate the single header directly.
 
 ## ESP-IDF and PlatformIO
 


### PR DESCRIPTION
# Summary
- Clarify that this project does not publish an official npm package, so users who find nlohmann-json (or similar) on npm know it is not maintained or endorsed here.
- Add short pointers in the FAQ and security policy so the same statement is easy to find after a scanner or search flags the npm name.

This is documentation-only, addressing #5292 after a malicious npm typosquat 

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.
