### PR TITLE
docs: qualify the operator>> stream positioning guarantee

### DIFF
--- a/docs/mkdocs/docs/api/operator_gtgt.md
+++ b/docs/mkdocs/docs/api/operator_gtgt.md
@@ -33,17 +33,44 @@ A UTF-8 byte order mark is silently ignored.
 Invalid Unicode escapes and unpaired surrogates in the input are reported as
 [`parse_error.101`](../home/exceptions.md#jsonexceptionparse_error101) with a detailed message.
 
-`operator>>` parses exactly one JSON value and leaves the stream positioned right after it, so it can be called
-repeatedly to read a sequence of concatenated JSON values from the same stream:
+`operator>>` parses exactly one JSON value, so it can be called repeatedly to read a sequence of concatenated JSON
+values from the same stream:
 
 ```cpp
 json j1, j2;
-input >> j1;  // parses the first value, stream now positioned right after it
+input >> j1;  // parses the first value
 input >> j2;  // parses the next value
 ```
 
-Note this does **not** work for [JSON Lines](../features/parsing/json_lines.md) (newline-delimited JSON) input --
-see that page for why and for the recommended alternative.
+!!! warning "A number must be followed by whitespace"
+
+    A number is only terminated by the character that follows it. That character is read from the stream to detect the
+    end of the number, and it is **not** put back. When a value that is a number is immediately followed by the next
+    value, the first character of that next value is lost:
+
+    ```cpp
+    std::istringstream input("1true");
+    json j1, j2;
+    input >> j1;  // j1 == 1
+    input >> j2;  // throws parse_error.101: the stream now starts at "rue"
+    ```
+
+    Separating the values with whitespace avoids this, because the character that is eaten is then the separator:
+
+    ```cpp
+    std::istringstream input("1 true");
+    json j1, j2;
+    input >> j1;  // j1 == 1
+    input >> j2;  // j2 == true
+    ```
+
+    Only numbers are affected. Values ending in a self-delimiting character do not read past themselves, so
+    `truefalse`, `[1][2]`, `{"a":1}{"b":2}`, and `"a""b"` can be read back to back without a separator.
+
+    This is tracked in [#5340](https://github.com/nlohmann/json/issues/5340).
+
+Note that reading concatenated values does **not** work for [JSON Lines](../features/parsing/json_lines.md)
+(newline-delimited JSON) input -- see that page for why and for the recommended alternative.
 
 !!! warning "Deprecation"
 

--- a/docs/mkdocs/docs/features/parsing/json_lines.md
+++ b/docs/mkdocs/docs/features/parsing/json_lines.md
@@ -49,4 +49,5 @@ JSON Lines input with more than one value is treated as invalid JSON by the [`pa
     with a JSON Lines input does not work, because the parser will try to parse one value after the last one.
 
     This is different from parsing a stream of *concatenated* (non-newline-delimited) JSON values, for which
-    `operator>>` does work -- see its [notes](../../api/operator_gtgt.md#notes) for details.
+    `operator>>` does work, provided that a value that is a number is followed by whitespace -- see its
+    [notes](../../api/operator_gtgt.md#notes) for details.


### PR DESCRIPTION
Short-term part of #5340.

## What

`operator>>`'s [notes](https://json.nlohmann.me/api/operator_gtgt/#notes) claim it "leaves the stream positioned right after" the parsed value, so concatenated JSON values can be read back to back. That does not hold when the value is a **number**.

A number is only terminated by the character that follows it. `lexer::scan_number()` reads that character and calls `lexer::unget()`, but `unget()` is deliberately simulated — it rewinds only the lexer's own bookkeeping (`chars_read_total`, `chars_read_current_line`, `token_string`), not the input. `input_stream_adapter::get_character()` consumes via `sbumpc()` with no matching `sungetc()`, so the terminating character stays consumed from the stream.

This PR documents the actual behaviour:

- `docs/mkdocs/docs/api/operator_gtgt.md` — drops the unqualified "positioned right after it" wording and adds a warning admonition showing the failing case (`1true`), the whitespace-separated fix (`1 true`), and which inputs are unaffected.
- `docs/mkdocs/docs/features/parsing/json_lines.md` — qualifies the cross-reference, which repeated the unqualified claim.

## Verification

Every claim in the new admonition was compiled and run against this branch's `include/` (i.e. unmodified parser):

| input | first value | second extraction |
| --- | --- | --- |
| `1true` | `1` | throws `parse_error.101` (`last read: 'r'`) |
| `1 true` | `1` | `true` |
| `truefalse` | `true` | `false` |
| `[1][2]` | `[1]` | `[2]` |
| `{"a":1}{"b":2}` | `{"a":1}` | `{"b":2}` |
| `"a""b"` | `"a"` | `"b"` |

Note the issue's original table lists `1 true` as working. It does produce the right values, but the stream position is still off by one — the byte that gets eaten just happens to be the separator. The wording here reflects that.

## Public API

**No breaking changes.** Documentation only — no header, no source, and no behaviour is touched. No amalgamation needed.

## Follow-up

The actual fix (giving `input_stream_adapter` a real unget and restoring a still-pending character at the end of a non-strict parse) is in #PLACEHOLDER, opened as a draft: it changes observable behaviour of `operator>>` and `sax_parse(strict=false)`, so it is a candidate for the next major release rather than a patch release. When that lands, the admonition added here should be replaced with a version note.

#5326 adds a "Strictness and trailing data" section to `features/parsing/index.md` that restates the positioning guarantee. It is still open, so this PR does not touch that file — whichever merges second should pick up the qualification.

---

- [x] The changes are described in detail, both the what and why.
- [x] An [existing issue](https://github.com/nlohmann/json/issues/5340) is referenced.
- [ ] Code coverage — N/A (documentation only; no code changed).
- [x] The [documentation](https://json.nlohmann.me) is updated.
- [ ] `make amalgamate` — N/A (no source code change).

---

*This pull request was written by Claude Code.*
