### PR TITLE
Fix to_bjdata() emitting the Draft-3-only 'B' marker in default Draft-2 mode

### DIFF
--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -1691,6 +1691,16 @@ class binary_writer
         }
         CharType dtype = it->second;
 
+        // the 'B' (byte) marker is only defined by BJData Draft 3; emitting it
+        // under the default Draft 2 mode would produce a stream that Draft 2
+        // readers reject, so such an object falls back to a plain object
+        // encoding instead (see the "Binary values" section of the BJData
+        // documentation)
+        if (dtype == 'B' && bjdata_version != bjdata_version_t::draft3)
+        {
+            return true;
+        }
+
         key = "_ArraySize_";
         // the dimensions are written verbatim as the header length below, so a
         // value that is not an array cannot produce a valid one: null emits 'Z'

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20226,6 +20226,16 @@ class binary_writer
         }
         CharType dtype = it->second;
 
+        // the 'B' (byte) marker is only defined by BJData Draft 3; emitting it
+        // under the default Draft 2 mode would produce a stream that Draft 2
+        // readers reject, so such an object falls back to a plain object
+        // encoding instead (see the "Binary values" section of the BJData
+        // documentation)
+        if (dtype == 'B' && bjdata_version != bjdata_version_t::draft3)
+        {
+            return true;
+        }
+
         key = "_ArraySize_";
         // the dimensions are written verbatim as the header length below, so a
         // value that is not an array cannot produce a valid one: null emits 'Z'

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -2586,7 +2586,12 @@ TEST_CASE("BJData")
                 CHECK(json::to_bjdata(json::from_bjdata(v_d), true, true) == v_d);
                 CHECK(json::to_bjdata(json::from_bjdata(v_D), true, true) == v_D);
                 CHECK(json::to_bjdata(json::from_bjdata(v_C), true, true) == v_C);
-                CHECK(json::to_bjdata(json::from_bjdata(v_B), true, true) == v_B);
+                // v_B uses the Draft-3-only 'B' marker, so it round-trips only when
+                // Draft 3 is explicitly selected (see GitHub issue #5404); the
+                // default Draft 2 falls back to a plain object instead, covered by
+                // the "ndarray with _ArrayType_ "byte" is gated by the BJData draft
+                // version" section below
+                CHECK(json::to_bjdata(json::from_bjdata(v_B), true, true, json::bjdata_version_t::draft3) == v_B);
             }
 
             SECTION("ndarray with data not matching _ArrayType_ is written as an object")
@@ -2629,8 +2634,10 @@ TEST_CASE("BJData")
                 // the C++ API stores an int literal as number_integer, so _ArrayType_
                 // names the wire type rather than the storage. Both storages have to
                 // produce the same typed array for every type.
+                // "byte" is checked separately below since it additionally requires
+                // BJData Draft 3 to be selected explicitly (see GitHub issue #5404).
                 for (const char* type :
-                        {"uint8", "int8", "uint16", "int16", "uint32", "int32", "uint64", "int64", "char", "byte"
+                        {"uint8", "int8", "uint16", "int16", "uint32", "int32", "uint64", "int64", "char"
                         })
                 {
                     CAPTURE(type);
@@ -2639,6 +2646,14 @@ TEST_CASE("BJData")
                     const auto from_text = json::to_bjdata(json::parse(text));
                     CHECK(from_text.at(0) == '[');
                     CHECK(from_text == json::to_bjdata(json({{"_ArrayType_", type}, {"_ArraySize_", {2, 3}}, {"_ArrayData_", {1, 2, 3, 4, 5, 6}}})));
+                }
+
+                {
+                    const std::string text = R"({"_ArrayType_":"byte","_ArraySize_":[2,3],"_ArrayData_":[1,2,3,4,5,6]})";
+                    const auto from_text = json::to_bjdata(json::parse(text), true, true, json::bjdata_version_t::draft3);
+                    CHECK(from_text.at(0) == '[');
+                    CHECK(from_text == json::to_bjdata(json({{"_ArrayType_", "byte"}, {"_ArraySize_", {2, 3}}, {"_ArrayData_", {1, 2, 3, 4, 5, 6}}}),
+                    true, true, json::bjdata_version_t::draft3));
                 }
 
                 // negative values under a signed type behave the same way
@@ -2822,6 +2837,36 @@ TEST_CASE("BJData")
                 const auto out_single_ok = json::to_bjdata(j_single_ok);
                 CHECK(out_single_ok.at(0) == '[');
                 CHECK(json::from_bjdata(out_single_ok) == json({1.5f}));
+            }
+
+            SECTION("ndarray with _ArrayType_ \"byte\" is gated by the BJData draft version")
+            {
+                // the 'B' (byte) marker used by _ArrayType_ "byte" is only defined
+                // by BJData Draft 3; Draft 2 (the default) has no such marker, so
+                // emitting it unconditionally produced a stream that a Draft 2
+                // reader could not parse as intended (see GitHub issue #5404).
+                // Two dimensions are used so that a successfully written ndarray
+                // round-trips back into the annotated object (a single dimension
+                // is, by the BJData ndarray convention, read back as a plain
+                // binary value rather than the annotated object, same as every
+                // other single-dimension ndarray of a non-"byte" type is read
+                // back as a plain array instead of the annotated object).
+                json const j_byte = json({{"_ArrayType_", "byte"}, {"_ArraySize_", {2, 3}}, {"_ArrayData_", {1, 2, 3, 4, 5, 6}}});
+
+                // default (Draft 2): falls back to a plain object and round-trips
+                const auto out_draft2 = json::to_bjdata(j_byte);
+                CHECK(out_draft2.at(0) == '{');
+                CHECK(json::from_bjdata(out_draft2) == j_byte);
+
+                // explicit Draft 2: same as the default
+                const auto out_draft2_explicit = json::to_bjdata(j_byte, true, true, json::bjdata_version_t::draft2);
+                CHECK(out_draft2_explicit.at(0) == '{');
+                CHECK(json::from_bjdata(out_draft2_explicit) == j_byte);
+
+                // Draft 3 explicitly selected: still uses the compact 'B' ndarray encoding
+                const auto out_draft3 = json::to_bjdata(j_byte, true, true, json::bjdata_version_t::draft3);
+                CHECK(out_draft3 == std::vector<uint8_t>({'[', '$', 'B', '#', '[', '$', 'i', '#', 'i', 2, 2, 3, 1, 2, 3, 4, 5, 6}));
+                CHECK(json::from_bjdata(out_draft3) == j_byte);
             }
         }
     }


