### PR TITLE
Fix update(merge_objects=true) throwing on primitive-to-object merge

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3516,7 +3516,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             if (merge_objects && it.value().is_object())
             {
                 auto it2 = m_data.m_value.object->find(it.key());
-                if (it2 != m_data.m_value.object->end())
+                // Only recurse when the existing value is itself an object.
+                // Otherwise overwrite, matching the documented "all other values
+                // are overwritten as usual" behavior (see #5402).
+                if (it2 != m_data.m_value.object->end() && it2->second.is_object())
                 {
                     it2->second.update(it.value(), true);
 #if JSON_DIAGNOSTICS

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -24870,7 +24870,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             if (merge_objects && it.value().is_object())
             {
                 auto it2 = m_data.m_value.object->find(it.key());
-                if (it2 != m_data.m_value.object->end())
+                // Only recurse when the existing value is itself an object.
+                // Otherwise overwrite, matching the documented "all other values
+                // are overwritten as usual" behavior (see #5402).
+                if (it2 != m_data.m_value.object->end() && it2->second.is_object())
                 {
                     it2->second.update(it.value(), true);
 #if JSON_DIAGNOSTICS

--- a/tests/src/unit-modifiers.cpp
+++ b/tests/src/unit-modifiers.cpp
@@ -801,6 +801,30 @@ TEST_CASE("modifiers")
                     j1.update(j2, true);
                     CHECK(j1 == json({{"string", "t"}, {"numbers", 1}}));
                 }
+
+                SECTION("overwrite primitive with object")
+                {
+                    json j1 = {{"k", 1}};
+                    json const j2 = {{"k", {{"x", 2}}}};
+                    j1.update(j2, true);
+                    CHECK(j1 == json({{"k", {{"x", 2}}}}));
+                }
+
+                SECTION("overwrite array with object")
+                {
+                    json j1 = {{"k", {1, 2}}};
+                    json const j2 = {{"k", {{"x", 2}}}};
+                    j1.update(j2, true);
+                    CHECK(j1 == json({{"k", {{"x", 2}}}}));
+                }
+
+                SECTION("overwrite nested primitive with object")
+                {
+                    json j1 = {{"k", {{"inner", 1}}}};
+                    json const j2 = {{"k", {{"inner", {{"x", 2}}}}}};
+                    j1.update(j2, true);
+                    CHECK(j1 == json({{"k", {{"inner", {{"x", 2}}}}}}));
+                }
             }
         }
     }

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1555,4 +1555,15 @@ TEST_CASE("issue #5338 - truncated CBOR tagged binary subtype is rejected")
     }
 }
 
+TEST_CASE("issue #5402 - update(merge_objects=true) overwrites a primitive with an object")
+{
+    json t = {{"k", 1}};
+    t.update(json{{"k", {{"x", 2}}}}, true);
+    CHECK(t == json({{"k", {{"x", 2}}}}));
+
+    json mixed = {{"keep", {{"a", 1}}}, {"replace", 1}};
+    mixed.update(json{{"keep", {{"b", 2}}}, {"replace", {{"x", 2}}}}, true);
+    CHECK(mixed == json({{"keep", {{"a", 1}, {"b", 2}}}, {"replace", {{"x", 2}}}}));
+}
+
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
Fixes #5402.

## What

`update(j, true)` recursed into an existing value whenever the source value was an object and the key already existed. If that existing value was a primitive (or an array, or null), the nested `update()` threw `type_error.312`, even though both top-level values were objects.

The docs say keys whose source value is an object are merged recursively, and all other values are overwritten as usual. `type_error.312` is only documented for calling `update()` on a non-object at the top level.

## Why

The recursive call did not check the type of the *existing* value. A primitive target is not an object, so it should be overwritten, not merged.

## Change

Only recurse when the existing value is itself an object:

```cpp
if (it2 != m_data.m_value.object->end() && it2->second.is_object())
```

Otherwise fall through to the existing overwrite assignment.

## Tests

- `unit-modifiers.cpp`: overwrite a primitive, an array, and a nested primitive with an object under `merge_objects=true`. Existing object-merge cases still pass.
- `unit-regression2.cpp`: the original reproducer plus a mixed case (one key merged, one key overwritten).

`test-modifiers_cpp11` and `test-regression2_cpp11` pass locally (214 and the new #5402 assertions).

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.