### PR TITLE
fix: throw when MessagePack size exceeds uint32 limit (#5320)

### DIFF
--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -578,6 +578,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDB));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write the string
                 oa->write_characters(
@@ -606,6 +610,10 @@ class binary_writer
                     // array 32
                     oa->write_character(to_char_type(0xDD));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    assert_msgpack_size(N, &j);
                 }
 
                 // step 2: write each element
@@ -684,6 +692,10 @@ class binary_writer
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 1.5: if this is an ext type, write the subtype
                 if (use_ext)
@@ -719,6 +731,10 @@ class binary_writer
                     // map 32
                     oa->write_character(to_char_type(0xDF));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    assert_msgpack_size(N, &j);
                 }
 
                 // step 2: write each element
@@ -992,6 +1008,17 @@ class binary_writer
         }
 
         return static_cast<std::int32_t>(size);
+    }
+
+    /*!
+    @throw out_of_range.412 if @a size exceeds the MessagePack uint32 length limit
+    */
+    void assert_msgpack_size(const std::size_t size, const BasicJsonType* const context = nullptr) const
+    {
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::uint32_t>(size)))
+        {
+            JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::uint32_t>::max)())), context));
+        }
     }
 
     /*!

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1967,4 +1967,30 @@ TEST_CASE("MessagePack with std::byte")
         }
     }
 }
+
+namespace
+{
+template<typename T, typename A = std::allocator<T>>
+struct huge_array : std::vector<T, A>
+{
+    using std::vector<T, A>::vector;
+    std::size_t size() const noexcept { return std::size_t{1} << 33; }
+};
+
+using huge_json = nlohmann::basic_json<
+    std::map, huge_array, std::string, bool, std::int64_t, std::uint64_t,
+    double, std::allocator, nlohmann::adl_serializer, std::vector<std::uint8_t>, void>;
+} // namespace
+
+TEST_CASE("issue #5320 - to_msgpack rejects sizes above uint32 limit")
+{
+    huge_json j = huge_json::array();
+    j.push_back(1);
+    j.push_back(2);
+    j.push_back(3);
+
+    CHECK_THROWS_WITH_AS(_ = huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 8589934592 exceeds maximum of 4294967295",
+        json::out_of_range&);
+}
 #endif


### PR DESCRIPTION
Fixes #5320

`to_msgpack()` now throws `out_of_range.412` when a string, array, binary, or object reports a size above `UINT32_MAX`, matching the documented MessagePack limit and the BSON fix pattern from #5314.

Adds a regression test using a container type that reports an oversized `size()` without allocating multi-gigabyte data.
