### PR TITLE
Swap diagnostic positions and cover remaining JSON_DIAGNOSTIC_POSITIONS cases

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/end_pos.md
+++ b/docs/mkdocs/docs/api/basic_json/end_pos.md
@@ -6,7 +6,7 @@ constexpr std::size_t end_pos() const noexcept;
 #endif
 ```
 
-Returns the position immediately following the last character of the JSON string from which the value was parsed from.
+Returns the UTF-8 byte offset immediately following the last character of the JSON text from which the value was parsed.
 
 | JSON type | return value                      |
 |-----------|-----------------------------------|
@@ -19,8 +19,9 @@ Returns the position immediately following the last character of the JSON string
 
 ## Return value
 
-the position of the character _following_ the last character of the given value in the parsed JSON string, if the
-value was created by the [`parse`](parse.md) function, or `std::string::npos` if the value was constructed otherwise
+the UTF-8 byte offset of the character _following_ the last character of the given value in the parsed JSON text, if
+the value was created by the [`parse`](parse.md) function, or `std::string::npos` if the value was constructed
+otherwise (including via [`sax_parse`](sax_parse.md) or a binary format parser)
 
 ## Exception safety
 
@@ -40,7 +41,18 @@ Constant.
 !!! warning "Invalidation"
 
     The returned positions are only valid as long as the JSON value is not changed. The positions are *not* updated
-    when the JSON value is changed.
+    when the JSON value is changed. Assigning, `push_back`, or `erase` leaves parent and remaining sibling positions
+    pointing at the original text; newly constructed replacements have `std::string::npos`.
+
+!!! note "Copy, move, and swap"
+
+    Copying a value copies its positions. Moving transfers them and resets the source to `std::string::npos`.
+    Swapping two `basic_json` values exchanges positions.
+
+!!! note "Wide strings"
+
+    Positions from `parse(std::wstring)` / `u16string` / `u32string` index the transcoded UTF-8 byte stream, not the
+    original wide string.
 
 ## Examples
 

--- a/docs/mkdocs/docs/api/basic_json/start_pos.md
+++ b/docs/mkdocs/docs/api/basic_json/start_pos.md
@@ -6,7 +6,7 @@ constexpr std::size_t start_pos() const noexcept;
 #endif
 ```
 
-Returns the position of the first character in the JSON string from which the value was parsed from.
+Returns the UTF-8 byte offset of the first character in the JSON text from which the value was parsed.
 
 | JSON type | return value                                   |
 |-----------|------------------------------------------------|
@@ -19,8 +19,9 @@ Returns the position of the first character in the JSON string from which the va
 
 ## Return value
 
-the position of the first character of the value in the parsed JSON string, if the value was created by the
-[`parse`](parse.md) function, or `std::string::npos` if the value was constructed otherwise
+the UTF-8 byte offset of the first character of the value in the parsed JSON text, if the value was created by the
+[`parse`](parse.md) function, or `std::string::npos` if the value was constructed otherwise (including via
+[`sax_parse`](sax_parse.md) or a binary format parser)
 
 ## Exception safety
 
@@ -40,7 +41,18 @@ Constant.
 !!! warning "Invalidation"
 
     The returned positions are only valid as long as the JSON value is not changed. The positions are *not* updated
-    when the JSON value is changed.
+    when the JSON value is changed. Assigning, `push_back`, or `erase` leaves parent and remaining sibling positions
+    pointing at the original text; newly constructed replacements have `std::string::npos`.
+
+!!! note "Copy, move, and swap"
+
+    Copying a value copies its positions. Moving transfers them and resets the source to `std::string::npos`.
+    Swapping two `basic_json` values exchanges positions.
+
+!!! note "Wide strings"
+
+    Positions from `parse(std::wstring)` / `u16string` / `u32string` index the transcoded UTF-8 byte stream, not the
+    original wide string.
 
 ## Examples
 

