### PR TITLE
Remove Lion Yang from sponsors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ You can sponsor this library at [GitHub Sponsors](https://github.com/sponsors/nl
 - [Steve Sperandeo](https://github.com/homer6)
 - [Robert Jefe Lindstädt](https://github.com/eljefedelrodeodeljefe)
 - [Steve Wagner](https://github.com/ciroque)
-- [Lion Yang](https://github.com/LionNatsu)
 
 ### Further support
 

--- a/docs/mkdocs/docs/home/sponsors.md
+++ b/docs/mkdocs/docs/home/sponsors.md
@@ -14,6 +14,5 @@ You can sponsor this library at [GitHub Sponsors](https://github.com/sponsors/nl
 - [Steve Sperandeo](https://github.com/homer6)
 - [Robert Jefe Lindstädt](https://github.com/eljefedelrodeodeljefe)
 - [Steve Wagner](https://github.com/ciroque)
-- [Lion Yang](https://github.com/LionNatsu)
 
 Thanks everyone!


### PR DESCRIPTION
Lion Yang's sponsorship has ended, so this removes their entry from the Named Sponsors list in the README and the mirrored docs page.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [ ] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [ ] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

Niels Lohmann

---
_Generated by [Claude Code](https://claude.ai/code/session_017rV8Rz7kAce7SJxuRuhGyr)_