### PR TITLE
Update CBOR references and half-float assertion bounds

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/binary_t.md
+++ b/docs/mkdocs/docs/api/basic_json/binary_t.md
@@ -13,9 +13,8 @@ is compatible with both of the binary data formats that use binary subtyping, (t
 incompatible with each other, and it is up to the user to translate between them). The subtype is added to `BinaryType`
 via the helper type [byte_container_with_subtype](../byte_container_with_subtype/index.md).
 
-[CBOR's RFC 7049](https://tools.ietf.org/html/rfc7049) describes this type as:
-> Major type 2: a byte string. The string's length in bytes is represented following the rules for positive integers
-> (major type 0).
+[CBOR's RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html#section-3.1) describes this type as:
+> Major type 2: A byte string. The number of bytes in the string is equal to the argument.
 
 [MessagePack's documentation on the bin type
 family](https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family) describes this type as:

--- a/docs/mkdocs/docs/features/binary_formats/cbor.md
+++ b/docs/mkdocs/docs/features/binary_formats/cbor.md
@@ -7,12 +7,12 @@ extremely small code sizes, fairly small message size, and extensibility without
 
     - [CBOR Website](http://cbor.io) - the main source on CBOR
     - [CBOR Playground](http://cbor.me) - an interactive webpage to translate between JSON and CBOR
-    - [RFC 7049](https://tools.ietf.org/html/rfc7049) - the CBOR specification
+    - [RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html) - the CBOR specification
 
 ## Serialization
 
 The library uses the following mapping from JSON values types to CBOR types according to the CBOR specification
-([RFC 7049](https://www.rfc-editor.org/rfc/rfc7049.html)):
+([RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html)):
 
 | JSON value type | value/range                                | CBOR type                         | first byte |
 |-----------------|--------------------------------------------|-----------------------------------|------------|

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -896,7 +896,7 @@ class binary_reader
                 const auto byte1 = static_cast<unsigned char>(byte1_raw);
                 const auto byte2 = static_cast<unsigned char>(byte2_raw);
 
-                // Code from RFC 7049, Appendix D, Figure 3:
+                // Code from RFC 8949, Appendix D, Figure 3:
                 // As half-precision floating-point numbers were only added
                 // to IEEE 754 in 2008, today's programming platforms often
                 // still only have limited support for them. It is very
@@ -909,8 +909,8 @@ class binary_reader
                 {
                     const int exp = (half >> 10u) & 0x1Fu;
                     const unsigned int mant = half & 0x3FFu;
-                    JSON_ASSERT(0 <= exp&& exp <= 32);
-                    JSON_ASSERT(mant <= 1024);
+                    JSON_ASSERT(exp <= 31);
+                    JSON_ASSERT(mant <= 1023);
                     switch (exp)
                     {
                         case 0:
@@ -2484,7 +2484,7 @@ class binary_reader
                 const auto byte1 = static_cast<unsigned char>(byte1_raw);
                 const auto byte2 = static_cast<unsigned char>(byte2_raw);
 
-                // Code from RFC 7049, Appendix D, Figure 3:
+                // Code from RFC 8949, Appendix D, Figure 3:
                 // As half-precision floating-point numbers were only added
                 // to IEEE 754 in 2008, today's programming platforms often
                 // still only have limited support for them. It is very
@@ -2497,8 +2497,8 @@ class binary_reader
                 {
                     const int exp = (half >> 10u) & 0x1Fu;
                     const unsigned int mant = half & 0x3FFu;
-                    JSON_ASSERT(0 <= exp&& exp <= 32);
-                    JSON_ASSERT(mant <= 1024);
+                    JSON_ASSERT(exp <= 31);
+                    JSON_ASSERT(mant <= 1023);
                     switch (exp)
                     {
                         case 0:

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11445,7 +11445,7 @@ class binary_reader
                 const auto byte1 = static_cast<unsigned char>(byte1_raw);
                 const auto byte2 = static_cast<unsigned char>(byte2_raw);
 
-                // Code from RFC 7049, Appendix D, Figure 3:
+                // Code from RFC 8949, Appendix D, Figure 3:
                 // As half-precision floating-point numbers were only added
                 // to IEEE 754 in 2008, today's programming platforms often
                 // still only have limited support for them. It is very
@@ -11458,8 +11458,8 @@ class binary_reader
                 {
                     const int exp = (half >> 10u) & 0x1Fu;
                     const unsigned int mant = half & 0x3FFu;
-                    JSON_ASSERT(0 <= exp&& exp <= 32);
-                    JSON_ASSERT(mant <= 1024);
+                    JSON_ASSERT(exp <= 31);
+                    JSON_ASSERT(mant <= 1023);
                     switch (exp)
                     {
                         case 0:
@@ -13033,7 +13033,7 @@ class binary_reader
                 const auto byte1 = static_cast<unsigned char>(byte1_raw);
                 const auto byte2 = static_cast<unsigned char>(byte2_raw);
 
-                // Code from RFC 7049, Appendix D, Figure 3:
+                // Code from RFC 8949, Appendix D, Figure 3:
                 // As half-precision floating-point numbers were only added
                 // to IEEE 754 in 2008, today's programming platforms often
                 // still only have limited support for them. It is very
@@ -13046,8 +13046,8 @@ class binary_reader
                 {
                     const int exp = (half >> 10u) & 0x1Fu;
                     const unsigned int mant = half & 0x3FFu;
-                    JSON_ASSERT(0 <= exp&& exp <= 32);
-                    JSON_ASSERT(mant <= 1024);
+                    JSON_ASSERT(exp <= 31);
+                    JSON_ASSERT(mant <= 1023);
                     switch (exp)
                     {
                         case 0:

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -2309,7 +2309,7 @@ TEST_CASE("all CBOR first bytes")
 }
 #endif
 
-TEST_CASE("examples from RFC 7049 Appendix A")
+TEST_CASE("examples from RFC 8949 Appendix A")
 {
     SECTION("numbers")
     {


### PR DESCRIPTION
## Summary

- Correct the CBOR half-precision exponent and mantissa assertion bounds.
- Update CBOR documentation, comments, and test naming from RFC 7049 to RFC 8949.
- Regenerate the amalgamated header.

## Rationale

The decoder masks the exponent with `0x1F` and the mantissa with `0x3FF`, so their maximum values are 31 and 1023. The previous bounds of 32 and 1024 could never be reached.

RFC 8949 obsoletes RFC 7049. The existing Appendix D, Figure 3 citation remains valid in RFC 8949. This change corrects debug invariants and stale references without changing CBOR encoding or decoding behavior.

## Testing

- `cmake --build build --parallel`
- `test-cbor_cpp11` passed.
- Full local CTest run: 106/109 passed. The three remaining MinGW floating-point parsing failures reproduced unchanged on the unmodified base commit `2e2368709`.
- Formatted with Artistic Style 3.4.13 and regenerated `single_include/nlohmann/json.hpp`.

Closes #5319