### PR TITLE
Fix/msgpack size limit greater than uint32

### DIFF
--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -580,8 +580,8 @@ class binary_writer
                 }
                 else
                 {
-                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
-                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(N), " exceeds maximum of ",
+                                                    std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
                 }
 
                 // step 2: write the string
@@ -614,8 +614,8 @@ class binary_writer
                 }
                 else
                 {
-                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
-                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(N), " exceeds maximum of ",
+                                                    std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
                 }
 
                 // step 2: write each element
@@ -696,8 +696,8 @@ class binary_writer
                 }
                 else
                 {
-                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
-                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(N), " exceeds maximum of ",
+                                                    std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
                 }
 
                 // step 1.5: if this is an ext type, write the subtype
@@ -737,8 +737,8 @@ class binary_writer
                 }
                 else
                 {
-                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
-                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(N), " exceeds maximum of ",
+                                                    std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
                 }
 
                 // step 2: write each element

--- a/include/nlohmann/detail/output/binary_writer.hpp
+++ b/include/nlohmann/detail/output/binary_writer.hpp
@@ -578,6 +578,11 @@ class binary_writer
                     oa->write_character(to_char_type(0xDB));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
+                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
+                }
 
                 // step 2: write the string
                 oa->write_characters(
@@ -606,6 +611,11 @@ class binary_writer
                     // array 32
                     oa->write_character(to_char_type(0xDD));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
+                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
                 }
 
                 // step 2: write each element
@@ -684,6 +694,11 @@ class binary_writer
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint32_t>(N));
                 }
+                else
+                {
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
+                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
+                }
 
                 // step 1.5: if this is an ext type, write the subtype
                 if (use_ext)
@@ -719,6 +734,11 @@ class binary_writer
                     // map 32
                     oa->write_character(to_char_type(0xDF));
                     write_number(static_cast<std::uint32_t>(N));
+                }
+                else
+                {
+                    JSON_THROW(out_of_range::create(412, concat("MessagePack size ", std::to_string(size), " exceeds maximum of ",
+                                                      std::to_string((std::numeric_limits<std::uint32_t>::max)())), &j));
                 }
 
                 // step 2: write each element

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1968,29 +1968,167 @@ TEST_CASE("MessagePack with std::byte")
     }
 }
 
-namespace
-{
 template<typename T, typename A = std::allocator<T>>
 struct huge_array : std::vector<T, A>
 {
-    using std::vector<T, A>::vector;
-    std::size_t size() const noexcept { return std::size_t{1} << 33; }
+    using base = std::vector<T, A>;
+    using base::base;
+
+    bool fake_size = false;
+
+    std::size_t size() const noexcept
+    {
+        if (fake_size)
+        {
+            return (std::numeric_limits<std::uint32_t>::max)() + 1ULL;
+        }
+
+        return base::size();
+    }
 };
 
-using huge_json = nlohmann::basic_json<
-    std::map, huge_array, std::string, bool, std::int64_t, std::uint64_t,
-    double, std::allocator, nlohmann::adl_serializer, std::vector<std::uint8_t>, void>;
-} // namespace
+using huge_json = nlohmann::basic_json <
+                  std::map, huge_array, std::string, bool, std::int64_t, std::uint64_t,
+                  double, std::allocator, nlohmann::adl_serializer,
+                  std::vector<std::uint8_t>, void >;
 
