### PR TITLE
Cut Unicode ill-formed byte sweeps to one representative prefix

### DIFF
--- a/tests/src/unit-unicode3.cpp
+++ b/tests/src/unit-unicode3.cpp
@@ -248,49 +248,42 @@ TEST_CASE("Unicode (3/5)" * doctest::skip())
 
             SECTION("ill-formed: wrong second byte")
             {
-                for (int byte1 = 0xF0; byte1 <= 0xF0; ++byte1)
+                // Property: an out-of-range 2nd byte is rejected regardless of
+                // later continuation bytes. Pin those to one valid value so
+                // this section does not sweep 192*64*64 combinations (#5418).
+                const int byte1 = 0xF0;
+                const int byte3 = 0x80;
+                const int byte4 = 0x80;
+                for (int byte2 = 0x00; byte2 <= 0xFF; ++byte2)
                 {
-                    for (int byte2 = 0x00; byte2 <= 0xFF; ++byte2)
+                    // skip correct second byte
+                    if (0x90 <= byte2 && byte2 <= 0xBF)
                     {
-                        // skip correct second byte
-                        if (0x90 <= byte2 && byte2 <= 0xBF)
-                        {
-                            continue;
-                        }
-
-                        for (int byte3 = 0x80; byte3 <= 0xBF; ++byte3)
-                        {
-                            for (int byte4 = 0x80; byte4 <= 0xBF; ++byte4)
-                            {
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
 
             SECTION("ill-formed: wrong third byte")
             {
-                for (int byte1 = 0xF0; byte1 <= 0xF0; ++byte1)
+                // Property: an out-of-range 3rd byte is rejected regardless of
+                // the 2nd/4th bytes. Pin those to one valid value (#5418).
+                const int byte1 = 0xF0;
+                const int byte2 = 0x90;
+                const int byte4 = 0x80;
+                for (int byte3 = 0x00; byte3 <= 0xFF; ++byte3)
                 {
-                    for (int byte2 = 0x90; byte2 <= 0xBF; ++byte2)
+                    // skip correct third byte
+                    if (0x80 <= byte3 && byte3 <= 0xBF)
                     {
-                        for (int byte3 = 0x00; byte3 <= 0xFF; ++byte3)
-                        {
-                            // skip correct third byte
-                            if (0x80 <= byte3 && byte3 <= 0xBF)
-                            {
-                                continue;
-                            }
-
-                            for (int byte4 = 0x80; byte4 <= 0xBF; ++byte4)
-                            {
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
 

--- a/tests/src/unit-unicode4.cpp
+++ b/tests/src/unit-unicode4.cpp
@@ -248,6 +248,11 @@ TEST_CASE("Unicode (4/5)" * doctest::skip())
 
             SECTION("ill-formed: wrong second byte")
             {
+                // Pin later continuation bytes; the 2nd-byte property does not
+                // depend on them. Lead bytes F1-F3 stay, as they define this
+                // sequence class (#5418).
+                const int byte3 = 0x80;
+                const int byte4 = 0x80;
                 for (int byte1 = 0xF1; byte1 <= 0xF3; ++byte1)
                 {
                     for (int byte2 = 0x00; byte2 <= 0xFF; ++byte2)
@@ -258,38 +263,29 @@ TEST_CASE("Unicode (4/5)" * doctest::skip())
                             continue;
                         }
 
-                        for (int byte3 = 0x80; byte3 <= 0xBF; ++byte3)
-                        {
-                            for (int byte4 = 0x80; byte4 <= 0xBF; ++byte4)
-                            {
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        check_utf8string(false, byte1, byte2, byte3, byte4);
+                        check_utf8dump(false, byte1, byte2, byte3, byte4);
                     }
                 }
             }
 
             SECTION("ill-formed: wrong third byte")
             {
+                // Pin 2nd/4th bytes to one valid continuation (#5418).
+                const int byte2 = 0x80;
+                const int byte4 = 0x80;
                 for (int byte1 = 0xF1; byte1 <= 0xF3; ++byte1)
                 {
-                    for (int byte2 = 0x80; byte2 <= 0xBF; ++byte2)
+                    for (int byte3 = 0x00; byte3 <= 0xFF; ++byte3)
                     {
-                        for (int byte3 = 0x00; byte3 <= 0xFF; ++byte3)
+                        // skip correct third byte
+                        if (0x80 <= byte3 && byte3 <= 0xBF)
                         {
-                            // skip correct third byte
-                            if (0x80 <= byte3 && byte3 <= 0xBF)
-                            {
-                                continue;
-                            }
-
-                            for (int byte4 = 0x80; byte4 <= 0xBF; ++byte4)
-                            {
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
+                            continue;
                         }
+
+                        check_utf8string(false, byte1, byte2, byte3, byte4);
+                        check_utf8dump(false, byte1, byte2, byte3, byte4);
                     }
                 }
             }

--- a/tests/src/unit-unicode5.cpp
+++ b/tests/src/unit-unicode5.cpp
@@ -248,49 +248,40 @@ TEST_CASE("Unicode (5/5)" * doctest::skip())
 
             SECTION("ill-formed: wrong second byte")
             {
-                for (int byte1 = 0xF4; byte1 <= 0xF4; ++byte1)
+                // Pin later continuation bytes (#5418). F4's valid 2nd byte
+                // range is 0x80-0x8F.
+                const int byte1 = 0xF4;
+                const int byte3 = 0x80;
+                const int byte4 = 0x80;
+                for (int byte2 = 0x00; byte2 <= 0xFF; ++byte2)
                 {
-                    for (int byte2 = 0x00; byte2 <= 0xFF; ++byte2)
+                    // skip correct second byte
+                    if (0x80 <= byte2 && byte2 <= 0x8F)
                     {
-                        // skip correct second byte
-                        if (0x80 <= byte2 && byte2 <= 0x8F)
-                        {
-                            continue;
-                        }
-
-                        for (int byte3 = 0x80; byte3 <= 0xBF; ++byte3)
-                        {
-                            for (int byte4 = 0x80; byte4 <= 0xBF; ++byte4)
-                            {
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
 
             SECTION("ill-formed: wrong third byte")
             {
-                for (int byte1 = 0xF4; byte1 <= 0xF4; ++byte1)
+                // Pin 2nd/4th bytes to one valid continuation (#5418).
+                const int byte1 = 0xF4;
+                const int byte2 = 0x80;
+                const int byte4 = 0x80;
+                for (int byte3 = 0x00; byte3 <= 0xFF; ++byte3)
                 {
-                    for (int byte2 = 0x80; byte2 <= 0x8F; ++byte2)
+                    // skip correct third byte
+                    if (0x80 <= byte3 && byte3 <= 0xBF)
                     {
-                        for (int byte3 = 0x00; byte3 <= 0xFF; ++byte3)
-                        {
-                            // skip correct third byte
-                            if (0x80 <= byte3 && byte3 <= 0xBF)
-                            {
-                                continue;
-                            }
-
-                            for (int byte4 = 0x80; byte4 <= 0xBF; ++byte4)
-                            {
-                                check_utf8string(false, byte1, byte2, byte3, byte4);
-                                check_utf8dump(false, byte1, byte2, byte3, byte4);
-                            }
-                        }
+                        continue;
                     }
+
+                    check_utf8string(false, byte1, byte2, byte3, byte4);
+                    check_utf8dump(false, byte1, byte2, byte3, byte4);
                 }
             }
 


### PR DESCRIPTION
## Summary

The Unicode \"wrong Nth byte\" sections swept every combination of the other continuation bytes. That property (\"byte N out of range ⇒ parse error\") does not depend on those bytes, and the Cartesian product dominated `ctest --no-skip` runtime (unicode4 alone was ~32% of the suite).

## Related Issue

Fixes #5418

## Changes Made

- Pin unrelated trailing bytes to one valid continuation in the wrong-2nd and wrong-3rd-byte sections of `unit-unicode3.cpp`, `unit-unicode4.cpp`, and `unit-unicode5.cpp`
- Keep sweeping the lead bytes that define each sequence class (F0 / F1–F3 / F4)
- Leave the fourth-byte sections to #5416 so this PR does not depend on that typo fix

## Testing

Commands executed:

- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test-unicode3_cpp11 test-unicode4_cpp11 test-unicode5_cpp11`
- `./tests/test-unicode{3,4,5}_cpp11 --no-skip -tce='*downloaded*'`

Results:

- unicode3: 1 passed, 2204940 assertions (was 19503948 before pinning)
- unicode4: 1 passed, 8814372 assertions (was 65425956)
- unicode5: 1 passed, 738572 assertions (was 14891468)

## Notes

Well-formed sweeps are unchanged. #5416 still needs to land independently for the dead fourth-byte sections. Further dump()-call reduction on ill-formed inputs is left for a follow-up, as is the binary roundtrip 4× parse cut described on the issue.

No amalgamation change: tests only.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`. (n/a — test-only)