### PR TITLE
Mark json::accept() nodiscard like parse()

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -4126,6 +4126,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief check if the input is valid JSON
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(InputType&& i,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)
@@ -4137,6 +4138,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename IteratorType, typename SentinelType = IteratorType,
              detail::enable_if_t<detail::can_compare_ne<IteratorType, SentinelType>::value, int> = 0>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(IteratorType first, SentinelType last,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -25480,6 +25480,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief check if the input is valid JSON
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(InputType&& i,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)
@@ -25491,6 +25492,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename IteratorType, typename SentinelType = IteratorType,
              detail::enable_if_t<detail::can_compare_ne<IteratorType, SentinelType>::value, int> = 0>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(IteratorType first, SentinelType last,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1555,4 +1555,18 @@ TEST_CASE("issue #5338 - truncated CBOR tagged binary subtype is rejected")
     }
 }
 
+TEST_CASE("issue #5407 - accept() overloads return a usable bool")
+{
+    // parse() already carries JSON_HEDLEY_WARN_UNUSED_RESULT; the two primary
+    // accept() overloads must as well. Using the return value is the
+    // observable contract those attributes protect.
+    CHECK(json::accept("true"));
+    CHECK(json::accept(std::string("true")));
+    const std::string array = "[1,2,3]";
+    CHECK(json::accept(array.begin(), array.end()));
+    CHECK(!json::accept("{"));
+    const std::string bad = "{";
+    CHECK(!json::accept(bad.begin(), bad.end()));
+}
+
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
## Summary

`parse()` is annotated with `JSON_HEDLEY_WARN_UNUSED_RESULT`. The two primary `accept()` overloads (istream/string and iterator pair) were not, while the deprecated span overload was. Discarding `accept()`'s bool therefore produced no diagnostic even though the function exists only for its return value.

## Related Issue

Fixes #5407

## Changes Made

- Add `JSON_HEDLEY_WARN_UNUSED_RESULT` to `accept(InputType&&)` and `accept(IteratorType, SentinelType)`
- Mirror the change in the amalgamated header
- Regression test that both overloads return a usable bool

## Testing

Commands executed:

- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test-regression2_cpp11`
- `./tests/test-regression2_cpp11 --no-skip -tce='*downloaded*' -tc='*5407*'`
- `./tests/test-regression2_cpp11 --no-skip -tce='*downloaded*'`

Results:

- issue #5407 case: 1 passed, 5 assertions
- full regression2: 10 passed, 140 assertions

## Notes

Amalgamated `single_include/nlohmann/json.hpp` by applying the same annotation the amalgamate script would emit from `include/`. `json_fwd.hpp` is unchanged.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`.