### PR TITLE
Resolve the TODO(niels) in get_ubjson_string

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -1988,7 +1988,11 @@ class binary_reader
     {
         if (get_char)
         {
-            get();  // TODO(niels): may we ignore N here?
+            // no get_ignore_noop() here: the byte read next must be a string
+            // length type specification, and a no-op ('N') is not valid in
+            // that position. No-ops at positions where a value may appear are
+            // already consumed by the callers via get_ignore_noop().
+            get();
         }
 
         if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "value")))

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -12582,7 +12582,11 @@ class binary_reader
     {
         if (get_char)
         {
-            get();  // TODO(niels): may we ignore N here?
+            // no get_ignore_noop() here: the byte read next must be a string
+            // length type specification, and a no-op ('N') is not valid in
+            // that position. No-ops at positions where a value may appear are
+            // already consumed by the callers via get_ignore_noop().
+            get();
         }
 
         if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "value")))

--- a/tests/src/unit-ubjson.cpp
+++ b/tests/src/unit-ubjson.cpp
@@ -1713,6 +1713,44 @@ TEST_CASE("UBJSON")
             CHECK(json::to_ubjson(json::from_ubjson(s_L)) == s_i);
         }
 
+        SECTION("no-op markers")
+        {
+            // A no-op ('N') is valid wherever a value may start; it is consumed
+            // by get_ignore_noop() before the value is read. It is not valid
+            // where a string length type specification is expected.
+
+            SECTION("accepted where a value may start")
+            {
+                // at top level, also repeated
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'N', 'i', 1})) == json(1));
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'N', 'N', 'N', 'i', 1})) == json(1));
+
+                // inside an array of unknown size, before and after an element
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'[', 'N', 'i', 1, ']'})) == json({1}));
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'[', 'i', 1, 'N', ']'})) == json({1}));
+
+                // inside an object of unknown size: before a key, between key
+                // and value, and before the closing '}'
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'{', 'N', 'U', 1, 'a', 'i', 1, '}'})) == json({{"a", 1}}));
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'{', 'U', 1, 'a', 'N', 'i', 1, '}'})) == json({{"a", 1}}));
+                CHECK(json::from_ubjson(std::vector<uint8_t>({'{', 'U', 1, 'a', 'i', 1, 'N', '}'})) == json({{"a", 1}}));
+            }
+
+            SECTION("rejected where a length type specification is expected")
+            {
+                json _;
+
+                // after the 'S' marker of a string value
+                std::vector<uint8_t> const v_S = {'S', 'N', 'U', 1, 'a'};
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v_S), "[json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON string: expected length type specification (U, i, I, l, L); last byte: 0x4E", json::parse_error&);
+
+                // as the key length of an object with a known size, where
+                // no-ops are not permitted in the first place
+                std::vector<uint8_t> const v_key = {'{', '#', 'i', 1, 'N', 'U', 1, 'a', 'i', 1};
+                CHECK_THROWS_WITH_AS(_ = json::from_ubjson(v_key), "[json.exception.parse_error.113] parse error at byte 5: syntax error while parsing UBJSON string: expected length type specification (U, i, I, l, L); last byte: 0x4E", json::parse_error&);
+            }
+        }
+
         SECTION("number")
         {
             SECTION("float")


### PR DESCRIPTION
## Summary

`binary_reader::get_ubjson_string` carried a decade-old open question:

```cpp
get();  // TODO(niels): may we ignore N here?
```

The answer is **no**, and the surrounding code already implements it correctly — it was just never written down or covered by a test.

Two reasons:

1. The byte read at that point must be a **string length type specification** (`U`, `i`, `I`, `l`, `L`). A no-op is not valid there, and a bare `N` in that position is genuinely malformed input that the reader correctly rejects with `parse_error.113`.
2. No-ops at positions where a *value* may start are already consumed before this function is reached: the array and object loops and `parse_ubjson_internal` go through `get_ignore_noop()`. The only caller that passes `get_char = true` for an object key is the *sized* (optimized) object path, where UBJSON does not permit no-ops at all.

So the `get()` is right as it stands. This PR replaces the TODO with a comment saying why, and pins the behavior with regression tests.

## Changes

- `include/nlohmann/detail/input/binary_reader.hpp` — TODO replaced by an explanatory comment. **No behavior change**; this is the only remaining `TODO` in the parsing headers.
- `tests/src/unit-ubjson.cpp` — new `SECTION("no-op markers")` under `parsing values`, 9 assertions:
  - **accepted**: `N i1` → `1`; `N N N i1` → `1`; `[N i1]` → `[1]`; `[i1 N]` → `[1]`; `{N U1"a" i1}` → `{"a":1}`; `{U1"a" N i1}` → `{"a":1}`; `{U1"a" i1 N}` → `{"a":1}`
  - **rejected** with `parse_error.113` ("expected length type specification"): `S N U1"a"` (no-op after the `S` marker) and `{#i1 N U1"a" i1}` (no-op as the key length of a sized object)
- `single_include/nlohmann/json.hpp` — regenerated via `make amalgamate`.

All of the above was verified against `develop` before writing the tests, and the full `UBJSON` test case passes locally (691 256 assertions).

## Breaking changes to the public API

None. The change is a comment plus tests; parser behavior, signatures, and ABI are untouched.

---

*This pull request was prepared by Claude Code.*
