### PR TITLE
Move the scanned string into the value instead of copying it

### DIFF
--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -222,7 +222,9 @@ class json_sax_dom_parser
 
     bool string(string_t& val)
     {
-        handle_value(val);
+        // the interface allows moving the value (see json_sax::string), which
+        // hands the lexer's buffer to the new value instead of copying it
+        handle_value(std::move(val));
         return true;
     }
 
@@ -532,7 +534,8 @@ class json_sax_dom_callback_parser
 
     bool string(string_t& val)
     {
-        handle_value(val);
+        // see json_sax_dom_parser::string()
+        handle_value(std::move(val));
         return true;
     }
 

--- a/include/nlohmann/detail/input/json_sax.hpp
+++ b/include/nlohmann/detail/input/json_sax.hpp
@@ -222,14 +222,16 @@ class json_sax_dom_parser
 
     bool string(string_t& val)
     {
-        // the interface allows moving the value (see json_sax::string), which
-        // hands the lexer's buffer to the new value instead of copying it
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }
 
     bool binary(binary_t& val)
     {
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }
@@ -534,13 +536,16 @@ class json_sax_dom_callback_parser
 
     bool string(string_t& val)
     {
-        // see json_sax_dom_parser::string()
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }
 
     bool binary(binary_t& val)
     {
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10935,7 +10935,9 @@ class json_sax_dom_parser
 
     bool string(string_t& val)
     {
-        handle_value(val);
+        // the interface allows moving the value (see json_sax::string), which
+        // hands the lexer's buffer to the new value instead of copying it
+        handle_value(std::move(val));
         return true;
     }
 
@@ -11245,7 +11247,8 @@ class json_sax_dom_callback_parser
 
     bool string(string_t& val)
     {
-        handle_value(val);
+        // see json_sax_dom_parser::string()
+        handle_value(std::move(val));
         return true;
     }
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -10935,14 +10935,16 @@ class json_sax_dom_parser
 
     bool string(string_t& val)
     {
-        // the interface allows moving the value (see json_sax::string), which
-        // hands the lexer's buffer to the new value instead of copying it
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }
 
     bool binary(binary_t& val)
     {
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }
@@ -11247,13 +11249,16 @@ class json_sax_dom_callback_parser
 
     bool string(string_t& val)
     {
-        // see json_sax_dom_parser::string()
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }
 
     bool binary(binary_t& val)
     {
+        // json_sax documents that the passed value may be moved from,
+        // so hand the buffer over instead of copying it
         handle_value(std::move(val));
         return true;
     }


### PR DESCRIPTION
The SAX interface documents that the string handed to `json_sax::string()` may be moved from:

## Stack

```
develop
└─ claude/parser-performance-research-4hkdf8    (#5283)
   └─ claude/dump-function-performance-hcj2bl   (#5285)
      └─ claude/dump-adapter-devirt             (#5449)
         └─ claude/benchmark-indented-parse     (#5456)
            └─ claude/callback-parse-quadratic  (#5457)  ← base of this PR
               └─ claude/dom-handler-moves      (this PR)
```

```cpp
/*!
@brief a string value was read
@param[in] val  string value
...
@note It is safe to move the passed string value.
*/
virtual bool string(string_t& val) = 0;
```

and the DOM handlers already move the one handed to `binary()`. `string()` did not:

```cpp
bool string(string_t& val)
{
    handle_value(val);          // lvalue -> copy-constructed into the DOM
    return true;
}

bool binary(binary_t& val)
{
    handle_value(std::move(val));
    return true;
}
```

so every string value was copy-constructed out of the lexer's token buffer. Moving hands that buffer to the new value instead. The allocation count is unchanged — the value needed one either way — but the copy is gone.

| | before | after | |
|---|---|---|---|
| `jeopardy` | 247.3 ms | 240.9 ms | −2.6% |
| `citm_catalog` | 4.61 ms | 4.48 ms | −2.8% |
| 40k × 30-char strings | 7.80 ms | 7.64 ms | −2.1% |

Applied to both `json_sax_dom_parser` and `json_sax_dom_callback_parser`.

### Why the object key is deliberately *not* moved

The obvious companion change — moving the key in `key()` — is a pessimization, and this PR does not make it.

The lexer reuses one `token_buffer` for every token, so it is sized for the largest token seen so far. Keys are usually short and values long. Moving the key hands that large buffer to a short key, leaving the buffer empty, so the next value has to grow a fresh one. Measured on a document of many small keys with longer values, that costs **+11.9%**. Moving only the value has the buffer follow the token it is actually sized for.

| variant | `jeopardy` | `citm_catalog` | 40k strings |
|---|---|---|---|
| move value only | −2.6% | −2.8% | **−2.1%** |
| move key only | +1.8% | −3.5% | **+11.9%** |

### Correctness

- Full suite passes at C++11 and C++17.
- A 717-file corpus (including the 188 must-fail cases of `nst_json_testsuite2`) yields identical values *and* identical error messages on both the contiguous and the streaming adapter.
- 48 000 randomized callback parses are unchanged.

### Public API impact

**No breaking changes.** No public signature changes. `json_sax::string()` already took `string_t&` by non-const reference and already documented that moving from it is safe, so a user-supplied SAX handler is unaffected — this changes only what the library's own DOM handlers do with the value they are given.

One consequence worth stating: after `string()` returns, the lexer's token buffer is empty rather than holding the token. Nothing in the library reads it there — the string case of `JSON_DIAGNOSTIC_POSITIONS` uses the recorded token start offset, and the number case, which does read `get_string().size()`, never moves.

---
*This pull request was prepared by Claude Code.*

