### PR TITLE
Ignore CBOR tags 0-5 and 21-23 (head bytes 0xC0-0xC5, 0xD5-0xD7)

### DIFF
--- a/docs/mkdocs/docs/features/binary_formats/cbor.md
+++ b/docs/mkdocs/docs/features/binary_formats/cbor.md
@@ -160,13 +160,10 @@ The library maps CBOR types to JSON value types as follows:
 
     The mapping is **incomplete** in the sense that not all CBOR types can be converted to a JSON value. The following CBOR types are not supported and will yield parse errors:
 
-     - date/time (0xC0..0xC1)
-     - bignum (0xC2..0xC3)
-     - decimal fraction (0xC4)
-     - bigfloat (0xC5)
-     - expected conversions (0xD5..0xD7)
      - simple values (0xE0..0xF3, 0xF8)
      - undefined (0xF7)
+
+    Tagged items (0xC0..0xDB) are not interpreted either; see the note on tagged items below.
 
 !!! warning "Negative integer overflow"
 
@@ -181,7 +178,7 @@ The library maps CBOR types to JSON value types as follows:
 
 !!! warning "Tagged items"
 
-    Tagged items will throw a parse error by default. They can be ignored by passing `cbor_tag_handler_t::ignore` to function `from_cbor`. They can be stored by passing `cbor_tag_handler_t::store` to function `from_cbor`.
+    Tagged items (0xC0..0xDB) will throw a parse error by default. They can be ignored by passing `cbor_tag_handler_t::ignore` to function `from_cbor`, in which case the tag is skipped and the enclosed data item is parsed on its own. They can be stored by passing `cbor_tag_handler_t::store` to function `from_cbor`. Note that no tag is ever interpreted: for instance, a text string tagged with tag 0 (date/time) stays a string.
 
 ??? example
 

--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -773,7 +773,13 @@ class binary_reader
             case 0xBF: // map (indefinite length)
                 return get_cbor_object(detail::unknown_size(), tag_handler);
 
-            case 0xC6: // tagged item
+            case 0xC0: // tagged item
+            case 0xC1:
+            case 0xC2:
+            case 0xC3:
+            case 0xC4:
+            case 0xC5:
+            case 0xC6:
             case 0xC7:
             case 0xC8:
             case 0xC9:
@@ -788,6 +794,9 @@ class binary_reader
             case 0xD2:
             case 0xD3:
             case 0xD4:
+            case 0xD5:
+            case 0xD6:
+            case 0xD7:
             case 0xD8: // tagged item (1 byte follows)
             case 0xD9: // tagged item (2 bytes follow)
             case 0xDA: // tagged item (4 bytes follow)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11395,7 +11395,13 @@ class binary_reader
             case 0xBF: // map (indefinite length)
                 return get_cbor_object(detail::unknown_size(), tag_handler);
 
-            case 0xC6: // tagged item
+            case 0xC0: // tagged item
+            case 0xC1:
+            case 0xC2:
+            case 0xC3:
+            case 0xC4:
+            case 0xC5:
+            case 0xC6:
             case 0xC7:
             case 0xC8:
             case 0xC9:
@@ -11410,6 +11416,9 @@ class binary_reader
             case 0xD2:
             case 0xD3:
             case 0xD4:
+            case 0xD5:
+            case 0xD6:
+            case 0xD7:
             case 0xD8: // tagged item (1 byte follows)
             case 0xD9: // tagged item (2 bytes follow)
             case 0xDA: // tagged item (4 bytes follow)

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -2565,11 +2565,13 @@ TEST_CASE("Tagged values")
     const json j = "s";
     auto v = json::to_cbor(j);
 
-    SECTION("0xC6..0xD4")
+    SECTION("0xC0..0xD7")
     {
         for (const auto b : std::vector<std::uint8_t>
     {
-        0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5,
+        0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4,
+        0xD5, 0xD6, 0xD7
     })
         {
             CAPTURE(b);
@@ -2590,6 +2592,48 @@ TEST_CASE("Tagged values")
             auto j_tagged_stored = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::store);
             CHECK(j_tagged_stored == j);
         }
