### PR TITLE
Install CMake package files from the Meson build

### DIFF
--- a/cmake/nlohmann_jsonTargets.cmake.in
+++ b/cmake/nlohmann_jsonTargets.cmake.in
@@ -1,0 +1,18 @@
+# Hand-written equivalent of the target export file that the CMake build
+# generates via install(EXPORT ...). Used by the Meson build, which cannot
+# reuse CMake's exporter.
+
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+@NLOHMANN_JSON_IMPORT_PREFIX_STEPS@
+if(_IMPORT_PREFIX STREQUAL "/")
+    set(_IMPORT_PREFIX "")
+endif()
+
+add_library(@NLOHMANN_JSON_EXPORTED_TARGET_NAME@ INTERFACE IMPORTED)
+set_target_properties(@NLOHMANN_JSON_EXPORTED_TARGET_NAME@ PROPERTIES
+    INTERFACE_COMPILE_FEATURES "cxx_std_11"
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@NLOHMANN_JSON_INCLUDE_INSTALL_DIR@"
+)
+
+set(_IMPORT_PREFIX)

--- a/meson.build
+++ b/meson.build
@@ -21,4 +21,46 @@ pkgc.generate(name: 'nlohmann_json',
     version: meson.project_version(),
     description: 'JSON for Modern C++'
 )
+
+# CMake package files, so that find_package(nlohmann_json) works after a Meson
+# install just like it does after a CMake install.
+cmake_config_dir = get_option('datadir') / 'cmake' / meson.project_name()
+
+# Number of directory levels between the config file and the install prefix,
+# used to make the generated target file relocatable.
+import_prefix_steps = []
+foreach component : cmake_config_dir.split('/')
+    import_prefix_steps += 'get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)'
+endforeach
+
+version_parts = meson.project_version().split('.')
+
+cmake_conf = configuration_data()
+cmake_conf.set('PROJECT_NAME', meson.project_name())
+cmake_conf.set('PROJECT_VERSION', meson.project_version())
+cmake_conf.set('PROJECT_VERSION_MAJOR', version_parts[0])
+cmake_conf.set('NLOHMANN_JSON_TARGET_NAME', 'nlohmann_json')
+cmake_conf.set('NLOHMANN_JSON_EXPORTED_TARGET_NAME', 'nlohmann_json::nlohmann_json')
+cmake_conf.set('NLOHMANN_JSON_TARGETS_EXPORT_NAME', meson.project_name() + 'Targets')
+cmake_conf.set('NLOHMANN_JSON_INCLUDE_INSTALL_DIR', get_option('includedir'))
+cmake_conf.set('NLOHMANN_JSON_IMPORT_PREFIX_STEPS', '\n'.join(import_prefix_steps))
+
+configure_file(
+    input: 'cmake/config.cmake.in',
+    output: meson.project_name() + 'Config.cmake',
+    configuration: cmake_conf,
+    install_dir: cmake_config_dir,
+)
+configure_file(
+    input: 'cmake/nlohmann_jsonConfigVersion.cmake.in',
+    output: meson.project_name() + 'ConfigVersion.cmake',
+    configuration: cmake_conf,
+    install_dir: cmake_config_dir,
+)
+configure_file(
+    input: 'cmake/nlohmann_jsonTargets.cmake.in',
+    output: meson.project_name() + 'Targets.cmake',
+    configuration: cmake_conf,
+    install_dir: cmake_config_dir,
+)
 endif


### PR DESCRIPTION
Fixes #3885.

The Meson build installed only the headers and a pkg-config file, so consumers using `find_package(nlohmann_json)` could not build against a Meson-installed copy.

This generates and installs `nlohmann_jsonConfig.cmake`, `nlohmann_jsonConfigVersion.cmake` and `nlohmann_jsonTargets.cmake` into `<datadir>/cmake/nlohmann_json`, the same location the CMake build uses.

- `cmake/config.cmake.in` and `cmake/nlohmann_jsonConfigVersion.cmake.in` are reused as-is from the CMake build.
- The targets file is generated by CMake's `install(EXPORT ...)`, so there is nothing to reuse; `cmake/nlohmann_jsonTargets.cmake.in` is added for the Meson build. It computes `_IMPORT_PREFIX` relative to its own location so the installed package stays relocatable.
- Only runs when not built as a subproject, alongside the existing header/pkg-config install rules.

Verified locally: `meson install --destdir` places the three files under `share/cmake/nlohmann_json`, and a separate CMake project doing `find_package(nlohmann_json 3.12.0 REQUIRED)` + `target_link_libraries(t PRIVATE nlohmann_json::nlohmann_json)` configures, builds and runs against it.