### PR TITLE
Fall back to object encoding for out-of-range BJData ndarray elements

### DIFF
--- a/docs/mkdocs/docs/features/binary_formats/bjdata.md
+++ b/docs/mkdocs/docs/features/binary_formats/bjdata.md
@@ -128,7 +128,7 @@ The library uses the following mapping from JSON values types to BJData types ac
     - every entry of `"_ArraySize_"` is a non-negative integer, and their product is representable as a `std::size_t`,
     - `"_ArrayData_"` holds exactly that many elements, and
     - every element of `"_ArrayData_"` is a number of the kind named by `"_ArrayType_"` (a floating-point number for
-      `single` and `double`, an integer otherwise).
+      `single` and `double`, an integer otherwise) and, for integer types, fits in that type's range without truncation.
 
     The current version of this library does not yet support automatic detection of and conversion from a nested JSON
     array input to a BJData ND-array.

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -1648,6 +1648,70 @@ class binary_writer
     }
 
     /*!
+    @brief whether an ndarray _ArrayData_ integer fits the BJData wire type
+
+    @param[in] el    an integer JSON value
+    @param[in] dtype BJData type marker (U/i/u/I/m/l/M/L/C/B)
+
+    @return true if `el` can be written as `dtype` without truncation
+    */
+    static bool bjdata_ndarray_element_in_range(const BasicJsonType& el, const CharType dtype)
+    {
+        if (el.is_number_unsigned())
+        {
+            const auto v = el.template get<std::uint64_t>();
+            switch (dtype)
+            {
+                case 'U':
+                case 'C':
+                case 'B':
+                    return value_in_range_of<std::uint8_t>(v);
+                case 'i':
+                    return value_in_range_of<std::int8_t>(v);
+                case 'u':
+                    return value_in_range_of<std::uint16_t>(v);
+                case 'I':
+                    return value_in_range_of<std::int16_t>(v);
+                case 'm':
+                    return value_in_range_of<std::uint32_t>(v);
+                case 'l':
+                    return value_in_range_of<std::int32_t>(v);
+                case 'M':
+                    return true;
+                case 'L':
+                    return value_in_range_of<std::int64_t>(v);
+                default:
+                    return true; // LCOV_EXCL_LINE
+            }
+        }
+
+        const auto v = el.template get<std::int64_t>();
+        switch (dtype)
+        {
+            case 'U':
+            case 'C':
+            case 'B':
+                return value_in_range_of<std::uint8_t>(v);
+            case 'i':
+                return value_in_range_of<std::int8_t>(v);
+            case 'u':
+                return value_in_range_of<std::uint16_t>(v);
+            case 'I':
+                return value_in_range_of<std::int16_t>(v);
+            case 'm':
+                return value_in_range_of<std::uint32_t>(v);
+            case 'l':
+                return value_in_range_of<std::int32_t>(v);
+            case 'M':
+                return value_in_range_of<std::uint64_t>(v);
+            case 'L':
+                return true;
+            default:
+                return true; // LCOV_EXCL_LINE
+        }
+    }
+
+    /*!
     @return false if the object is successfully converted to a bjdata ndarray, true if the type or size is invalid
     */
     bool write_bjdata_ndarray(const typename BasicJsonType::object_t& value, const bool use_count, const bool use_type, const bjdata_version_t bjdata_version)
@@ -1713,10 +1777,20 @@ class binary_writer
         // was built (parsing stores non-negative integers as unsigned, the C++
         // API stores int literals as signed), so both are accepted here and the
         // writes below go through get<>, which reads the member that is active.
