### PR TITLE
avoid sign extension in char_traits<signed char>::to_int_type

### DIFF
--- a/include/nlohmann/detail/meta/type_traits.hpp
+++ b/include/nlohmann/detail/meta/type_traits.hpp
@@ -231,7 +231,9 @@ struct char_traits<signed char> : std::char_traits<char>
     // Redefine to_int_type function
     static int_type to_int_type(char_type c) noexcept
     {
-        return static_cast<int_type>(c);
+        // cast via unsigned char: sign-extending a negative char_type would make
+        // byte 0xFF indistinguishable from eof()
+        return static_cast<int_type>(static_cast<unsigned char>(c));
     }
 
     static char_type to_char_type(int_type i) noexcept

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3994,7 +3994,9 @@ struct char_traits<signed char> : std::char_traits<char>
     // Redefine to_int_type function
     static int_type to_int_type(char_type c) noexcept
     {
-        return static_cast<int_type>(c);
+        // cast via unsigned char: sign-extending a negative char_type would make
+        // byte 0xFF indistinguishable from eof()
+        return static_cast<int_type>(static_cast<unsigned char>(c));
     }
 
     static char_type to_char_type(int_type i) noexcept

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -427,6 +427,29 @@ TEST_CASE("deserialization")
                 CHECK(l.events == std::vector<std::string>({"boolean(true)"}));
             }
 
+            SECTION("from std::vector<signed char>")
+            {
+                std::vector<signed char> const v = {'t', 'r', 'u', 'e'};
+                CHECK(json::parse(v) == json(true));
+                CHECK(json::accept(v));
+
+                SaxEventLogger l;
+                CHECK(json::sax_parse(v, &l));
+                CHECK(l.events.size() == 1);
+                CHECK(l.events == std::vector<std::string>({"boolean(true)"}));
+
+                // bytes outside ASCII are negative here and must not be sign-extended
+                std::vector<signed char> const umlaut = {'"', static_cast<signed char>(0xC3), static_cast<signed char>(0xA9), '"'};
+                CHECK(json::parse(umlaut) == json("\xC3\xA9"));
+                CHECK(json::accept(umlaut));
+
+                // 0xFF must not be reported as end of input
+                std::vector<signed char> const trailing = {'t', 'r', 'u', 'e', static_cast<signed char>(0xFF)};
+                json _;
+                CHECK_THROWS_WITH_AS(_ = json::parse(trailing), "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'true\xFF'; expected end of input", json::parse_error&);
+                CHECK(!json::accept(trailing));
+            }
+
             SECTION("from std::array")
             {
                 std::array<uint8_t, 5> const v { {'t', 'r', 'u', 'e'} };

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -438,13 +438,14 @@ TEST_CASE("deserialization")
                 CHECK(l.events.size() == 1);
                 CHECK(l.events == std::vector<std::string>({"boolean(true)"}));
 
-                // bytes outside ASCII are negative here and must not be sign-extended
-                std::vector<signed char> const umlaut = {'"', static_cast<signed char>(0xC3), static_cast<signed char>(0xA9), '"'};
+                // bytes outside ASCII are negative here and must not be sign-extended;
+                // 0xC3 and 0xA9 do not fit in signed char (MSVC C4309), so spell them as negative values
+                std::vector<signed char> const umlaut = {'"', static_cast<signed char>(0xC3 - 0x100), static_cast<signed char>(0xA9 - 0x100), '"'};
                 CHECK(json::parse(umlaut) == json("\xC3\xA9"));
                 CHECK(json::accept(umlaut));
 
-                // 0xFF must not be reported as end of input
-                std::vector<signed char> const trailing = {'t', 'r', 'u', 'e', static_cast<signed char>(0xFF)};
+                // 0xFF (spelled as -1 to stay in range) must not be reported as end of input
+                std::vector<signed char> const trailing = {'t', 'r', 'u', 'e', static_cast<signed char>(0xFF - 0x100)};
                 json _;
                 CHECK_THROWS_WITH_AS(_ = json::parse(trailing), "[json.exception.parse_error.101] parse error at line 1, column 5: syntax error while parsing value - invalid literal; last read: 'true\xFF'; expected end of input", json::parse_error&);
                 CHECK(!json::accept(trailing));

--- a/tests/src/unit-type_traits.cpp
+++ b/tests/src/unit-type_traits.cpp
@@ -53,4 +53,33 @@ TEST_CASE("type traits")
             // NOLINTEND(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
         }
     }
