### PR TITLE
Reject JSON Patch move when from is a prefix of path

### DIFF
--- a/docs/mkdocs/docs/api/basic_json/patch.md
+++ b/docs/mkdocs/docs/api/basic_json/patch.md
@@ -34,6 +34,8 @@ Strong guarantee: if an exception is thrown, there are no changes in the JSON va
   ("add", "remove", "move")
 - Throws [`out_of_range.411`](../../home/exceptions.md#jsonexceptionout_of_range411) if an "add" operation's target
   location has a parent that is neither an object nor an array.
+- Throws [`out_of_range.413`](../../home/exceptions.md#jsonexceptionout_of_range413) if a "move" operation's `from`
+  location is a proper prefix of `path` (RFC 6902 §4.4).
 - Throws [`other_error.501`](../../home/exceptions.md#jsonexceptionother_error501) if "test" operation was
   unsuccessful.
 
@@ -75,3 +77,5 @@ is thrown. In any case, the original value is not changed: the patch is applied 
 - Added in version 2.0.0.
 - Added [`out_of_range.411`](../../home/exceptions.md#jsonexceptionout_of_range411) and stopped relying on an internal assertion when an "add" operation's
   target location has a non-object/non-array parent in version 3.13.0.
+- Added [`out_of_range.413`](../../home/exceptions.md#jsonexceptionout_of_range413) when a "move" operation's `from`
+  location is a proper prefix of `path` in version 3.13.0.

--- a/docs/mkdocs/docs/api/basic_json/patch_inplace.md
+++ b/docs/mkdocs/docs/api/basic_json/patch_inplace.md
@@ -30,6 +30,8 @@ No guarantees, value may be corrupted by an unsuccessful patch operation.
   ("add", "remove", "move")
 - Throws [`out_of_range.411`](../../home/exceptions.md#jsonexceptionout_of_range411) if an "add" operation's target
   location has a parent that is neither an object nor an array.
+- Throws [`out_of_range.413`](../../home/exceptions.md#jsonexceptionout_of_range413) if a "move" operation's `from`
+  location is a proper prefix of `path` (RFC 6902 §4.4).
 - Throws [`other_error.501`](../../home/exceptions.md#jsonexceptionother_error501) if "test" operation was
   unsuccessful.
 
@@ -72,3 +74,5 @@ function throws an exception.
 - Added in version 3.11.0.
 - Added [`out_of_range.411`](../../home/exceptions.md#jsonexceptionout_of_range411) and stopped relying on an internal assertion when an "add" operation's
   target location has a non-object/non-array parent in version 3.13.0.
+- Added [`out_of_range.413`](../../home/exceptions.md#jsonexceptionout_of_range413) when a "move" operation's `from`
+  location is a proper prefix of `path` in version 3.13.0.

--- a/docs/mkdocs/docs/home/exceptions.md
+++ b/docs/mkdocs/docs/home/exceptions.md
@@ -933,6 +933,20 @@ BSON stores the length of documents, arrays, strings, and binary values in a sig
     [`to_bson`](../api/basic_json/to_bson.md) produced documents with negative length prefixes that
     [`from_bson`](../api/basic_json/from_bson.md) rejected.
 
+### json.exception.out_of_range.413
+
+A JSON Patch `move` operation is forbidden when the `from` location is a proper prefix of the `path` location. [RFC 6902 §4.4](https://datatracker.ietf.org/doc/html/rfc6902#section-4.4) requires that a location cannot be moved into one of its children. The check compares JSON Pointer reference tokens, so an escaped token such as `/a~1b` (the single token `a/b`) is not treated as a prefix of `/a`.
+
+!!! failure "Example message"
+
+    ```
+    JSON Patch 'move': 'from' must not be a proper prefix of 'path'
+    ```
+
+!!! note
+
+    This exception was added in version 3.13.0. Before that, object targets happened to throw [`out_of_range.403`](#jsonexceptionout_of_range403) as a side effect of the subsequent `add`, while array targets silently produced a corrupted document.
+
 ## Further exceptions
 
 This exception is thrown in case of errors that cannot be classified with the

--- a/docs/mkdocs/docs/home/exceptions.md
+++ b/docs/mkdocs/docs/home/exceptions.md
@@ -940,7 +940,7 @@ A JSON Patch `move` operation is forbidden when the `from` location is a proper 
 !!! failure "Example message"
 
     ```
-    JSON Patch 'move': 'from' must not be a proper prefix of 'path'
+    JSON Patch 'move': 'from' '/0' must not be a proper prefix of 'path' '/0/0'
     ```
 
 !!! note

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5013,6 +5013,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     const auto from_path = get_value("move", "from", true).template get<string_t>();
                     json_pointer from_ptr(from_path);
 
+                    // RFC 6902 §4.4: "from" MUST NOT be a proper prefix of "path"
+                    const auto& from_tokens = from_ptr.reference_tokens;
+                    const auto& path_tokens = ptr.reference_tokens;
+                    if (from_tokens.size() < path_tokens.size() &&
+                            std::equal(from_tokens.begin(), from_tokens.end(), path_tokens.begin()))
+                    {
+                        JSON_THROW(parse_error::create(105, 0, "JSON patch 'move': 'from' must not be a proper prefix of 'path'", &val));
+                    }
+
                     // the "from" location must exist - use at()
                     basic_json const v = result.at(from_ptr);
 

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5013,13 +5013,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     const auto from_path = get_value("move", "from", true).template get<string_t>();
                     json_pointer from_ptr(from_path);
 
-                    // RFC 6902 §4.4: "from" MUST NOT be a proper prefix of "path"
-                    const auto& from_tokens = from_ptr.reference_tokens;
-                    const auto& path_tokens = ptr.reference_tokens;
-                    if (from_tokens.size() < path_tokens.size() &&
-                            std::equal(from_tokens.begin(), from_tokens.end(), path_tokens.begin()))
+                    // RFC 6902 §4.4: "from" MUST NOT be a proper prefix of "path".
+                    // Compare ancestors with json_pointer::operator== so the check is
+                    // by reference token, not a raw-string prefix (so /a~1b is "a/b").
+                    for (json_pointer ancestor = ptr; !ancestor.empty(); )
                     {
-                        JSON_THROW(parse_error::create(105, 0, "JSON patch 'move': 'from' must not be a proper prefix of 'path'", &val));
+                        ancestor = ancestor.parent_pointer();
+                        if (ancestor == from_ptr)
+                        {
+                            JSON_THROW(out_of_range::create(413, "JSON Patch 'move': 'from' must not be a proper prefix of 'path'", nullptr));
+                        }
                     }
 
                     // the "from" location must exist - use at()

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5021,7 +5021,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                         ancestor = ancestor.parent_pointer();
                         if (ancestor == from_ptr)
                         {
-                            JSON_THROW(out_of_range::create(413, "JSON Patch 'move': 'from' must not be a proper prefix of 'path'", nullptr));
+                            JSON_THROW(out_of_range::create(413, detail::concat("JSON Patch 'move': 'from' '", from_path, "' must not be a proper prefix of 'path' '", path, "'"), nullptr));
                         }
                     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -26375,7 +26375,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                         ancestor = ancestor.parent_pointer();
                         if (ancestor == from_ptr)
                         {
-                            JSON_THROW(out_of_range::create(413, "JSON Patch 'move': 'from' must not be a proper prefix of 'path'", nullptr));
+                            JSON_THROW(out_of_range::create(413, detail::concat("JSON Patch 'move': 'from' '", from_path, "' must not be a proper prefix of 'path' '", path, "'"), nullptr));
                         }
                     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
-// JSON_HAS_CPP_17
+ // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -21519,10 +21519,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22220,8 +22220,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                       std::forward<CompatibleType>(val))))
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -23024,7 +23024,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23066,7 +23066,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23216,7 +23216,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;
@@ -26366,6 +26366,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 {
                     const auto from_path = get_value("move", "from", true).template get<string_t>();
                     json_pointer from_ptr(from_path);
+
+                    // RFC 6902 §4.4: "from" MUST NOT be a proper prefix of "path"
+                    const auto& from_tokens = from_ptr.reference_tokens;
+                    const auto& path_tokens = ptr.reference_tokens;
+                    if (from_tokens.size() < path_tokens.size() &&
+                            std::equal(from_tokens.begin(), from_tokens.end(), path_tokens.begin()))
+                    {
+                        JSON_THROW(parse_error::create(105, 0, "JSON patch 'move': 'from' must not be a proper prefix of 'path'", &val));
+                    }
 
                     // the "from" location must exist - use at()
                     basic_json const v = result.at(from_ptr);

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-#include <cstdint> // int64_t, uint64_t
-#include <map> // map
-#include <memory> // allocator
-#include <string> // string
-#include <vector> // vector
+    #include <cstdint> // int64_t, uint64_t
+    #include <map> // map
+    #include <memory> // allocator
+    #include <string> // string
+    #include <vector> // vector
 
-// #include <nlohmann/detail/abi_macros.hpp>
+    // #include <nlohmann/detail/abi_macros.hpp>
 
 
-/*!
-@brief namespace for Niels Lohmann
-@see https://github.com/nlohmann
-@since version 1.0.0
-*/
-NLOHMANN_JSON_NAMESPACE_BEGIN
+    /*!
+    @brief namespace for Niels Lohmann
+    @see https://github.com/nlohmann
+    @since version 1.0.0
+    */
+    NLOHMANN_JSON_NAMESPACE_BEGIN
 
-/*!
-@brief default JSONSerializer template argument
+    /*!
+    @brief default JSONSerializer template argument
 
-This serializer ignores the template arguments and uses ADL
-([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-for serialization.
-*/
-template<typename T = void, typename SFINAE = void>
-struct adl_serializer;
+    This serializer ignores the template arguments and uses ADL
+    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+    for serialization.
+    */
+    template<typename T = void, typename SFINAE = void>
+    struct adl_serializer;
 
-/// a class to store JSON values
-/// @sa https://json.nlohmann.me/api/basic_json/
-template<template<typename U, typename V, typename... Args> class ObjectType =
-         std::map,
-         template<typename U, typename... Args> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
-         class NumberIntegerType = std::int64_t,
-         class NumberUnsignedType = std::uint64_t,
-         class NumberFloatType = double,
-         template<typename U> class AllocatorType = std::allocator,
-         template<typename T, typename SFINAE = void> class JSONSerializer =
-         adl_serializer,
-         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-         class CustomBaseClass = void>
-class basic_json;
+    /// a class to store JSON values
+    /// @sa https://json.nlohmann.me/api/basic_json/
+    template<template<typename U, typename V, typename... Args> class ObjectType =
+    std::map,
+    template<typename U, typename... Args> class ArrayType = std::vector,
+    class StringType = std::string, class BooleanType = bool,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
+    class NumberFloatType = double,
+    template<typename U> class AllocatorType = std::allocator,
+    template<typename T, typename SFINAE = void> class JSONSerializer =
+    adl_serializer,
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
+    class basic_json;
 
-/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-/// @sa https://json.nlohmann.me/api/json_pointer/
-template<typename RefStringType>
-class json_pointer;
+    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+    /// @sa https://json.nlohmann.me/api/json_pointer/
+    template<typename RefStringType>
+    class json_pointer;
 
-/*!
-@brief default specialization
-@sa https://json.nlohmann.me/api/json/
-*/
-using json = basic_json<>;
+    /*!
+    @brief default specialization
+    @sa https://json.nlohmann.me/api/json/
+    */
+    using json = basic_json<>;
 
-/// @brief a minimal map-like container that preserves insertion order
-/// @sa https://json.nlohmann.me/api/ordered_map/
-template<class Key, class T, class IgnoredLess, class Allocator>
-struct ordered_map;
+    /// @brief a minimal map-like container that preserves insertion order
+    /// @sa https://json.nlohmann.me/api/ordered_map/
+    template<class Key, class T, class IgnoredLess, class Allocator>
+    struct ordered_map;
 
-/// @brief specialization that maintains the insertion order of object keys
-/// @sa https://json.nlohmann.me/api/ordered_json/
-using ordered_json = basic_json<nlohmann::ordered_map>;
+    /// @brief specialization that maintains the insertion order of object keys
+    /// @sa https://json.nlohmann.me/api/ordered_json/
+    using ordered_json = basic_json<nlohmann::ordered_map>;
 
-NLOHMANN_JSON_NAMESPACE_END
+    NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
- // JSON_HAS_CPP_17
+// JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -21519,10 +21519,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-    )
+                                 )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22220,8 +22220,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                           std::forward<CompatibleType>(val))))
+            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                       std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -23024,7 +23024,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23066,7 +23066,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23216,7 +23216,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;
@@ -26367,13 +26367,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     const auto from_path = get_value("move", "from", true).template get<string_t>();
                     json_pointer from_ptr(from_path);
 
-                    // RFC 6902 §4.4: "from" MUST NOT be a proper prefix of "path"
-                    const auto& from_tokens = from_ptr.reference_tokens;
-                    const auto& path_tokens = ptr.reference_tokens;
-                    if (from_tokens.size() < path_tokens.size() &&
-                            std::equal(from_tokens.begin(), from_tokens.end(), path_tokens.begin()))
+                    // RFC 6902 §4.4: "from" MUST NOT be a proper prefix of "path".
+                    // Compare ancestors with json_pointer::operator== so the check is
+                    // by reference token, not a raw-string prefix (so /a~1b is "a/b").
+                    for (json_pointer ancestor = ptr; !ancestor.empty(); )
                     {
-                        JSON_THROW(parse_error::create(105, 0, "JSON patch 'move': 'from' must not be a proper prefix of 'path'", &val));
+                        ancestor = ancestor.parent_pointer();
+                        if (ancestor == from_ptr)
+                        {
+                            JSON_THROW(out_of_range::create(413, "JSON Patch 'move': 'from' must not be a proper prefix of 'path'", nullptr));
+                        }
                     }
 
                     // the "from" location must exist - use at()

--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -1388,3 +1388,13 @@ TEST_CASE("JSON patch - add to a primitive parent (regression #4292)")
         CHECK_THROWS_AS(doc.patch(patch), json::out_of_range&);
     }
 }
+
+TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §4.4)")
+{
+    // Moving a location into one of its own children must fail. Without the
+    // prefix check, array targets "succeed" with a corrupted document.
+    json doc = json::parse("[[1,2],3]");
+    json const patch = json::parse(R"([{"op":"move","from":"/0","path":"/0/0"}])");
+    CHECK_THROWS_AS(doc.patch(patch), json::parse_error&);
+    CHECK(doc == json::parse("[[1,2],3]"));
+}

--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -1391,13 +1391,11 @@ TEST_CASE("JSON patch - add to a primitive parent (regression #4292)")
 
 TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §4.4)")
 {
-    const auto *const prefix_error = "[json.exception.out_of_range.413] JSON Patch 'move': 'from' must not be a proper prefix of 'path'";
-
     SECTION("nested array (the MUST-violation that previously succeeded)")
     {
         json doc = json::parse("[[1,2],3]");
         json const patch = json::parse(R"([{"op":"move","from":"/0","path":"/0/0"}])");
-        CHECK_THROWS_WITH_AS(doc.patch(patch), prefix_error, json::out_of_range&);
+        CHECK_THROWS_WITH_AS(doc.patch(patch), "[json.exception.out_of_range.413] JSON Patch 'move': 'from' '/0' must not be a proper prefix of 'path' '/0/0'", json::out_of_range&);
         CHECK(doc == json::parse("[[1,2],3]"));
     }
 
@@ -1405,7 +1403,7 @@ TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §
     {
         json doc = json::parse("[[1,2],3]");
         json const patch = json::parse(R"([{"op":"move","from":"/0","path":"/0/0"}])");
-        CHECK_THROWS_WITH_AS(doc.patch_inplace(patch), prefix_error, json::out_of_range&);
+        CHECK_THROWS_WITH_AS(doc.patch_inplace(patch), "[json.exception.out_of_range.413] JSON Patch 'move': 'from' '/0' must not be a proper prefix of 'path' '/0/0'", json::out_of_range&);
         CHECK(doc == json::parse("[[1,2],3]"));
     }
 
@@ -1428,7 +1426,7 @@ TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §
     {
         json doc = json::parse(R"({"a":1})");
         json const patch = json::parse(R"([{"op":"move","from":"","path":"/a"}])");
-        CHECK_THROWS_WITH_AS(doc.patch(patch), prefix_error, json::out_of_range&);
+        CHECK_THROWS_WITH_AS(doc.patch(patch), "[json.exception.out_of_range.413] JSON Patch 'move': 'from' '' must not be a proper prefix of 'path' '/a'", json::out_of_range&);
         CHECK(doc == json::parse(R"({"a":1})"));
     }
 
@@ -1443,7 +1441,7 @@ TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §
     {
         json doc = json::parse("[1,2]");
         json const patch = json::parse(R"([{"op":"move","from":"","path":"/-"}])");
-        CHECK_THROWS_WITH_AS(doc.patch(patch), prefix_error, json::out_of_range&);
+        CHECK_THROWS_WITH_AS(doc.patch(patch), "[json.exception.out_of_range.413] JSON Patch 'move': 'from' '' must not be a proper prefix of 'path' '/-'", json::out_of_range&);
         CHECK(doc == json::parse("[1,2]"));
     }
 

--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -1391,10 +1391,66 @@ TEST_CASE("JSON patch - add to a primitive parent (regression #4292)")
 
 TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §4.4)")
 {
-    // Moving a location into one of its own children must fail. Without the
-    // prefix check, array targets "succeed" with a corrupted document.
-    json doc = json::parse("[[1,2],3]");
-    json const patch = json::parse(R"([{"op":"move","from":"/0","path":"/0/0"}])");
-    CHECK_THROWS_AS(doc.patch(patch), json::parse_error&);
-    CHECK(doc == json::parse("[[1,2],3]"));
+    const auto prefix_error = "[json.exception.out_of_range.413] JSON Patch 'move': 'from' must not be a proper prefix of 'path'";
+
+    SECTION("nested array (the MUST-violation that previously succeeded)")
+    {
+        json doc = json::parse("[[1,2],3]");
+        json const patch = json::parse(R"([{"op":"move","from":"/0","path":"/0/0"}])");
+        CHECK_THROWS_WITH_AS(doc.patch(patch), prefix_error, json::out_of_range&);
+        CHECK(doc == json::parse("[[1,2],3]"));
+    }
+
+    SECTION("patch_inplace rejects the same move and leaves the document unchanged")
+    {
+        json doc = json::parse("[[1,2],3]");
+        json const patch = json::parse(R"([{"op":"move","from":"/0","path":"/0/0"}])");
+        CHECK_THROWS_WITH_AS(doc.patch_inplace(patch), prefix_error, json::out_of_range&);
+        CHECK(doc == json::parse("[[1,2],3]"));
+    }
+
+    SECTION("from == path is allowed (not a proper prefix)")
+    {
+        json const doc = json::parse(R"({"a":[1,2]})");
+        json const patch = json::parse(R"([{"op":"move","from":"/a","path":"/a"}])");
+        CHECK(doc.patch(patch) == doc);
+    }
+
+    SECTION("escaped token is a single reference token, not a string prefix")
+    {
+        // /a~1b is the token "a/b", not /a followed by b
+        json const doc = json::parse(R"({"a":{"x":1},"a/b":{"y":2}})");
+        json const patch = json::parse(R"([{"op":"move","from":"/a","path":"/a~1b/y"}])");
+        CHECK(doc.patch(patch) == json::parse(R"({"a/b":{"y":{"x":1}}})"));
+    }
+
+    SECTION("root from is a proper prefix of any non-root path")
+    {
+        json doc = json::parse(R"({"a":1})");
+        json const patch = json::parse(R"([{"op":"move","from":"","path":"/a"}])");
+        CHECK_THROWS_WITH_AS(doc.patch(patch), prefix_error, json::out_of_range&);
+        CHECK(doc == json::parse(R"({"a":1})"));
+    }
+
+    SECTION("root path is not prefixed by a non-root from")
+    {
+        json const doc = json::parse(R"({"a":{"b":1}})");
+        json const patch = json::parse(R"([{"op":"move","from":"/a","path":""}])");
+        CHECK(doc.patch(patch) == json::parse(R"({"b":1})"));
+    }
+
+    SECTION("append token '-' still counts as a child of from")
+    {
+        json doc = json::parse("[1,2]");
+        json const patch = json::parse(R"([{"op":"move","from":"","path":"/-"}])");
+        CHECK_THROWS_WITH_AS(doc.patch(patch), prefix_error, json::out_of_range&);
+        CHECK(doc == json::parse("[1,2]"));
+    }
+
+    SECTION("path is a prefix of from is allowed (move a child onto its parent)")
+    {
+        json const doc = json::parse(R"({"a":{"b":1,"c":2}})");
+        json const patch = json::parse(R"([{"op":"move","from":"/a/b","path":"/a"}])");
+        CHECK(doc.patch(patch) == json::parse(R"({"a":1})"));
+    }
 }

--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -1391,7 +1391,7 @@ TEST_CASE("JSON patch - add to a primitive parent (regression #4292)")
 
 TEST_CASE("JSON patch move from a proper prefix of path is rejected (RFC 6902 §4.4)")
 {
-    const auto prefix_error = "[json.exception.out_of_range.413] JSON Patch 'move': 'from' must not be a proper prefix of 'path'";
+    const auto *const prefix_error = "[json.exception.out_of_range.413] JSON Patch 'move': 'from' must not be a proper prefix of 'path'";
 
     SECTION("nested array (the MUST-violation that previously succeeded)")
     {


### PR DESCRIPTION
## Summary

A JSON Patch \`move\` whose \`from\` is a proper prefix of \`path\` is forbidden by RFC 6902 §4.4. The implementation did remove-then-add with no prefix check, so array targets succeeded with a nonsensical document.

## Related Issue

Fixes #5397

## Changes Made

- Reject the operation with parse_error.105 when \`from\` is a proper prefix of \`path\`
- Regression test on a nested array that previously \"succeeded\"

## Testing

Commands executed:

- \`python3 tools/amalgamate/amalgamate.py -c tools/amalgamate/config_json.json -s .\`
- \`cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug\`
- \`cmake --build build --target test-json_patch_cpp11\`
- \`./tests/test-json_patch_cpp11 --no-skip -tce='*downloaded*' -tc='*move from a proper prefix*'\`

Results:

- 1 passed, 2 assertions

## Notes

Object targets already happened to throw out_of_range.403 as a side effect of the subsequent add. Arrays are the MUST-violation.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running \`make amalgamate\`.