### PR TITLE
Test ordered_json binary formats, flatten, and patch

### DIFF
--- a/tests/src/unit-ordered_json.cpp
+++ b/tests/src/unit-ordered_json.cpp
@@ -70,6 +70,83 @@ TEST_CASE("ordered_json")
     CHECK(oj1.dump() == "{\"c\":1,\"b\":2,\"a\":3,\"d\":42}");
 }
 
+TEST_CASE("ordered_json binary formats preserve insertion order")
+{
+    ordered_json oj;
+    oj["z"] = 1;
+    oj["a"] = 2;
+    oj["m"] = 3;
+
+    SECTION("CBOR")
+    {
+        const auto packed = ordered_json::to_cbor(oj);
+        const auto back = ordered_json::from_cbor(packed);
+        CHECK(back.dump() == "{\"z\":1,\"a\":2,\"m\":3}");
+    }
+
+    SECTION("MessagePack")
+    {
+        const auto packed = ordered_json::to_msgpack(oj);
+        const auto back = ordered_json::from_msgpack(packed);
+        CHECK(back.dump() == "{\"z\":1,\"a\":2,\"m\":3}");
+    }
+
+    SECTION("BSON")
+    {
+        const auto packed = ordered_json::to_bson(oj);
+        const auto back = ordered_json::from_bson(packed);
+        CHECK(back.dump() == "{\"z\":1,\"a\":2,\"m\":3}");
+    }
+
+    SECTION("UBJSON")
+    {
+        const auto packed = ordered_json::to_ubjson(oj);
+        const auto back = ordered_json::from_ubjson(packed);
+        CHECK(back.dump() == "{\"z\":1,\"a\":2,\"m\":3}");
+    }
+}
+
+TEST_CASE("ordered_json flatten, unflatten, and patch")
+{
+    ordered_json oj;
+    oj["z"] = {{"b", 1}};
+    oj["a"] = 2;
+
+    SECTION("flatten/unflatten keep object key order")
+    {
+        const auto flat = oj.flatten();
+        CHECK(flat.dump() == "{\"/z/b\":1,\"/a\":2}");
+        CHECK(flat.unflatten().dump() == oj.dump());
+    }
+
+    SECTION("diff/patch round-trip")
+    {
+        ordered_json other = oj;
+        other["a"] = 9;
+        const auto patch = ordered_json::diff(oj, other);
+        CHECK(oj.patch(patch) == other);
+
+        ordered_json inplace = oj;
+        inplace.patch_inplace(patch);
+        CHECK(inplace == other);
+    }
+
+    SECTION("update merge_objects=true recurses into objects")
+    {
+        ordered_json target;
+        target["z"] = {{"b", 1}, {"c", 2}};
+        target["a"] = 3;
+        ordered_json source;
+        source["z"] = {{"c", 9}, {"d", 4}};
+        target.update(source, true);
+        CHECK(target["z"]["b"] == 1);
+        CHECK(target["z"]["c"] == 9);
+        CHECK(target["z"]["d"] == 4);
+        CHECK(target["a"] == 3);
+        CHECK(target.dump() == "{\"z\":{\"b\":1,\"c\":9,\"d\":4},\"a\":3}");
+    }
+}
+
 TEST_CASE("regression test for issue #3732 - iteration_proxy_value<iter_impl<ordered_json>>")
 {
     // Naming the proxy type in a function-parameter position forces eager


### PR DESCRIPTION
## Summary

`unit-ordered_json.cpp` only checked insertion order and one compile regression. Binary formats, flatten/unflatten, patch, and `update(merge_objects=true)` were exercised almost exclusively with default `nlohmann::json`, so ordered_map-specific behavior could regress silently.

## Related Issue

Fixes #5421

## Changes Made

- CBOR, MessagePack, BSON, and UBJSON round-trips that assert insertion order is preserved
- flatten/unflatten key-order checks
- diff/patch and patch_inplace round-trips
- `update(..., true)` recursive object merge on ordered_json

## Testing

Commands executed:

- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test-ordered_json_cpp11`
- `./tests/test-ordered_json_cpp11 --no-skip -tce='*downloaded*'`

Results:

- 4 test cases passed, 31 assertions, 0 failed

## Notes

This does not add every binary-format edge case listed on the issue (duplicate keys in binary maps, BJData, std::format). It pins the order-sensitive APIs most likely to differ from `std::map`.

No amalgamation change: tests only.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`. (n/a — test-only)