### PR TITLE
Create objects for pointer tokens that cannot be array indices

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/operator[].md
+++ b/docs/mkdocs/docs/api/basic_json/operator[].md
@@ -128,10 +128,13 @@ Strong exception safety: if an exception occurs, the original value stays intact
 
         When the JSON pointer traverses intermediate levels that don't exist at all yet (not just a missing
         leaf), each missing level is created as an array or an object depending on whether the corresponding
-        pointer token parses as a non-negative integer: a numeric token creates an array, a non-numeric token
-        creates an object. For example, on an initially `#!json null` value, `/foo/0/0/0` creates nested arrays,
-        while `/foo/one/one/one` creates nested objects. This is not specified by the JSON Pointer RFC; it is
-        this library's own, intentional disambiguation rule. See also [JSON Pointer](../../features/json_pointer.md).
+        pointer token is a valid array index: a token that is a nonempty sequence of digits without a leading
+        `0` (or the token `-`) creates an array, and every other token creates an object. For example, on an
+        initially `#!json null` value, `/foo/0/0/0` creates nested arrays, while `/foo/one/one/one` creates
+        nested objects. Tokens such as `01` or the empty token cannot be array indices (cf. RFC 6901, Sect. 4)
+        and therefore create objects, just as they would if the level already existed as an object. This is not
+        specified by the JSON Pointer RFC; it is this library's own, intentional disambiguation rule. See also
+        [JSON Pointer](../../features/json_pointer.md).
 
 ## Examples
 

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -396,15 +396,19 @@ class json_pointer
             // convert null values to arrays or objects before continuing
             if (ptr->is_null())
             {
-                // check if the reference token is a number
-                const bool nums =
-                    std::all_of(reference_token.begin(), reference_token.end(),
-                                [](const unsigned char x)
+                // check if the reference token is a valid array index, that is
+                // a nonempty sequence of digits without a leading '0'
+                // (cf. RFC 6901, Sect. 4); tokens that could never be a valid
+                // array index (such as "01" or "") are treated as object keys
+                const bool nums = !reference_token.empty()
+                                  && (reference_token.size() == 1 || reference_token[0] != '0')
+                                  && std::all_of(reference_token.begin(), reference_token.end(),
+                                                 [](const unsigned char x)
                 {
                     return std::isdigit(x);
                 });
 
-                // change value to an array for numbers or "-" or to object otherwise
+                // change value to an array for array indices or "-" or to object otherwise
                 *ptr = (nums || reference_token == "-")
                        ? detail::value_t::array
                        : detail::value_t::object;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -15937,15 +15937,19 @@ class json_pointer
             // convert null values to arrays or objects before continuing
             if (ptr->is_null())
             {
-                // check if the reference token is a number
-                const bool nums =
-                    std::all_of(reference_token.begin(), reference_token.end(),
-                                [](const unsigned char x)
+                // check if the reference token is a valid array index, that is
+                // a nonempty sequence of digits without a leading '0'
+                // (cf. RFC 6901, Sect. 4); tokens that could never be a valid
+                // array index (such as "01" or "") are treated as object keys
+                const bool nums = !reference_token.empty()
+                                  && (reference_token.size() == 1 || reference_token[0] != '0')
+                                  && std::all_of(reference_token.begin(), reference_token.end(),
+                                                 [](const unsigned char x)
                 {
                     return std::isdigit(x);
                 });
 
-                // change value to an array for numbers or "-" or to object otherwise
+                // change value to an array for array indices or "-" or to object otherwise
                 *ptr = (nums || reference_token == "-")
                        ? detail::value_t::array
                        : detail::value_t::object;

--- a/tests/src/unit-json_pointer.cpp
+++ b/tests/src/unit-json_pointer.cpp
@@ -396,6 +396,72 @@ TEST_CASE("JSON pointers")
         }
     }
 
+    SECTION("creating intermediate levels")
+    {
+        SECTION("tokens that are valid array indices create arrays")
+        {
+            json j;
+            j["/0"_json_pointer] = 1;
+            CHECK(j == json({1}));
+
+            json j2;
+            j2["/2"_json_pointer] = 1;
+            CHECK(j2 == json({nullptr, nullptr, 1}));
+
+            json j3;
+            j3["/-"_json_pointer] = 1;
+            CHECK(j3 == json({1}));
+
+            json j4;
+            j4["/foo/0/0"_json_pointer] = 1;
+            CHECK(j4 == json({{"foo", {{1}}}}));
+        }
+
+        SECTION("tokens that are no valid array indices create objects")
+        {
+            json j;
+            j["/one"_json_pointer] = 1;
+            CHECK(j == json({{"one", 1}}));
+
+            // leading '0' can never be a valid array index (RFC 6901, Sect. 4)
+            json j2;
+            j2["/01"_json_pointer] = 1;
+            CHECK(j2 == json({{"01", 1}}));
+
+            // the empty token is a valid object key, but no valid array index
+            json j3;
+            j3["/"_json_pointer] = 1;
+            CHECK(j3 == json({{"", 1}}));
+        }
+
+        SECTION("creating a level yields the same result as reusing it (#5357)")
+        {
+            json j;
+            j["/a/b/01/d"_json_pointer] = "value";
+
+            json j_init = json::object();
+            j_init["/a/b"_json_pointer] = json::object();
+            j_init["/a/b/01/d"_json_pointer] = "value";
+
+            const json expected = json::parse(R"({"a":{"b":{"01":{"d":"value"}}}})");
+            CHECK(j == expected);
+            CHECK(j_init == expected);
+
+            // unflatten uses the same key
+            const json flat = {{"/a/b/01/d", "value"}};
+            CHECK(flat.unflatten() == expected);
+        }
+
+        SECTION("existing arrays still reject invalid indices")
+        {
+            json j = {1, 2, 3};
+            CHECK_THROWS_WITH_AS(j["/01"_json_pointer],
+                                 "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+            CHECK_THROWS_WITH_AS(j.at("/01"_json_pointer),
+                                 "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'", json::parse_error&);
+        }
+    }
+
     SECTION("flatten")
     {
         json j =


### PR DESCRIPTION
> [!IMPORTANT]
> **This is a draft to support the discussion in #5357 — not a change that is ready to merge.** It implements one of several possible answers so we have something concrete to talk about. See "Open questions" below.

Fixes #5357 (discussed in #5356, related to #4446).

## Problem

When `operator[](json_pointer)` traverses an intermediate level that does not exist yet, the `null` value has to be turned into either an array or an object. The rule in `json_pointer::get_unchecked()` was "all characters are digits → array, otherwise object".

That predicate is looser than what actually counts as an array index (RFC 6901, Sect. 4: a nonempty sequence of digits without a leading `0`). So tokens that can *never* be a valid array index still selected an array, and the subsequent index conversion then failed:

```cpp
json j;
j["/a/b/01/d"_json_pointer] = "value";
// [json.exception.parse_error.106] array index '01' must not begin with '0'

json j2;
j2["/"_json_pointer] = 1;
// [json.exception.out_of_range.404] unresolved reference token ''
```

Both `01` and `""` are perfectly valid *object keys*, and both work if the level already exists as an object:

```cpp
json j;
j["/a/b"_json_pointer] = json::object();
j["/a/b/01/d"_json_pointer] = "value";  // OK: {"a":{"b":{"01":{"d":"value"}}}}
```

So whether the pointer worked depended on whether the level had been created beforehand. `unflatten()` (which goes through `get_and_create()`, a different rule) already produced the object form for the same key.

## Change

Test the reference token against the RFC 6901 grammar for array indices instead of "is all digits". Tokens that cannot be an array index now create an object, which is what they would resolve to on an existing object.

| pointer on `null` | before | after |
|---|---|---|
| `/0`, `/2`, `/-`, `/foo/0/0` | array | array (unchanged) |
| `/one` | object | object (unchanged) |
| `/01` | `parse_error.106` | `{"01": …}` |
| `/` (empty token) | `out_of_range.404` | `{"": …}` |

## Breaking changes

**No breaking API changes.** No signature, type, or macro changes.

Behavior changes only in cases that previously always threw: a pointer token matching `0[0-9]+` or the empty token, applied to a `null` value via the non-const `operator[]`. Any program that got a value out of such a pointer before still gets the same value; only programs relying on the `parse_error.106` / `out_of_range.404` exception in this specific situation would notice. Existing arrays are untouched — `j["/01"_json_pointer]` on `{1,2,3}` still throws `parse_error.106`.

## Open questions (why this is a draft)

1. **Is "no working program changes behavior" a good enough bar?** The change is observable, and someone may be relying on the throw to reject leading-zero tokens.
2. **`get_and_create()` (used by `unflatten()`) still uses a third rule**: only the token `"0"` starts an array, so `json{{"/foo/1", 1}}.unflatten()` yields `{"foo":{"1":1}}` (object) while `j["/foo/1"_json_pointer]` yields an array. Aligning those two would be a genuine breaking change, so it is deliberately *not* part of this PR. Should it be a separate v4 item?
3. **The empty-token part could be split out.** It is the same bug class, but it changes a `404` into a success, which is arguably a bigger surprise than the `01` case. Happy to drop it if we only want the reported issue fixed.
4. **The original request in #5356 was a mode where all tokens are treated as strings.** This PR does not do that; it only removes cases where the heuristic picks a type that provably cannot work. A real "always object" mode would need new API surface and could be discussed separately.

## Also in this PR

- Tests in `unit-json_pointer.cpp` covering array-index tokens, non-index tokens, and that creating a level now gives the same result as reusing an existing one.
- The `operator[]` documentation note about creating intermediate levels now states the rule in terms of valid array indices and mentions the `01` / empty-token cases.

<sub>Drafted by Claude Code.</sub>
