### PR TITLE
docs: correct to_bson complexity

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/to_bson.md
+++ b/docs/mkdocs/docs/api/basic_json/to_bson.md
@@ -46,7 +46,9 @@ Strong guarantee: if an exception is thrown, there are no changes in the JSON va
 
 ## Complexity
 
-Linear in the size of the JSON value `j`.
+Proportional to the size of the JSON value `j` multiplied by its maximum nesting
+depth, `O(n × d)`. BSON length prefixes are computed recursively before nested
+values are written.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- correct the `to_bson` complexity documentation to account for recursive length calculation
- describe the complexity in terms of the JSON size and maximum nesting depth

Issue: #5308

This is documentation-only; runtime behavior is unchanged.