### PR TITLE
Make contains(json_pointer) return false instead of throwing on unrepresentable array-index tokens

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -748,6 +748,20 @@ class json_pointer
                         }
                     }
 
+                    // the reference token consists only of digits at this point (cf. checks
+                    // above); however, its numeric value might not be representable, in which
+                    // case array_index() would throw out_of_range.404/410 -- contains() must
+                    // not throw (see #5395), so such a reference token is treated as "not found"
+                    errno = 0; // strtoull() does not reset errno on success
+                    char* p_end = nullptr; // NOLINT(misc-const-correctness)
+                    const unsigned long long magnitude = std::strtoull(reference_token.c_str(), &p_end, 10); // NOLINT(runtime/int)
+                    if (JSON_HEDLEY_UNLIKELY(errno == ERANGE // the value exceeds ULLONG_MAX
+                                             || magnitude >= static_cast<unsigned long long>((std::numeric_limits<typename BasicJsonType::size_type>::max)()))) // NOLINT(runtime/int)
+                    {
+                        // the array index cannot be represented as size_type
+                        return false;
+                    }
+
                     const auto idx = array_index<BasicJsonType>(reference_token);
                     if (idx >= ptr->size())
                     {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16394,6 +16394,20 @@ class json_pointer
                         }
                     }
 
+                    // the reference token consists only of digits at this point (cf. checks
+                    // above); however, its numeric value might not be representable, in which
+                    // case array_index() would throw out_of_range.404/410 -- contains() must
+                    // not throw (see #5395), so such a reference token is treated as "not found"
+                    errno = 0; // strtoull() does not reset errno on success
+                    char* p_end = nullptr; // NOLINT(misc-const-correctness)
+                    const unsigned long long magnitude = std::strtoull(reference_token.c_str(), &p_end, 10); // NOLINT(runtime/int)
+                    if (JSON_HEDLEY_UNLIKELY(errno == ERANGE // the value exceeds ULLONG_MAX
+                                             || magnitude >= static_cast<unsigned long long>((std::numeric_limits<typename BasicJsonType::size_type>::max)()))) // NOLINT(runtime/int)
+                    {
+                        // the array index cannot be represented as size_type
+                        return false;
+                    }
+
                     const auto idx = array_index<BasicJsonType>(reference_token);
                     if (idx >= ptr->size())
                     {

--- a/tests/src/unit-json_pointer.cpp
+++ b/tests/src/unit-json_pointer.cpp
@@ -319,6 +319,44 @@ TEST_CASE("JSON pointers")
 
                 CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
                 CHECK_THROWS_WITH_AS(j_const[jp] == 1, throw_msg.c_str(), json::out_of_range&);
+
+                // #5395: contains() must not throw for a reference token that is a
+                // syntactically valid array index but numerically exceeds ULLONG_MAX
+                // (causing strtoull() to set errno to ERANGE) -- it should just report
+                // that the pointer does not resolve to an element
+                CHECK(!j.contains(jp));
+                CHECK(!j_const.contains(jp));
+            }
+
+            {
+                // #5395: same as above, but using the exact reproduction from the issue
+                json::json_pointer const jp("/99999999999999999999");
+                std::string const throw_msg = "[json.exception.out_of_range.404] unresolved reference token '99999999999999999999'";
+
+                CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const[jp] == 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j.at(jp) = 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const.at(jp) == 1, throw_msg.c_str(), json::out_of_range&);
+
+                CHECK(!j.contains(jp));
+                CHECK(!j_const.contains(jp));
+            }
+
+            {
+                // #5395: a reference token that is numerically representable in
+                // unsigned long long but exceeds size_type's max (e.g. ULLONG_MAX
+                // itself on typical 64-bit platforms, where size_type's max equals
+                // ULLONG_MAX) must not make contains() throw either
+                json::json_pointer const jp("/18446744073709551615");
+                std::string const throw_msg = "[json.exception.out_of_range.410] array index 18446744073709551615 exceeds size_type";
+
+                CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const[jp] == 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j.at(jp) = 1, throw_msg.c_str(), json::out_of_range&);
+                CHECK_THROWS_WITH_AS(j_const.at(jp) == 1, throw_msg.c_str(), json::out_of_range&);
+
+                CHECK(!j.contains(jp));
+                CHECK(!j_const.contains(jp));
             }
 
             // on some machines, the check below is not constant
