### PR TITLE
CI: Add clang 21&22 to Ubuntu CLang build matrix

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15-bullseye', '16', '17', '18', '19', '20', '21', 'latest']
+        compiler: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15-bullseye', '16', '17', '18', '19', '20', '21', '22', 'latest']
     container: silkeh/clang:${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15-bullseye', '16', '17', '18', '19', '20', 'latest']
+        compiler: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15-bullseye', '16', '17', '18', '19', '20', '21', 'latest']
     container: silkeh/clang:${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/mkdocs/docs/community/quality_assurance.md
+++ b/docs/mkdocs/docs/community/quality_assurance.md
@@ -66,6 +66,7 @@ Note: Some modern features (like C++20 ranges or filesystem support) may be disa
         | Clang 20.1.1                                 | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
         | Clang 20.1.8 with GNU-like command-line      | x86_64       | Windows Server 2022 (Build 20348) | GitHub    |
         | Clang 21.1.8                                 | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
+        | Clang 22.1.8                                 | x86_64       | Ubuntu 22.04.1 LTS                | GitHub    |
         | CUDA 11.8.0 (nvcc)                           | x86_64       | Ubuntu 22.04 LTS                  | GitHub    |
         | CUDA 12.1.1 (nvcc)                           | x86_64       | Ubuntu 22.04 LTS                  | GitHub    |
         | CUDA 12.6.3 (nvcc)                           | x86_64       | Ubuntu 22.04 LTS                  | GitHub    |


### PR DESCRIPTION
**Current state**: The Ubuntu CI build matrix ([ci_test_compilers_clang](https://github.com/nlohmann/json/blob/develop/.github/workflows/ubuntu.yml#L215)) pins many Clang versions explicitly, but stops at Clang 20 before jumping to latest. Clang 21 was therefore only covered incidentally, via the latest tag.

**Problem**: `silkeh/clang:latest` has moved to Clang 22 and we've silently lost coverage of Clang 21.

**Proposed change**: Add an explicit 21 and 22 entries to the Ubuntu Clang build matrix. Both [silkeh/clang:21](https://hub.docker.com/r/silkeh/clang/tags?name=21) and [silkeh/clang:22](https://hub.docker.com/r/silkeh/clang/tags?name=22) images already exist.

**Discussion**: https://github.com/nlohmann/json/discussions/5345 , [Contribution Guidelines: Wanted](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#wanted)

**Scope**: CI-only. No source, functionality, tests, docs, or coverage affected.

---

In case this is mandatory, I comply with [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md), namely [Developer Certificate of Origin (DCO) version 1.1](https://developercertificate.org/)
