### PR TITLE
Make serializer's indent_string lazily allocated

### DIFF
--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -71,7 +71,7 @@ class serializer
         , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
         , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
-        , indent_string(512, indent_char)
+        , indent_string()
         , error_handler(error_handler_)
     {}
 
@@ -126,6 +126,10 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.empty()))
+                    {
+                        indent_string.resize(512, indent_char);
+                    }
                     if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
@@ -199,6 +203,10 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.empty()))
+                    {
+                        indent_string.resize(512, indent_char);
+                    }
                     if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
@@ -260,6 +268,10 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.empty()))
+                    {
+                        indent_string.resize(512, indent_char);
+                    }
                     if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
@@ -1010,7 +1022,7 @@ class serializer
 
     /// the indentation character
     const char indent_char;
-    /// the indentation string
+    /// the indentation string (lazily allocated on first use by a pretty-print branch)
     string_t indent_string;
 
     /// error_handler how to react on decoding errors

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -20150,7 +20150,7 @@ class serializer
         , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
         , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
         , indent_char(ichar)
-        , indent_string(512, indent_char)
+        , indent_string()
         , error_handler(error_handler_)
     {}
 
@@ -20205,6 +20205,10 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.empty()))
+                    {
+                        indent_string.resize(512, indent_char);
+                    }
                     if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
@@ -20278,6 +20282,10 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.empty()))
+                    {
+                        indent_string.resize(512, indent_char);
+                    }
                     if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
@@ -20339,6 +20347,10 @@ class serializer
 
                     // variable to hold indentation for recursive calls
                     const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.empty()))