--- a/docs/mkdocs/docs/api/basic_json/swap.md
+++ b/docs/mkdocs/docs/api/basic_json/swap.md
@@ -34,10 +34,14 @@ void swap(typename binary_t::container_type& other);
 ```
 
 1. Exchanges the contents of the JSON value with those of `other`. Does not invoke any move, copy, or swap operations on
-   individual elements. All iterators and references remain valid. The past-the-end iterator is invalidated. 
+   individual elements. All iterators and references remain valid. The past-the-end iterator is invalidated. When
+   [`JSON_DIAGNOSTIC_POSITIONS`](../macros/json_diagnostic_positions.md) is enabled, diagnostic byte positions are
+   exchanged as well.
 2. Exchanges the contents of the JSON value from `left` with those of `right`. Does not invoke any move, copy, or swap
    operations on individual elements. All iterators and references remain valid. The past-the-end iterator is
-   invalidated. Implemented as a friend function callable via ADL.
+   invalidated. Implemented as a friend function callable via ADL. When
+   [`JSON_DIAGNOSTIC_POSITIONS`](../macros/json_diagnostic_positions.md) is enabled, diagnostic byte positions are
+   exchanged as well.
 3. Exchanges the contents of a JSON array with those of `other`. Does not invoke any move, copy, or swap operations on
    individual elements. All iterators and references remain valid. The past-the-end iterator is invalidated. 
 4. Exchanges the contents of a JSON object with those of `other`. Does not invoke any move, copy, or swap operations on
@@ -79,6 +83,15 @@ void swap(typename binary_t::container_type& other);
 ## Complexity
 
 Constant.
+
+## Notes
+
+!!! note "Diagnostic positions"
+
+    When [`JSON_DIAGNOSTIC_POSITIONS`](../macros/json_diagnostic_positions.md) is enabled, overloads (1) and (2)
+    exchange `start_pos()` / `end_pos()` together with the value. Overloads (3)–(7) only exchange the contained
+    container (`array_t`, `object_t`, `string_t`, or `binary_t`); the `basic_json` object's diagnostic positions stay
+    put because the other argument is not a JSON value.
 
 ## Examples
 

--- a/docs/mkdocs/docs/api/macros/json_diagnostic_positions.md
+++ b/docs/mkdocs/docs/api/macros/json_diagnostic_positions.md
@@ -55,15 +55,38 @@ When the macro is not defined, the library will define it to its default value.
 
 !!! note "Availability"
 
-    Diagnostic positions are only available if the value was created by the [`parse`](../basic_json/parse.md) function.
-    The [`sax_parse`](../basic_json/sax_parse.md) function or all other means to create a JSON value **do not** set the
-    diagnostic positions and [`start_pos()`](../basic_json/start_pos.md) and [`end_pos()`](../basic_json/end_pos.md)
-    will only return `std::string::npos` for these values.
+    Diagnostic positions are only available if the value was created by the [`parse`](../basic_json/parse.md) function
+    from JSON text. The [`sax_parse`](../basic_json/sax_parse.md) function, a user-constructed `json_sax_dom_parser`
+    (which has no lexer and therefore cannot record offsets), binary format parsers
+    (`from_cbor` / `from_msgpack` / `from_ubjson` / `from_bjdata` / `from_bson`), and all other means to create a JSON
+    value **do not** set the diagnostic positions. [`start_pos()`](../basic_json/start_pos.md) and
+    [`end_pos()`](../basic_json/end_pos.md) return `std::string::npos` for these values.
+
+!!! note "UTF-8 byte offsets"
+
+    Positions are UTF-8 byte offsets in the input the lexer consumed. For `#!cpp std::string` / stream / iterator /
+    contiguous-container input they index that byte sequence. Wide-string input (`#!cpp std::wstring`,
+    `#!cpp std::u16string`, `#!cpp std::u32string`) is transcoded to UTF-8 first, so the offsets index the *transcoded*
+    byte stream and cannot be used to subscript the original wide string.
+
+!!! note "Byte-order mark"
+
+    A UTF-8 BOM (`EF BB BF`) is skipped as input but still counted, so a document that starts with a BOM has root
+    [`start_pos()`](../basic_json/start_pos.md) `== 3`.
+
+!!! note "Copy, move, and swap"
+
+    The copy constructor copies positions, including on children: the copy keeps offsets into the original parse input
+    even though it never saw that buffer. The move constructor transfers positions and resets the source to
+    `std::string::npos`. [`swap`](../basic_json/swap.md) of two `basic_json` values exchanges positions. Type-specific
+    `swap` overloads (`array_t` / `object_t` / `string_t` / `binary_t`) only exchange container storage and leave
+    positions in place.
 
 !!! warning "Invalidation"
 
     The returned positions are only valid as long as the JSON value is not changed. The positions are *not* updated
-    when the JSON value is changed.
+    when the JSON value is changed. Assigning, `push_back`, or `erase` leaves parent and remaining sibling positions
+    pointing at the original text; newly constructed replacements have `std::string::npos`.
 
 ## Examples
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1266,8 +1266,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         : json_base_class_t(std::forward<json_base_class_t>(other)),
           m_data(std::move(other.m_data)) // cppcheck-suppress[accessForwarded] TODO check
 #if JSON_DIAGNOSTIC_POSITIONS
