### PR TITLE
CBOR store: fall back to ignore for non-binary tagged items

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -899,7 +899,11 @@ class binary_reader
                                 return parse_cbor_internal(true, tag_handler);
                         }
                         get();
-                        return get_cbor_binary(b) && sax->binary(b);
+                        if ((current >= 0x40 && current <= 0x5B) || current == 0x5F)
+                        {
+                            return get_cbor_binary(b) && sax->binary(b);
+                        }
+                        return parse_cbor_internal(false, cbor_tag_handler_t::ignore);
                     }
 
                     default:                 // LCOV_EXCL_LINE

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
-// JSON_HAS_CPP_17
+ // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -11521,7 +11521,11 @@ class binary_reader
                                 return parse_cbor_internal(true, tag_handler);
                         }
                         get();
-                        return get_cbor_binary(b) && sax->binary(b);
+                        if ((current >= 0x40 && current <= 0x5B) || current == 0x5F)
+                        {
+                            return get_cbor_binary(b) && sax->binary(b);
+                        }
+                        return parse_cbor_internal(false, cbor_tag_handler_t::ignore);
                     }
 
                     default:                 // LCOV_EXCL_LINE
@@ -17344,7 +17348,9 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
@@ -17512,6 +17518,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDB));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write the string
                 oa->write_characters(
@@ -17540,6 +17550,10 @@ class binary_writer
                     // array 32
                     oa->write_character(to_char_type(0xDD));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    assert_msgpack_size(N, &j);
                 }
 
                 // step 2: write each element
@@ -17618,6 +17632,10 @@ class binary_writer
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 1.5: if this is an ext type, write the subtype
                 if (use_ext)
@@ -17654,6 +17672,10 @@ class binary_writer
                     oa->write_character(to_char_type(0xDF));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    assert_msgpack_size(N, &j);
+                }
 
                 // step 2: write each element
                 for (const auto& el : *j.m_data.m_value.object)
@@ -17666,7 +17688,9 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
@@ -17888,11 +17912,18 @@ class binary_writer
 
             case value_t::discarded:
             default:
-                break;
+            {
+                throw_on_discarded(j);
+            }
         }
     }
 
   private:
+    static void throw_on_discarded(const BasicJsonType& j)
+    {
+        JSON_THROW(type_error::create(318, concat("cannot serialize ", j.type_name(), " values to binary format"), &j));
+    }
+
     //////////
     // BSON //
     //////////
@@ -17926,6 +17957,17 @@ class binary_writer
         }
 
         return static_cast<std::int32_t>(size);
+    }
+
+    /*!
+    @throw out_of_range.412 if @a size exceeds the MessagePack uint32 length limit
+    */
+    void assert_msgpack_size(const std::size_t size, const BasicJsonType* const context = nullptr) const
+    {
+        if (JSON_HEDLEY_UNLIKELY(!value_in_range_of<std::uint32_t>(size)))
+        {
+            JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ", std::to_string((std::numeric_limits<std::uint32_t>::max)())), context));
+        }
     }
 
     /*!
@@ -18157,8 +18199,7 @@ class binary_writer
             // LCOV_EXCL_START
             case value_t::discarded:
             default:
-                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
-                return 0ul;
+                throw_on_discarded(j);
                 // LCOV_EXCL_STOP
         }
     }
@@ -18204,8 +18245,7 @@ class binary_writer
             // LCOV_EXCL_START
             case value_t::discarded:
             default:
-                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
-                return;
+                throw_on_discarded(j);
                 // LCOV_EXCL_STOP
         }
     }
@@ -21501,10 +21541,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22202,8 +22242,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                       std::forward<CompatibleType>(val))))
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -23006,7 +23046,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23048,7 +23088,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23198,7 +23238,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -103,10 +103,20 @@ TEST_CASE("CBOR")
     {
         SECTION("discarded")
         {
-            // discarded values are not serialized
             json const j = json::value_t::discarded;
-            const auto result = json::to_cbor(j);
-            CHECK(result.empty());
+            CHECK_THROWS_WITH_AS(json::to_cbor(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
+        }
+
+        SECTION("discarded in array")
+        {
+            json const j = {json::value_t::discarded, json::value_t::discarded, 1};
+            CHECK_THROWS_WITH_AS(json::to_cbor(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
+        }
+
+        SECTION("discarded in object")
+        {
+            json const j = {{"foo", 1}, {"bar", json::value_t::discarded}};
+            CHECK_THROWS_WITH_AS(json::to_cbor(j), "[json.exception.type_error.318] cannot serialize discarded values to binary format", json::type_error&);
         }
 
         SECTION("NaN")
@@ -2514,6 +2524,23 @@ TEST_CASE("examples from RFC 8949 Appendix A")
         CHECK(json::to_cbor(json::binary(std::vector<uint8_t> {}, 8589934590)) == std::vector<uint8_t> {0xdb, 0x00, 0x00, 0x00, 0x01, 0xff, 0xff, 0xff, 0xfe, 0x40});
         CHECK(!json::from_cbor(json::to_cbor(json::binary(std::vector<uint8_t> {}, 8589934590)), true, true, json::cbor_tag_handler_t::ignore).get_binary().has_subtype());
         CHECK(json::from_cbor(json::to_cbor(json::binary(std::vector<uint8_t> {}, 8589934590)), true, true, json::cbor_tag_handler_t::store).get_binary().subtype() == 8589934590);
+    }
+
+    SECTION("cbor_tag_handler_t::store falls back for non-binary tagged items (#5316)")
+    {
+        // CBOR self-describe tag (55799) followed by a map
+        const std::vector<uint8_t> self_describe_map{0xD9, 0xD9, 0xF7, 0xA1, 0x61, 0x61, 0x01};
+        const json j_ignore = json::from_cbor(self_describe_map, true, true, json::cbor_tag_handler_t::ignore);
+        CHECK(j_ignore == json({{"a", 1}}));
+        const json j_store = json::from_cbor(self_describe_map, true, true, json::cbor_tag_handler_t::store);
+        CHECK(j_store == j_ignore);
+
+        // tag 24 over an unsigned integer
+        const std::vector<uint8_t> tagged_uint{0xD8, 0x18, 0x00};
+        const json j_uint_ignore = json::from_cbor(tagged_uint, true, true, json::cbor_tag_handler_t::ignore);
+        CHECK(j_uint_ignore == json(0));
+        const json j_uint_store = json::from_cbor(tagged_uint, true, true, json::cbor_tag_handler_t::store);
+        CHECK(j_uint_store == j_uint_ignore);
     }
 
     SECTION("arrays")


### PR DESCRIPTION
Fixes #5316 (part 1)

`cbor_tag_handler_t::store` assumed every tagged item is a byte string. Tagged maps, arrays, and other non-binary values therefore failed with `parse_error.113` even though `ignore` accepted the same input (notably CBOR self-describe tag 55799).

When the tagged item is not a binary head byte, fall back to `ignore` parsing instead of forcing binary decoding. Binary tags still store the subtype as before.

Does not change behavior for tag numbers 6–20 over binary strings (part 2 of #5316).
