### PR TITLE
ci: retry ubuntu-toolchain-r PPA add to survive Launchpad flakiness

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -163,7 +163,15 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
           apt-get install -y --no-install-recommends software-properties-common ca-certificates gnupg make git
-          add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # add-apt-repository resolves the PPA through the Launchpad API,
+          # which intermittently times out or fails the team lookup (the plain
+          # "deb ..." sources below never hit Launchpad and never flake).
+          # Retry with backoff so a transient Launchpad blip does not fail CI.
+          for attempt in 1 2 3 4 5; do
+            add-apt-repository -y ppa:ubuntu-toolchain-r/test && break
+            echo "::warning::add-apt-repository ppa:ubuntu-toolchain-r/test failed (attempt ${attempt}/5); retrying"
+            sleep $((attempt * 10))
+          done
           apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main"
           apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic universe"
           apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main"


### PR DESCRIPTION
## What

Wrap the `add-apt-repository -y ppa:ubuntu-toolchain-r/test` call in the `ci_test_compilers_gcc_old` job (`.github/workflows/ubuntu.yml`) in a retry-with-backoff loop.

## Why

The `ci_test_compilers_gcc_old` job installs old GCC (4.8 / 4.9 / 5 / 6) on an `ubuntu:20.04` container. Its first step runs:

```
add-apt-repository -y ppa:ubuntu-toolchain-r/test
```

Unlike the plain `apt-add-repository "deb ..."` lines that follow (which just append apt source entries), this call resolves the PPA through the **Launchpad API** to fetch its metadata and signing key. That lookup intermittently times out or fails the team lookup:

```
Cannot add PPA: 'ppa:~ubuntu-toolchain-r/ubuntu/test'.
ERROR: '~ubuntu-toolchain-r' user or team does not exist.
```

The failure is **transient and matrix-local**: in the run that surfaced this (on #5304, a docs-only PR), only the `(5)` matrix job failed — after hanging ~9 minutes — while the identical command in the `(4.8)`, `(4.9)`, and `(6)` jobs succeeded in the same run. The red CI was unrelated to the PR's changes.

## Fix

Retry only the Launchpad-dependent call, up to 5 times with linear backoff, emitting a warning between attempts:

```bash
for attempt in 1 2 3 4 5; do
  add-apt-repository -y ppa:ubuntu-toolchain-r/test && break
  echo "::warning::add-apt-repository ppa:ubuntu-toolchain-r/test failed (attempt ${attempt}/5); retrying"
  sleep $((attempt * 10))
done
```

The subsequent `apt-add-repository "deb ..."` sources never contact Launchpad and never flake, so they are left unchanged. No behavior change beyond resilience: on success the loop breaks on the first iteration, identical to before.

## Notes

- CI / workflow change only; no library or documentation changes.
- Unblocks #5304 (and any other PR that happens to land on a Launchpad blip).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhihRBpo7PWso98Q1cyrZz)_