### PR TITLE
Test patch_inplace partial apply and std::formatter width/align

### DIFF
--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -1388,3 +1388,32 @@ TEST_CASE("JSON patch - add to a primitive parent (regression #4292)")
         CHECK_THROWS_AS(doc.patch(patch), json::out_of_range&);
     }
 }
+
+TEST_CASE("JSON patch_inplace")
+{
+    SECTION("matches patch() on success")
+    {
+        json doc = {{"a", 1}, {"b", json::array({2, 3})}};
+        const json patch = {{{"op", "replace"}, {"path", "/a"}, {"value", 9}}};
+        const json expected = doc.patch(patch);
+        doc.patch_inplace(patch);
+        CHECK(doc == expected);
+    }
+
+    SECTION("leaves earlier operations applied when a later op throws")
+    {
+        json doc = {{"a", 1}, {"b", 2}};
+        const json patch =
+        {
+            {{"op", "replace"}, {"path", "/a"}, {"value", 9}},
+            {{"op", "replace"}, {"path", "/missing"}, {"value", 0}}
+        };
+        CHECK_THROWS_AS(doc.patch_inplace(patch), json::out_of_range&);
+        CHECK(doc["a"] == 9);
+        CHECK(doc["b"] == 2);
+        // patch() copies first, so the original is unchanged
+        json const original = {{"a", 1}, {"b", 2}};
+        CHECK_THROWS_AS(original.patch(patch), json::out_of_range&);
+        CHECK(original["a"] == 1);
+    }
+}

--- a/tests/src/unit-std-format.cpp
+++ b/tests/src/unit-std-format.cpp
@@ -52,6 +52,9 @@ TEST_CASE("std::formatter<nlohmann::json>")
         CHECK(std::format("{:2}", j) == j.dump(2));
         CHECK(std::format("{:#2}", j) == j.dump(2));
         CHECK(std::format("{:8}", j) == j.dump(8));
+        // multi-digit width exercises the 2nd+ iterations of the width loop
+        CHECK(std::format("{:12}", j) == j.dump(12));
+        CHECK(std::format("{:#12}", j) == j.dump(12));
     }
 
     SECTION("fill-and-align sets the indent character, like dump(indent, indent_char)")
@@ -64,6 +67,13 @@ TEST_CASE("std::formatter<nlohmann::json>")
         // JSON values -- only the fill character before it is used as the indent character
         CHECK(std::format("{:.<3}", j) == j.dump(3, '.'));
         CHECK(std::format("{:.^3}", j) == j.dump(3, '.'));
+        // bare alignment with no fill char is accepted and ignored; indent stays
+        // compact unless '#' or a width requests pretty-printing
+        CHECK(std::format("{:<}", j) == j.dump());
+        CHECK(std::format("{:>}", j) == j.dump());
+        CHECK(std::format("{:^}", j) == j.dump());
+        CHECK(std::format("{:<#}", j) == j.dump(4));
+        CHECK(std::format("{:>2}", j) == j.dump(2));
     }
 
     SECTION("format args with no meaning for JSON values are rejected")


### PR DESCRIPTION
## Summary

Two small coverage holes from #5423:

- `patch_inplace()` had no unit tests (only a docs example). Its contract vs `patch()` — the document stays partially modified if a later operation throws — was untested.
- `std::formatter` never used a multi-digit width (`{:12}`) or a bare alignment with no fill (`{:<}` / `{:>}` / `{:^}`).

## Related Issue

Fixes #5423

## Changes Made

- Add `TEST_CASE(\"JSON patch_inplace\")` covering success parity with `patch()` and leftover mutations after a later op throws
- Add `{:12}` / `{:#12}` checks so the formatter width loop runs more than one digit
- Add bare-align specs `{:<}`, `{:>}`, `{:^}`, `{:<#}`, `{:>2}`

## Testing

Commands executed:

- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test-json_patch_cpp11 test-std-format_cpp20`
- `./tests/test-json_patch_cpp11 --no-skip -tce='*downloaded*' -tc='JSON patch_inplace'`
- `./tests/test-std-format_cpp20 --no-skip -tce='*downloaded*'`

Results:

- patch_inplace: passed
- std-format: 1 passed, 33 assertions

## Notes

This PR covers items 2 and 3 of #5423 (formatter gaps and `patch_inplace`). Item 1 (untested public macro configurations / extra CI targets) is left for a follow-up; it needs CMake/CI wiring rather than unit tests.

No amalgamation change: tests only.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`. (n/a — test-only)