### PR TITLE
Format-check the documentation examples in CI

### DIFF
--- a/.github/workflows/check_amalgamation.yml
+++ b/.github/workflows/check_amalgamation.yml
@@ -67,8 +67,18 @@ jobs:
           ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=none --quiet \
             $INCLUDE_DIR/json.hpp $INCLUDE_DIR/json_fwd.hpp
 
+          # fail loudly if a directory is renamed or removed: find would only warn
+          # about the missing path and silently drop its files from the check
+          SOURCE_DIRS="docs/mkdocs/docs/examples include tests"
+          for DIR in $SOURCE_DIRS; do
+            if [ ! -d "$DIR" ]; then
+              echo "::error::source directory '$DIR' does not exist"
+              exit 1
+            fi
+          done
+
           ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=none --quiet \
-            $(find docs/examples include tests -type f \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' \) -not -path 'tests/thirdparty/*' -not -path 'tests/abi/include/nlohmann/*' | sort)
+            $(find $SOURCE_DIRS -type f \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' \) -not -path 'tests/thirdparty/*' -not -path 'tests/abi/include/nlohmann/*' | sort)
 
       - name: Build patch and check for differences
         id: diff

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -7,7 +7,6 @@ on:
       - develop
     paths:
       - docs/mkdocs/**
-      - docs/examples/**
   workflow_dispatch:
 
 # we don't want to have concurrent jobs, and we don't want to cancel running jobs to avoid broken publications

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -294,7 +294,7 @@ file(GLOB_RECURSE INDENT_FILES
         ${PROJECT_SOURCE_DIR}/tests/src/*.cpp
         ${PROJECT_SOURCE_DIR}/tests/src/*.hpp
         ${PROJECT_SOURCE_DIR}/tests/benchmarks/src/benchmarks.cpp
-    ${PROJECT_SOURCE_DIR}/docs/examples/*.cpp
+    ${PROJECT_SOURCE_DIR}/docs/mkdocs/docs/examples/*.cpp
 )
 
 set(include_dir ${PROJECT_SOURCE_DIR}/single_include/nlohmann)

--- a/docs/mkdocs/docs/examples/parser_callback_t.cpp
+++ b/docs/mkdocs/docs/examples/parser_callback_t.cpp
@@ -9,13 +9,13 @@ int main()
     auto text = R"({"IDs": [116, 943], "Width": 800})";
 
     // discard the array when the parser reads its opening bracket
-    json j_array_start = json::parse(text, [](int /*depth*/, json::parse_event_t event, json & /*parsed*/)
+    json j_array_start = json::parse(text, [](int /*depth*/, json::parse_event_t event, json& /*parsed*/)
     {
         return event != json::parse_event_t::array_start;
     });
 
     // discard the same array when the parser reads its closing bracket
-    json j_array_end = json::parse(text, [](int /*depth*/, json::parse_event_t event, json & /*parsed*/)
+    json j_array_end = json::parse(text, [](int /*depth*/, json::parse_event_t event, json& /*parsed*/)
     {
         return event != json::parse_event_t::array_end;
     });
@@ -33,7 +33,7 @@ int main()
     });
 
     // discard the top-level object
-    json j_root = json::parse(text, [](int /*depth*/, json::parse_event_t event, json & /*parsed*/)
+    json j_root = json::parse(text, [](int /*depth*/, json::parse_event_t event, json& /*parsed*/)
     {
         return event != json::parse_event_t::object_end;
     });


### PR DESCRIPTION
The documentation examples have never been format-checked by CI. Both format checks pointed at `docs/examples`, a path that does not exist — the examples live in `docs/mkdocs/docs/examples`. In each case the missing path failed silently rather than erroring:

| Location | Failure mode |
| --- | --- |
| `.github/workflows/check_amalgamation.yml` | `find` printed an error for the missing path and exited nonzero, but its status was swallowed by command substitution. astyle simply received a shorter file list and the step exited 0. |
| `cmake/ci.cmake` | `file(GLOB_RECURSE ...)` over a missing directory silently yields nothing, so the `ci_test_amalgamation` target (still active via `.github/workflows/ubuntu.yml`) skipped the examples too. |
| `.github/workflows/publish_documentation.yml` | Dead `docs/examples/**` path filter. |

Both checks now resolve 231 example files, up from 0.

For `publish_documentation.yml` the filter was removed rather than repointed: `docs/mkdocs/**` is already listed and covers `docs/mkdocs/docs/examples`, so repointing would have been redundant.

## Formatting fix

With the check repaired, `make amalgamate` reformats exactly one file that had drifted behind it: `docs/mkdocs/docs/examples/parser_callback_t.cpp`, where three lambda parameters read `json & /*parsed*/` instead of `json& /*parsed*/` (`--align-reference=type`).

To confirm nothing else had drifted in the meantime, astyle was run over the full 384-file post-fix list — no further changes — and no verbatim copies of the old spelling remain elsewhere in the docs.

## Failing loudly on a future rename

A rename silently shrinking the file list is the root cause here, not the stale path itself. The workflow now checks each source directory exists before the `find` and fails with a GitHub error annotation if one does not:

```
::error::source directory 'docs/examples' does not exist
```

Verified in both directions: it passes on the current paths, and fails with exactly that message when fed the old one.

Guarding `find`'s own exit status instead would not have been enough here without also adding `set -o pipefail` — this workflow uses the default `bash -e {0}` shell and the file list is piped through `sort`, so the pipeline reports `sort`'s status, not `find`'s.

## Notes for reviewers

- **Commit order is deliberate.** The formatting fix lands first so that each commit is green under its own CI configuration. Reversed, the intermediate commit would enable a check that fails on a file it had only just started looking at.
- **No local/CI gap for contributors.** Since the check gets stricter, `make pretty` was compared against the new CI file list: it covers all 384 files plus the two amalgamated headers, which CI formats in the preceding astyle call. `make amalgamate` therefore remains a faithful local pre-check.

## API impact

**No breaking changes.** This touches CI configuration and comment whitespace in one documentation example. No changes to any header, to `single_include/`, or to the public API. The amalgamated headers are unchanged by this PR.

---

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced. — n/a, no existing issue.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code. — n/a, no library code changed.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated. — example reformatted; rendered output is unchanged.
- [x] The source code is amalgamated by running `make amalgamate`.

---

*This pull request was prepared by Claude Code.*