-        , start_position(other.start_position) // cppcheck-suppress[accessForwarded] TODO check
-        , end_position(other.end_position) // cppcheck-suppress[accessForwarded] TODO check
+        , start_position(other.start_position) // cppcheck-suppress[accessForwarded]
+        , end_position(other.end_position) // cppcheck-suppress[accessForwarded]
 #endif
     {
         // check that the passed value is valid

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -3543,6 +3543,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     {
         std::swap(m_data.m_type, other.m_data.m_type);
         std::swap(m_data.m_value, other.m_data.m_value);
+#if JSON_DIAGNOSTIC_POSITIONS
+        std::swap(start_position, other.start_position);
+        std::swap(end_position, other.end_position);
+#endif
 
         set_parents();
         other.set_parents();

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
-// JSON_HAS_CPP_17
+ // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -21519,10 +21519,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22220,8 +22220,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                       std::forward<CompatibleType>(val))))
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -23024,7 +23024,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23066,7 +23066,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23216,7 +23216,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;
@@ -24897,6 +24897,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     {
         std::swap(m_data.m_type, other.m_data.m_type);
         std::swap(m_data.m_value, other.m_data.m_value);
+#if JSON_DIAGNOSTIC_POSITIONS
+        std::swap(start_position, other.start_position);
+        std::swap(end_position, other.end_position);
+#endif
 
         set_parents();
         other.set_parents();

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-#include <cstdint> // int64_t, uint64_t
-#include <map> // map
-#include <memory> // allocator
-#include <string> // string
-#include <vector> // vector
+    #include <cstdint> // int64_t, uint64_t
+    #include <map> // map
+    #include <memory> // allocator
+    #include <string> // string
+    #include <vector> // vector
 
-// #include <nlohmann/detail/abi_macros.hpp>
+    // #include <nlohmann/detail/abi_macros.hpp>
 
 
-/*!
-@brief namespace for Niels Lohmann
-@see https://github.com/nlohmann
-@since version 1.0.0
-*/
-NLOHMANN_JSON_NAMESPACE_BEGIN
+    /*!
+    @brief namespace for Niels Lohmann
+    @see https://github.com/nlohmann
+    @since version 1.0.0
+    */
+    NLOHMANN_JSON_NAMESPACE_BEGIN
 
-/*!
-@brief default JSONSerializer template argument
+    /*!
+    @brief default JSONSerializer template argument
 
-This serializer ignores the template arguments and uses ADL
-([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-for serialization.
-*/
-template<typename T = void, typename SFINAE = void>
-struct adl_serializer;
+    This serializer ignores the template arguments and uses ADL
+    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+    for serialization.
+    */
+    template<typename T = void, typename SFINAE = void>
+    struct adl_serializer;
 
-/// a class to store JSON values
-/// @sa https://json.nlohmann.me/api/basic_json/
-template<template<typename U, typename V, typename... Args> class ObjectType =
-         std::map,
-         template<typename U, typename... Args> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
-         class NumberIntegerType = std::int64_t,
-         class NumberUnsignedType = std::uint64_t,
-         class NumberFloatType = double,
-         template<typename U> class AllocatorType = std::allocator,
-         template<typename T, typename SFINAE = void> class JSONSerializer =
-         adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-         class CustomBaseClass = void>
-class basic_json;
+    /// a class to store JSON values
+    /// @sa https://json.nlohmann.me/api/basic_json/
+    template<template<typename U, typename V, typename... Args> class ObjectType =
+    std::map,
+    template<typename U, typename... Args> class ArrayType = std::vector,
+    class StringType = std::string, class BooleanType = bool,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
+    class NumberFloatType = double,
+    template<typename U> class AllocatorType = std::allocator,
+    template<typename T, typename SFINAE = void> class JSONSerializer =
+    adl_serializer,
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
+    class basic_json;
 
-/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-/// @sa https://json.nlohmann.me/api/json_pointer/
-template<typename RefStringType>
-class json_pointer;
+    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+    /// @sa https://json.nlohmann.me/api/json_pointer/
+    template<typename RefStringType>
+    class json_pointer;
 
-/*!
-@brief default specialization
-@sa https://json.nlohmann.me/api/json/
-*/
-using json = basic_json<>;
+    /*!
+    @brief default specialization
+    @sa https://json.nlohmann.me/api/json/
+    */
+    using json = basic_json<>;
 
-/// @brief a minimal map-like container that preserves insertion order
-/// @sa https://json.nlohmann.me/api/ordered_map/
-template<class Key, class T, class IgnoredLess, class Allocator>
-struct ordered_map;
+    /// @brief a minimal map-like container that preserves insertion order
+    /// @sa https://json.nlohmann.me/api/ordered_map/
+    template<class Key, class T, class IgnoredLess, class Allocator>
+    struct ordered_map;
 
-/// @brief specialization that maintains the insertion order of object keys
-/// @sa https://json.nlohmann.me/api/ordered_json/
-using ordered_json = basic_json<nlohmann::ordered_map>;
+    /// @brief specialization that maintains the insertion order of object keys
+    /// @sa https://json.nlohmann.me/api/ordered_json/
+    using ordered_json = basic_json<nlohmann::ordered_map>;
 
-NLOHMANN_JSON_NAMESPACE_END
+    NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
- // JSON_HAS_CPP_17
+// JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -21519,10 +21519,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-    )
+                                 )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22220,8 +22220,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                           std::forward<CompatibleType>(val))))
+            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                       std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -22620,8 +22620,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         : json_base_class_t(std::forward<json_base_class_t>(other)),
           m_data(std::move(other.m_data)) // cppcheck-suppress[accessForwarded] TODO check
 #if JSON_DIAGNOSTIC_POSITIONS
