### PR TITLE
check all BSON reads and add an EOF check for booleans

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -197,7 +197,10 @@ class binary_reader
     {
         const std::size_t document_start = chars_read;
         std::int32_t document_size{};
-        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+        if (!get_number<std::int32_t, true>(input_format_t::bson, document_size))
+        {
+            return false;
+        }
 
         if (JSON_HEDLEY_UNLIKELY(!sax->start_object(detail::unknown_size())))
         {
@@ -287,7 +290,10 @@ class binary_reader
 
         // All BSON binary values have a subtype
         std::uint8_t subtype{};
-        get_number<std::uint8_t>(input_format_t::bson, subtype);
+        if (JSON_HEDLEY_UNLIKELY(!get_number<std::uint8_t>(input_format_t::bson, subtype)))
+        {
+            return false;
+        }
         result.set_subtype(subtype);
 
         return get_binary(input_format_t::bson, len, result);
@@ -340,7 +346,8 @@ class binary_reader
 
             case 0x08: // boolean
             {
-                return sax->boolean(get() != 0);
+                std::uint8_t value{};
+                return get_number<std::uint8_t>(input_format_t::bson, value) && sax->boolean(value != 0);
             }
 
             case 0x0A: // null
@@ -431,7 +438,10 @@ class binary_reader
     {
         const std::size_t document_start = chars_read;
         std::int32_t document_size{};
-        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+        if (!get_number<std::int32_t, true>(input_format_t::bson, document_size))
+        {
+            return false;
+        }
 
         if (JSON_HEDLEY_UNLIKELY(!sax->start_array(detail::unknown_size())))
         {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10746,7 +10746,10 @@ class binary_reader
     {
         const std::size_t document_start = chars_read;
         std::int32_t document_size{};
-        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+        if (!get_number<std::int32_t, true>(input_format_t::bson, document_size))
+        {
+            return false;
+        }
 
         if (JSON_HEDLEY_UNLIKELY(!sax->start_object(detail::unknown_size())))
         {
@@ -10836,7 +10839,10 @@ class binary_reader
 
         // All BSON binary values have a subtype
         std::uint8_t subtype{};
-        get_number<std::uint8_t>(input_format_t::bson, subtype);
+        if (JSON_HEDLEY_UNLIKELY(!get_number<std::uint8_t>(input_format_t::bson, subtype)))
+        {
+            return false;
+        }
         result.set_subtype(subtype);
 
         return get_binary(input_format_t::bson, len, result);
@@ -10889,7 +10895,8 @@ class binary_reader
 
             case 0x08: // boolean
             {
-                return sax->boolean(get() != 0);
+                std::uint8_t value{};
+                return get_number<std::uint8_t>(input_format_t::bson, value) && sax->boolean(value != 0);
             }
 
             case 0x0A: // null
@@ -10980,7 +10987,10 @@ class binary_reader
     {
         const std::size_t document_start = chars_read;
         std::int32_t document_size{};
-        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+        if (!get_number<std::int32_t, true>(input_format_t::bson, document_size))
+        {
+            return false;
+        }
 
         if (JSON_HEDLEY_UNLIKELY(!sax->start_array(detail::unknown_size())))
         {

--- a/tests/src/unit-bson.cpp
+++ b/tests/src/unit-bson.cpp
@@ -825,6 +825,41 @@ TEST_CASE("Incomplete BSON Input")
         CHECK(!json::sax_parse(incomplete_bson, &scp, json::input_format_t::bson));
     }
 
+    SECTION("Incomplete BSON Input 5")
+    {
+        std::vector<std::uint8_t> const incomplete_bson =
+        {
+            0x09, 0x00, 0x00, 0x00, // size (little endian)
+            0x08,                   // entry: boolean
+            'b', '\x00'             // key, unexpected EOF before the value
+        };
+
+        json _;
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(incomplete_bson), "[json.exception.parse_error.110] parse error at byte 8: syntax error while parsing BSON number: unexpected end of input", json::parse_error&);
+        CHECK(json::from_bson(incomplete_bson, true, false).is_discarded());
+
+        SaxCountdown scp(0);
+        CHECK(!json::sax_parse(incomplete_bson, &scp, json::input_format_t::bson));
+    }
+
+    SECTION("Incomplete BSON Input 6")
+    {
+        std::vector<std::uint8_t> const incomplete_bson =
+        {
+            0x0F, 0x00, 0x00, 0x00, // size (little endian)
+            0x05,                   // entry: binary
+            'b', '\x00',            // key
+            0x00, 0x00, 0x00, 0x00  // length, unexpected EOF before the subtype
+        };
+
+        json _;
+        CHECK_THROWS_WITH_AS(_ = json::from_bson(incomplete_bson), "[json.exception.parse_error.110] parse error at byte 12: syntax error while parsing BSON number: unexpected end of input", json::parse_error&);
+        CHECK(json::from_bson(incomplete_bson, true, false).is_discarded());
+
+        SaxCountdown scp(0);
+        CHECK(!json::sax_parse(incomplete_bson, &scp, json::input_format_t::bson));
+    }
+
     SECTION("Improve coverage")
     {
         SECTION("key")


### PR DESCRIPTION
Fixes #5309.

The BSON reader discarded the return values of three `get_number()` calls (the document size in `parse_bson_internal` and `parse_bson_array`, and the subtype in `get_bson_binary`) and read the boolean value with a bare `get()` that has no EOF check. As the issue notes, no truncated input escapes as an accepted document, but the failures surface downstream instead of at the failed read: a boolean truncated at EOF emits `boolean(true)` to the SAX handler before the element-list check reports the error, and a binary truncated at the subtype byte calls `set_subtype()` and `get_binary()` after its own parse error has already fired.

The two document-size reads now short-circuit with a plain `if (!...)` rather than `JSON_HEDLEY_UNLIKELY`, because that macro takes a single argument and the comma in `get_number<std::int32_t, true>` would be parsed as a macro argument separator; this matches the existing unwrapped call sites for the string, binary, and int32 element types. The subtype read keeps the `JSON_HEDLEY_UNLIKELY` guard, and the boolean is routed through `get_number<std::uint8_t>` so it gets the same EOF handling as every other element type.

Error messages for these truncated inputs now name the failed read (for example "BSON number" at byte 8 instead of "BSON element list" at byte 9). The existing "Incomplete BSON Input 2" assertion is unaffected because that input fails earlier, in `get_bson_cstring`. Valid input parses identically.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.

Two new sections, "Incomplete BSON Input 5" and "Incomplete BSON Input 6", cover the boolean and subtype paths; the document-size branches are exercised by the existing "Incomplete BSON Input 4" and the empty-input cases. No documentation change is needed.
