### PR TITLE
to_bson() silently emits corrupt documents when a length exceeds INT32_MAX

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/to_bson.md
+++ b/docs/mkdocs/docs/api/basic_json/to_bson.md
@@ -40,6 +40,9 @@ Strong guarantee: if an exception is thrown, there are no changes in the JSON va
   is not an object; example: `"to serialize to BSON, top-level type must be object, but is string"`
 - Throws [`out_of_range.409`](../../home/exceptions.md#jsonexceptionout_of_range409) if a key in the JSON object contains
   a null byte (code point U+0000); example: `"BSON key cannot contain code point U+0000 (at byte 2)"`
+- Throws [`out_of_range.412`](../../home/exceptions.md#jsonexceptionout_of_range412) if the length of a document, array,
+  string, or binary value exceeds the range of the 32-bit BSON length field; example:
+  `"BSON length 2147483661 exceeds maximum of 2147483647"`
 
 ## Complexity
 

--- a/docs/mkdocs/docs/home/exceptions.md
+++ b/docs/mkdocs/docs/home/exceptions.md
@@ -898,6 +898,22 @@ A JSON Patch `add` operation cannot be applied because the target location's par
 
     This exception was added in version 3.13.0. Before that, this situation hit an internal assertion (aborting the program in debug builds) or was silently ignored when assertions were disabled.
 
+### json.exception.out_of_range.412
+
+BSON stores the length of documents, arrays, strings, and binary values in a signed 32-bit integer. This exception is thrown when a value is too large to be described by such a length field.
+
+!!! failure "Example message"
+
+    ```
+    BSON length 2147483661 exceeds maximum of 2147483647
+    ```
+
+!!! note
+
+    This exception was added in version 3.13.0. Before that, the length was silently truncated, and
+    [`to_bson`](../api/basic_json/to_bson.md) produced documents with negative length prefixes that
+    [`from_bson`](../api/basic_json/from_bson.md) rejected.
+
 ## Further exceptions
 
 This exception is thrown in case of errors that cannot be classified with the

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -986,7 +986,7 @@ class binary_writer
     */
     static std::int32_t to_bson_length(const std::size_t size)
     {
-        if (JSON_HEDLEY_UNLIKELY(size > static_cast<std::size_t>((std::numeric_limits<std::int32_t>::max)())))
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::int32_t>(size)))
         {
             JSON_THROW(out_of_range::create(412, concat("BSON length ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::int32_t>::max)())), nullptr));
         }

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -980,6 +980,21 @@ class binary_writer
     }
 
     /*!
+    @brief Checks that @a size fits into the 32-bit length field used by BSON
+    @return The size as a signed 32-bit integer
+    @throw out_of_range.412 if @a size exceeds the range of std::int32_t
+    */
+    static std::int32_t to_bson_length(const std::size_t size)
+    {
+        if (JSON_HEDLEY_UNLIKELY(size > static_cast<std::size_t>((std::numeric_limits<std::int32_t>::max)())))
+        {
+            JSON_THROW(out_of_range::create(412, concat("BSON length ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::int32_t>::max)())), nullptr));
+        }
+
+        return static_cast<std::int32_t>(size);
+    }
+
+    /*!
     @brief Writes the given @a element_type and @a name to the output adapter
     */
     void write_bson_entry_header(const string_t& name,
@@ -1027,7 +1042,7 @@ class binary_writer
     {
         write_bson_entry_header(name, 0x02);
 
-        write_number<std::int32_t>(static_cast<std::int32_t>(value.size() + 1ul), true);
+        write_number<std::int32_t>(to_bson_length(value.size() + 1ul), true);
         oa->write_characters(
             reinterpret_cast<const CharType*>(value.c_str()),
             value.size() + 1);
@@ -1142,7 +1157,7 @@ class binary_writer
                           const typename BasicJsonType::array_t& value)
     {
         write_bson_entry_header(name, 0x04); // array
-        write_number<std::int32_t>(static_cast<std::int32_t>(calc_bson_array_size(value)), true);
+        write_number<std::int32_t>(to_bson_length(calc_bson_array_size(value)), true);
 
         std::size_t array_index = 0ul;
 
@@ -1162,7 +1177,7 @@ class binary_writer
     {
         write_bson_entry_header(name, 0x05);
 
-        write_number<std::int32_t>(static_cast<std::int32_t>(value.size()), true);
+        write_number<std::int32_t>(to_bson_length(value.size()), true);
         write_number(value.has_subtype() ? static_cast<std::uint8_t>(value.subtype()) : static_cast<std::uint8_t>(0x00));
 
         oa->write_characters(reinterpret_cast<const CharType*>(value.data()), value.size());
@@ -1284,7 +1299,7 @@ class binary_writer
     */
     void write_bson_object(const typename BasicJsonType::object_t& value)
     {
-        write_number<std::int32_t>(static_cast<std::int32_t>(calc_bson_object_size(value)), true);
+        write_number<std::int32_t>(to_bson_length(calc_bson_object_size(value)), true);
 
         for (const auto& el : value)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -17765,6 +17765,21 @@ class binary_writer
     }
 
     /*!
+    @brief Checks that @a size fits into the 32-bit length field used by BSON
+    @return The size as a signed 32-bit integer
+    @throw out_of_range.412 if @a size exceeds the range of std::int32_t
+    */
+    static std::int32_t to_bson_length(const std::size_t size)
+    {
+        if (JSON_HEDLEY_UNLIKELY(size > static_cast<std::size_t>((std::numeric_limits<std::int32_t>::max)())))
+        {
+            JSON_THROW(out_of_range::create(412, concat("BSON length ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::int32_t>::max)())), nullptr));
+        }
+
+        return static_cast<std::int32_t>(size);
+    }
+
+    /*!
     @brief Writes the given @a element_type and @a name to the output adapter
     */
     void write_bson_entry_header(const string_t& name,
@@ -17812,7 +17827,7 @@ class binary_writer
     {
         write_bson_entry_header(name, 0x02);
 
-        write_number<std::int32_t>(static_cast<std::int32_t>(value.size() + 1ul), true);
+        write_number<std::int32_t>(to_bson_length(value.size() + 1ul), true);
         oa->write_characters(
             reinterpret_cast<const CharType*>(value.c_str()),
             value.size() + 1);
@@ -17927,7 +17942,7 @@ class binary_writer
                           const typename BasicJsonType::array_t& value)
     {
         write_bson_entry_header(name, 0x04); // array
-        write_number<std::int32_t>(static_cast<std::int32_t>(calc_bson_array_size(value)), true);
+        write_number<std::int32_t>(to_bson_length(calc_bson_array_size(value)), true);
 
         std::size_t array_index = 0ul;
 
@@ -17947,7 +17962,7 @@ class binary_writer
     {
         write_bson_entry_header(name, 0x05);
 
-        write_number<std::int32_t>(static_cast<std::int32_t>(value.size()), true);
+        write_number<std::int32_t>(to_bson_length(value.size()), true);
         write_number(value.has_subtype() ? static_cast<std::uint8_t>(value.subtype()) : static_cast<std::uint8_t>(0x00));
 
         oa->write_characters(reinterpret_cast<const CharType*>(value.data()), value.size());
@@ -18069,7 +18084,7 @@ class binary_writer
     */
     void write_bson_object(const typename BasicJsonType::object_t& value)
     {
-        write_number<std::int32_t>(static_cast<std::int32_t>(calc_bson_object_size(value)), true);
+        write_number<std::int32_t>(to_bson_length(calc_bson_object_size(value)), true);
 
         for (const auto& el : value)
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -17771,7 +17771,7 @@ class binary_writer
     */
     static std::int32_t to_bson_length(const std::size_t size)
     {
-        if (JSON_HEDLEY_UNLIKELY(size > static_cast<std::size_t>((std::numeric_limits<std::int32_t>::max)())))
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::int32_t>(size)))
         {
             JSON_THROW(out_of_range::create(412, concat("BSON length ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::int32_t>::max)())), nullptr));
         }

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -28,9 +28,10 @@ class huge_binary_t : public std::vector<std::uint8_t>
   public:
     using std::vector<std::uint8_t>::vector;
 
-    size_type size() const noexcept
+    size_type size() const noexcept // NOLINT(readability-convert-member-functions-to-static)
     {
-        return static_cast<size_type>(2147483648ULL); // 2^31 > INT32_MAX
+        // one byte more than the BSON length field can represent
+        return static_cast<size_type>((std::numeric_limits<std::int32_t>::max)()) + 1;
     }
 };
 

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -11,11 +11,33 @@
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
+#include <cstdint>
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <vector>
 #include "make_test_data_available.hpp"
 #include "test_utils.hpp"
+
+namespace
+{
+// a binary container that reports a size beyond INT32_MAX without allocating
+// that much memory, so the BSON length overflow can be tested cheaply
+class huge_binary_t : public std::vector<std::uint8_t>
+{
+  public:
+    using std::vector<std::uint8_t>::vector;
+
+    size_type size() const noexcept
+    {
+        return static_cast<size_type>(2147483648ULL); // 2^31 > INT32_MAX
+    }
+};
+
+using huge_binary_json = nlohmann::basic_json <
+                         std::map, std::vector, std::string, bool, std::int64_t, std::uint64_t,
+                         double, std::allocator, nlohmann::adl_serializer, huge_binary_t, void >;
+} // namespace
 
 TEST_CASE("BSON")
 {
@@ -78,6 +100,14 @@ TEST_CASE("BSON")
 #else
         CHECK_THROWS_WITH_AS(json::to_bson(j), "[json.exception.out_of_range.409] BSON key cannot contain code point U+0000 (at byte 2)", json::out_of_range&);
 #endif
+    }
+
+    SECTION("lengths exceeding INT32_MAX cannot be serialized to BSON")
+    {
+        huge_binary_json j;
+        j["b"] = huge_binary_json::binary(huge_binary_t{});
+
+        CHECK_THROWS_WITH_AS(huge_binary_json::to_bson(j), "[json.exception.out_of_range.412] BSON length 2147483661 exceeds maximum of 2147483647", huge_binary_json::out_of_range&);
     }
 
     SECTION("string length must be at least 1")


### PR DESCRIPTION
Fixes #5307.

## What

BSON length fields are 32-bit signed integers, but all four sites that wrote one used an unchecked `static_cast<std::int32_t>`: `write_bson_string`, `write_bson_array`, `write_bson_binary`, and `write_bson_object`. When a string, binary value, array, or document exceeded `INT32_MAX` bytes the cast wrapped, and `to_bson()` returned successfully with negative length prefixes. Output that `from_bson()` cannot read back, with no diagnostic at serialization time.

This adds a checked helper, `to_bson_length()`, which throws a new `out_of_range.412` when a length does not fit into `std::int32_t`, and routes all four sites through it.

## Test

Reproducing the bug directly needs a 2 GiB value (~6 GB RAM), which is not suitable for CI. Instead the test defines a file-local `huge_binary_t` deriving from `std::vector<std::uint8_t>` that hides `size()` to report 2^31 without allocating, and uses it as the `BinaryType` of a `basic_json` specialization. The size calls are statically dispatched, so the writer sees an oversized value and throws before allocating or writing anything.

Verified against the unpatched header first, where the test crashes rather than emitting corrupt output: `write_bson_binary` reaches `write_characters()` and reads past the end of the empty buffer. With the fix it throws the expected message.

## Docs

New `json.exception.out_of_range.412` section in `docs/mkdocs/docs/home/exceptions.md`, plus the corresponding entry under Exceptions in `docs/mkdocs/docs/api/basic_json/to_bson.md`.

---

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.
