### PR TITLE
Add an Ecosystem page for third-party projects built on nlohmann::json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [Specializing enum conversion](#specializing-enum-conversion)
   - [Binary formats (BSON, CBOR, MessagePack, UBJSON, and BJData)](#binary-formats-bson-cbor-messagepack-ubjson-and-bjdata)
 - [Customers](#customers)
+- [Ecosystem](#ecosystem)
 - [Supported compilers](#supported-compilers)
 - [Integration](#integration)
   - [CMake](#cmake)
@@ -1185,6 +1186,11 @@ auto cbor = json::to_msgpack(j); // 0xD5 (fixext2), 0x10, 0xCA, 0xFE
 The library is used in multiple projects, applications, operating systems, etc. The list below is not exhaustive, but the result of an internet search. If you know further customers of the library, please let me know, see [contact](#contact).
 
 [![logos of customers using the library](docs/mkdocs/docs/images/customers.png)](https://json.nlohmann.me/home/customers/)
+
+## Ecosystem
+
+Beyond projects that use the library, there are third-party projects that build on top of it - schema validators,
+language bindings, format converters, and the like. See the curated [Ecosystem](https://json.nlohmann.me/community/ecosystem/) page.
 
 ## Supported compilers
 

--- a/docs/mkdocs/docs/community/ecosystem.md
+++ b/docs/mkdocs/docs/community/ecosystem.md
@@ -1,0 +1,40 @@
+# Ecosystem
+
+The projects below build on top of `nlohmann::json` rather than merely using it - schema validators, language
+bindings, format converters, and similar building blocks. The list is not exhaustive, and is curated rather than
+automatically generated. If you maintain or know of a project that belongs here,
+[please let me know](mailto:mail@nlohmann.me).
+
+For products, applications, and organizations that use the library, see [Customers](../home/customers.md) instead.
+
+## Schema validation
+
+- [**json-schema-validator**](https://github.com/pboettch/json-schema-validator), a JSON Schema (draft 7) validator
+  with human-readable error messages
+
+## Serialization and reflection
+
+- [**nlohmann_json_reflect**](https://github.com/1261385937/nlohmann_json_reflect), a reflection extension for
+  (de)serializing nested containers-in-structs-in-containers
+
+## Encodings
+
+- [**base-encode-decode**](https://github.com/saxonnicholls/base-encode-decode), a header-only Base64/32/16/8/4/2
+  (and DNA/RNA) encoding library, with an adapter that serializes binary data through `nlohmann::json`
+
+## Language bindings and interop
+
+- [**pybind11_json**](https://github.com/pybind/pybind11_json), a bidirectional type caster between
+  `nlohmann::json` and Python objects for [pybind11](https://github.com/pybind/pybind11) bindings
+- [**nanobind_json**](https://github.com/ianhbell/nanobind_json), the same idea for
+  [nanobind](https://github.com/wjakob/nanobind) bindings
+- [**nlohmann_json_qt**](https://github.com/dpurgin/nlohmann_json_qt), deserialization helpers for Qt types
+  (`QString`, `QUrl`, `QDateTime`, `QVector`, ...) from `nlohmann::json`
+- [**vulkan2json**](https://github.com/Fadis/vulkan2json), serialization and deserialization of Vulkan API structs
+
+## Format converters
+
+- [**tojson**](https://github.com/mircodz/tojson), a header-only converter between YAML/XML documents and
+  `nlohmann::json`
+- [**json2xml**](https://github.com/testillano/json2xml), a header-only converter from `nlohmann::json` to XML for
+  simple configuration documents

--- a/docs/mkdocs/docs/community/index.md
+++ b/docs/mkdocs/docs/community/index.md
@@ -1,5 +1,6 @@
 # Community
 
+- [Ecosystem](ecosystem.md) - third-party projects built on top of this library
 - [Code of Conduct](code_of_conduct.md) - the rules and norms of this project
 - [Contribution Guidelines](contribution_guidelines.md) - guidelines how to contribute to this project
 - [Governance](governance.md) - the governance model of this project

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -308,6 +308,7 @@ nav:
           - 'NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH': api/macros/nlohmann_json_version_major.md
   - Community:
       - community/index.md
+      - community/ecosystem.md
       - "Code of Conduct": community/code_of_conduct.md
       - community/contribution_guidelines.md
       - community/quality_assurance.md


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line and make sure you follow the checklist.]

## What

Adds a new **Ecosystem** documentation page (`docs/mkdocs/docs/community/ecosystem.md`) that curates third-party projects built *on top of* `nlohmann::json` — schema validation, language bindings, format converters, and reflection/serialization helpers. Linked from `Community` in the docs nav, from `docs/mkdocs/docs/community/index.md`, and from a short new `## Ecosystem` stub in `README.md` (mirroring how `## Customers` links out to its own docs page).

Current entries:
- Schema validation: [pboettch/json-schema-validator](https://github.com/pboettch/json-schema-validator)
- Serialization and reflection: [1261385937/nlohmann_json_reflect](https://github.com/1261385937/nlohmann_json_reflect)
- Encodings: [saxonnicholls/base-encode-decode](https://github.com/saxonnicholls/base-encode-decode)
- Language bindings and interop: [pybind/pybind11_json](https://github.com/pybind/pybind11_json), [ianhbell/nanobind_json](https://github.com/ianhbell/nanobind_json), [dpurgin/nlohmann_json_qt](https://github.com/dpurgin/nlohmann_json_qt), [Fadis/vulkan2json](https://github.com/Fadis/vulkan2json)
- Format converters: [mircodz/tojson](https://github.com/mircodz/tojson), [testillano/json2xml](https://github.com/testillano/json2xml)

## Why

Prompted by a mail pointing at `base-encode-decode`, an encoding library with a dedicated `nlohmann::json` adapter header. The existing `Customers` page catalogues products/organizations that *use* the library, which is a different category from projects that *extend* it — there was no place to point the latter.

## How the list was curated

`Customers` is explicitly "the result of an internet search," so the same approach was used here: GitHub API searches (`nlohmann in:name,description`, `"JSON for Modern C++" in:description`, `topic:nlohmann-json`, plus category probes for schema/reflection/bindings/converters), unioned and filtered against a blocklist for application-shaped descriptions, then every survivor was individually verified by reading its README/source for an actual `nlohmann::json` dependency. General web search (Google-style queries, Hacker News, awesome-lists) was also tried as a supplement and turned up nothing beyond what GitHub search already found; Reddit is unreachable from this environment (blocked at the domain level for both fetch and search), so that angle is uncovered.

Five initial candidates were dropped during verification, for reasons worth noting since they contradict what a superficial GitHub search suggests:
- `lefticus/json2cpp` — reimplements a compatible API rather than depending on `nlohmann::json`
- `ArthurSonzogni/nlohmann_json_cmake_fetchcontent` — archived; its own README says it's obsolete since v3.11.3 added native `FetchContent` support
- `LoneWanderer-GH/nlohmann-json-gdb` — stale (no push since 2020) and redundant with the GDB pretty-printer this repo already ships at `tools/gdb_pretty_printer` (documented in `docs/mkdocs/docs/home/debugging.md`)
- `hzeller/jcxxgen` — stale (2021), 6 stars, self-described work-in-progress
- `Patchy66/nlohmann_json_reflection` — 0 stars, requires unreleased C++26 reflection

## Breaking changes

None — this is a documentation-only change (`README.md`, `docs/mkdocs/mkdocs.yml`, and two files under `docs/mkdocs/docs/community/`). No headers under `include/` or `single_include/` were touched, so no amalgamation was needed.

---

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced. *(none — prompted by mail, not an issue)*
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. *(docs-only change, no code touched)*
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`. *(not applicable — no header changes)*

🤖 Written by Claude Code on behalf of Niels Lohmann.