@@ -334,6 +372,10 @@ TEST_CASE("JSON pointers")
 
                 CHECK_THROWS_WITH_AS(j[jp] = 1, throw_msg.c_str(), json::out_of_range&);
                 CHECK_THROWS_WITH_AS(j_const[jp] == 1, throw_msg.c_str(), json::out_of_range&);
+
+                // #5395: contains() must not throw for a reference token exceeding size_type's max
+                CHECK(!j.contains(jp));
+                CHECK(!j_const.contains(jp));
             }
 
             DOCTEST_MSVC_SUPPRESS_WARNING_POP


### PR DESCRIPTION
## Summary

`contains(const json_pointer&)` is documented (`docs/mkdocs/docs/api/basic_json/contains.md`) to never throw. However, when a JSON Pointer reference token consists only of digits (so it looks like a valid array index) but its numeric value cannot be represented — either because it exceeds `size_type`'s maximum, or because it exceeds `ULLONG_MAX` and causes `strtoull()` to set `errno` to `ERANGE` — `contains()` fell through to the internal `array_index()` helper, which throws `out_of_range.410` or `out_of_range.404` respectively.

```cpp
json arr = json::array({1, 2, 3});
arr.contains(json::json_pointer("/18446744073709551615")); // used to throw out_of_range.410
arr.contains(json::json_pointer("/99999999999999999999")); // used to throw out_of_range.404 (ERANGE)
```

Both should simply return `false`, the same way `contains()` already handles other malformed tokens (a leading zero like `"00"`, non-numeric tokens like `"one"`, `"+1"`, `"-"`, etc.) without throwing.

### Fix

In `include/nlohmann/detail/json_pointer.hpp`, the array branch of `json_pointer::contains()` already validates a reference token's *characters* before calling `array_index()`. This adds a check of the token's *magnitude* in the same style: it parses the token with `strtoull()` and returns `false` when `errno == ERANGE` or when the parsed value is not smaller than `size_type`'s maximum — before `array_index()` (which performs the same parse again and throws in these cases) is ever called.

`operator[]`, `at()`, and every other consumer of `json_pointer` are untouched and keep throwing `out_of_range.404`/`.410` for these inputs, since those are documented to throw — only `contains()`'s contract required a fix.

### Changes
- `include/nlohmann/detail/json_pointer.hpp`: pre-check the numeric magnitude of an array reference token in `json_pointer::contains()` before delegating to `array_index()`, returning `false` instead of letting the exception propagate.
- `single_include/nlohmann/json.hpp`: regenerated via `make amalgamate`.
- `tests/src/unit-json_pointer.cpp`: added test cases for a token exceeding `size_type`'s max, a token exceeding `ULLONG_MAX` (forcing `ERANGE`), verifying `contains()` returns `false` for both without throwing, while confirming `operator[]`/`at()` still correctly throw for the very same inputs (regression guard), and that the existing malformed-token tests (`"00"`, `"one"`, `"+1"`, `"1+1"`, `"-"`) are unaffected.

## Breaking change?

No. This is not a breaking change to the public API. `contains(const json_pointer&)` is documented to never throw; the old behavior (throwing `out_of_range.410`/`.404` for these inputs) violated that documented contract. This fix only changes behavior for the specific edge case of a purely numeric, syntactically valid array-index token that cannot be represented as a size — previously an uncaught exception, now a `false` return, per the documented API. `operator[]`, `at()`, and all other json_pointer consumers keep their existing, documented throwing behavior; no signatures changed.

Fixes #5395

— opened by Claude Code on behalf of @nlohmann