+                    {
+                        indent_string.resize(512, indent_char);
+                    }
                     if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
                     {
                         indent_string.resize(indent_string.size() * 2, ' ');
@@ -21089,7 +21101,7 @@ class serializer
 
     /// the indentation character
     const char indent_char;
-    /// the indentation string
+    /// the indentation string (lazily allocated on first use by a pretty-print branch)
     string_t indent_string;
 
     /// error_handler how to react on decoding errors

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -14,6 +14,40 @@ using nlohmann::json;
 #include <array>
 #include <sstream>
 #include <iomanip>
+#include <cstdlib>
+#include <new>
+
+namespace
+{
+// heap allocation counter used by the regression test for issue #5413
+// (https://github.com/nlohmann/json/issues/5413); disabled (and thus a
+// no-op besides the counting) unless explicitly toggled on
+bool count_heap_allocations = false; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+std::size_t heap_allocations = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+} // namespace
+
+void* operator new (std::size_t size) // NOLINT(cppcoreguidelines-owning-memory,misc-new-delete-overloads)
+{
+    if (count_heap_allocations)
+    {
+        ++heap_allocations;
+    }
+    if (void* ptr = std::malloc(size)) // NOLINT(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    {
+        return ptr;
+    }
+    throw std::bad_alloc(); // NOLINT(hicpp-exception-baseclass)
+}
+
+void operator delete (void* ptr) noexcept // NOLINT(cppcoreguidelines-owning-memory,misc-new-delete-overloads)
+{
+    std::free(ptr); // NOLINT(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+}
+
+void operator delete (void* ptr, std::size_t /*size*/) noexcept // NOLINT(cppcoreguidelines-owning-memory,misc-new-delete-overloads)
+{
+    std::free(ptr); // NOLINT(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+}
 
 TEST_CASE("serialization")
 {
@@ -380,5 +414,78 @@ TEST_CASE("dump for basic_json with long double number_float_t")
         check_same(-2.25L, -2.25);
         check_same(1.0L,    1.0);
         check_same(100.0L,  100.0);
+    }
+}
+
+TEST_CASE("regression test for issue #5413 - lazily allocated indent_string")
+{
+    // the serializer used to unconditionally allocate a 512-byte
+    // indent_string in its constructor, even though it is only ever read
+    // inside the pretty_print branches of dump(). This wasted a heap
+    // allocation (and its matching deallocation) on every single compact
+    // (i.e. non-pretty, the default) dump() call. indent_string is now
+    // allocated lazily, the first time a pretty-print branch actually
+    // needs it -- so a compact dump() must perform strictly fewer heap
+    // allocations than a pretty dump() of the same value.
+    const json j = {{"level", "info"}, {"msg", "hello world"}, {"id", 12345}};
+
+    // warm up anything unrelated to indentation (e.g., one-time locale
+    // lookups) that might otherwise allocate on first use regardless of
+    // pretty-printing, so it does not skew the counts measured below
+    const auto warmup = j.dump();
+    const auto warmup_pretty = j.dump(4);
+    CHECK(!warmup.empty());
+    CHECK(!warmup_pretty.empty());
+
+    SECTION("compact dump() has a stable, minimal allocation count")
+    {
+        count_heap_allocations = true;
+
+        heap_allocations = 0;
+        const auto compact1 = j.dump();
+        const auto allocs_compact1 = heap_allocations;
+
+        heap_allocations = 0;
+        const auto compact2 = j.dump(-1);
+        const auto allocs_compact2 = heap_allocations;
+
+        count_heap_allocations = false;
+
+        CHECK(compact1 == compact2);
+        // dump() and dump(-1) both take the compact code path and must
+        // never touch indent_string, so they allocate identically often
+        CHECK(allocs_compact1 == allocs_compact2);
+    }
+
+    SECTION("first pretty dump() allocates more than a compact dump()")
+    {
+        // use a tiny value whose compact ({"a":1}, 7 bytes) and pretty
+        // ({"a": 1} with 1-space indent, 11 bytes) serializations both stay
+        // well inside every common std::string small-string-optimization
+        // buffer (>= 15 bytes on libstdc++/MSVC STL, >= 22 on libc++), so
+        // building the result string itself causes no heap allocation
+        // either way -- isolating indent_string as the only thing that can
+        // possibly account for a difference in allocation count
+        const json tiny = {{"a", 1}};
+
+        count_heap_allocations = true;
+
+        heap_allocations = 0;
+        const auto compact = tiny.dump();
+        const auto allocs_compact = heap_allocations;
+
+        heap_allocations = 0;
+        const auto pretty = tiny.dump(1);
+        const auto allocs_pretty = heap_allocations;
+
+        count_heap_allocations = false;
+
+        CHECK(compact == "{\"a\":1}");
+        CHECK(pretty == "{\n \"a\": 1\n}");
+        // a fresh serializer is created per dump() call; the pretty branch
+        // lazily allocates indent_string on its first use, so it must
+        // allocate at least once more than the compact branch, which never
+        // touches indent_string at all
+        CHECK(allocs_pretty > allocs_compact);
     }
 }


### PR DESCRIPTION
## Summary

`dump()` performs an avoidable per-call heap allocation for `indent_string`. The `serializer` constructor unconditionally allocated a 512-byte `indent_string`, even though it is only ever read inside the `pretty_print` branches of `dump()`. This wastes a heap allocation (and its matching deallocation) on every compact (i.e. default, `indent = -1`) `dump()` call — the most common case (logging, per-record serialization, `dump()` in a loop).

`indent_string` is now default-constructed empty (no allocation) and lazily grown to 512 bytes, filled with `indent_char`, the first time a pretty-print branch actually needs it. The existing doubling/growth logic for indents deeper than 512 characters is otherwise untouched, so output remains byte-identical to before the change — including in the pre-existing edge case where growth beyond the initial buffer fills with `' '` instead of `indent_char` for large/tab indents (this is a separate, already-tracked correctness bug; see "Out of scope" below).

Fixes #5413

## Out of scope (intentional)

Issue #5413 describes **two** avoidable allocations in `dump()`. This PR addresses only the first (`indent_string`), per the issue's own recommendation:

- **`shared_ptr`-based output adapter**: left untouched. Devirtualizing/removing the per-call `make_shared` for the output adapter overlaps the open, unmerged PR #5285 ("Speed up dump()..."), and the issue explicitly says this "should be coordinated with that PR rather than done independently."
- **Fill-character bug for large/tab indents**: the growth logic's use of `' '` instead of `indent_char` when doubling past the initial buffer is a known, separate correctness bug tracked by open PR #5186 ("Fix indentation overflow and correctness bug"). This PR deliberately preserves that existing (buggy) behavior bit-for-bit rather than fixing it, to avoid conflicting with or duplicating #5186's work.

## Breaking change?

**No.** This is an internal, behavior-preserving change to `detail::serializer` — a private implementation detail not exposed in the public API. Output of `dump()` is unchanged for all indentation values.

## Testing

- Added a regression test in `tests/src/unit-serialization.cpp` (`"regression test for issue #5413 - lazily allocated indent_string"`) using an operator-new-counting technique (matching the approach from the issue's own benchmark) to verify:
  1. Compact `dump()` and `dump(-1)` allocate identically (i.e., consistently, without ever touching `indent_string`).
  2. A tiny value whose compact and pretty serializations both stay within every common std::string SSO buffer size — isolating `indent_string` as the only possible source of an allocation-count difference — shows a first pretty `dump()` allocates strictly more than a compact `dump()`, which is only true once `indent_string` is allocated lazily. This test fails against the pre-fix code (verified locally: `2 > 2` is false) and passes against the fix.
- Ran the existing pretty-print-heavy test files (`unit-serialization.cpp`, `unit-inspection.cpp` — which already has a test explicitly exercising the `>512`-byte growth/doubling path via `dump(1024)` — `unit-regression1.cpp`, `unit-regression2.cpp`, `unit-allocator.cpp`) unmodified, both before and after the change, offline via clang++ -std=c++11. All relevant assertions pass identically before and after (some pre-existing, unrelated failures occur in both cases due to missing downloaded external test-suite data, not related to this change).

— opened by Claude Code on behalf of @nlohmann