### PR TITLE
reject out-of-range array index in const json_pointer access

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/operator[].md
+++ b/docs/mkdocs/docs/api/basic_json/operator[].md
@@ -79,6 +79,8 @@ Strong exception safety: if an exception occurs, the original value stays intact
       JSON pointer `ptr` begins with '0'.
     - Throws [`parse_error.109`](../../home/exceptions.md#jsonexceptionparse_error109) if an array index in the passed
       JSON pointer `ptr` is not a number.
+    - Throws [`out_of_range.401`](../../home/exceptions.md#jsonexceptionout_of_range401) if an array index in the
+      passed JSON pointer `ptr` is out of range for the const version.
     - Throws [`out_of_range.402`](../../home/exceptions.md#jsonexceptionout_of_range402) if the array index '-' is used
       in the passed JSON pointer `ptr` for the const version.
     - Throws [`out_of_range.404`](../../home/exceptions.md#jsonexceptionout_of_range404) if the JSON pointer `ptr` can

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -517,6 +517,7 @@ class json_pointer
 
     @throw parse_error.106   if an array index begins with '0'
     @throw parse_error.109   if an array index was not a number
+    @throw out_of_range.401  if an array index is out of range
     @throw out_of_range.402  if the array index '-' is used
     @throw out_of_range.404  if the JSON pointer can not be resolved
     */
@@ -542,8 +543,14 @@ class json_pointer
                         JSON_THROW(detail::out_of_range::create(402, detail::concat("array index '-' (", std::to_string(ptr->m_data.m_value.array->size()), ") is out of range"), ptr));
                     }
 
-                    // use unchecked array access
-                    ptr = &ptr->operator[](array_index<BasicJsonType>(reference_token));
+                    const auto idx = array_index<BasicJsonType>(reference_token);
+                    // the const array operator[] is unchecked, so bounds check here
+                    if (JSON_HEDLEY_UNLIKELY(idx >= ptr->m_data.m_value.array->size()))
+                    {
+                        JSON_THROW(detail::out_of_range::create(401, detail::concat(
+                                "array index ", std::to_string(idx), " is out of range"), ptr));
+                    }
+                    ptr = &ptr->operator[](idx);
                     break;
                 }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15940,6 +15940,7 @@ class json_pointer
 
     @throw parse_error.106   if an array index begins with '0'
     @throw parse_error.109   if an array index was not a number
+    @throw out_of_range.401  if an array index is out of range
     @throw out_of_range.402  if the array index '-' is used
     @throw out_of_range.404  if the JSON pointer can not be resolved
     */
@@ -15965,8 +15966,14 @@ class json_pointer
                         JSON_THROW(detail::out_of_range::create(402, detail::concat("array index '-' (", std::to_string(ptr->m_data.m_value.array->size()), ") is out of range"), ptr));
                     }
 
-                    // use unchecked array access
-                    ptr = &ptr->operator[](array_index<BasicJsonType>(reference_token));
+                    const auto idx = array_index<BasicJsonType>(reference_token);
+                    // the const array operator[] is unchecked, so bounds check here
+                    if (JSON_HEDLEY_UNLIKELY(idx >= ptr->m_data.m_value.array->size()))
+                    {
+                        JSON_THROW(detail::out_of_range::create(401, detail::concat(
+                                "array index ", std::to_string(idx), " is out of range"), ptr));
+                    }
+                    ptr = &ptr->operator[](idx);
                     break;
                 }
 

--- a/tests/src/unit-json_pointer.cpp
+++ b/tests/src/unit-json_pointer.cpp
@@ -378,11 +378,15 @@ TEST_CASE("JSON pointers")
             CHECK(j["/2"_json_pointer] == j[2]);
 
             // assign to nonexisting index
+            CHECK_THROWS_WITH_AS(j["/3"_json_pointer],
+                                 "[json.exception.out_of_range.401] array index 3 is out of range", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j.at("/3"_json_pointer),
                                  "[json.exception.out_of_range.401] array index 3 is out of range", json::out_of_range&);
             CHECK(!j.contains("/3"_json_pointer));
 
             // assign to nonexisting index (with gap)
+            CHECK_THROWS_WITH_AS(j["/5"_json_pointer],
+                                 "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
             CHECK_THROWS_WITH_AS(j.at("/5"_json_pointer),
                                  "[json.exception.out_of_range.401] array index 5 is out of range", json::out_of_range&);
             CHECK(!j.contains("/5"_json_pointer));


### PR DESCRIPTION
The const `operator[](json_pointer)` overload resolves an array reference token with `ptr->operator[](array_index(token))`, which lands on the const `operator[](size_type)`, a bare `std::vector::operator[]` with no range check. `array_index()` accepts any decimal in `0 .. SIZE_MAX-1`, so on `{"a":[1,2,3]}` a pointer like `/a/5` computes `array->data() + idx * sizeof(basic_json)` and hands back a const reference built from whatever heap bytes follow the array. AddressSanitizer reports a heap-buffer-overflow read there. Since the type byte and the `json_value` union are then read from unrelated memory, a type byte that happens to land on `object`/`array`/`string`/`binary` makes the following 8 bytes get used as a pointer and dereferenced.

The check belongs in `get_unchecked()` rather than at the call site: a caller passes a string, so it cannot tell whether a token is in range without resolving the pointer itself. The same function already throws `out_of_range.402` for `-`, which is likewise an index past the end, and `get_checked()` a few lines below performs exactly the `idx >= size()` test that was missing here, so this mirrors it and reuses its 401 message. That makes `j["/a/5"_json_pointer]` report what `j.at("/a/5"_json_pointer)` already reports for the same pointer. In-range pointers resolve unchanged, and the non-const overload keeps filling the array with nulls as documented.

Verified with the full test suite (109/109) plus `make check-amalgamation` and `cpplint`. The new checks in `unit-json_pointer.cpp` fail on develop and pass here.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.
