### PR TITLE
Do not write BJData ndarrays whose size overflows std::size_t

### DIFF
--- a/docs/mkdocs/docs/features/binary_formats/bjdata.md
+++ b/docs/mkdocs/docs/features/binary_formats/bjdata.md
@@ -116,9 +116,19 @@ The library uses the following mapping from JSON values types to BJData types ac
     ```
 
     Likewise, when a JSON object in the above form is serialized using
-    [`to_bjdata`](../../api/basic_json/to_bjdata.md), it is automatically converted into a compact BJData ND-array. The
-    only exception is, that when the 1-dimensional vector stored in `"_ArraySize_"` contains a single integer or two
-    integers with one being 1, a regular 1-D optimized array is generated.
+    [`to_bjdata`](../../api/basic_json/to_bjdata.md), it is automatically converted into a compact BJData ND-array. When
+    the 1-dimensional vector stored in `"_ArraySize_"` contains a single integer or two integers with one being 1, a
+    regular 1-D optimized array is generated instead.
+
+    An object is only converted if the annotation actually describes a packed array; otherwise it is serialized as a
+    regular JSON object. This requires all of the following:
+
+    - `"_ArrayType_"` is one of `uint8`, `int8`, `uint16`, `int16`, `uint32`, `int32`, `uint64`, `int64`, `single`,
+      `double`, `char`, or `byte`,
+    - every entry of `"_ArraySize_"` is a non-negative integer, and their product is representable as a `std::size_t`,
+    - `"_ArrayData_"` holds exactly that many elements, and
+    - every element of `"_ArrayData_"` is a number of the kind named by `"_ArrayType_"` (a floating-point number for
+      `single` and `double`, an integer otherwise).
 
     The current version of this library does not yet support automatic detection of and conversion from a nested JSON
     array input to a BJData ND-array.

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -1670,7 +1670,23 @@ class binary_writer
             {
                 return true;
             }
-            len *= static_cast<std::size_t>(el.template get<std::uint64_t>());
+
+            // a dimension that does not fit into std::size_t, or a product that
+            // overflows it, would wrap around and could match the size of
+            // _ArrayData_ by accident; the resulting header announces an
+            // element count that no reader can honor (the binary reader rejects
+            // it with out_of_range.408), so encode as a plain object instead
+            const auto dim = el.template get<std::uint64_t>();
+            if (!value_in_range_of<std::size_t>(dim))
+            {
+                return true;
+            }
+            const auto dim_size = static_cast<std::size_t>(dim);
+            if (dim_size != 0 && len > (std::numeric_limits<std::size_t>::max)() / dim_size)
+            {
+                return true;
+            }
+            len *= dim_size;
         }
 
         key = "_ArrayData_";

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18573,7 +18573,23 @@ class binary_writer
             {
                 return true;
             }
-            len *= static_cast<std::size_t>(el.template get<std::uint64_t>());
+
+            // a dimension that does not fit into std::size_t, or a product that
+            // overflows it, would wrap around and could match the size of
+            // _ArrayData_ by accident; the resulting header announces an
+            // element count that no reader can honor (the binary reader rejects
+            // it with out_of_range.408), so encode as a plain object instead
+            const auto dim = el.template get<std::uint64_t>();
+            if (!value_in_range_of<std::size_t>(dim))
+            {
+                return true;
+            }
+            const auto dim_size = static_cast<std::size_t>(dim);
+            if (dim_size != 0 && len > (std::numeric_limits<std::size_t>::max)() / dim_size)
+            {
+                return true;
+            }
+            len *= dim_size;
         }
 
         key = "_ArrayData_";

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2730,6 +2730,27 @@ TEST_CASE("BJData")
                 CHECK(json::from_bjdata(json::to_bjdata(j_type), true, true) == j_type);
                 CHECK(json::from_bjdata(json::to_bjdata(j_size), true, true) == j_size);
             }
+
+            SECTION("ndarray whose dimensions overflow stays as object")
+            {
+                // the product of the dimensions wraps around std::size_t to 0
+                // and so matches the size of the empty _ArrayData_; writing this
+                // as an ndarray would announce an element count no reader can
+                // honor, so it has to stay a plain object
+                json j_overflow = json({{"_ArrayData_", json::array()}, {"_ArraySize_", {9223372036854775808ull, 2}}, {"_ArrayType_", "uint8"}});
+                CHECK(json::from_bjdata(json::to_bjdata(j_overflow), true, true) == j_overflow);
+
+                // a single dimension that does not fit into std::size_t is
+                // rejected for the same reason (only observable where
+                // std::size_t is narrower than 64 bit)
+                json j_huge = json({{"_ArrayData_", json::array()}, {"_ArraySize_", {18446744073709551615ull}}, {"_ArrayType_", "uint8"}});
+                CHECK(json::from_bjdata(json::to_bjdata(j_huge), true, true) == j_huge);
+
+                // a well-formed ndarray is still encoded as one
+                json j_ok = json({{"_ArrayData_", {1, 2, 3, 4, 5, 6}}, {"_ArraySize_", {2, 3}}, {"_ArrayType_", "uint8"}});
+                CHECK(json::to_bjdata(j_ok) == std::vector<uint8_t>({'[', '$', 'U', '#', '[', 'i', 2, 'i', 3, ']', 1, 2, 3, 4, 5, 6}));
+                CHECK(json::from_bjdata(json::to_bjdata(j_ok), true, true) == j_ok);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`write_bjdata_ndarray()` multiplied the `_ArraySize_` dimensions into a `std::size_t` with no overflow check:

```cpp
len *= static_cast<std::size_t>(el.template get<std::uint64_t>());
```

A product that wraps around to a value that happens to match the size of `_ArrayData_` passes the subsequent length check, so the writer emits an ndarray header announcing an element count that cannot be represented:

```cpp
json j = json::parse(R"({"_ArrayType_":"uint8","_ArraySize_":[9223372036854775808,2],"_ArrayData_":[]})");
auto b = json::to_bjdata(j);
// 5b 24 55 23 5b 4d 00 00 00 00 00 00 00 80 69 02 5d
//   -> an ndarray of 2^64 elements, followed by no data