-        , start_position(other.start_position) // cppcheck-suppress[accessForwarded] TODO check
-        , end_position(other.end_position) // cppcheck-suppress[accessForwarded] TODO check
+        , start_position(other.start_position) // cppcheck-suppress[accessForwarded]
+        , end_position(other.end_position) // cppcheck-suppress[accessForwarded]
 #endif
     {
         // check that the passed value is valid
@@ -23024,7 +23024,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23066,7 +23066,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23216,7 +23216,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;

--- a/tests/src/unit-class_parser_diagnostic_positions.cpp
+++ b/tests/src/unit-class_parser_diagnostic_positions.cpp
@@ -211,6 +211,7 @@ class SaxCountdown : public nlohmann::json::json_sax_t
 json parser_helper(const std::string& s);
 bool accept_helper(const std::string& s);
 void comments_helper(const std::string& s);
+void trailing_comma_helper(const std::string& s);
 
 json parser_helper(const std::string& s)
 {
@@ -227,8 +228,11 @@ json parser_helper(const std::string& s)
     nlohmann::detail::json_sax_dom_parser<json, nlohmann::detail::string_input_adapter_type> sdp(j_sax);
     json::sax_parse(s, &sdp);
     CHECK(j_sax == j);
+    CHECK(j_sax.start_pos() == std::string::npos);
+    CHECK(j_sax.end_pos() == std::string::npos);
 
     comments_helper(s);
+    trailing_comma_helper(s);
 
     return j;
 }
@@ -264,10 +268,11 @@ bool accept_helper(const std::string& s)
     // 6. check if this approach came to the same result
     CHECK(ok_noexcept == ok_noexcept_cb);
 
-    // 7. check if comments are properly ignored
+    // 7. check if comments or trailing commas are properly ignored
     if (ok_accept)
     {
         comments_helper(s);
+        trailing_comma_helper(s);
     }
 
     // 8. return result
@@ -304,6 +309,38 @@ void comments_helper(const std::string& s)
 
         CHECK_NOTHROW(_ = json::parse(json_with_comment, nullptr, true, true));
         CHECK(json::accept(json_with_comment, true));
+    }
+}
+
+void trailing_comma_helper(const std::string& s)
+{
+    json _;
+
+    // parse/accept with default parser
+    CHECK_NOTHROW(_ = json::parse(s));
+    CHECK(json::accept(s));
+
+    // parse/accept while allowing trailing commas
+    CHECK_NOTHROW(_ = json::parse(s, nullptr, false, false, true));
+    CHECK(json::accept(s, false, true));
+
+    // note: [,] and {,} are not allowed
+    if (s.size() > 1 && (s.back() == ']' || s.back() == '}') && !_.empty())
+    {
+        std::vector<std::string> json_with_trailing_commas;
+        json_with_trailing_commas.push_back(s.substr(0, s.size() - 1) + " ," + s.back());
+        json_with_trailing_commas.push_back(s.substr(0, s.size() - 1) + "," + s.back());
+        json_with_trailing_commas.push_back(s.substr(0, s.size() - 1) + ", " + s.back());
+
+        for (const auto& json_with_trailing_comma : json_with_trailing_commas)
+        {
+            CAPTURE(json_with_trailing_comma)
+            CHECK_THROWS_AS(_ = json::parse(json_with_trailing_comma), json::parse_error);
+            CHECK(!json::accept(json_with_trailing_comma));
+
+            CHECK_NOTHROW(_ = json::parse(json_with_trailing_comma, nullptr, true, false, true));
+            CHECK(json::accept(json_with_trailing_comma, false, true));
+        }
     }
 }
 
@@ -1954,4 +1991,20 @@ TEST_CASE("parser class")
             CHECK(j.end_pos() == root_type_json_str.size() - end_whitespace.size());
         }
     }
+}
+
+TEST_CASE("trailing commas record diagnostic positions")
+{
+    // The skipped comma still occupies input, so end_pos must cover it.
+    const std::string array_with_comma = "[1, 2, ]";
+    const json ja = json::parse(array_with_comma, nullptr, true, false, true);
+    CHECK(ja == json::array({1, 2}));
+    CHECK(ja.start_pos() == 0);
+    CHECK(ja.end_pos() == array_with_comma.size());
+
+    const std::string object_with_comma = "{\"a\": 1, }";
+    const json jo = json::parse(object_with_comma, nullptr, true, false, true);
+    CHECK(jo == json({{"a", 1}}));
+    CHECK(jo.start_pos() == 0);
+    CHECK(jo.end_pos() == object_with_comma.size());
 }

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -1263,3 +1263,46 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-32)", T, c
     CHECK(json::sax_parse(v, &l));
     CHECK(l.events.size() == 1);
 }
