### PR TITLE
CI: build the MinGW Clang matrix without debug info

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -153,10 +153,16 @@ jobs:
         with:
           platform: x64
           version: 12.2.0 # https://github.com/egor-tensin/setup-mingw/issues/14
+      # CMAKE_CXX_FLAGS_DEBUG is overridden to drop the default -g: linking
+      # test-regression2_cpp20 intermittently fails with "relocation truncated
+      # to fit: IMAGE_REL_AMD64_SECREL against `.debug_line'" because the
+      # MinGW linker cannot relocate the debug sections this test produces.
+      # The tests are only built and run here, so the debug info is not used.
       - name: Run CMake
         run: cmake -S . -B build ^
              -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe" ^
              -DCMAKE_CXX_FLAGS="--target=x86_64-w64-mingw32 -stdlib=libstdc++ -pthread" ^
+             -DCMAKE_CXX_FLAGS_DEBUG="-g0" ^
              -DCMAKE_EXE_LINKER_FLAGS="-lwinpthread" ^
              -G"MinGW Makefiles" ^
              -DCMAKE_BUILD_TYPE=Debug ^


### PR DESCRIPTION
The `clang` matrix in `windows.yml` fails intermittently while linking `test-regression2_cpp20`:

```
CMakeFiles\test-regression2_cpp20.dir/objects.a(unit-regression2.cpp.obj):unit-regression2.c:(.debug_info+0x16):
relocation truncated to fit: IMAGE_REL_AMD64_SECREL against `.debug_line'
```

## Why this is not a code problem

- The failure moves between matrix entries. On [run 30912117075](https://github.com/nlohmann/json/actions/runs/30912117075) `clang (13.0.1)` failed while `15.0.7`, `16.0.6` and `19.1.7` linked the same binary fine. Re-running the **same commit** flipped it: `13.0.1` passed and `11.0.1` failed instead, with a byte-identical message.
- It happens on unrelated branches. [Run 30885925478](https://github.com/nlohmann/json/actions/runs/30885925478) on `claude/binary-writer-output-sinks` hit the same error on the same target.
- The siblings reported as failures in those runs are `Error 130` (SIGINT) — `fail-fast` cancelling them, not real failures.

So it is the size of the debug sections that `unit-regression2.cpp` produces at C++20, not any one Clang version: the MinGW linker cannot relocate `DW_AT_stmt_list` into `.debug_line` once it grows past what a 32-bit `SECREL` relocation can address.

## The change

Override `CMAKE_CXX_FLAGS_DEBUG` to `-g0` for that matrix, so no debug sections are emitted and the relocation cannot occur. This is a categorical fix rather than a probabilistic one.

The jobs build the tests and run them under `ctest`; nothing consumes the debug info. doctest's failure output uses `__FILE__`/`__LINE__`, so `--output-on-failure` is unaffected.

Everything else about the Debug build is unchanged. Verified by configuring the project both ways:

```
default Debug:  CXX_FLAGS = -g  -std=gnu++11 ... -Wno-deprecated -Wno-float-equal
with -g0:       CXX_FLAGS = -g0 -std=gnu++11 ... -Wno-deprecated -Wno-float-equal
```

No optimization flag is added and `NDEBUG` stays undefined, so `JSON_ASSERT` remains active.

## Result

[Run 30921367054](https://github.com/nlohmann/json/actions/runs/30921367054) on this branch: all nine `clang` matrix entries pass, including `11.0.1` and `13.0.1`, the two that had been failing.

Job times are modestly better for the entries that previously ran to completion — `15.0.7` 9m→8m, `16.0.6` 9m→8m, `19.1.7` 9m→7m.

## Scope

Only the `clang` job is changed, because that is where the failure has been observed. The `mingw` job (GCC 12.2.0) uses the same linker and the same `Debug` build type, so it carries the same latent risk — I left it alone rather than change a job that is not failing.

## Public API

**No changes to the public API.** This touches only `.github/workflows/windows.yml`; no library, test, or documentation source is modified.

---

- [x] The changes are described in detail, both the what and why.
- [ ] An existing issue is referenced — none filed; the evidence is in the CI runs linked above.
- [x] All new code is covered by tests (no code change; the workflow itself is the test).
- [x] The [documentation](https://json.nlohmann.me) is updated (not applicable).
- [x] `make amalgamate` was run (not applicable — no header changes).

---

*This pull request was written by Claude Code.*