+        //
+        // dtype also names the wire *range*. An in-kind integer that does not
+        // fit (e.g. 256 as uint8) is static_cast-truncated today, so the value
+        // round-trips to a different number with no error. That is the same
+        // class of silent corruption as a wrong kind; fall back to a plain
+        // object encoding instead.
         const bool ndarray_is_float = (dtype == 'd' || dtype == 'D');
         for (const auto& el : value.at(key))
         {
             if (ndarray_is_float ? !el.is_number_float() : !el.is_number_integer())
+            {
+                return true;
+            }
+            if (!ndarray_is_float && !bjdata_ndarray_element_in_range(el, dtype))
             {
                 return true;
             }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -3722,71 +3722,71 @@ NLOHMANN_JSON_NAMESPACE_END
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
-    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
-    #include <cstdint> // int64_t, uint64_t
-    #include <map> // map
-    #include <memory> // allocator
-    #include <string> // string
-    #include <vector> // vector
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
 
-    // #include <nlohmann/detail/abi_macros.hpp>
+// #include <nlohmann/detail/abi_macros.hpp>
 
 
-    /*!
-    @brief namespace for Niels Lohmann
-    @see https://github.com/nlohmann
-    @since version 1.0.0
-    */
-    NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
 
-    /*!
-    @brief default JSONSerializer template argument
+/*!
+@brief default JSONSerializer template argument
 
-    This serializer ignores the template arguments and uses ADL
-    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
-    for serialization.
-    */
-    template<typename T = void, typename SFINAE = void>
-    struct adl_serializer;
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
 
-    /// a class to store JSON values
-    /// @sa https://json.nlohmann.me/api/basic_json/
-    template<template<typename U, typename V, typename... Args> class ObjectType =
-    std::map,
-    template<typename U, typename... Args> class ArrayType = std::vector,
-    class StringType = std::string, class BooleanType = bool,
-    class NumberIntegerType = std::int64_t,
-    class NumberUnsignedType = std::uint64_t,
-    class NumberFloatType = double,
-    template<typename U> class AllocatorType = std::allocator,
-    template<typename T, typename SFINAE = void> class JSONSerializer =
-    adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
-    class CustomBaseClass = void>
-    class basic_json;
+/// a class to store JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+         class CustomBaseClass = void>
+class basic_json;
 
-    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
-    /// @sa https://json.nlohmann.me/api/json_pointer/
-    template<typename RefStringType>
-    class json_pointer;
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer;
 
-    /*!
-    @brief default specialization
-    @sa https://json.nlohmann.me/api/json/
-    */
-    using json = basic_json<>;
+/*!
+@brief default specialization
+@sa https://json.nlohmann.me/api/json/
+*/
+using json = basic_json<>;
 
-    /// @brief a minimal map-like container that preserves insertion order
-    /// @sa https://json.nlohmann.me/api/ordered_map/
-    template<class Key, class T, class IgnoredLess, class Allocator>
-    struct ordered_map;
+/// @brief a minimal map-like container that preserves insertion order
+/// @sa https://json.nlohmann.me/api/ordered_map/
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
 
-    /// @brief specialization that maintains the insertion order of object keys
-    /// @sa https://json.nlohmann.me/api/ordered_json/
-    using ordered_json = basic_json<nlohmann::ordered_map>;
+/// @brief specialization that maintains the insertion order of object keys
+/// @sa https://json.nlohmann.me/api/ordered_json/
+using ordered_json = basic_json<nlohmann::ordered_map>;
 
-    NLOHMANN_JSON_NAMESPACE_END
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
@@ -5873,7 +5873,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 // #include <nlohmann/detail/macro_scope.hpp>
-// JSON_HAS_CPP_17
+ // JSON_HAS_CPP_17
 #ifdef JSON_HAS_CPP_17
     #include <optional> // optional
 #endif
@@ -18591,6 +18591,70 @@ class binary_writer
     }
 
     /*!
+    @brief whether an ndarray _ArrayData_ integer fits the BJData wire type
+
+    @param[in] el    an integer JSON value
+    @param[in] dtype BJData type marker (U/i/u/I/m/l/M/L/C/B)
+
+    @return true if `el` can be written as `dtype` without truncation
+    */
+    static bool bjdata_ndarray_element_in_range(const BasicJsonType& el, const CharType dtype)
+    {
+        if (el.is_number_unsigned())
+        {
+            const auto v = el.template get<std::uint64_t>();
+            switch (dtype)
+            {
+                case 'U':
+                case 'C':
+                case 'B':
+                    return value_in_range_of<std::uint8_t>(v);
+                case 'i':
+                    return value_in_range_of<std::int8_t>(v);
+                case 'u':
+                    return value_in_range_of<std::uint16_t>(v);
+                case 'I':
+                    return value_in_range_of<std::int16_t>(v);
+                case 'm':
+                    return value_in_range_of<std::uint32_t>(v);
+                case 'l':
+                    return value_in_range_of<std::int32_t>(v);
+                case 'M':
+                    return true;
+                case 'L':
+                    return value_in_range_of<std::int64_t>(v);
+                default:
+                    return true; // LCOV_EXCL_LINE
+            }
+        }
+
+        const auto v = el.template get<std::int64_t>();
+        switch (dtype)
+        {
+            case 'U':
+            case 'C':
+            case 'B':
+                return value_in_range_of<std::uint8_t>(v);
+            case 'i':
+                return value_in_range_of<std::int8_t>(v);
+            case 'u':
+                return value_in_range_of<std::uint16_t>(v);
+            case 'I':
+                return value_in_range_of<std::int16_t>(v);
+            case 'm':
+                return value_in_range_of<std::uint32_t>(v);
+            case 'l':
+                return value_in_range_of<std::int32_t>(v);
+            case 'M':
+                return value_in_range_of<std::uint64_t>(v);
+            case 'L':
+                return true;
+            default:
+                return true; // LCOV_EXCL_LINE
+        }
+    }
+
+    /*!
     @return false if the object is successfully converted to a bjdata ndarray, true if the type or size is invalid
     */
     bool write_bjdata_ndarray(const typename BasicJsonType::object_t& value, const bool use_count, const bool use_type, const bjdata_version_t bjdata_version)