+
+TEST_CASE("accept and sax_parse ignore trailing commas")
+{
+    const std::string array_with_comma = "[1, 2, ]";
+    const std::string object_with_comma = "{\"a\": 1, }";
+
+    CHECK(!json::accept(array_with_comma));
+    CHECK(json::accept(array_with_comma, false, true));
+    CHECK(!json::accept(object_with_comma));
+    CHECK(json::accept(object_with_comma, false, true));
+
+    {
+        SaxEventLogger l;
+        CHECK(!json::sax_parse(array_with_comma, &l));
+    }
+    {
+        SaxEventLogger l;
+        CHECK(json::sax_parse(array_with_comma, &l, json::input_format_t::json, true, false, true));
+        CHECK(l.events == std::vector<std::string>(
+        {
+            "start_array()", "number_unsigned(1)", "number_unsigned(2)", "end_array()"
+        }));
+    }
+    {
+        SaxEventLogger l;
+        CHECK(!json::sax_parse(object_with_comma, &l));
+    }
+    {
+        SaxEventLogger l;
+        CHECK(json::sax_parse(object_with_comma, &l, json::input_format_t::json, true, false, true));
+        CHECK(l.events == std::vector<std::string>(
+        {
+            "start_object()", "key(a)", "number_unsigned(1)", "end_object()"
+        }));
+    }
+
+    CHECK(!json::accept("[,]", false, true));
+    CHECK(!json::accept("{,}", false, true));
+    {
+        SaxEventLogger l;
+        CHECK(!json::sax_parse("[,]", &l, json::input_format_t::json, true, false, true));
+    }
+}

--- a/tests/src/unit-diagnostic-positions.cpp
+++ b/tests/src/unit-diagnostic-positions.cpp
@@ -12,6 +12,12 @@
 #define JSON_DIAGNOSTIC_POSITIONS 1
 #include <nlohmann/json.hpp>
 
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
 using json = nlohmann::json;
 
 TEST_CASE("Better diagnostics with positions")
@@ -81,13 +87,17 @@ TEST_CASE("Better diagnostics with positions")
     SECTION("copy constructor keeps start/end positions")
     {
         const std::string text = R"({"a":1,"b":[2]})";
-        const json a = json::parse(text);
+        json a = json::parse(text);
+        const auto child_start = a.at("a").start_pos();
+        const auto child_end = a.at("a").end_pos();
         const json b = a;
-        CHECK(b.start_pos() == a.start_pos());
-        CHECK(b.end_pos() == a.end_pos());
-        CHECK(b.at("a").start_pos() == a.at("a").start_pos());
-        CHECK(b.at("b").end_pos() == a.at("b").end_pos());
+        // mutate the original so the copy is an independent snapshot
+        a["a"] = 42;
+        CHECK(b.at("a").start_pos() == child_start);
+        CHECK(b.at("a").end_pos() == child_end);
         CHECK(text.substr(b.at("a").start_pos(), b.at("a").end_pos() - b.at("a").start_pos()) == "1");
+        CHECK(a.at("a").start_pos() == std::string::npos);
+        CHECK(a.at("a").end_pos() == std::string::npos);
     }
 
     SECTION("move constructor resets the source positions to npos")
@@ -96,11 +106,14 @@ TEST_CASE("Better diagnostics with positions")
         json a = json::parse(text);
         const auto start = a.start_pos();
         const auto end = a.end_pos();
-        json b = std::move(a);
+        const json b = std::move(a);
         CHECK(b.start_pos() == start);
         CHECK(b.end_pos() == end);
+        // The move constructor is specified to reset the source to npos.
+        // NOLINTBEGIN(clang-analyzer-cplusplus.Move)
         CHECK(a.start_pos() == std::string::npos);
         CHECK(a.end_pos() == std::string::npos);
+        // NOLINTEND(clang-analyzer-cplusplus.Move)
     }
 
     SECTION("swap exchanges positions")
@@ -117,5 +130,220 @@ TEST_CASE("Better diagnostics with positions")
         CHECK(a.end_pos() == b_end);
         CHECK(b.start_pos() == a_start);
         CHECK(b.end_pos() == a_end);
