### PR TITLE
Relax the UBJSON fuzzer's round-trip check from byte-exact to value-exact

### DIFF
--- a/tests/src/fuzzer-parse_ubjson.cpp
+++ b/tests/src/fuzzer-parse_ubjson.cpp
@@ -21,6 +21,18 @@ array data, it performs the following steps:
 - j4 = from_ubjson(vec3)
 - assert(j1 == j4)
 
+Re-serializing j2/j3/j4 with the same use_size/use_type settings is checked
+for value-stability rather than byte-exact stability: from_ubjson(to_ubjson(j2))
+must equal j2 (and likewise for j3, j4). Byte-exact stability does not hold in
+general, because a UBJSON value can lose type fidelity across a round trip
+(e.g. a binary_t value serialized without the optimized "$U#" array header is
+parsed back as a plain array of numbers, see #5398 and the discussion on
+PR #5494) - the numeric value is preserved, but the writer's smallest-type
+selection for the now-plain numbers may legitimately pick a different, but
+equally valid, single-byte type marker than the dedicated binary-data writer
+would have. Both encodings are valid UBJSON and both decode to the same
+value, so this is not treated as a round-trip failure here.
+
 The provided function `LLVMFuzzerTestOneInput` can be used in different fuzzer
 drivers.
 */
@@ -56,10 +68,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
             json const j3 = json::from_ubjson(vec3);
             json const j4 = json::from_ubjson(vec4);
 
-            // serializations must match
-            assert(json::to_ubjson(j2, false, false) == vec2);
-            assert(json::to_ubjson(j3, true, false) == vec3);
-            assert(json::to_ubjson(j4, true, true) == vec4);
+            // re-serializing must be value-stable (see the note above on why
+            // byte-exact stability is not guaranteed in general)
+            assert(json::from_ubjson(json::to_ubjson(j2, false, false)) == j2);
+            assert(json::from_ubjson(json::to_ubjson(j3, true, false)) == j3);
+            assert(json::from_ubjson(json::to_ubjson(j4, true, true)) == j4);
         }
         catch (const json::parse_error&)
         {


### PR DESCRIPTION
## Summary

PR #5494 fixed an OSS-Fuzz crash in `tests/src/fuzzer-parse_bjdata.cpp` that turned out to be caused by an overly-strict, pre-existing assertion rather than the bug it was ostensibly fixing: `assert(to_bjdata(j2, ...) == vec2)` assumes byte-exact round-trip stability, which BJData does not actually guarantee. A `binary_t` value serialized through the non-optimized (`$U#`-less) array encoding is parsed back as a plain array of numbers, since `from_bjdata()` can't distinguish "array of uint8 numbers" from "array of bytes" without the optimized header — and re-serializing that plain array goes through the generic smallest-type writer, which (long predating that PR, and correctly) prefers the `i` (int8) marker over `U` (uint8) for small positive integers. Both encodings are valid and decode to the same value, so this isn't a real round-trip failure.

`tests/src/fuzzer-parse_ubjson.cpp` has the identical byte-exact assertion pattern and is susceptible to the exact same divergence — it just hasn't been fuzzed into failing yet. This PR applies the same fix preventively: mirrors PR #5494's change by relaxing the round-trip checks from byte-exact (`to_ubjson(j2, ...) == vec2`) to value-exact (`from_ubjson(to_ubjson(j2, ...)) == j2`), with a comment explaining why byte-exact stability isn't guaranteed.

Verified with a standalone `binary_t` round-trip through `to_ubjson()`/`from_ubjson()` (non-optimized encoding) that the byte-exact assertion fails (`U`/`i` marker divergence) while the value-exact one holds. Ran the full `unit-ubjson.cpp` suite offline: 691,563/691,564 assertions pass, with the sole failure being the expected stub/test-data-download check (not a regression).

## Breaking change?

No breaking changes — this is a test-only change (`tests/src/fuzzer-parse_ubjson.cpp`), no changes under `include/`.

## Test plan

- [x] Standalone repro: `json::binary_t` round-tripped through `to_ubjson`/`from_ubjson` via non-optimized encoding reproduces the `U`/`i` marker divergence pre-fix, and is correctly tolerated by the new value-exact assertion post-fix.
- [x] `tests/src/unit-ubjson.cpp` run offline (stubbed `test_data.hpp`): 691,563/691,564 assertions pass; the one failure is the expected "test data not downloaded" stub case.