### PR TITLE
Throw type_error.318 when serializing discarded values to binary formats

### DIFF
--- a/docs/mkdocs/docs/home/exceptions.md
+++ b/docs/mkdocs/docs/home/exceptions.md
@@ -771,6 +771,21 @@ The dynamic type of the object cannot be represented in the requested serializat
 
     Encapsulate the JSON value in an object. That is, instead of serializing `#!json true`, serialize `#!json {"value": true}`
 
+### json.exception.type_error.318
+
+The dynamic type of the object cannot be represented in the requested serialization format (e.g., a discarded value cannot be serialized to CBOR, MessagePack, or UBJSON)
+
+!!! failure "Example messages"
+
+    Serializing a discarded value to MessagePack:
+    ```
+    [json.exception.type_error.318] cannot serialize discarded values to binary format
+    ```
+
+!!! tip
+
+    Check for discarded values with `is_discarded()` before calling binary serialization functions, or handle parse errors at the point where JSON is parsed.
+
 ## Out of range
 
 This exception is thrown in case a library function is called on an input parameter that exceeds the expected range, for instance, in the case of array indices or nonexisting object keys.

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -410,7 +410,9 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
@@ -578,6 +580,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDB));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write the string
                 oa->write_characters(
@@ -606,6 +612,10 @@ class binary_writer
                     // array 32
                     oa->write_character(to_char_type(0xDD));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    assert_msgpack_size(N, &j);
                 }
 
                 // step 2: write each element
@@ -684,6 +694,10 @@ class binary_writer
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 1.5: if this is an ext type, write the subtype
                 if (use_ext)
@@ -720,6 +734,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDF));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write each element
                 for (const auto& el : *j.m_data.m_value.object)
@@ -732,7 +750,9 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
@@ -954,11 +974,18 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
   private:
+    static void throw_on_discarded(const BasicJsonType& j)
+    {
+        JSON_THROW(type_error::create(318, concat("cannot serialize ", j.type_name(), " values to binary format"), &j));
+    }
+
     //////////
     // BSON //
     //////////
@@ -992,6 +1019,17 @@ class binary_writer
         }
 
         return static_cast<std::int32_t>(size);
