### PR TITLE
Move the CBOR doc block to the function it describes

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -465,15 +465,6 @@ class binary_reader
     // CBOR //
     //////////
 
-    /*!
-    @param[in] get_char  whether a new character should be retrieved from the
-                         input (true) or whether the last read character should
-                         be considered instead (false)
-    @param[in] tag_handler how CBOR tags should be treated
-
-    @return whether a valid CBOR value was passed to the SAX parser
-    */
-
     template<typename NumberType>
     bool get_cbor_negative_integer()
     {
@@ -492,6 +483,14 @@ class binary_reader
         return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
     }
 
+    /*!
+    @param[in] get_char  whether a new character should be retrieved from the
+                         input (true) or whether the last read character should
+                         be considered instead (false)
+    @param[in] tag_handler how CBOR tags should be treated
+
+    @return whether a valid CBOR value was passed to the SAX parser
+    */
     bool parse_cbor_internal(const bool get_char,
                              const cbor_tag_handler_t tag_handler)
     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11059,15 +11059,6 @@ class binary_reader
     // CBOR //
     //////////
 
-    /*!
-    @param[in] get_char  whether a new character should be retrieved from the
-                         input (true) or whether the last read character should
-                         be considered instead (false)
-    @param[in] tag_handler how CBOR tags should be treated
-
-    @return whether a valid CBOR value was passed to the SAX parser
-    */
-
     template<typename NumberType>
     bool get_cbor_negative_integer()
     {
@@ -11086,6 +11077,14 @@ class binary_reader
         return sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
     }
 
+    /*!
+    @param[in] get_char  whether a new character should be retrieved from the
+                         input (true) or whether the last read character should
+                         be considered instead (false)
+    @param[in] tag_handler how CBOR tags should be treated
+
+    @return whether a valid CBOR value was passed to the SAX parser
+    */
     bool parse_cbor_internal(const bool get_char,
                              const cbor_tag_handler_t tag_handler)
     {


### PR DESCRIPTION
The Doxygen block for `get_char` / `tag_handler` sits above `get_cbor_negative_integer()`, which takes neither:

```cpp
/*!
@param[in] get_char  whether a new character should be retrieved from the ...
@param[in] tag_handler how CBOR tags should be treated

@return whether a valid CBOR value was passed to the SAX parser
*/

template<typename NumberType>
bool get_cbor_negative_integer()
```

Both names, and the `@return` line about "a valid CBOR value passed to the SAX parser", describe `parse_cbor_internal(const bool get_char, const cbor_tag_handler_t tag_handler)` — the function that follows a little further down.

So Doxygen attaches this documentation to `get_cbor_negative_integer()`, whose own parameters are none, while `parse_cbor_internal()` renders with no description at all.

Moved the block down to `parse_cbor_internal()`. Nothing else changed — no code, no signature, no wording.

### On `single_include`

Per CONTRIBUTING the single-header file is generated, so I did not hand-write anything new there: I made the same move in `single_include/nlohmann/json.hpp` so it matches what `make amalgamate` produces from the edited source. I could not run the full target locally because `make pretty` needs `astyle`, which I don't have — running only `amalgamate.py` reformats the whole file's indentation, which would have buried this change in ~140 unrelated lines. The two diffs are symmetric, 17 lines each; happy to regenerate properly if you'd rather.

### Checked

Two other blocks in the same file document `get_char` and are correct — `parse_ubjson_internal(const bool get_char = true)` and `get_ubjson_string(string_t&, const bool get_char = true)` really do take it. Both untouched.