### PR DESCRIPTION
## Stacked PR

This PR is stacked on top of #5473 (fix for #5403) and is based on its branch `issue-5403-bjdata-uint-range` rather than `develop`. It should be reviewed and merged after that PR.

## Summary

In the same BJData ndarray writer touched by #5473, `_ArrayType_ = "byte"` mapped unconditionally to the BJData type marker `'B'`, regardless of the `bjdata_version` requested for `to_bjdata()`. But `'B'` is defined only by [BJData Draft 3][BJDataBinArr]; the docs (`docs/mkdocs/docs/features/binary_formats/bjdata.md`, "Binary values") say the Draft 3 optimized binary array "must be explicitly enabled using the `version` parameter of `to_bjdata`".

With the default `version = draft2`, this produced a stream containing a marker that Draft 2 does not define and, unlike every other `_ArrayType_`, the value round-tripped back through `from_bjdata` as a **binary** value instead of the original annotated object — because a `'B'`-typed optimized array without the ndarray flag is otherwise the library's own encoding for binary data.

[BJDataBinArr]: https://github.com/NeuroJSON/bjdata/blob/master/Binary_JData_Specification.md#optimized-binary-array

```cpp
json j;
j["_ArrayType_"] = "byte";
j["_ArraySize_"] = json::array({2});
j["_ArrayData_"] = json::array({1, 2});
auto v = json::to_bjdata(j);  // default draft2 — used to emit the 'B' marker anyway
// from_bjdata(v) used to give a binary value, not the original object
```

## Fix

`write_bjdata_ndarray` now checks `bjdata_version` right after resolving `dtype` from `_ArrayType_`: if `dtype == 'B'` and `bjdata_version` is not `draft3`, it falls back to the same plain-object encoding already used by this function for other invalid-annotation cases (the same mechanism added/reused in #5473). Draft 3 explicitly selected keeps emitting the compact `'B'` ndarray encoding exactly as before.

## Tests

- Updated the existing round-trip check for `v_B` in the `"optimized ndarray (type and vector-size ndarray with JData annotations)"` section to pass `bjdata_version_t::draft3` explicitly, since `v_B` uses the Draft-3-only `'B'` marker.
- Split `"byte"` out of the generic type loop in `"ndarray parsed from text is written as a typed array"` into its own check that explicitly selects Draft 3.
- Added a new section, `"ndarray with _ArrayType_ "byte" is gated by the BJData draft version"`, covering:
  - default (Draft 2) falls back to a plain object and round-trips
  - explicit Draft 2 behaves the same as the default
  - explicit Draft 3 still uses the compact `'B'` ndarray encoding, with an exact expected byte sequence, and round-trips correctly

Ran the full `unit-bjdata` suite offline (compiled against `include/` with a stub `test_data.hpp`): 693941/693942 assertions pass; the one failure and the one skipped test case are pre-existing and unrelated (they require downloaded test data, unavailable in this offline setup) — identical to the baseline on `develop`. Also ran `unit-ubjson`, `unit-binary_formats`, and `unit-regression2` offline with no new failures.

## Breaking change?

No breaking changes to the public API. This changes only the wire output of `to_bjdata()` for annotated objects with `_ArrayType_ = "byte"` under the default (Draft 2) mode: such objects now serialize as plain objects (matching every other invalid-for-the-current-mode annotation already handled by this function) instead of emitting a Draft-3-only marker that Draft 2 readers do not define. Draft 3 output is unchanged.

Fixes #5404.

— opened by Claude Code on behalf of @nlohmann