### PR TITLE
Don't overwrite BUILD.bazel while making a release

### DIFF
--- a/.github/workflows/check_bazel.yml
+++ b/.github/workflows/check_bazel.yml
@@ -1,0 +1,31 @@
+name: "Check BUILD.bazel updated"
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout pull request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Reset scripts to use the develop branch
+        run: |
+          git fetch origin develop
+          git checkout origin/develop -- cmake/scripts
+
+      - name: Check whether BUILD.bazel has been updated
+        run: |
+          cmake -DCHECK=ON -P cmake/scripts/gen_bazel_build_file.cmake

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,6 +17,7 @@ license(
 
 cc_library(
     name = "json",
+    # BEGIN GENERATED HDRS LIST
     hdrs = [
         "include/nlohmann/adl_serializer.hpp",
         "include/nlohmann/byte_container_with_subtype.hpp",
@@ -49,6 +50,7 @@ cc_library(
         "include/nlohmann/detail/meta/detected.hpp",
         "include/nlohmann/detail/meta/identity_tag.hpp",
         "include/nlohmann/detail/meta/is_sax.hpp",
+        "include/nlohmann/detail/meta/logic.hpp",
         "include/nlohmann/detail/meta/std_fs.hpp",
         "include/nlohmann/detail/meta/type_traits.hpp",
         "include/nlohmann/detail/meta/void_t.hpp",
@@ -65,9 +67,9 @@ cc_library(
         "include/nlohmann/thirdparty/hedley/hedley.hpp",
         "include/nlohmann/thirdparty/hedley/hedley_undef.hpp",
     ],
+    # END GENERATED HDRS LIST
     includes = ["include"],
     visibility = ["//visibility:public"],
-    alwayslink = True,
 )
 
 cc_library(

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ all:
 	@echo "amalgamate - amalgamate files single_include/nlohmann/json{,_fwd}.hpp from the include/nlohmann sources"
 	@echo "ChangeLog.md - generate ChangeLog file"
 	@echo "check-amalgamation - check whether sources have been amalgamated"
+	@echo "check-bazel - check whether BUILD.bazel has been updated"
 	@echo "clean - remove built files"
 	@echo "doctest - compile example files and check their output"
 	@echo "fuzz_testing - prepare fuzz testing of the JSON parser"
@@ -171,7 +172,10 @@ check-amalgamation:
 	@mv $(AMALGAMATED_FILE)~ $(AMALGAMATED_FILE)
 	@mv $(AMALGAMATED_FWD_FILE)~ $(AMALGAMATED_FWD_FILE)
 
-BUILD.bazel: $(SRCS)
+check-bazel:
+	cmake -DCHECK=ON -P cmake/scripts/gen_bazel_build_file.cmake
+
+update_bazel:
 	cmake -P cmake/scripts/gen_bazel_build_file.cmake
 
 ##########################################################################
@@ -204,7 +208,7 @@ json.tar.xz:
 
 # We use `-X` to make the resulting ZIP file reproducible, see
 # <https://content.pivotal.io/blog/barriers-to-deterministic-reproducible-zip-files>.
-include.zip: BUILD.bazel
+include.zip:
 	zip -9 --recurse-paths -X include.zip $(SRCS) $(AMALGAMATED_FILE) $(AMALGAMATED_FWD_FILE) BUILD.bazel MODULE.bazel meson.build LICENSE.MIT
 
 # Create the files for a release and add signatures and hashes.

--- a/cmake/scripts/gen_bazel_build_file.cmake
+++ b/cmake/scripts/gen_bazel_build_file.cmake
@@ -1,24 +1,44 @@
-# generate Bazel BUILD file
+# Re-generate Bazel BUILD file.
 
 set(PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
 set(BUILD_FILE "${PROJECT_ROOT}/BUILD.bazel")
 
+# Find the current set of header file names.
 file(GLOB_RECURSE HEADERS LIST_DIRECTORIES false RELATIVE "${PROJECT_ROOT}" "include/*.hpp")
+list(SORT HEADERS CASE SENSITIVE)
 
-file(WRITE "${BUILD_FILE}" [=[
-cc_library(
-    name = "json",
-    hdrs = [
-]=])
+# Read the existing BUILD file.
+file(READ "${BUILD_FILE}" BUILD_CONTENT)
 
+# Generate the replacement content.
+set(START_MARKER "# BEGIN GENERATED HDRS LIST")
+set(END_MARKER "# END GENERATED HDRS LIST")
+set(REPLACEMENT "${START_MARKER}\n    hdrs = [\n")
 foreach(header ${HEADERS})
-    file(APPEND "${BUILD_FILE}" "        \"${header}\",\n")
+    string(APPEND REPLACEMENT "        \"${header}\",\n")
 endforeach()
+string(APPEND REPLACEMENT "    ],\n    ${END_MARKER}")
 
-file(APPEND "${BUILD_FILE}" [=[
-    ],
-    includes = ["include"],
-    visibility = ["//visibility:public"],
-    alwayslink = True,
-)
-]=])
+# Find the existing PREFIX and SUFFIX surrounding the content.
+string(FIND "${BUILD_CONTENT}" "${START_MARKER}" START_POS)
+string(FIND "${BUILD_CONTENT}" "${END_MARKER}" END_POS)
+if(START_POS EQUAL -1 OR END_POS EQUAL -1)
+    message(FATAL_ERROR "Markers not found in BUILD.bazel")
+endif()
+string(SUBSTRING "${BUILD_CONTENT}" 0 ${START_POS} PREFIX)
+string(LENGTH "${END_MARKER}" END_MARKER_LEN)
+math(EXPR SUFFIX_POS "${END_POS} + ${END_MARKER_LEN}")
+string(SUBSTRING "${BUILD_CONTENT}" ${SUFFIX_POS} -1 SUFFIX)
+
+# Write out the updated file (or fail when in CHECK mode).
+set(NEW_BUILD_CONTENT "${PREFIX}${REPLACEMENT}${SUFFIX}")
+if("${BUILD_CONTENT}" STREQUAL "${NEW_BUILD_CONTENT}")
+    message(STATUS "BUILD.bazel is up to date.")
+else()
+    if(CHECK)
+        message(FATAL_ERROR "BUILD.bazel is stale. Run 'make update_bazel' to update it.")
+    else()
+        file(WRITE "${BUILD_FILE}" "${NEW_BUILD_CONTENT}")
+        message(STATUS "Updated ${BUILD_FILE}")
+    endif()
+endif()


### PR DESCRIPTION
Instead, add automation to 'develop' to ensure that it's always kept up to date.

Add missing header file 'logic.hpp'.

Re-apply e509007d "Remove alwayslink=True Bazel flag", which was accidentally reverted previously by the broken update script.
