### PR TITLE
Documentation review: exceptions from binary-format hardening, and tuple reference types

### DIFF
--- a/docs/mkdocs/docs/features/conversions.md
+++ b/docs/mkdocs/docs/features/conversions.md
@@ -66,8 +66,14 @@ auto t = j.get<std::tuple<double, std::string, int>>();  // {1.0, "hello", 42}
     std::get<1>(refs) = "world";  // modifies j[1] in place
     ```
 
-    A referenced type must be one the library actually stores (or an arithmetic type it can convert to/from);
-    otherwise this is a compile error.
+    A referenced element must name the type the library actually *stores* — one of [`boolean_t`](../api/basic_json/boolean_t.md),
+    [`number_integer_t`](../api/basic_json/number_integer_t.md), [`number_unsigned_t`](../api/basic_json/number_unsigned_t.md),
+    [`number_float_t`](../api/basic_json/number_float_t.md), [`string_t`](../api/basic_json/string_t.md),
+    [`binary_t`](../api/basic_json/binary_t.md), [`array_t`](../api/basic_json/array_t.md), or
+    [`object_t`](../api/basic_json/object_t.md). There is nothing else to refer to, so a reference to any other type is a
+    compile error even when a conversion would exist: `#!cpp std::tuple<int&>` is rejected, because the library stores a
+    `#!cpp number_integer_t` (`#!cpp std::int64_t` by default) and not an `#!cpp int`. This restriction applies only to
+    reference elements — a plain `#!cpp std::tuple<int>` converts by value as usual.
 
 ## Implicit conversions
 

--- a/docs/mkdocs/docs/home/exceptions.md
+++ b/docs/mkdocs/docs/home/exceptions.md
@@ -291,15 +291,19 @@ A JSON Pointer array index must be a number.
 
 ### json.exception.parse_error.110
 
-When parsing CBOR or MessagePack, the byte vector ends before the complete value has been read.
+When parsing a [binary format](../features/binary_formats/index.md), the byte vector ends before the complete value has
+been read.
 
-!!! failure "Example message"
+!!! failure "Example messages"
 
     ```
     [json.exception.parse_error.110] parse error at byte 5: syntax error while parsing CBOR string: unexpected end of input
     ```
     ```
     [json.exception.parse_error.110] parse error at byte 2: syntax error while parsing UBJSON value: expected end of input; last byte: 0x5A
+    ```
+    ```
+    [json.exception.parse_error.110] parse error at byte 8: syntax error while parsing BSON number: unexpected end of input
     ```
 
 ### json.exception.parse_error.112
@@ -329,10 +333,14 @@ An unexpected byte was read in a [binary format](../features/binary_formats/inde
     ```
     [json.exception.parse_error.112] parse error at byte 9: syntax error while parsing CBOR value: negative integer overflow
     ```
+    ```
+    [json.exception.parse_error.112] parse error at byte 5: syntax error while parsing BSON document: document size 6 does not match the number of bytes read (5)
+    ```
 
 ### json.exception.parse_error.113
 
-While parsing a map key, a value that is not a string has been read.
+A string could not be read from a [binary format](../features/binary_formats/index.md): either a value that is not a
+string was read where one was required (for instance as a map key), or the string's length specification is invalid.
 
 !!! failure "Example messages"
 
@@ -344,6 +352,9 @@ While parsing a map key, a value that is not a string has been read.
     ```
     ```
     [json.exception.parse_error.113] parse error at byte 2: syntax error while parsing UBJSON char: byte after 'C' must be in range 0x00..0x7F; last byte: 0x82
+    ```
+    ```
+    [json.exception.parse_error.113] parse error at byte 3: syntax error while parsing BJData string: string length must not be negative
     ```
 
 ### json.exception.parse_error.114
@@ -853,12 +864,20 @@ and this exception no longer occurs.
 
 ### json.exception.out_of_range.408
 
-The size (following `#`) of an UBJSON array or object exceeds the maximal capacity.
+The size of an array or object in a [binary format](../features/binary_formats/index.md) exceeds the maximal capacity:
+the size following `#` for [UBJSON](../features/binary_formats/ubjson.md)/[BJData](../features/binary_formats/bjdata.md),
+or the encoded length for [CBOR](../features/binary_formats/cbor.md).
 
-!!! failure "Example message"
+!!! failure "Example messages"
 
     ```
     excessive array size: 8658170730974374167
+    ```
+    ```
+    [json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive array size
+    ```
+    ```
+    [json.exception.out_of_range.408] syntax error while parsing CBOR size: excessive map size
     ```
 
 ### json.exception.out_of_range.409


### PR DESCRIPTION
## Summary

Documentation corrections found while auditing everything merged into `develop` since #5271, and then re-reviewing the release-notes draft against the code.

**1. Exceptions from the binary-format hardening round.** #5274, #5284, #5287 and #5332 added input-validation rejections; only #5314 updated `exceptions.md`. Two entries had become claims the code contradicts:

- **`parse_error.110`** said *"When parsing **CBOR or MessagePack**"*. BSON throws it as of #5332, and UBJSON already did — the entry's own example was a UBJSON message. Generalized; added the BSON EOF example.
- **`out_of_range.408`** said *"The size (following `#`) of an **UBJSON** array or object"*. CBOR throws it as of #5274. Generalized; added both CBOR examples.
- **`parse_error.113`** said *"While parsing a **map key**"* — already contradicted by its own UBJSON-`char` example. Broadened to cover invalid length specifications; added the negative-string-length example.
- **`parse_error.112`**: added the BSON document-size-mismatch example (#5287).

**2. Which types may be referenced in a tuple extraction.** The note I added in #5271 said a referenced type must be one the library stores *"or an arithmetic type it can convert to/from"*. That parenthetical is wrong: `is_compatible_reference_type` requires an exact match against the stored types, so `std::tuple<int&>` is rejected by `static_assert` — the library stores `number_integer_t` (`std::int64_t`), and there is no `int` to bind to. Only the *by-value* case is permissive. Corrected to list the eight admissible types, give the `int&` counter-example, and separate the two cases.

## Does this break the public API?

**No.** Documentation-only — no header, behavior, or ABI change.

## Test plan

- [x] Every new example message copied verbatim from the originating PR's regression tests (`unit-bson.cpp`, `unit-cbor.cpp`, `unit-bjdata.cpp`).
- [x] Generalized descriptions checked against `binary_reader.hpp` on `develop` for which formats actually throw each code.
- [x] Tuple claim verified against `is_compatible_reference_type` in `type_traits.hpp` and the `static_assert` in `from_json.hpp`, cross-checked with the reference tests in `unit-constructor1.cpp`.
- [x] All new relative links resolve to existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)