### PR TITLE
Add JSON_HEDLEY_WARN_UNUSED_RESULT to the current accept() overloads

### DIFF
--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -4130,6 +4130,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief check if the input is valid JSON
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(InputType&& i,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)
@@ -4141,6 +4142,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename IteratorType, typename SentinelType = IteratorType,
              detail::enable_if_t<detail::can_compare_ne<IteratorType, SentinelType>::value, int> = 0>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(IteratorType first, SentinelType last,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -25684,6 +25684,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief check if the input is valid JSON
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(InputType&& i,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)
@@ -25695,6 +25696,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/accept/
     template<typename IteratorType, typename SentinelType = IteratorType,
              detail::enable_if_t<detail::can_compare_ne<IteratorType, SentinelType>::value, int> = 0>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
     static bool accept(IteratorType first, SentinelType last,
                        const bool ignore_comments = false,
                        const bool ignore_trailing_commas = false)


### PR DESCRIPTION
## Summary

`accept()` is a pure query: its only effect is the returned `bool` telling the caller whether the input is valid JSON, so discarding that result is always a bug. Both `parse()` overloads and the **deprecated** `accept(detail::span_input_adapter&&, ...)` overload are already annotated with `JSON_HEDLEY_WARN_UNUSED_RESULT`, but the two **current, recommended** `accept()` overloads were missing it — an internal inconsistency rather than a deliberate policy difference.

This PR adds `JSON_HEDLEY_WARN_UNUSED_RESULT` to:
- `static bool accept(InputType&& i, ...)`
- `static bool accept(IteratorType first, SentinelType last, ...)`

matching the exact style/placement already used on the adjacent `parse()` overloads.

Fixes #5407

## Validation

- Compiled a minimal reproducer (`json::accept("[1,2,3]");` with the result discarded) with `-Wunused-result` before and after the change: before, no diagnostic was produced; after, the compiler emits `warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]`.
- Ran the existing test files that exercise `accept()` (`unit-class_parser.cpp`, `unit-deserialization.cpp`) by compiling them directly against `include/` — all assertions pass, and there are no build failures caused by the new annotation.
- No dedicated "annotations present" test file exists in `tests/src` (searched for `WARN_UNUSED_RESULT`/`nodiscard`), so no new test file was introduced, per the repo's existing test conventions.
- Ran `make amalgamate` and committed the resulting changes to `single_include/nlohmann/json.hpp`.

## Breaking change?

No breaking changes. This adds a diagnostic-only annotation (`JSON_HEDLEY_WARN_UNUSED_RESULT`, which expands to `[[nodiscard]]`-equivalent behavior where supported, and to nothing otherwise). It does not change any function signature, behavior, or ABI. Code that currently discards the result of `accept()` under `-Werror` may newly fail to compile; this is the intended fix.

— opened by Claude Code on behalf of @nlohmann