### PR TITLE
Guard <version> inclusion with JSON_HAS_CPP_20

### DIFF
--- a/include/nlohmann/detail/macro_scope.hpp
+++ b/include/nlohmann/detail/macro_scope.hpp
@@ -58,9 +58,11 @@
     #define JSON_HAS_CPP_11
 #endif
 
-#ifdef __has_include
-    #if __has_include(<version>)
-        #include <version>
+#ifdef JSON_HAS_CPP_20
+    #ifdef __has_include
+        #if __has_include(<version>)
+            #include <version>
+        #endif
     #endif
 #endif
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -2433,9 +2433,11 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #define JSON_HAS_CPP_11
 #endif
 
-#ifdef __has_include
-    #if __has_include(<version>)
-        #include <version>
+#ifdef JSON_HAS_CPP_20
+    #ifdef __has_include
+        #if __has_include(<version>)
+            #include <version>
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
## Summary

Guard the inclusion of `<version>` with `JSON_HAS_CPP_20` and regenerate the amalgamated single-header file.

## Problem

`detail/macro_scope.hpp` currently probes for `<version>` using `__has_include` and includes it whenever the header is physically available.

However, `<version>` was introduced in C++20. A standard library installation may provide the header even when the translation unit is compiled in C++11, C++14, or C++17 mode. In that case, `__has_include(<version>)` succeeds despite the active language mode not supporting the header, potentially causing consumers to fail while including nlohmann/json.

The root cause is that header availability is checked without first checking the active C++ language standard.

## Changes

- Check `JSON_HAS_CPP_20` before probing for and including `<version>`.
- Regenerate `single_include/nlohmann/json.hpp` from the multiple-header sources using the repository's amalgamation tooling.

## Testing

The complete test suite was run on Arch Linux x86_64 with GCC 16.1.1 and libstdc++ 20260728:

```text
cmake -S . -B build
cmake --build build -j 10
ctest --test-dir build -j 10 --output-on-failure

100% tests passed, 0 tests failed out of 109
```

The configured test matrix covered C++11, C++14, C++17, C++20, and C++23.

Additional targeted compilation checks were performed with GCC 16.1.1 and Clang 22.1.8 for both the multiple-header and single-header variants:

- C++11 builds compile successfully and no longer include `<version>`.
- C++20 builds compile successfully and continue to include `<version>`.

## Regression test note

No dedicated unit test was added because this behavior cannot be meaningfully observed with a regular runtime assertion. A reliable regression test would need a separate compile-only fixture that places a deliberately incompatible fake `version` header before the standard library include paths, then builds both the multiple-header and single-header variants in a pre-C++20 language mode.

That requires additional build-system test infrastructure disproportionate to this preprocessor guard change. The targeted dependency and compilation checks described above were used instead.

- [x] The changes are described in detail, both the what and why.
- [x] No existing issue was identified for this fix.
- [ ] The code coverage remained at 100%. No dedicated regression test was added for the reason described above.
- [x] Documentation changes are not applicable because this does not change the public API.
- [x] The source code was amalgamated by running `make amalgamate`.
