### PR TITLE
Remove unused <iomanip> include

### DIFF
--- a/include/nlohmann/detail/output/serializer.hpp
+++ b/include/nlohmann/detail/output/serializer.hpp
@@ -18,7 +18,6 @@
 #include <cstdio> // snprintf
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
-#include <iomanip> // setfill, setw
 #include <type_traits> // is_same
 #include <utility> // move
 

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -18970,7 +18970,6 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <cstdio> // snprintf
 #include <limits> // numeric_limits
 #include <string> // string, char_traits
-#include <iomanip> // setfill, setw
 #include <type_traits> // is_same
 #include <utility> // move
 


### PR DESCRIPTION
## Summary

Remove the unused `<iomanip>` include from `include/nlohmann/detail/output/serializer.hpp` and update the corresponding single header entry. The serializer implementation does not use any `<iomanip>` manipulators, so this removes an unconditional standard-library include without changing the public API.

This addresses the concrete cleanup described in #5294.

## Validation

- Release CMake configure and build passed with `JSON_BuildTests=ON` and `JSON_CI=ON`.
- `ctest` passed: 109/109 tests.
- The single-header integration executable passed.
- `git diff --check` passed.
- A word-boundary search found no `<iomanip>` or `setw`/`setfill` use in the production headers after the change.

No new code paths were added, so no test file was needed and coverage is unchanged.

## Checklist

- [x] The changes are described in detail, both the what and why.
- [x] The code coverage remains unchanged; this is a two-line generated/source include removal.
- [x] No documentation update is needed.
- [x] The single header was updated with the source change.