json::from_bjdata(b);
// throws out_of_range.408 "excessive ndarray size caused overflow"
```

So `to_bjdata()` produces output that this library's own `from_bjdata()` rejects. It is reachable by parsing untrusted JSON and re-encoding it as BJData, and a third-party BJData reader without the same guard could act on the bogus element count.

The binary **reader** already performs exactly this overflow check; the writer was missing the matching one.

There is a second, related issue on platforms where `std::size_t` is narrower than 64 bits: `static_cast<std::size_t>(el.get<std::uint64_t>())` silently truncates, so a dimension of `2^32 + 1` becomes `1`.

## Fix

Mirror the reader's pre-multiplication overflow check, and reject a single dimension that does not fit into `std::size_t`.

Such objects now fall back to a plain object encoding — which is what the surrounding type and length validation already does for annotations it cannot represent — and they round-trip unchanged. Well-formed ndarrays are unaffected.

## Public API

**No breaking changes.** No public declaration changes; `write_bjdata_ndarray` is internal.

The observable change is confined to `to_bjdata()` on malformed JData annotations that previously produced undecodable output: those are now encoded as ordinary objects and round-trip correctly. No well-formed ndarray changes its encoding.

## Testing

Added `SECTION("ndarray whose dimensions overflow stays as object")` to `unit-bjdata.cpp`, covering the overflowing product, an over-large single dimension, and a byte-exact check that a well-formed `2×3` ndarray still encodes as an ndarray.

**The overflow round-trip assertion fails on `develop`** (throws `out_of_range.408`) **and passes with this change.**

`unit-bjdata` runs 693,905 passing assertions with no regressions. Also verified by fuzzing the invariant `decode(encode(decode(x))) == decode(x)` for all five binary formats under ASAN/UBSAN — ~1.3M executions for BJData alone, ~5.5M in total, with no violations. Compiles clean at C++11 and C++17 with `-Wall -Wextra -Werror -Wconversion -Wsign-conversion`. Amalgamation regenerated; `make check-amalgamation` passes.


## Documentation

The BJData feature page described the 1-D vector case as the *only* exception to ND-array conversion. That was already
incomplete on `develop` — the writer has always fallen back to a plain object encoding for an unknown `_ArrayType_`, a
dimension that is not a non-negative integer, an `_ArrayData_` whose length does not match the product of the
dimensions, and elements that are not numbers of the annotated kind. A second commit spells out the full set of
conditions, including the overflow check added here, so the documented behavior matches the implementation.

Each documented condition was verified against the actual encoder output.

---

— written by Claude Code on behalf of @nlohmann
