### PR TITLE
Fix dead Unicode tests for a malformed fourth UTF-8 byte

### DIFF
--- a/tests/src/unit-unicode3.cpp
+++ b/tests/src/unit-unicode3.cpp
@@ -296,25 +296,24 @@ TEST_CASE("Unicode (3/5)" * doctest::skip())
 
             SECTION("ill-formed: wrong fourth byte")
             {
-                for (int byte1 = 0xF0; byte1 <= 0xF0; ++byte1)
+                // Pin unrelated trailing bytes to a representative valid value.
+                // Sweeping all valid byte2/byte3 combinations would add hundreds
+                // of thousands of iterations; the fourth-byte property does not
+                // depend on those values. Previously this section compared
+                // byte3 (always in 0x80..0xBF here) and never executed a check.
+                const int byte1 = 0xF0;
+                const int byte2 = 0x90;
+                const int byte3 = 0x80;
+                for (int byte4 = 0x00; byte4 <= 0xFF; ++byte4)
                 {
-                    for (int byte2 = 0x90; byte2 <= 0xBF; ++byte2)
+                    // skip correct fourth byte
+                    if (0x80 <= byte4 && byte4 <= 0xBF)
                     {
-                        for (int byte3 = 0x80; byte3 <= 0xBF; ++byte3)
-                        {
-                            for (int byte4 = 0x00; byte4 <= 0xFF; ++byte4)
-                            {
-                                // skip fourth second byte
-                                if (0x80 <= byte3 && byte3 <= 0xBF)
-                                {
-                                    continue;
-                                }
-
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
         }

--- a/tests/src/unit-unicode4.cpp
+++ b/tests/src/unit-unicode4.cpp
@@ -296,25 +296,23 @@ TEST_CASE("Unicode (4/5)" * doctest::skip())
 
             SECTION("ill-formed: wrong fourth byte")
             {
-                for (int byte1 = 0xF1; byte1 <= 0xF3; ++byte1)
+                // Pin unrelated bytes to representative valid values. The
+                // previous guard checked byte3 (always valid in this loop) so
+                // the body never ran. Sweeping every valid prefix would add
+                // ~2.3e6 iterations; the fourth-byte property is independent.
+                const int byte1 = 0xF1;
+                const int byte2 = 0x80;
+                const int byte3 = 0x80;
+                for (int byte4 = 0x00; byte4 <= 0xFF; ++byte4)
                 {
-                    for (int byte2 = 0x80; byte2 <= 0xBF; ++byte2)
+                    // skip correct fourth byte
+                    if (0x80 <= byte4 && byte4 <= 0xBF)
                     {
-                        for (int byte3 = 0x80; byte3 <= 0xBF; ++byte3)
-                        {
-                            for (int byte4 = 0x00; byte4 <= 0xFF; ++byte4)
-                            {
-                                // skip correct fourth byte
-                                if (0x80 <= byte3 && byte3 <= 0xBF)
-                                {
-                                    continue;
-                                }
-
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
         }

--- a/tests/src/unit-unicode5.cpp
+++ b/tests/src/unit-unicode5.cpp
@@ -296,25 +296,22 @@ TEST_CASE("Unicode (5/5)" * doctest::skip())
 
             SECTION("ill-formed: wrong fourth byte")
             {
-                for (int byte1 = 0xF4; byte1 <= 0xF4; ++byte1)
+                // Pin unrelated bytes to representative valid values. The
+                // previous guard checked byte3 (always valid in this loop) so
+                // the body never ran.
+                const int byte1 = 0xF4;
+                const int byte2 = 0x80;
+                const int byte3 = 0x80;
+                for (int byte4 = 0x00; byte4 <= 0xFF; ++byte4)
                 {
-                    for (int byte2 = 0x80; byte2 <= 0x8F; ++byte2)
+                    // skip correct fourth byte
+                    if (0x80 <= byte4 && byte4 <= 0xBF)
                     {
-                        for (int byte3 = 0x80; byte3 <= 0xBF; ++byte3)
-                        {
-                            for (int byte4 = 0x00; byte4 <= 0xFF; ++byte4)
-                            {
-                                // skip correct fourth byte
-                                if (0x80 <= byte3 && byte3 <= 0xBF)
-                                {
-                                    continue;
-                                }
-
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
         }


### PR DESCRIPTION
## Summary

The `SECTION("ill-formed: wrong fourth byte")` blocks in `unit-unicode3.cpp`, `unit-unicode4.cpp`, and `unit-unicode5.cpp` compared `byte3` instead of `byte4`. In those loops `byte3` is always a valid continuation byte (`0x80..0xBF`), so the body never ran and a malformed fourth byte was never tested.

## Related Issue

Fixes #5416

## Changes Made

- Compare `byte4` when skipping valid fourth bytes
- Pin the other bytes to a representative valid prefix so the property is tested without adding millions of extra iterations (see #5418)
- Restore the "skip correct fourth byte" comment (it was garbled in unicode3)

## Testing

Commands executed:

- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test-unicode3_cpp11 test-unicode4_cpp11 test-unicode5_cpp11`
- `./tests/test-unicode3_cpp11 --no-skip -tce='*downloaded*'`
- `./tests/test-unicode4_cpp11 --no-skip -tce='*downloaded*'`
- `./tests/test-unicode5_cpp11 --no-skip -tce='*downloaded*'`

Results:

- unicode3: 1 passed, 19503948 assertions
- unicode4: 1 passed, 65425956 assertions
- unicode5: 1 passed, 14891468 assertions

The `check test suite is downloaded` case was excluded because this environment does not have the extra test data tarball; those Unicode cases do not use it.

## Notes

A naive `byte3` → `byte4` swap would add ~3 million extra iterations across the three files. Pinning unrelated trailing bytes matches the approach discussed on #5416 / #5418: the property under test does not depend on the other continuation bytes.

No amalgamation change: tests only.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`. (n/a — test-only)