### PR TITLE
Prevent stack overflow in json_pointer::flatten

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -910,7 +910,7 @@ class json_pointer
                         {
                             const auto index = i - 1;
                             stack.emplace_back(detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
-                                                &current.value->m_data.m_value.array->operator[](index));
+                                               &current.value->m_data.m_value.array->operator[](index));
                         }
                     }
                     break;

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -876,58 +876,81 @@ class json_pointer
                         const BasicJsonType& value,
                         BasicJsonType& result)
     {
-        switch (value.type())
+        struct flatten_task
         {
-            case detail::value_t::array:
-            {
-                if (value.m_data.m_value.array->empty())
-                {
-                    // flatten empty array as null
-                    result[reference_string] = nullptr;
-                }
-                else
-                {
-                    // iterate array and use index as a reference string
-                    for (std::size_t i = 0; i < value.m_data.m_value.array->size(); ++i)
-                    {
-                        flatten(detail::concat<string_t>(reference_string, '/', std::to_string(i)),
-                                value.m_data.m_value.array->operator[](i), result);
-                    }
-                }
-                break;
-            }
+            string_t reference_string;
+            const BasicJsonType* value;
+        };
 
-            case detail::value_t::object:
-            {
-                if (value.m_data.m_value.object->empty())
-                {
-                    // flatten empty object as null
-                    result[reference_string] = nullptr;
-                }
-                else
-                {
-                    // iterate object and use keys as reference string
-                    for (const auto& element : *value.m_data.m_value.object)
-                    {
-                        flatten(detail::concat<string_t>(reference_string, '/', detail::escape(element.first)), element.second, result);
-                    }
-                }
-                break;
-            }
+        std::vector<flatten_task> stack;
+        stack.push_back({reference_string, &value});
 
-            case detail::value_t::null:
-            case detail::value_t::string:
-            case detail::value_t::boolean:
-            case detail::value_t::number_integer:
-            case detail::value_t::number_unsigned:
-            case detail::value_t::number_float:
-            case detail::value_t::binary:
-            case detail::value_t::discarded:
-            default:
+        while (!stack.empty())
+        {
+            auto current = std::move(stack.back());
+            stack.pop_back();
+
+            switch (current.value->type())
             {
-                // add a primitive value with its reference string
-                result[reference_string] = value;
-                break;
+                case detail::value_t::array:
+                {
+                    if (current.value->m_data.m_value.array->empty())
+                    {
+                        // flatten empty array as null
+                        result[current.reference_string] = nullptr;
+                    }
+                    else
+                    {
+                        // iterate array and use index as a reference string
+                        for (std::size_t i = current.value->m_data.m_value.array->size(); i > 0; --i)
+                        {
+                            const auto index = i - 1;
+                            stack.push_back({detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
+                                             &current.value->m_data.m_value.array->operator[](index)});
+                        }
+                    }
+                    break;
+                }
+
+                case detail::value_t::object:
+                {
+                    if (current.value->m_data.m_value.object->empty())
+                    {
+                        // flatten empty object as null
+                        result[current.reference_string] = nullptr;
+                    }
+                    else
+                    {
+                        // iterate object and use keys as reference string
+                        std::vector<flatten_task> children;
+                        children.reserve(current.value->m_data.m_value.object->size());
+                        for (const auto& element : *current.value->m_data.m_value.object)
+                        {
+                            children.push_back({detail::concat<string_t>(current.reference_string, '/', detail::escape(element.first)),
+                                                &element.second});
+                        }
+                        for (auto it = children.rbegin(); it != children.rend(); ++it)
+                        {
+                            stack.push_back(std::move(*it));
+                        }
+                    }
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                {
+                    // add a primitive value with its reference string
+                    result[current.reference_string] = *current.value;
+                    break;
+                }
             }
         }
     }

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -880,10 +880,14 @@ class json_pointer
         {
             string_t reference_string;
             const BasicJsonType* value;
+
+            flatten_task(string_t reference_string_, const BasicJsonType* value_)
+                : reference_string(std::move(reference_string_)), value(value_)
+            {}
         };
 
         std::vector<flatten_task> stack;
-        stack.push_back({reference_string, &value});
+        stack.emplace_back(reference_string, &value);
 
         while (!stack.empty())
         {
@@ -905,8 +909,8 @@ class json_pointer
                         for (std::size_t i = current.value->m_data.m_value.array->size(); i > 0; --i)
                         {
                             const auto index = i - 1;
-                            stack.push_back({detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
-                                             &current.value->m_data.m_value.array->operator[](index)});
+                            stack.emplace_back(detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
+                                                &current.value->m_data.m_value.array->operator[](index));
                         }
                     }
                     break;
@@ -926,12 +930,13 @@ class json_pointer
                         children.reserve(current.value->m_data.m_value.object->size());
                         for (const auto& element : *current.value->m_data.m_value.object)
                         {
-                            children.push_back({detail::concat<string_t>(current.reference_string, '/', detail::escape(element.first)),
-                                                &element.second});
+                            children.emplace_back(detail::concat<string_t>(current.reference_string, '/', detail::escape(element.first)),
+                                                  &element.second);
                         }
+                        // Push children in reverse so the LIFO stack preserves object iteration order.
                         for (auto it = children.rbegin(); it != children.rend(); ++it)
                         {
-                            stack.push_back(std::move(*it));
+                            stack.emplace_back(std::move(*it));
                         }
                     }
                     break;

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -881,7 +881,7 @@ class json_pointer
             string_t reference_string;
             const BasicJsonType* value;
 