+
+        a.swap(b);
+        CHECK(a.start_pos() == a_start);
+        CHECK(a.end_pos() == a_end);
+        CHECK(b.start_pos() == b_start);
+        CHECK(b.end_pos() == b_end);
+    }
+
+    SECTION("type-specific swap leaves positions on the basic_json object")
+    {
+        json j = json::parse("[1,2]");
+        const auto start = j.start_pos();
+        const auto end = j.end_pos();
+        json::array_t other = {3, 4};
+        j.swap(other);
+        CHECK(j == json::array({3, 4}));
+        CHECK(j.start_pos() == start);
+        CHECK(j.end_pos() == end);
+    }
+
+    SECTION("mutation does not update parent or sibling positions")
+    {
+        const std::string text = R"({"a":1,"b":[2,3]})";
+        json j = json::parse(text);
+        const auto root_start = j.start_pos();
+        const auto root_end = j.end_pos();
+        const auto b_start = j.at("b").start_pos();
+        const auto b_end = j.at("b").end_pos();
+        const auto b0_start = j.at("b").at(0).start_pos();
+        const auto b0_end = j.at("b").at(0).end_pos();
+        const auto b1_start = j.at("b").at(1).start_pos();
+        const auto b1_end = j.at("b").at(1).end_pos();
+
+        j["a"] = 42;
+        CHECK(j.at("a").start_pos() == std::string::npos);
+        CHECK(j.at("a").end_pos() == std::string::npos);
+        CHECK(j.start_pos() == root_start);
+        CHECK(j.end_pos() == root_end);
+        CHECK(j.at("b").start_pos() == b_start);
+        CHECK(j.at("b").end_pos() == b_end);
+
+        j["c"] = 5;
+        CHECK(j.at("c").start_pos() == std::string::npos);
+        CHECK(j.start_pos() == root_start);
+        CHECK(j.end_pos() == root_end);
+
+        j["b"].push_back(4);
+        CHECK(j.at("b").back().start_pos() == std::string::npos);
+        CHECK(j.at("b").back().end_pos() == std::string::npos);
+        CHECK(j.at("b").start_pos() == b_start);
+        CHECK(j.at("b").end_pos() == b_end);
+        CHECK(j.at("b").at(0).start_pos() == b0_start);
+        CHECK(j.at("b").at(0).end_pos() == b0_end);
+
+        j["b"].erase(0);
+        CHECK(j.at("b").at(0).start_pos() == b1_start);
+        CHECK(j.at("b").at(0).end_pos() == b1_end);
+        CHECK(j.at("b").start_pos() == b_start);
+        CHECK(j.at("b").end_pos() == b_end);
+        CHECK(j.start_pos() == root_start);
+        CHECK(j.end_pos() == root_end);
+    }
+
+    SECTION("input adapters record the same UTF-8 byte offsets")
+    {
+        const std::string text = R"({"a":1})";
+        const json expected = json::parse(text);
+        const auto check_same = [&](const json & actual)
+        {
+            CHECK(actual == expected);
+            CHECK(actual.start_pos() == expected.start_pos());
+            CHECK(actual.end_pos() == expected.end_pos());
+            CHECK(actual.at("a").start_pos() == expected.at("a").start_pos());
+            CHECK(actual.at("a").end_pos() == expected.at("a").end_pos());
+        };
+
+        {
+            std::istringstream ss(text);
+            check_same(json::parse(ss));
+        }
+
+        check_same(json::parse(text.begin(), text.end()));
+
+        {
+            const std::vector<std::uint8_t> v(text.begin(), text.end());
+            check_same(json::parse(v));
+            check_same(json::parse(v.begin(), v.end()));
+        }
+
+        {
+            const char* path = "nlohmann_json_diag_pos_5420.json";
+            {
+                std::ofstream out(path, std::ios::binary | std::ios::trunc);
+                out << text;
+                REQUIRE(out.good());
+            }
+            {
+                std::ifstream in(path, std::ios::binary);
+                REQUIRE(in.good());
+                check_same(json::parse(in));
+            }
+            static_cast<void>(::remove(path));
+        }
+    }
+
+    SECTION("BOM-prefixed input counts the three BOM bytes")
+    {
+        const std::string text = "\xEF\xBB\xBF{\"a\":1}";
+        const json j = json::parse(text);
+        CHECK(j.start_pos() == 3);
+        CHECK(j.end_pos() == text.size());
+        CHECK(text.substr(j.start_pos(), j.end_pos() - j.start_pos()) == "{\"a\":1}");
+
+        std::istringstream ss(text);
+        const json from_stream = json::parse(ss);
+        CHECK(from_stream.start_pos() == 3);
+        CHECK(from_stream.end_pos() == text.size());
+    }
+
+    SECTION("wide-string positions index the transcoded UTF-8 stream")
+    {
+        const std::string ascii = R"({"a":1})";
+        const json from_utf8 = json::parse(ascii);
+
+        const std::u16string u16_ascii(ascii.begin(), ascii.end());
+        const json from_u16_ascii = json::parse(u16_ascii);
+        CHECK(from_u16_ascii.start_pos() == from_utf8.start_pos());
+        CHECK(from_u16_ascii.end_pos() == from_utf8.end_pos());
+
+        const std::u32string u32_ascii(ascii.begin(), ascii.end());
+        const json from_u32_ascii = json::parse(u32_ascii);
+        CHECK(from_u32_ascii.start_pos() == from_utf8.start_pos());
+        CHECK(from_u32_ascii.end_pos() == from_utf8.end_pos());
+
+#ifndef __INTEL_COMPILER
+        // "ä" is one code unit in UTF-16/32 and two UTF-8 bytes, so the
+        // reported offsets cannot index the original wide string.
+        const std::string utf8 = "[\"ä\"]";
+        const json from_utf8_umlaut = json::parse(utf8);
+        const std::u16string u16 = u"[\"ä\"]";
+        const json from_u16 = json::parse(u16);
+        CHECK(from_u16.start_pos() == 0);
+        CHECK(from_u16.end_pos() == utf8.size());
+        CHECK(from_u16.end_pos() == from_utf8_umlaut.end_pos());
+        CHECK(u16.size() != from_u16.end_pos());
+        CHECK(from_u16.at(0).end_pos() - from_u16.at(0).start_pos() == std::string("\"ä\"").size());
+
+        const std::u32string u32 = U"[\"ä\"]";
+        const json from_u32 = json::parse(u32);
+        CHECK(from_u32.end_pos() == utf8.size());
+        CHECK(u32.size() != from_u32.end_pos());
+#endif
+    }
+
+    SECTION("binary formats leave positions as npos")
+    {
+        const json src = {{"a", 1}};
+        const auto check_npos = [](const json & j)
+        {
+            CHECK(j.start_pos() == std::string::npos);
+            CHECK(j.end_pos() == std::string::npos);
+            CHECK(j.at("a").start_pos() == std::string::npos);
+            CHECK(j.at("a").end_pos() == std::string::npos);
+        };
+
+        const json cbor = json::from_cbor(json::to_cbor(src));
+        CHECK(cbor == src);
+        check_npos(cbor);
+
+        const json msgpack = json::from_msgpack(json::to_msgpack(src));
+        CHECK(msgpack == src);
+        check_npos(msgpack);
+
+        const json ubjson = json::from_ubjson(json::to_ubjson(src));
+        CHECK(ubjson == src);
+        check_npos(ubjson);
+
+        const json bjdata = json::from_bjdata(json::to_bjdata(src));
+        CHECK(bjdata == src);
+        check_npos(bjdata);
+
+        const json bson = json::from_bson(json::to_bson(src));
+        CHECK(bson == src);
+        check_npos(bson);
+    }
+
+    SECTION("user-constructed SAX DOM parser yields npos")
+    {
+        const std::string text = R"({"a":1})";
+        json j_sax;
+        nlohmann::detail::json_sax_dom_parser<json, nlohmann::detail::string_input_adapter_type> sdp(j_sax);
+        CHECK(json::sax_parse(text, &sdp));
+        CHECK(j_sax == json::parse(text));
+        CHECK(j_sax.start_pos() == std::string::npos);
+        CHECK(j_sax.end_pos() == std::string::npos);
+        CHECK(j_sax.at("a").start_pos() == std::string::npos);
+        CHECK(j_sax.at("a").end_pos() == std::string::npos);
+    }
+
+    SECTION("trailing commas are included in end_pos when ignored")
+    {
+        const std::string array_with_comma = "[1, 2, ]";
+        const json ja = json::parse(array_with_comma, nullptr, true, false, true);
+        CHECK(ja == json::array({1, 2}));
+        CHECK(ja.start_pos() == 0);
+        CHECK(ja.end_pos() == array_with_comma.size());
+        CHECK(array_with_comma.substr(ja.at(0).start_pos(), ja.at(0).end_pos() - ja.at(0).start_pos()) == "1");
+        CHECK(array_with_comma.substr(ja.at(1).start_pos(), ja.at(1).end_pos() - ja.at(1).start_pos()) == "2");
+
+        const std::string object_with_comma = "{\"a\": 1, }";
+        const json jo = json::parse(object_with_comma, nullptr, true, false, true);
+        CHECK(jo == json({{"a", 1}}));
+        CHECK(jo.start_pos() == 0);
+        CHECK(jo.end_pos() == object_with_comma.size());
+        CHECK(object_with_comma.substr(jo.at("a").start_pos(), jo.at("a").end_pos() - jo.at("a").start_pos()) == "1");
     }
 }

