### PR TITLE
Exercise trailing commas with diagnostic positions enabled

### DIFF
--- a/tests/src/unit-class_parser_diagnostic_positions.cpp
+++ b/tests/src/unit-class_parser_diagnostic_positions.cpp
@@ -211,6 +211,7 @@ class SaxCountdown : public nlohmann::json::json_sax_t
 json parser_helper(const std::string& s);
 bool accept_helper(const std::string& s);
 void comments_helper(const std::string& s);
+void trailing_comma_helper(const std::string& s);
 
 json parser_helper(const std::string& s)
 {
@@ -229,6 +230,7 @@ json parser_helper(const std::string& s)
     CHECK(j_sax == j);
 
     comments_helper(s);
+    trailing_comma_helper(s);
 
     return j;
 }
@@ -264,10 +266,11 @@ bool accept_helper(const std::string& s)
     // 6. check if this approach came to the same result
     CHECK(ok_noexcept == ok_noexcept_cb);
 
-    // 7. check if comments are properly ignored
+    // 7. check if comments or trailing commas are properly ignored
     if (ok_accept)
     {
         comments_helper(s);
+        trailing_comma_helper(s);
     }
 
     // 8. return result
@@ -304,6 +307,36 @@ void comments_helper(const std::string& s)
 
         CHECK_NOTHROW(_ = json::parse(json_with_comment, nullptr, true, true));
         CHECK(json::accept(json_with_comment, true));
+    }
+}
+
+void trailing_comma_helper(const std::string& s)
+{
+    json _;
+
+    CHECK_NOTHROW(_ = json::parse(s));
+    CHECK(json::accept(s));
+
+    CHECK_NOTHROW(_ = json::parse(s, nullptr, false, false, true));
+    CHECK(json::accept(s, false, true));
+
+    // note: [,] and {,} are not allowed
+    if (s.size() > 1 && (s.back() == ']' || s.back() == '}') && !_.empty())
+    {
+        std::vector<std::string> json_with_trailing_commas;
+        json_with_trailing_commas.push_back(s.substr(0, s.size() - 1) + " ," + s.back());
+        json_with_trailing_commas.push_back(s.substr(0, s.size() - 1) + "," + s.back());
+        json_with_trailing_commas.push_back(s.substr(0, s.size() - 1) + ", " + s.back());
+
+        for (const auto& json_with_trailing_comma : json_with_trailing_commas)
+        {
+            CAPTURE(json_with_trailing_comma)
+            CHECK_THROWS_AS(_ = json::parse(json_with_trailing_comma), json::parse_error);
+            CHECK(!json::accept(json_with_trailing_comma));
+
+            CHECK_NOTHROW(_ = json::parse(json_with_trailing_comma, nullptr, true, false, true));
+            CHECK(json::accept(json_with_trailing_comma, false, true));
+        }
     }
 }
 
@@ -1954,4 +1987,38 @@ TEST_CASE("parser class")
             CHECK(j.end_pos() == root_type_json_str.size() - end_whitespace.size());
         }
     }
+}
+
+TEST_CASE("trailing commas record diagnostic positions")
+{
+    // ignore_trailing_commas was never exercised with JSON_DIAGNOSTIC_POSITIONS=1.
+    // The skipped comma still occupies input, so end_pos must cover it.
+    const std::string array_with_comma = "[1, 2, ]";
+    const json ja = json::parse(array_with_comma, nullptr, true, false, true);
+    CHECK(ja == json::array({1, 2}));
+    CHECK(ja.start_pos() == 0);
+    CHECK(ja.end_pos() == array_with_comma.size());
+
+    const std::string object_with_comma = "{\"a\": 1, }";
+    const json jo = json::parse(object_with_comma, nullptr, true, false, true);
+    CHECK(jo == json({{"a", 1}}));
+    CHECK(jo.start_pos() == 0);
+    CHECK(jo.end_pos() == object_with_comma.size());
+}
+
+TEST_CASE("trailing commas record diagnostic positions")
+{
+    // ignore_trailing_commas was never exercised with JSON_DIAGNOSTIC_POSITIONS=1.
+    // The skipped comma still occupies input, so end_pos must cover it.
+    const std::string array_with_comma = "[1, 2, ]";
+    const json ja = json::parse(array_with_comma, nullptr, true, false, true);
+    CHECK(ja == json::array({1, 2}));
+    CHECK(ja.start_pos() == 0);
+    CHECK(ja.end_pos() == array_with_comma.size());
+
+    const std::string object_with_comma = "{\"a\": 1, }";
+    const json jo = json::parse(object_with_comma, nullptr, true, false, true);
+    CHECK(jo == json({{"a", 1}}));
+    CHECK(jo.start_pos() == 0);
+    CHECK(jo.end_pos() == object_with_comma.size());
 }


### PR DESCRIPTION
## Summary

`unit-class_parser_diagnostic_positions.cpp` drifted from `unit-class_parser.cpp` and never gained `trailing_comma_helper()`. `ignore_trailing_commas` was therefore untested with `JSON_DIAGNOSTIC_POSITIONS=1`, even though the skipped comma changes how many characters the lexer has consumed when `end_array`/`end_object` record `end_pos`.

## Related Issue

Fixes #5417

## Changes Made

- Port `trailing_comma_helper()` and call it from `parser_helper` / `accept_helper` like the base file
- Add a dedicated case that `end_pos` covers a trailing comma when that option is on

The full define-based recompilation / file merge described on the issue is left as a follow-up; this PR closes the coverage hole that already shipped.

## Testing

Commands executed:

- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test-class_parser_diagnostic_positions_cpp11`
- `./tests/test-class_parser_diagnostic_positions_cpp11 --no-skip -tce='*downloaded*'`

Results:

- 3 passed, 10394 assertions, 0 failed

## Notes

No amalgamation change: tests only. #5342 filter-array sections and the last-read-diagnostics adapter block from the issue are still only in the base file.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`. (n/a — test-only)