-            flatten_task(string_t reference_string_, const BasicJsonType* value_)
+            flatten_task(string_t reference_string_, const BasicJsonType* value_) noexcept
                 : reference_string(std::move(reference_string_)), value(value_)
             {}
         };

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16660,58 +16660,81 @@ class json_pointer
                         const BasicJsonType& value,
                         BasicJsonType& result)
     {
-        switch (value.type())
+        struct flatten_task
         {
-            case detail::value_t::array:
-            {
-                if (value.m_data.m_value.array->empty())
-                {
-                    // flatten empty array as null
-                    result[reference_string] = nullptr;
-                }
-                else
-                {
-                    // iterate array and use index as a reference string
-                    for (std::size_t i = 0; i < value.m_data.m_value.array->size(); ++i)
-                    {
-                        flatten(detail::concat<string_t>(reference_string, '/', std::to_string(i)),
-                                value.m_data.m_value.array->operator[](i), result);
-                    }
-                }
-                break;
-            }
+            string_t reference_string;
+            const BasicJsonType* value;
+        };
 
-            case detail::value_t::object:
-            {
-                if (value.m_data.m_value.object->empty())
-                {
-                    // flatten empty object as null
-                    result[reference_string] = nullptr;
-                }
-                else
-                {
-                    // iterate object and use keys as reference string
-                    for (const auto& element : *value.m_data.m_value.object)
-                    {
-                        flatten(detail::concat<string_t>(reference_string, '/', detail::escape(element.first)), element.second, result);
-                    }
-                }
-                break;
-            }
+        std::vector<flatten_task> stack;
+        stack.push_back({reference_string, &value});
 
-            case detail::value_t::null:
-            case detail::value_t::string:
-            case detail::value_t::boolean:
-            case detail::value_t::number_integer:
-            case detail::value_t::number_unsigned:
-            case detail::value_t::number_float:
-            case detail::value_t::binary:
-            case detail::value_t::discarded:
-            default:
+        while (!stack.empty())
+        {
+            auto current = std::move(stack.back());
+            stack.pop_back();
+
+            switch (current.value->type())
             {
-                // add a primitive value with its reference string
-                result[reference_string] = value;
-                break;
+                case detail::value_t::array:
+                {
+                    if (current.value->m_data.m_value.array->empty())
+                    {
+                        // flatten empty array as null
+                        result[current.reference_string] = nullptr;
+                    }
+                    else
+                    {
+                        // iterate array and use index as a reference string
+                        for (std::size_t i = current.value->m_data.m_value.array->size(); i > 0; --i)
+                        {
+                            const auto index = i - 1;
+                            stack.push_back({detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
+                                             &current.value->m_data.m_value.array->operator[](index)});
+                        }
+                    }
+                    break;
+                }
+
+                case detail::value_t::object:
+                {
+                    if (current.value->m_data.m_value.object->empty())
+                    {
+                        // flatten empty object as null
+                        result[current.reference_string] = nullptr;
+                    }
+                    else
+                    {
+                        // iterate object and use keys as reference string
+                        std::vector<flatten_task> children;
+                        children.reserve(current.value->m_data.m_value.object->size());
+                        for (const auto& element : *current.value->m_data.m_value.object)
+                        {
+                            children.push_back({detail::concat<string_t>(current.reference_string, '/', detail::escape(element.first)),
+                                                &element.second});
+                        }
+                        for (auto it = children.rbegin(); it != children.rend(); ++it)
+                        {
+                            stack.push_back(std::move(*it));
+                        }
+                    }
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                {
+                    // add a primitive value with its reference string
+                    result[current.reference_string] = *current.value;
+                    break;
+                }
             }
         }
     }

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16664,10 +16664,14 @@ class json_pointer
         {
             string_t reference_string;
             const BasicJsonType* value;
+
+            flatten_task(string_t reference_string_, const BasicJsonType* value_)
+                : reference_string(std::move(reference_string_)), value(value_)
+            {}
         };
 
         std::vector<flatten_task> stack;
-        stack.push_back({reference_string, &value});
+        stack.emplace_back(reference_string, &value);
 
         while (!stack.empty())
         {
@@ -16689,8 +16693,8 @@ class json_pointer
                         for (std::size_t i = current.value->m_data.m_value.array->size(); i > 0; --i)
                         {
                             const auto index = i - 1;
-                            stack.push_back({detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
-                                             &current.value->m_data.m_value.array->operator[](index)});
+                            stack.emplace_back(detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
+                                                &current.value->m_data.m_value.array->operator[](index));
                         }
                     }
                     break;
@@ -16710,12 +16714,13 @@ class json_pointer
                         children.reserve(current.value->m_data.m_value.object->size());
                         for (const auto& element : *current.value->m_data.m_value.object)
                         {
-                            children.push_back({detail::concat<string_t>(current.reference_string, '/', detail::escape(element.first)),
-                                                &element.second});
+                            children.emplace_back(detail::concat<string_t>(current.reference_string, '/', detail::escape(element.first)),
+                                                  &element.second);
                         }
+                        // Push children in reverse so the LIFO stack preserves object iteration order.
                         for (auto it = children.rbegin(); it != children.rend(); ++it)
                         {
-                            stack.push_back(std::move(*it));
+                            stack.emplace_back(std::move(*it));
                         }
                     }
                     break;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16694,7 +16694,7 @@ class json_pointer
                         {
                             const auto index = i - 1;
                             stack.emplace_back(detail::concat<string_t>(current.reference_string, '/', std::to_string(index)),
-                                                &current.value->m_data.m_value.array->operator[](index));
+                                               &current.value->m_data.m_value.array->operator[](index));
                         }
                     }
                     break;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -16665,7 +16665,7 @@ class json_pointer
             string_t reference_string;
             const BasicJsonType* value;
 