+
+    SECTION("char_traits")
+    {
+        SECTION("to_int_type does not sign-extend")
+        {
+            using unsigned_traits = nlohmann::detail::char_traits<unsigned char>;
+            using signed_traits = nlohmann::detail::char_traits<signed char>;
+
+            CHECK(unsigned_traits::to_int_type(static_cast<unsigned char>(0x7F)) == 0x7F);
+            CHECK(unsigned_traits::to_int_type(static_cast<unsigned char>(0x80)) == 0x80);
+            CHECK(unsigned_traits::to_int_type(static_cast<unsigned char>(0xFF)) == 0xFF);
+
+            CHECK(signed_traits::to_int_type(static_cast<signed char>(0x7F)) == 0x7F);
+            CHECK(signed_traits::to_int_type(static_cast<signed char>(0x80)) == 0x80);
+            CHECK(signed_traits::to_int_type(static_cast<signed char>(0xFF)) == 0xFF);
+        }
+
+        SECTION("no byte value collides with eof")
+        {
+            using unsigned_traits = nlohmann::detail::char_traits<unsigned char>;
+            using signed_traits = nlohmann::detail::char_traits<signed char>;
+
+            for (int i = 0; i < 256; ++i)
+            {
+                CHECK(unsigned_traits::to_int_type(static_cast<unsigned char>(i)) != unsigned_traits::eof());
+                CHECK(signed_traits::to_int_type(static_cast<signed char>(i)) != signed_traits::eof());
+            }
+        }
+    }
 }

--- a/tests/src/unit-type_traits.cpp
+++ b/tests/src/unit-type_traits.cpp
@@ -66,8 +66,9 @@ TEST_CASE("type traits")
             CHECK(unsigned_traits::to_int_type(static_cast<unsigned char>(0xFF)) == 0xFF);
 
             CHECK(signed_traits::to_int_type(static_cast<signed char>(0x7F)) == 0x7F);
-            CHECK(signed_traits::to_int_type(static_cast<signed char>(0x80)) == 0x80);
-            CHECK(signed_traits::to_int_type(static_cast<signed char>(0xFF)) == 0xFF);
+            // 0x80 and 0xFF do not fit in signed char (MSVC C4309), so spell them as negative values
+            CHECK(signed_traits::to_int_type(static_cast<signed char>(0x80 - 0x100)) == 0x80);
+            CHECK(signed_traits::to_int_type(static_cast<signed char>(0xFF - 0x100)) == 0xFF);
         }
 
         SECTION("no byte value collides with eof")


### PR DESCRIPTION
`char_traits` is specialized here for `unsigned char`, `signed char` and `std::byte` so that byte containers can be handed to the parser, and each specialization widens a character into a 64-bit `int_type` whose `eof()` is all-ones. The `signed char` specialization casts the character straight to `int_type`, and since every byte above 0x7F is negative in that type, the conversion sign-extends: 0xFF becomes 0xFFFFFFFFFFFFFFFF, which is exactly `eof()`. So for an input whose element type is `signed char`, a 0xFF byte is read as end of input and whatever follows it is dropped without an error, which means a document can carry trailing data past a `strict` check: `from_cbor` on `01 FF 41 42 43` returns `1` instead of raising `parse_error.110`, and `parse` on `true` followed by 0xFF behaves the same way. Every other byte above 0x7F picks up the same high bits and stops matching its case label, so CBOR `0xF5` is reported as an invalid byte and a plain UTF-8 `é` is rejected as ill-formed. I noticed it while lining the three specializations up against each other, since the `unsigned char` one cannot sign-extend and the `std::byte` one deliberately goes through `std::to_integer<unsigned char>`, leaving `signed char` as the only one that widens a negative value. Casting through `unsigned char` first gives all three the same 0..255 range, and because `to_char_type` maps the value back with a single cast the round trip is unchanged for every byte.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [ ] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.