@@ -18656,10 +18720,20 @@ class binary_writer
         // was built (parsing stores non-negative integers as unsigned, the C++
         // API stores int literals as signed), so both are accepted here and the
         // writes below go through get<>, which reads the member that is active.
+        //
+        // dtype also names the wire *range*. An in-kind integer that does not
+        // fit (e.g. 256 as uint8) is static_cast-truncated today, so the value
+        // round-trips to a different number with no error. That is the same
+        // class of silent corruption as a wrong kind; fall back to a plain
+        // object encoding instead.
         const bool ndarray_is_float = (dtype == 'd' || dtype == 'D');
         for (const auto& el : value.at(key))
         {
             if (ndarray_is_float ? !el.is_number_float() : !el.is_number_integer())
+            {
+                return true;
+            }
+            if (!ndarray_is_float && !bjdata_ndarray_element_in_range(el, dtype))
             {
                 return true;
             }
@@ -21519,10 +21593,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool allow_exceptions = true,
         const bool ignore_comments = false,
         const bool ignore_trailing_commas = false
-                                 )
+    )
     {
         return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
-            std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
+               std::move(cb), allow_exceptions, ignore_comments, ignore_trailing_commas);
     }
 
   private:
@@ -22220,8 +22294,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                detail::enable_if_t <
                    !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
     basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
-            JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                       std::forward<CompatibleType>(val))))
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
     {
         JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
         set_parents();
@@ -23024,7 +23098,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
         JSONSerializer<ValueType>::from_json(*this, ret);
@@ -23066,7 +23140,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
     {
         return JSONSerializer<ValueType>::from_json(*this);
     }
@@ -23216,7 +23290,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                    detail::has_from_json<basic_json_t, ValueType>::value,
                    int > = 0 >
     ValueType & get_to(ValueType& v) const noexcept(noexcept(
-            JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
     {
         JSONSerializer<ValueType>::from_json(*this, v);
         return v;

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2623,6 +2623,62 @@ TEST_CASE("BJData")
                 CHECK(json::from_bjdata(out_neg) == j_neg);
             }
 
+            SECTION("ndarray with out-of-range _ArrayData_ is written as an object")
+            {
+                // The writer used to static_cast-truncate values that did not
+                // fit the named type (256 as uint8 became 0). Fall back to a
+                // plain object so the value is not silently changed.
+
+                auto check_object_fallback = [](const json& j)
+                {
+                    const auto out = json::to_bjdata(j);
+                    CHECK(out.at(0) == '{');
+                    CHECK(json::from_bjdata(out) == j);
+                };
+
+                auto check_ndarray = [](const json& j)
+                {
+                    // 1-D annotated objects encode as a packed array, which
+                    // from_bjdata() returns as a JSON array rather than the
+                    // original annotation object
+                    const auto out = json::to_bjdata(j);
+                    CHECK(out.at(0) == '[');
+                };
+
+                // reported case: 256 does not fit uint8
+                check_object_fallback(json({{"_ArrayType_", "uint8"}, {"_ArraySize_", {2}}, {"_ArrayData_", {1, 256}}}));
+                check_object_fallback(json::parse(R"({"_ArrayType_":"uint8","_ArraySize_":[2],"_ArrayData_":[1,256]})"));
+
+                // negative value does not fit any unsigned type
+                check_object_fallback(json({{"_ArrayType_", "uint8"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-1}}}));
+                check_object_fallback(json({{"_ArrayType_", "uint16"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-1}}}));
+                check_object_fallback(json({{"_ArrayType_", "uint32"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-1}}}));
+                check_object_fallback(json({{"_ArrayType_", "uint64"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-1}}}));
+                check_object_fallback(json({{"_ArrayType_", "char"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-1}}}));
+                check_object_fallback(json({{"_ArrayType_", "byte"}, {"_ArraySize_", {1}}, {"_ArrayData_", {256}}}));
+
+                // signed types: one past the max / one below the min
+                check_object_fallback(json({{"_ArrayType_", "int8"}, {"_ArraySize_", {1}}, {"_ArrayData_", {128}}}));
+                check_object_fallback(json({{"_ArrayType_", "int8"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-129}}}));
+                check_object_fallback(json({{"_ArrayType_", "int16"}, {"_ArraySize_", {1}}, {"_ArrayData_", {32768}}}));
+                check_object_fallback(json({{"_ArrayType_", "int16"}, {"_ArraySize_", {1}}, {"_ArrayData_", {-32769}}}));
+                check_object_fallback(json({{"_ArrayType_", "int32"}, {"_ArraySize_", {1}}, {"_ArrayData_", {2147483648ll}}}));
+                check_object_fallback(json::parse(R"({"_ArrayType_":"int32","_ArraySize_":[1],"_ArrayData_":[-2147483649]})"));
+                check_object_fallback(json::parse(R"({"_ArrayType_":"int64","_ArraySize_":[1],"_ArrayData_":[9223372036854775808]})"));
+
+                // unsigned types: one past the max
+                check_object_fallback(json({{"_ArrayType_", "uint16"}, {"_ArraySize_", {1}}, {"_ArrayData_", {65536}}}));
+                check_object_fallback(json::parse(R"({"_ArrayType_":"uint32","_ArraySize_":[1],"_ArrayData_":[4294967296]})"));
+                check_object_fallback(json({{"_ArrayType_", "char"}, {"_ArraySize_", {1}}, {"_ArrayData_", {256}}}));
+
+                // in-range values still encode as an ndarray, including the
+                // extrema of each integer type
+                check_ndarray(json({{"_ArrayType_", "uint8"}, {"_ArraySize_", {2}}, {"_ArrayData_", {0, 255}}}));
+                check_ndarray(json({{"_ArrayType_", "int8"}, {"_ArraySize_", {2}}, {"_ArrayData_", {-128, 127}}}));
+                check_ndarray(json({{"_ArrayType_", "uint16"}, {"_ArraySize_", {1}}, {"_ArrayData_", {65535}}}));
+                check_ndarray(json({{"_ArrayType_", "int16"}, {"_ArraySize_", {2}}, {"_ArrayData_", {-32768, 32767}}}));
+            }
+
             SECTION("ndarray parsed from text is written as a typed array")
             {
                 // json::parse stores a non-negative integer as number_unsigned while
@@ -3883,6 +3939,18 @@ TEST_CASE("BJData use_type requires use_size")
         CHECK_NOTHROW(json::to_bjdata(j, true, false));
         CHECK_NOTHROW(json::to_bjdata(j, true, true));
     }