-            flatten_task(string_t reference_string_, const BasicJsonType* value_)
+            flatten_task(string_t reference_string_, const BasicJsonType* value_) noexcept
                 : reference_string(std::move(reference_string_)), value(value_)
             {}
         };

--- a/tests/src/unit-regression2.cpp
+++ b/tests/src/unit-regression2.cpp
@@ -1571,4 +1571,14 @@ TEST_CASE("issue #5402 - update(merge_objects=true) overwrites a primitive with 
     CHECK(mixed == json({{"keep", {{"a", 1}, {"b", 2}}}, {"replace", {{"x", 2}}}}));
 }
 
+TEST_CASE("issue #5393 - flatten deeply nested values without overflowing the stack")
+{
+    constexpr std::size_t depth = 100000;
+    const auto deep = json::parse(std::string(depth, '[') + "0" + std::string(depth, ']'));
+    const auto flattened = deep.flatten();
+    CHECK(flattened.size() == 1);
+    CHECK(flattened.begin().value() == 0);
+    CHECK(flattened.begin().key().size() == depth * 2);
+}
+
 DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
## Summary

Replace the recursive implementation of `json_pointer::flatten()` with an explicit work stack so deeply nested values no longer exhaust the call stack. Existing traversal order and empty-container handling are preserved.

This addresses the `flatten()` portion of #5393.

## Validation

- `test-regression2_cpp11` and `test-regression2_cpp20` pass, including a 100,000-level nesting regression.
- `test-json_pointer_cpp11` and `test-json_pointer_cpp20` pass.
- The generated-header `single_detail_json_pointer` smoke executable passes.
- `git diff --check` passes.

- [x] The changes are described in detail, both the what and why.
- [x] An existing issue is referenced.
- [x] The source code is amalgamated.