--- a/tests/src/unit-diagnostic-positions.cpp
+++ b/tests/src/unit-diagnostic-positions.cpp
@@ -77,4 +77,45 @@ TEST_CASE("Better diagnostics with positions")
         CHECK_THROWS_WITH_AS(doc.patch(patch),
                              "[json.exception.out_of_range.411] (/foo/bar) (bytes 14-24) cannot add value: the JSON Patch 'add' target's parent is of type string, but must be an object or array", json::out_of_range);
     }
+
+    SECTION("copy constructor keeps start/end positions")
+    {
+        const std::string text = R"({"a":1,"b":[2]})";
+        const json a = json::parse(text);
+        const json b = a;
+        CHECK(b.start_pos() == a.start_pos());
+        CHECK(b.end_pos() == a.end_pos());
+        CHECK(b.at("a").start_pos() == a.at("a").start_pos());
+        CHECK(b.at("b").end_pos() == a.at("b").end_pos());
+        CHECK(text.substr(b.at("a").start_pos(), b.at("a").end_pos() - b.at("a").start_pos()) == "1");
+    }
+
+    SECTION("move constructor resets the source positions to npos")
+    {
+        const std::string text = R"({"a":1})";
+        json a = json::parse(text);
+        const auto start = a.start_pos();
+        const auto end = a.end_pos();
+        json b = std::move(a);
+        CHECK(b.start_pos() == start);
+        CHECK(b.end_pos() == end);
+        CHECK(a.start_pos() == std::string::npos);
+        CHECK(a.end_pos() == std::string::npos);
+    }
+
+    SECTION("swap exchanges positions")
+    {
+        json a = json::parse(R"({"a":1})");
+        json b = json::parse(R"({"bb":22})");
+        const auto a_start = a.start_pos();
+        const auto a_end = a.end_pos();
+        const auto b_start = b.start_pos();
+        const auto b_end = b.end_pos();
+        using std::swap;
+        swap(a, b);
+        CHECK(a.start_pos() == b_start);
+        CHECK(a.end_pos() == b_end);
+        CHECK(b.start_pos() == a_start);
+        CHECK(b.end_pos() == a_end);
+    }
 }


