### PR TITLE
Make diff() linear when an array shrinks

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -5128,19 +5128,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 // We now reached the end of at least one array
                 // in a second pass, traverse the remaining elements
 
-                // remove my remaining elements
-                const auto end_index = static_cast<difference_type>(result.size());
-                while (i < source.size())
+                // remove my remaining elements, highest index first; appending
+                // in that order avoids the quadratic reinsertion done before
+                for (std::size_t j = source.size(); j > i; --j)
                 {
-                    // add operations in reverse order to avoid invalid
-                    // indices
-                    result.insert(result.begin() + end_index, object(
+                    result.push_back(object(
                     {
                         {"op", "remove"},
-                        {"path", detail::concat<string_t>(path, '/', detail::to_string<string_t>(i))}
+                        {"path", detail::concat<string_t>(path, '/', detail::to_string<string_t>(j - 1))}
                     }));
-                    ++i;
                 }
+                i = source.size();
 
                 // add other remaining elements
                 while (i < target.size())

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -26482,19 +26482,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 // We now reached the end of at least one array
                 // in a second pass, traverse the remaining elements
 
-                // remove my remaining elements
-                const auto end_index = static_cast<difference_type>(result.size());
-                while (i < source.size())
+                // remove my remaining elements, highest index first; appending
+                // in that order avoids the quadratic reinsertion done before
+                for (std::size_t j = source.size(); j > i; --j)
                 {
-                    // add operations in reverse order to avoid invalid
-                    // indices
-                    result.insert(result.begin() + end_index, object(
+                    result.push_back(object(
                     {
                         {"op", "remove"},
-                        {"path", detail::concat<string_t>(path, '/', detail::to_string<string_t>(i))}
+                        {"path", detail::concat<string_t>(path, '/', detail::to_string<string_t>(j - 1))}
                     }));
-                    ++i;
                 }
+                i = source.size();
 
                 // add other remaining elements
                 while (i < target.size())

--- a/tests/src/unit-json_patch.cpp
+++ b/tests/src/unit-json_patch.cpp
@@ -1388,3 +1388,84 @@ TEST_CASE("JSON patch - add to a primitive parent (regression #4292)")
         CHECK_THROWS_AS(doc.patch(patch), json::out_of_range&);
     }
 }
+
+TEST_CASE("JSON patch - diff emits array removals in descending index order")
+{
+    SECTION("array shrunk to empty")
+    {
+        json const source = {0, 1, 2, 3, 4};
+        json const target = json::array();
+
+        json const patch = json::diff(source, target);
+
+        json const expected = R"(
+            [
+                {"op": "remove", "path": "/4"},
+                {"op": "remove", "path": "/3"},
+                {"op": "remove", "path": "/2"},
+                {"op": "remove", "path": "/1"},
+                {"op": "remove", "path": "/0"}
+            ]
+        )"_json;
+
+        CHECK(patch == expected);
+        CHECK(source.patch(patch) == target);
+    }
+
+    SECTION("array partially shrunk, after a replacement at a common index")
+    {
+        json const source = {0, 1, 2, 3, 4};
+        json const target = {0, 9};
+
+        json const patch = json::diff(source, target);
+
+        // the replacement comes first, then the removals, highest index first
+        json const expected = R"(
+            [
+                {"op": "replace", "path": "/1", "value": 9},
+                {"op": "remove", "path": "/4"},
+                {"op": "remove", "path": "/3"},
+                {"op": "remove", "path": "/2"}
+            ]
+        )"_json;
+
+        CHECK(patch == expected);
+        CHECK(source.patch(patch) == target);
+    }
+
+    SECTION("nested array shrunk")
+    {
+        json const source = {{"a", {0, 1, 2}}};
+        json const target = {{"a", json::array()}};
+
+        json const patch = json::diff(source, target);
+
+        json const expected = R"(
+            [
+                {"op": "remove", "path": "/a/2"},
+                {"op": "remove", "path": "/a/1"},
+                {"op": "remove", "path": "/a/0"}
+            ]
+        )"_json;
+
+        CHECK(patch == expected);
+        CHECK(source.patch(patch) == target);
+    }
+
+    SECTION("many removals still round-trip")
+    {
+        json source = json::array();
+        for (int i = 0; i < 1000; ++i)
+        {
+            source.push_back(i);
+        }
+        json const target = json::array();
+
+        json const patch = json::diff(source, target);
+
+        CHECK(patch.size() == 1000);
+        CHECK(patch.front().at("path") == "/999");
+        CHECK(patch.back().at("path") == "/0");
+        CHECK(source.patch(patch) == target);
+    }
+}


### PR DESCRIPTION
Closes #5460.

`basic_json::diff()` is documented as linear in the lengths of `source` and `target`, but when the
source array is longer than the target it is quadratic in the number of removed elements.

The trailing `remove` operations must be emitted highest index first, and that ordering was
produced by inserting each one at the same position in the result array. Every insert shifts all
the operations already emitted at that position, so emitting *k* removals costs O(k²) moves of
`basic_json` values.

This appends them in descending index order instead. The `add` branch that follows only runs when
the target is longer, so the two loops are mutually exclusive and appending lands at exactly the
position the inserts targeted. **The emitted patch is unchanged.**

### Effect

Apple clang 17, `-O2`, macOS arm64, `diff(array_of_n, json::array())`:

| n | before | after |
|---|---|---|
| 8,000 | 211 ms | 5.4 ms |
| 16,000 | 849 ms | 7.7 ms |
| 32,000 | 3,325 ms | 12.5 ms |
| 64,000 | 13,356 ms | 25.4 ms |

An array of 20,000 small objects with half of them deleted goes from 312 ms to 6.8 ms. Growing and
element-wise diffs were already linear and are untouched.

### Verifying that the output does not change

- 50,000 random source/target pairs (nulls, booleans, numbers, strings, nested arrays and objects,
  keys containing `/` and `~`): the dumped patch is **byte-identical** before and after, and
  `source.patch(diff(source, target)) == target` holds in both.
- The [json-patch-tests](https://github.com/json-patch/json-patch-tests) suite still passes 108/108.
- The existing unit tests are unchanged.

### Tests

`tests/src/unit-json_patch.cpp` gains a test case pinning the order and content of the emitted
removals: an array shrunk to empty, a partial shrink following a replacement at a common index, a
nested array, and a 1,000 element shrink that must still round-trip.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The code coverage remained at 100%. A test case for every new line of code.
- [ ] If applicable, the documentation is updated. (No change: the documented complexity is what
      this restores.)
- [x] The source code is amalgamated.