-TEST_CASE("MessagePack Sizes above uint32 limit")
+TEST_CASE("MessagePack Size above uint32 for array")
 {
     huge_json j = huge_json::array();
+
     j.push_back(1);
     j.push_back(2);
     j.push_back(3);
 
-    CHECK_THROWS_WITH_AS(_ = huge_json::to_msgpack(j),
-        "[json.exception.out_of_range.412] MessagePack size 8589934592 exceeds maximum of 4294967295",
+    auto& array = j.get_ref<huge_json::array_t&>();
+    array.fake_size = true;
+
+    CHECK_THROWS_WITH_AS(
+        huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 4294967296 exceeds maximum of 4294967295",
+        json::out_of_range&);
+
+    array.fake_size = false;
+}
+
+template<typename K, typename V,
+         typename C = std::less<K>,
+         typename A = std::allocator<std::pair<const K, V>>>
+                                     struct huge_map : std::map<K, V, C, A>
+{
+    using base = std::map<K, V, C, A>;
+    using base::base;
+
+    bool fake_size = false;
+
+    std::size_t size() const noexcept
+    {
+        if (fake_size)
+        {
+            return static_cast<std::size_t>(UINT32_MAX) + 1ULL;
+        }
+
+        return base::size();
+    }
+};
+
+TEST_CASE("MessagePack Size above uint32 for object")
+{
+    using huge_json = nlohmann::basic_json <
+                      huge_map,
+                      std::vector,
+                      std::string,
+                      bool,
+                      std::int64_t,
+                      std::uint64_t,
+                      double,
+                      std::allocator,
+                      nlohmann::adl_serializer,
+                      std::vector<std::uint8_t>,
+                      void >;
+
+    huge_json j = huge_json::object();
+
+    j["one"] = 1;
+    j["two"] = 2;
+
+    auto& object = j.get_ref<huge_json::object_t&>();
+    object.fake_size = true;
+
+    CHECK_THROWS_WITH_AS(
+        huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 4294967296 exceeds maximum of 4294967295",
+        json::out_of_range&);
+
+    object.fake_size = false;
+}
+
+struct huge_string : std::string
+{
+    using std::string::string;
+
+    std::size_t size() const noexcept
+    {
+        return static_cast<std::size_t>(UINT32_MAX) + 1ULL;
+    }
+};
+
+TEST_CASE("MessagePack Size above uint32 for string")
+{
+    using huge_json = nlohmann::basic_json <
+                      std::map,
+                      std::vector,
+                      huge_string,
+                      bool,
+                      std::int64_t,
+                      std::uint64_t,
+                      double,
+                      std::allocator,
+                      nlohmann::adl_serializer,
+                      std::vector<std::uint8_t>,
+                      void >;
+
+    huge_json j = "hello";
+
+    CHECK_THROWS_WITH_AS(
+        huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 4294967296 exceeds maximum of 4294967295",
+        json::out_of_range&);
+}
+
+struct huge_binary : std::vector<std::uint8_t>
+{
+    using std::vector<std::uint8_t>::vector;
+
+    std::size_t size() const noexcept
+    {
+        return static_cast<std::size_t>(UINT32_MAX) + 1ULL;
+    }
+};
+
+TEST_CASE("MessagePack Size above uint32 for binary")
+{
+    using huge_json = nlohmann::basic_json <
+                      std::map,
+                      std::vector,
+                      std::string,
+                      bool,
+                      std::int64_t,
+                      std::uint64_t,
+                      double,
+                      std::allocator,
+                      nlohmann::adl_serializer,
+                      huge_binary,
+                      void >;
+
+    huge_json j = huge_json::binary(huge_binary{});
+
+    j.get_binary().push_back(0x01);
+    j.get_binary().push_back(0x02);
+
+    CHECK_THROWS_WITH_AS(
+        huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 4294967296 exceeds maximum of 4294967295",
         json::out_of_range&);
 }
 

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -1967,4 +1967,31 @@ TEST_CASE("MessagePack with std::byte")
         }
     }
 }
+
+namespace
+{
+template<typename T, typename A = std::allocator<T>>
+struct huge_array : std::vector<T, A>
+{
+    using std::vector<T, A>::vector;
+    std::size_t size() const noexcept { return std::size_t{1} << 33; }
+};
+
+using huge_json = nlohmann::basic_json<
+    std::map, huge_array, std::string, bool, std::int64_t, std::uint64_t,
+    double, std::allocator, nlohmann::adl_serializer, std::vector<std::uint8_t>, void>;
+} // namespace
+
+TEST_CASE("MessagePack Sizes above uint32 limit")
+{
+    huge_json j = huge_json::array();
+    j.push_back(1);
+    j.push_back(2);
+    j.push_back(3);
+
+    CHECK_THROWS_WITH_AS(_ = huge_json::to_msgpack(j),
+        "[json.exception.out_of_range.412] MessagePack size 8589934592 exceeds maximum of 4294967295",
+        json::out_of_range&);
+}
+
 #endif


### PR DESCRIPTION
Fixes :  https://github.com/nlohmann/json/issues/5320

to_msgpack() now throws out_of_range.412 when a string, array, binary, or object reports a size above UINT32_MAX, matching the documented MessagePack limit and the BSON fix pattern from https://github.com/nlohmann/json/pull/5314.

Adds a regression test using a container type that reports an oversized size() without allocating multi-gigabyte data.
------------------------------------------------------------------------------------------------------------------
- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an [existing issue](https://github.com/nlohmann/json/issues) is referenced.
- [x] The [Code coverage](https://coveralls.io/github/nlohmann/json) remained at 100%. A test case for every new line of code.
- [x] If applicable, the [documentation](https://json.nlohmann.me) is updated.
- [x] The source code is amalgamated by running `make amalgamate`.