### PR DESCRIPTION
## Summary

With `JSON_DIAGNOSTIC_POSITIONS`, copy construction copies `start_pos`/`end_pos` and move construction resets the source to `npos`, but `basic_json::swap` only swapped the payload. `std::swap` therefore left diagnostic positions attached to the wrong object. That is a **behavior fix**, not just extra coverage.

The rest of #5420 was test/docs holes around that API. This PR now covers them instead of leaving a follow-up.

## Related Issue

Fixes #5420

## Changes Made

**Behavior**

- Exchange `start_position`/`end_position` in `basic_json::swap()` when positions are enabled (type-specific `array_t`/`object_t`/`string_t`/`binary_t` overloads still leave positions on the `basic_json` object)

**Tests (the rest of #5420)**

- Copy (children keep offsets into the original input; mutating the original does not affect the copy)
- Move (source is `npos`)
- Swap of two `basic_json` values, plus type-specific container swap
- Mutation: `operator[]`, `push_back`, `erase` leave parent/sibling spans pointing at the original text; replacements are `npos`
- Input adapters: `istringstream`, `ifstream`, iterator pairs, contiguous `vector`, UTF-8 BOM (`start_pos() == 3`)
- Wide strings: positions are UTF-8 byte offsets of the *transcoded* stream and cannot index the original `u16string`/`u32string`
- Binary formats (`from_cbor`/`from_msgpack`/`from_ubjson`/`from_bjdata`/`from_bson`) yield `npos`
- User-constructed `json_sax_dom_parser` (no lexer) yields `npos`
- `ignore_trailing_commas`: `end_pos` covers the skipped comma; `accept()`/`sax_parse()` with the flag on (the hole #5417 / #5431 left open)

**Docs**

- UTF-8 byte offsets, BOM, copy/move/swap, mutation invalidation, SAX/binary `npos`

## Testing

Commands executed:

- `python3 tools/amalgamate/amalgamate.py` is not sufficient by itself; `single_include/nlohmann/json.hpp` is restored from `develop` with only the `swap` change (CI amalgamation check failed on the first commit because amalgamate.py was run without astyle)
- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug -DJSON_FastTests=ON`
- `cmake --build build --target test-diagnostic-positions_cpp11 test-class_parser_diagnostic_positions_cpp11 test-deserialization_cpp11`
- `./tests/test-diagnostic-positions_cpp11 --no-skip -tce='*downloaded*'`
- `./tests/test-class_parser_diagnostic_positions_cpp11 --no-skip -tce='*downloaded*'`
- `./tests/test-deserialization_cpp11 --no-skip -tce='*downloaded*'`

Results:

- diagnostic-positions: 1 passed, 137 assertions
- class_parser_diagnostic_positions: 2 passed, 10790 assertions
- deserialization: 11 passed, 468 assertions

## Notes

Assignment already swapped positions (`operator=(basic_json other)`). Member `swap` was the hole. Positions describe a span in the original parse input; they are not recomputed when the value is later mutated.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`.