### PR TITLE
Stop dump() from heap-allocating its output adapter per call

### DIFF
--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -62,7 +62,8 @@ class serializer
 
   public:
     /*!
-    @param[in] s  output stream to serialize to
+    @param[in] s  output adapter to serialize to; not owned by the serializer,
+                  so it must outlive it (it lives at the call site)
     @param[in] ichar  indentation character to use
     @param[in] pretty_print_  whether the output shall be pretty-printed
     @param[in] ensure_ascii_ If @a ensure_ascii_ is true, all non-ASCII
@@ -76,12 +77,12 @@ class serializer
     being threaded through every call to @ref dump, @ref dump_internal and
     @ref dump_iteratively.
     */
-    serializer(output_adapter_t<char> s, const char ichar,
+    serializer(output_adapter_protocol<char>* s, const char ichar,
                const bool pretty_print_ = false,
                const bool ensure_ascii_ = false,
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
-        : o(std::move(s))
+        : o(s)
         , locale(std::localeconv())
         , indent_char(ichar)
         , pretty_print(pretty_print_)
@@ -1678,8 +1679,8 @@ class serializer
         const char decimal_point;
     };
 
-    /// the output of the serializer
-    output_adapter_t<char> o = nullptr;
+    /// the output of the serializer (non-owning; the adapter lives at the call site)
+    output_adapter_protocol<char>* o = nullptr;
 
     /// a (hopefully) large enough character buffer
     std::array<char, 64> number_buffer{{}};

--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -77,12 +77,12 @@ class serializer
     being threaded through every call to @ref dump, @ref dump_internal and
     @ref dump_iteratively.
     */
-    serializer(output_adapter_protocol<char>* s, const char ichar,
+    serializer(output_adapter_protocol<char>& s, const char ichar,
                const bool pretty_print_ = false,
                const bool ensure_ascii_ = false,
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
-        : o(s)
+        : o(&s)
         , locale(std::localeconv())
         , indent_char(ichar)
         , pretty_print(pretty_print_)

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1347,13 +1347,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (indent >= 0)
         {
-            serializer s(&string_adapter, indent_char,
+            serializer s(string_adapter, indent_char,
                          true, ensure_ascii, static_cast<std::size_t>(indent), error_handler);
             s.dump(*this);
         }
         else
         {
-            serializer s(&string_adapter, indent_char,
+            serializer s(string_adapter, indent_char,
                          false, ensure_ascii, 0, error_handler);
             s.dump(*this);
         }
@@ -4085,7 +4085,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         // do the actual serialization
         detail::output_stream_adapter<char> stream_adapter(o);
-        serializer s(&stream_adapter, o.fill(),
+        serializer s(stream_adapter, o.fill(),
                      pretty_print, false, static_cast<std::size_t>(indentation));
         s.dump(j);
         return o;

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -1343,16 +1343,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
         string_t result;
+        detail::output_string_adapter<char, string_t> string_adapter(result);
 
         if (indent >= 0)
         {
-            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+            serializer s(&string_adapter, indent_char,
                          true, ensure_ascii, static_cast<std::size_t>(indent), error_handler);
             s.dump(*this);
         }
         else
         {
-            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+            serializer s(&string_adapter, indent_char,
                          false, ensure_ascii, 0, error_handler);
             s.dump(*this);
         }
@@ -4083,7 +4084,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         o.width(0);
 
         // do the actual serialization
-        serializer s(detail::output_adapter<char>(o), o.fill(),
+        detail::output_stream_adapter<char> stream_adapter(o);
+        serializer s(&stream_adapter, o.fill(),
                      pretty_print, false, static_cast<std::size_t>(indentation));
         s.dump(j);
         return o;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21425,12 +21425,12 @@ class serializer
     being threaded through every call to @ref dump, @ref dump_internal and
     @ref dump_iteratively.
     */
-    serializer(output_adapter_protocol<char>* s, const char ichar,
+    serializer(output_adapter_protocol<char>& s, const char ichar,
                const bool pretty_print_ = false,
                const bool ensure_ascii_ = false,
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
-        : o(s)
+        : o(&s)
         , locale(std::localeconv())
         , indent_char(ichar)
         , pretty_print(pretty_print_)
@@ -24743,13 +24743,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (indent >= 0)
         {
-            serializer s(&string_adapter, indent_char,
+            serializer s(string_adapter, indent_char,
                          true, ensure_ascii, static_cast<std::size_t>(indent), error_handler);
             s.dump(*this);
         }
         else
         {
-            serializer s(&string_adapter, indent_char,
+            serializer s(string_adapter, indent_char,
                          false, ensure_ascii, 0, error_handler);
             s.dump(*this);
         }
@@ -27481,7 +27481,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         // do the actual serialization
         detail::output_stream_adapter<char> stream_adapter(o);
-        serializer s(&stream_adapter, o.fill(),
+        serializer s(stream_adapter, o.fill(),
                      pretty_print, false, static_cast<std::size_t>(indentation));
         s.dump(j);
         return o;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -21410,7 +21410,8 @@ class serializer
 
   public:
     /*!
-    @param[in] s  output stream to serialize to
+    @param[in] s  output adapter to serialize to; not owned by the serializer,
+                  so it must outlive it (it lives at the call site)
     @param[in] ichar  indentation character to use
     @param[in] pretty_print_  whether the output shall be pretty-printed
     @param[in] ensure_ascii_ If @a ensure_ascii_ is true, all non-ASCII
@@ -21424,12 +21425,12 @@ class serializer
     being threaded through every call to @ref dump, @ref dump_internal and
     @ref dump_iteratively.
     */
-    serializer(output_adapter_t<char> s, const char ichar,
+    serializer(output_adapter_protocol<char>* s, const char ichar,
                const bool pretty_print_ = false,
                const bool ensure_ascii_ = false,
                const std::size_t indent_step_ = 0,
                error_handler_t error_handler_ = error_handler_t::strict)
-        : o(std::move(s))
+        : o(s)
         , locale(std::localeconv())
         , indent_char(ichar)
         , pretty_print(pretty_print_)
@@ -23026,8 +23027,8 @@ class serializer
         const char decimal_point;
     };
 
-    /// the output of the serializer
-    output_adapter_t<char> o = nullptr;
+    /// the output of the serializer (non-owning; the adapter lives at the call site)
+    output_adapter_protocol<char>* o = nullptr;
 
     /// a (hopefully) large enough character buffer
     std::array<char, 64> number_buffer{{}};
@@ -24738,16 +24739,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                   const error_handler_t error_handler = error_handler_t::strict) const
     {
         string_t result;
+        detail::output_string_adapter<char, string_t> string_adapter(result);
 
         if (indent >= 0)
         {
-            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+            serializer s(&string_adapter, indent_char,
                          true, ensure_ascii, static_cast<std::size_t>(indent), error_handler);
             s.dump(*this);
         }
         else
         {
-            serializer s(detail::output_adapter<char, string_t>(result), indent_char,
+            serializer s(&string_adapter, indent_char,
                          false, ensure_ascii, 0, error_handler);
             s.dump(*this);
         }
@@ -27478,7 +27480,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         o.width(0);
 
         // do the actual serialization
-        serializer s(detail::output_adapter<char>(o), o.fill(),
+        detail::output_stream_adapter<char> stream_adapter(o);
+        serializer s(&stream_adapter, o.fill(),
                      pretty_print, false, static_cast<std::size_t>(indentation));
         s.dump(j);
         return o;

--- a/tests/src/unit-convenience.cpp
+++ b/tests/src/unit-convenience.cpp
@@ -98,7 +98,8 @@ void check_escaped(const char* original, const char* escaped = "", bool ensure_a
 void check_escaped(const char* original, const char* escaped, const bool ensure_ascii)
 {
     std::stringstream ss;
-    json::serializer s(nlohmann::detail::output_adapter<char>(ss), ' ', false, ensure_ascii);
+    nlohmann::detail::output_stream_adapter<char> adapter(ss);
+    json::serializer s(&adapter, ' ', false, ensure_ascii);
     s.dump_escaped(original);
     s.flush(); // dump_escaped writes into the serializer's internal buffer
     CHECK(ss.str() == escaped);

--- a/tests/src/unit-convenience.cpp
+++ b/tests/src/unit-convenience.cpp
@@ -99,7 +99,7 @@ void check_escaped(const char* original, const char* escaped, const bool ensure_
 {
     std::stringstream ss;
     nlohmann::detail::output_stream_adapter<char> adapter(ss);
-    json::serializer s(&adapter, ' ', false, ensure_ascii);
+    json::serializer s(adapter, ' ', false, ensure_ascii);
     s.dump_escaped(original);
     s.flush(); // dump_escaped writes into the serializer's internal buffer
     CHECK(ss.str() == escaped);


### PR DESCRIPTION
## What & why

Follow-up to #5413, which flagged two per-call heap allocations in `dump()`. #5285 (the base of this PR) already removed the first — the eager 512-byte `indent_string`. This removes the second.

The serializer held its output sink as `output_adapter_t<char>`, i.e. `std::shared_ptr<output_adapter_protocol<char>>`, and both `dump()` and `operator<<` built it with `std::make_shared` — **one heap allocation (adapter object + control block) on every call**, for a sink that only wraps a reference to the caller's `string`/`ostream`.

This PR holds the sink as a **non-owning** `output_adapter_protocol<char>*` and constructs the concrete adapter on the stack at the call site instead. The write path is unchanged — `o->write_characters(...)` still runs exactly as before — so this is purely about where the adapter lives, not how output is produced.

## Stack

```
develop
└─ claude/parser-performance-research-4hkdf8    (#5283)
   └─ claude/dump-function-performance-hcj2bl   (#5285)  ← base of this PR
      └─ claude/dump-adapter-devirt             (this PR)
         └─ claude/benchmark-indented-parse     (#5456)
            └─ claude/callback-parse-quadratic  (#5457)
               └─ claude/dom-handler-moves      (#5458)
```

Stacked on #5285 because it builds directly on that PR's serializer rewrite (the write buffer already makes the remaining `o->write_characters` calls rare, so removing the `shared_ptr` finishes the job cleanly). Once #5285 lands on `develop`, this retargets to `develop` unchanged.

## The change (3 files, +19/−13)

- `serializer`: ctor takes `output_adapter_protocol<char>*` and the member `o` becomes a non-owning raw pointer instead of an owning `shared_ptr`.
- `dump()`: constructs `output_string_adapter<char, string_t>` on the stack, passes its address (the adapter outlives the serializer — both are locals, adapter declared first).
- `operator<<`: same, with `output_stream_adapter<char>`.

The serializer stays `serializer<basic_json>` — no new template parameter, so the `friend`/alias declarations are untouched. Lifetime is safe because `serializer`'s copy/move are already `= delete`d and it never outlives its constructing scope.

## Effect

A compact `dump()` of a small object drops from **2 heap allocations to 1** (only the returned string remains), ~3% faster on that workload; larger dumps are unaffected. On `develop` (before this branch) the same call did 4 allocations, so the branch as a whole takes it 4 → 1.

## Verification

- **Byte-for-byte identical output** across 854 combinations — 13 curated values (null/bool/ints/float/strings with escapes/multibyte/binary/empty & deeply-nested/wide containers) × 5 indents × 2 indent chars × 2 `ensure_ascii` × 3 error handlers, plus the `operator<<` path — FNV-1a digest matches the pre-change base exactly, for both the modular headers and `single_include`.
- Allocation count measured via a global `operator new` counter (2 → 1).
- Compiles clean at C++11 / C++17 / C++20, `-O2`.
- `single_include` updated to match (the diff is exactly the four hunks above).

### Public API impact

**No breaking changes to the documented public API.** `dump()` and `operator<<` keep their signatures and their behavior, and the output is byte-for-byte identical.

One internal signature changes, in `nlohmann::detail`, so it only affects code that constructs the serializer itself:

- `detail::serializer`'s constructor takes `output_adapter_protocol<char>&` (non-owning) instead of `output_adapter_t<char>` (an owning `std::shared_ptr`), and the member `o` becomes a raw pointer.
- Ownership moves to the caller: the adapter must now outlive the serializer. At both call sites they are locals with the adapter declared first, and `serializer`'s copy and move are already `= delete`d, so it cannot escape its constructing scope.

This is source- **and** ABI-breaking for anyone who instantiated `detail::serializer` directly — an undocumented internal type, but one a precompiled wrapper could name. It is the same caveat class as the `detail::input_adapter()` return-type change documented in #5283.

---

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced. _(#5413)_
- [ ] The code coverage remained at 100%. _(pure refactor of already-covered lines; no new branches — behavior is exercised by the existing serialization tests, confirmed byte-identical)_
- [x] If applicable, the documentation is updated. _(no public API or option changes)_
- [x] The source code is amalgamated. _(`single_include` updated; the four hunks are applied identically to the amalgamated header)_


---
_Generated by [Claude Code](https://claude.ai/code)_