+}
+
+TEST_CASE("issue #5403 out-of-range ndarray elements fall back to object")
+{
+    // 256 does not fit uint8; previously static_cast truncated it to 0
+    json const j = {{"_ArrayType_", "uint8"}, {"_ArraySize_", {2}}, {"_ArrayData_", {1, 256}}};
+    const auto out = json::to_bjdata(j);
+    CHECK(out.at(0) == '{');
+    CHECK(json::from_bjdata(out) == j);
+
+    json const in_range = {{"_ArrayType_", "uint8"}, {"_ArraySize_", {2}}, {"_ArrayData_", {1, 255}}};
+    CHECK(json::to_bjdata(in_range).at(0) == '[');
 }
 
 TEST_CASE("BJData roundtrips" * doctest::skip())


### PR DESCRIPTION
## Summary

`to_bjdata()` validated that ndarray `_ArrayData_` elements were the right number *kind* (integer vs float) but not that they fit the named `_ArrayType_`. An element such as `256` with `_ArrayType_ = \"uint8\"` was `static_cast`-truncated to `0` and round-tripped as a different value with no error.

## Related Issue

Fixes #5403

## Changes Made

- Range-check each integer `_ArrayData_` element against the BJData wire type (`uint8`/`int8`/`uint16`/…/`char`/`byte`) before writing
- If any element does not fit, fall back to plain object encoding (same path as a wrong kind, unknown type, or overflowed `_ArraySize_`)
- Document the range requirement next to the existing kind check in `bjdata.md`

## Testing

Commands executed:

- `python3 tools/amalgamate/amalgamate.py -c tools/amalgamate/config_json.json -s .`
- `cmake -S . -B build -DJSON_BuildTests=ON -DCMAKE_BUILD_TYPE=Debug -DJSON_FastTests=ON`
- `cmake --build build --target test-bjdata_cpp11`
- `./build/tests/test-bjdata_cpp11 --no-skip -tc='*5403*'`
- `./build/tests/test-bjdata_cpp11 --no-skip -tc=BJData -sc='parsing values,array,*out-of-range*,*not matching*'`

Results:

- issue #5403: 1 passed, 3 assertions
- nested ndarray fallback tests: 1 passed, 48 assertions

## Notes

In-range extrema (`0`/`255` for uint8, `-128`/`127` for int8, …) still encode as packed ndarrays. Floating-point types are unchanged (IEEE truncation of `double` to `single` is expected).

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`.