+    }
+
+    SECTION("0xC0..0xD7 with a binary payload")
+    {
+        // the tag value is embedded in the head byte, so there is no subtype byte to
+        // read: store mode must unwrap the tag and leave the binary subtype unset,
+        // unlike 0xD8..0xDB where the following byte(s) become the subtype
+        const json j_binary = json::binary({0xCA, 0xFE});
+        const auto v_binary = json::to_cbor(j_binary);
+
+        for (const auto b : std::vector<std::uint8_t>
+    {
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5,
+        0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4,
+        0xD5, 0xD6, 0xD7
+    })
+        {
+            CAPTURE(b);
+
+            auto v_tagged = v_binary;
+            v_tagged.insert(v_tagged.begin(), b);
+
+            json _;
+            CHECK_THROWS_AS(_ = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::error), json::parse_error);
+
+            auto j_tagged = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::ignore);
+            CHECK(j_tagged == j_binary);
+            CHECK_FALSE(j_tagged.get_binary().has_subtype());
+
+            auto j_tagged_stored = json::from_cbor(v_tagged, true, true, json::cbor_tag_handler_t::store);
+            CHECK(j_tagged_stored == j_binary);
+            CHECK_FALSE(j_tagged_stored.get_binary().has_subtype());
+        }
+
+        // contrast: 0xD8 reads the next byte as the subtype
+        auto v_subtyped = v_binary;
+        v_subtyped.insert(v_subtyped.begin(), 0x42);
+        v_subtyped.insert(v_subtyped.begin(), 0xD8);
+
+        auto j_subtyped = json::from_cbor(v_subtyped, true, true, json::cbor_tag_handler_t::store);
+        CHECK(j_subtyped.get_binary().has_subtype());
+        CHECK(j_subtyped.get_binary().subtype() == 0x42);
     }
 
     SECTION("0xD8 - 1 byte follows")


### PR DESCRIPTION
Fixes #5315.

Every byte in `0xC0`–`0xDB` is major type 6 (tag), but the `switch` in `parse_cbor_internal()` enumerated only `0xC6`–`0xD4` and `0xD8`–`0xDB`. Head bytes `0xC0`–`0xC5` and `0xD5`–`0xD7` fell through to `default:` and were reported as `parse_error.112` in *every* handler mode, including `ignore` and `store`.

This adds the missing head bytes to the tagged-item case list, so they are handled exactly like tags 6–20 already are:

- `cbor_tag_handler_t::error` (the default) still throws — unchanged.
- `ignore` skips the tag head and parses the enclosed data item.
- `store` parses the enclosed item; as with tags 6–20, no subtype is recorded (only the `0xD8`–`0xDB` forms carry one today).

No tag is interpreted: a text string tagged 0 stays a string, `0xC2` over a byte string stays a byte string.

### Changes

- `include/nlohmann/detail/input/binary_reader.hpp` (and the amalgamated header): add `case 0xC0`–`0xC5` and `case 0xD5`–`0xD7` to the tagged-item block.
- `tests/src/unit-cbor.cpp`: the "Tagged values" section that swept `0xC6..0xD4` now sweeps `0xC0..0xD7`, asserting throw in `error` mode and the original value in `ignore`/`store` mode for each head byte.
- `docs/.../cbor.md`: the "Incomplete mapping" list no longer claims tags 0–5 and 21–23 are unsupported; the tagged-items note now states the range and that tags are skipped, not interpreted.

The "all CBOR first bytes" test needed no change — it parses in the default `error` mode, where these bytes still throw `parse_error.112`.

### Verification

`test-cbor_cpp11` passes (the only failures in my local run are the test cases requiring the downloaded test-data fixtures, which I did not fetch). The reproduction from the issue now works:

```
{"t":"2026-07-27T00:00:00Z"}
```

and a sweep of `0xC0`–`0xD7` confirms every head byte throws in `error` mode and yields the enclosed value in `ignore` and `store` mode.