+    }
+
+    /*!
+    @throw out_of_range.412 if @a size exceeds the MessagePack uint32 length limit
+    */
+    void assert_msgpack_size(const std::size_t size, const BasicJsonType* const context = nullptr) const
+    {
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::uint32_t>(size)))
+        {
+            JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::uint32_t>::max)())), context));
+        }
     }
 
     /*!
@@ -1223,8 +1261,7 @@ class binary_writer
             // LCOV_EXCL_START
             case value_t::discarded:
             default:
-                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
-                return 0ul;
+                throw_on_discarded(j);
                 // LCOV_EXCL_STOP
         }
     }
@@ -1270,8 +1307,7 @@ class binary_writer
             // LCOV_EXCL_START
             case value_t::discarded:
             default:
-                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
-                return;
+                throw_on_discarded(j);
                 // LCOV_EXCL_STOP
         }
     }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
-// JSON_HAS_CPP_17
+ // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -17344,7 +17344,9 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
@@ -17512,6 +17514,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDB));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write the string
                 oa->write_characters(
@@ -17540,6 +17546,10 @@ class binary_writer
                     // array 32
                     oa->write_character(to_char_type(0xDD));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    assert_msgpack_size(N, &j);
                 }
 
                 // step 2: write each element
@@ -17618,6 +17628,10 @@ class binary_writer
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 1.5: if this is an ext type, write the subtype
                 if (use_ext)
@@ -17654,6 +17668,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDF));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write each element
                 for (const auto& el : *j.m_data.m_value.object)
@@ -17666,7 +17684,9 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
@@ -17888,11 +17908,18 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
   private:
+    static void throw_on_discarded(const BasicJsonType& j)
+    {
+        JSON_THROW(type_error::create(318, concat("cannot serialize ", j.type_name(), " values to binary format"), &j));
+    }
+
     //////////
     // BSON //
     //////////
@@ -17926,6 +17953,17 @@ class binary_writer
         }
 
         return static_cast<std::int32_t>(size);
+    }
+
+    /*!
+    @throw out_of_range.412 if @a size exceeds the MessagePack uint32 length limit
+    */
+    void assert_msgpack_size(const std::size_t size, const BasicJsonType* const context = nullptr) const
+    {
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::uint32_t>(size)))
+        {
+            JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::uint32_t>::max)())), context));
+        }
     }
 
     /*!
@@ -18157,8 +18195,7 @@ class binary_writer
             // LCOV_EXCL_START
             case value_t::discarded:
             default:
-                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
-                return 0ul;
+                throw_on_discarded(j);
                 // LCOV_EXCL_STOP
         }
     }
@@ -18204,8 +18241,7 @@ class binary_writer
             // LCOV_EXCL_START
             case value_t::discarded:
             default:
-                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
-                return;
+                throw_on_discarded(j);
                 // LCOV_EXCL_STOP
         }
     }
@@ -21501,10 +21537,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22202,8 +22238,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                       std::forward<CompatibleType>(val))))
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -23006,7 +23042,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23048,7 +23084,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23198,7 +23234,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -103,10 +103,20 @@ TEST_CASE("CBOR")
     {
         SECTION("discarded")
         {
-            // discarded values are not serialized
             json const j = json::value_t::discarded;
-            const auto result = json::to_cbor(j);
-            CHECK(result.empty());
+            CHECK_THROWS_WITH_AS(json::to_cbor(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
+        }
+
+        SECTION("discarded in array")
+        {
+            json const j = {json::value_t::discarded, json::value_t::discarded, 1};
+            CHECK_THROWS_WITH_AS(json::to_cbor(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
+        }
+
+        SECTION("discarded in object")
+        {
+            json const j = {{"foo", 1}, {"bar", json::value_t::discarded}};
+            CHECK_THROWS_WITH_AS(json::to_cbor(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
         }
 
         SECTION("NaN")

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -106,10 +106,20 @@ TEST_CASE("MessagePack")
     {
         SECTION("discarded")
         {
-            // discarded values are not serialized
             json const j = json::value_t::discarded;
-            const auto result = json::to_msgpack(j);
-            CHECK(result.empty());
+            CHECK_THROWS_WITH_AS(json::to_msgpack(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
+        }
+
+        SECTION("discarded in array")
+        {
+            json const j = {json::value_t::discarded, json::value_t::discarded, 1};
+            CHECK_THROWS_WITH_AS(json::to_msgpack(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
+        }
+
+        SECTION("discarded in object")
+        {
+            json const j = {{"foo", 1}, {"bar", json::value_t::discarded}};
+            CHECK_THROWS_WITH_AS(json::to_msgpack(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
         }
 
         SECTION("null")
@@ -1966,5 +1976,31 @@ TEST_CASE("MessagePack with std::byte")
             CHECK(direct_result == original);
         }
     }
+}
+
+namespace
+{
+template<typename T, typename A = std::allocator<T>>
+struct huge_array : std::vector<T, A>
+{
+    using std::vector<T, A>::vector;
+    std::size_t size() const noexcept { return std::size_t{1} << 33; }
+};
+
+using huge_json = nlohmann::basic_json<
+    std::map, huge_array, std::string, bool, std::int64_t, std::uint64_t,
+    double, std::allocator, nlohmann::adl_serializer, std::vector<std::uint8_t>, void>;
+} // namespace
+
+TEST_CASE("issue #5320 - to_msgpack rejects sizes above uint32 limit")
+{
+    huge_json j = huge_json::array();
+    j.push_back(1);
+    j.push_back(2);
+    j.push_back(3);
+
+    CHECK_THROWS_WITH_AS(_ = huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 8589934592 exceeds maximum of 4294967295",
+        json::out_of_range&);
 }
 #endif

--- a/tests/src/unit-ubjson.cpp
+++ b/tests/src/unit-ubjson.cpp
@@ -101,10 +101,8 @@ TEST_CASE("UBJSON")
     {
         SECTION("discarded")
         {
-            // discarded values are not serialized
             json const j = json::value_t::discarded;
-            const auto result = json::to_ubjson(j);
-            CHECK(result.empty());
+            CHECK_THROWS_WITH_AS(json::to_ubjson(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
         }
 
         SECTION("null")
@@ -2143,8 +2141,7 @@ TEST_CASE("UBJSON")
         SECTION("discarded")
         {
             json const j = {json::value_t::discarded, json::value_t::discarded};
-            std::vector<uint8_t> expected = {'[', '$', 'N', '#', 'i', 2};
-            CHECK(json::to_ubjson(j, true, true) == expected);
+            CHECK_THROWS_WITH_AS(json::to_ubjson(j, true, true), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
         }
     }
 }


### PR DESCRIPTION
Fixes #4714

Discarded JSON values silently produced broken CBOR, MessagePack, and UBJSON output when nested in arrays or objects (element count/header written but payload skipped). Serialization now throws `type_error.318` instead, matching the approach discussed in the issue thread.

Adds regression tests for top-level, array, and object cases. Documents the new exception id.
