### PR TITLE
Cut test suite runtime in binary roundtrips and integer sweeps

### DIFF
--- a/tests/src/test_utils.hpp
+++ b/tests/src/test_utils.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint> // uint8_t
+#include <cstddef> // size_t
 #include <fstream> // ifstream, istreambuf_iterator, ios
 #include <vector> // vector
 
@@ -23,6 +24,23 @@ namespace utils
 // ordinary function call does.
 template<typename T>
 inline void ignore_return_value(T&& /*unused*/) noexcept {}
+
+// Walk [first, last] inclusive with a stride, always visiting last.
+// stride 7 is coprime to 256, so every low-byte residue is still hit.
+template<typename T>
+T next_integer_sample(T i, T last, T stride)
+{
+    if (i >= last)
+    {
+        return static_cast<T>(last + 1);
+    }
+    if (stride > 0 && i > static_cast<T>(last - stride))
+    {
+        return last;
+    }
+    const T n = static_cast<T>(i + stride);
+    return n < last ? n : last;
+}
 
 inline std::vector<std::uint8_t> read_binary_file(const std::string& filename)
 {

--- a/tests/src/unit-binary_formats.cpp
+++ b/tests/src/unit-binary_formats.cpp
@@ -14,7 +14,7 @@ using nlohmann::json;
 #include <fstream>
 #include "make_test_data_available.hpp"
 
-TEST_CASE("Binary Formats" * doctest::skip())
+TEST_CASE("Binary Formats")
 {
     SECTION("canada.json")
     {
@@ -133,45 +133,6 @@ TEST_CASE("Binary Formats" * doctest::skip())
         CHECK((100.0 * double(ubjson_3_size) / double(json_size)) == Approx(84.963));
     }
 
-    SECTION("jeopardy.json")
-    {
-        const auto* filename = TEST_DATA_DIRECTORY "/jeopardy/jeopardy.json";
-        json j = json::parse(std::ifstream(filename));
-
-        const auto json_size = j.dump().size();
-        const auto bjdata_1_size = json::to_bjdata(j).size();
-        const auto bjdata_2_size = json::to_bjdata(j, true).size();
-        const auto bjdata_3_size = json::to_bjdata(j, true, true).size();
-        const auto bson_size = json::to_bson({{"", j}}).size(); // wrap array in object for BSON
-        const auto cbor_size = json::to_cbor(j).size();
-        const auto msgpack_size = json::to_msgpack(j).size();
-        const auto ubjson_1_size = json::to_ubjson(j).size();
-        const auto ubjson_2_size = json::to_ubjson(j, true).size();
-        const auto ubjson_3_size = json::to_ubjson(j, true, true).size();
-
-        CHECK(json_size == 52508728);
-        CHECK(bjdata_1_size == 50710965);
-        CHECK(bjdata_2_size == 51144830);
-        CHECK(bjdata_3_size == 51144830);
-        CHECK(bson_size == 56008520);
-        CHECK(cbor_size == 46187320);
-        CHECK(msgpack_size == 46158575);
-        CHECK(ubjson_1_size == 50710965);
-        CHECK(ubjson_2_size == 51144830);
-        CHECK(ubjson_3_size == 49861422);
-
-        CHECK((100.0 * double(json_size) / double(json_size)) == Approx(100.0));
-        CHECK((100.0 * double(bjdata_1_size) / double(json_size)) == Approx(96.576));
-        CHECK((100.0 * double(bjdata_2_size) / double(json_size)) == Approx(97.402));
-        CHECK((100.0 * double(bjdata_3_size) / double(json_size)) == Approx(97.402));
-        CHECK((100.0 * double(bson_size) / double(json_size)) == Approx(106.665));
-        CHECK((100.0 * double(cbor_size) / double(json_size)) == Approx(87.961));
-        CHECK((100.0 * double(msgpack_size) / double(json_size)) == Approx(87.906));
-        CHECK((100.0 * double(ubjson_1_size) / double(json_size)) == Approx(96.576));
-        CHECK((100.0 * double(ubjson_2_size) / double(json_size)) == Approx(97.402));
-        CHECK((100.0 * double(ubjson_3_size) / double(json_size)) == Approx(94.958));
-    }
-
     SECTION("sample.json")
     {
         const auto* filename = TEST_DATA_DIRECTORY "/json_testsuite/sample.json";
@@ -208,4 +169,43 @@ TEST_CASE("Binary Formats" * doctest::skip())
         CHECK((100.0 * double(ubjson_2_size) / double(json_size)) == Approx(89.264));
         CHECK((100.0 * double(ubjson_3_size) / double(json_size)) == Approx(89.450));
     }
+}
+
+TEST_CASE("Binary Formats jeopardy.json" * doctest::skip())
+{
+    const auto* filename = TEST_DATA_DIRECTORY "/jeopardy/jeopardy.json";
+    json j = json::parse(std::ifstream(filename));
+
+    const auto json_size = j.dump().size();
+    const auto bjdata_1_size = json::to_bjdata(j).size();
+    const auto bjdata_2_size = json::to_bjdata(j, true).size();
+    const auto bjdata_3_size = json::to_bjdata(j, true, true).size();
+    const auto bson_size = json::to_bson({{"", j}}).size(); // wrap array in object for BSON
+    const auto cbor_size = json::to_cbor(j).size();
+    const auto msgpack_size = json::to_msgpack(j).size();
+    const auto ubjson_1_size = json::to_ubjson(j).size();
+    const auto ubjson_2_size = json::to_ubjson(j, true).size();
+    const auto ubjson_3_size = json::to_ubjson(j, true, true).size();
+
+    CHECK(json_size == 52508728);
+    CHECK(bjdata_1_size == 50710965);
+    CHECK(bjdata_2_size == 51144830);
+    CHECK(bjdata_3_size == 51144830);
+    CHECK(bson_size == 56008520);
+    CHECK(cbor_size == 46187320);
+    CHECK(msgpack_size == 46158575);
+    CHECK(ubjson_1_size == 50710965);
+    CHECK(ubjson_2_size == 51144830);
+    CHECK(ubjson_3_size == 49861422);
+
+    CHECK((100.0 * double(json_size) / double(json_size)) == Approx(100.0));
+    CHECK((100.0 * double(bjdata_1_size) / double(json_size)) == Approx(96.576));
+    CHECK((100.0 * double(bjdata_2_size) / double(json_size)) == Approx(97.402));
+    CHECK((100.0 * double(bjdata_3_size) / double(json_size)) == Approx(97.402));
+    CHECK((100.0 * double(bson_size) / double(json_size)) == Approx(106.665));
+    CHECK((100.0 * double(cbor_size) / double(json_size)) == Approx(87.961));
+    CHECK((100.0 * double(msgpack_size) / double(json_size)) == Approx(87.906));
+    CHECK((100.0 * double(ubjson_1_size) / double(json_size)) == Approx(96.576));
+    CHECK((100.0 * double(ubjson_2_size) / double(json_size)) == Approx(97.402));
+    CHECK((100.0 * double(ubjson_3_size) / double(json_size)) == Approx(94.958));
 }

--- a/tests/src/unit-bjdata.cpp
+++ b/tests/src/unit-bjdata.cpp
@@ -417,7 +417,7 @@ TEST_CASE("BJData")
 
                 SECTION("-32768..-129 (int16)")
                 {
-                    for (int32_t i = -32768; i <= -129; ++i)
+                    for (int32_t i = -32768; i <= -129; i = utils::next_integer_sample(i, static_cast<int32_t>(-129), 7))
                     {
                         CAPTURE(i)
 
@@ -577,7 +577,7 @@ TEST_CASE("BJData")
 
                 SECTION("256..32767 (int16)")
                 {
-                    for (size_t i = 256; i <= 32767; ++i)
+                    for (size_t i = 256; i <= 32767; i = utils::next_integer_sample(i, static_cast<size_t>(32767), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -910,7 +910,7 @@ TEST_CASE("BJData")
 
                 SECTION("256..32767 (int16)")
                 {
-                    for (size_t i = 256; i <= 32767; ++i)
+                    for (size_t i = 256; i <= 32767; i = utils::next_integer_sample(i, static_cast<size_t>(32767), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -3962,45 +3962,27 @@ TEST_CASE("BJData roundtrips" * doctest::skip())
         {
             CAPTURE(filename)
 
+            std::ifstream f_json(filename);
+            const json j1 = json::parse(f_json);
+            auto packed = utils::read_binary_file(filename + ".bjdata");
+
             {
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse BJData file
-                auto packed = utils::read_binary_file(filename + ".bjdata");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_bjdata(packed));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": std::ifstream");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse BJData file
                 std::ifstream f_bjdata(filename + ".bjdata", std::ios::binary);
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_bjdata(f_bjdata));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": output to output adapters");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                json const j1 = json::parse(f_json);
-
-                // parse BJData file
-                auto packed = utils::read_binary_file(filename + ".bjdata");
-
                 {
                     INFO_WITH_TEMP(filename + ": output adapters: std::vector<uint8_t>");
                     std::vector<uint8_t> vec;

--- a/tests/src/unit-cbor.cpp
+++ b/tests/src/unit-cbor.cpp
@@ -290,7 +290,7 @@ TEST_CASE("CBOR")
 
                 SECTION("-65536..-257")
                 {
-                    for (int32_t i = -65536; i <= -257; ++i)
+                    for (int32_t i = -65536; i <= -257; i = utils::next_integer_sample(i, static_cast<int32_t>(-257), 7))
                     {
                         CAPTURE(i)
 
@@ -478,7 +478,7 @@ TEST_CASE("CBOR")
 
                 SECTION("256..65535")
                 {
-                    for (size_t i = 256; i <= 65535; ++i)
+                    for (size_t i = 256; i <= 65535; i = utils::next_integer_sample(i, static_cast<size_t>(65535), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -613,7 +613,7 @@ TEST_CASE("CBOR")
 
                 SECTION("-32768..-129 (int 16)")
                 {
-                    for (int16_t i = -32768; i <= static_cast<std::int16_t>(-129); ++i)
+                    for (int16_t i = -32768; i <= static_cast<std::int16_t>(-129); i = utils::next_integer_sample(i, static_cast<int16_t>(-129), static_cast<int16_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -718,7 +718,7 @@ TEST_CASE("CBOR")
 
                 SECTION("256..65535 (two-byte uint16_t)")
                 {
-                    for (size_t i = 256; i <= 65535; ++i)
+                    for (size_t i = 256; i <= 65535; i = utils::next_integer_sample(i, static_cast<size_t>(65535), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -2204,60 +2204,34 @@ TEST_CASE("CBOR roundtrips" * doctest::skip())
         {
             CAPTURE(filename)
 
+            std::ifstream f_json(filename);
+            const json j1 = json::parse(f_json);
+            const auto packed = utils::read_binary_file(filename + ".cbor");
+
             {
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse CBOR file
-                const auto packed = utils::read_binary_file(filename + ".cbor");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_cbor(packed));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": std::ifstream");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse CBOR file
                 std::ifstream f_cbor(filename + ".cbor", std::ios::binary);
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_cbor(f_cbor));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse CBOR file
-                const auto packed = utils::read_binary_file(filename + ".cbor");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_cbor({packed.data(), packed.size()}));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": output to output adapters");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                json const j1 = json::parse(f_json);
-
-                // parse CBOR file
-                const auto packed = utils::read_binary_file(filename + ".cbor");
-
                 if (exclude_packed.count(filename) == 0u)
                 {
                     {

--- a/tests/src/unit-large_json.cpp
+++ b/tests/src/unit-large_json.cpp
@@ -17,7 +17,7 @@ TEST_CASE("tests on very large JSONs")
 {
     SECTION("issue #1419 - Segmentation fault (stack overflow) due to unbounded recursion")
     {
-        const auto depth = 5000000;
+        const auto depth = 500000;
 
         std::string s(static_cast<std::size_t>(2 * depth), '[');
         std::fill(s.begin() + depth, s.end(), ']');

--- a/tests/src/unit-msgpack.cpp
+++ b/tests/src/unit-msgpack.cpp
@@ -255,7 +255,7 @@ TEST_CASE("MessagePack")
 
                 SECTION("256..65535 (int 16)")
                 {
-                    for (size_t i = 256; i <= 65535; ++i)
+                    for (size_t i = 256; i <= 65535; i = utils::next_integer_sample(i, static_cast<size_t>(65535), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -440,7 +440,7 @@ TEST_CASE("MessagePack")
 
                 SECTION("-32768..-129 (int 16)")
                 {
-                    for (int16_t i = -32768; i <= static_cast<std::int16_t>(-129); ++i)
+                    for (int16_t i = -32768; i <= static_cast<std::int16_t>(-129); i = utils::next_integer_sample(i, static_cast<int16_t>(-129), static_cast<int16_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -646,7 +646,7 @@ TEST_CASE("MessagePack")
 
                 SECTION("256..65535 (uint 16)")
                 {
-                    for (size_t i = 256; i <= 65535; ++i)
+                    for (size_t i = 256; i <= 65535; i = utils::next_integer_sample(i, static_cast<size_t>(65535), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -1822,60 +1822,34 @@ TEST_CASE("MessagePack roundtrips" * doctest::skip())
         {
             CAPTURE(filename)
 
+            std::ifstream f_json(filename);
+            const json j1 = json::parse(f_json);
+            auto packed = utils::read_binary_file(filename + ".msgpack");
+
             {
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse MessagePack file
-                auto packed = utils::read_binary_file(filename + ".msgpack");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_msgpack(packed));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": std::ifstream");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse MessagePack file
                 std::ifstream f_msgpack(filename + ".msgpack", std::ios::binary);
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_msgpack(f_msgpack));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse MessagePack file
-                auto packed = utils::read_binary_file(filename + ".msgpack");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_msgpack({packed.data(), packed.size()}));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": output to output adapters");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                json const j1 = json::parse(f_json);
-
-                // parse MessagePack file
-                auto packed = utils::read_binary_file(filename + ".msgpack");
-
                 if (exclude_packed.count(filename) == 0u)
                 {
                     {

--- a/tests/src/unit-ubjson.cpp
+++ b/tests/src/unit-ubjson.cpp
@@ -264,7 +264,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("-32768..-129 (int16)")
                 {
-                    for (int32_t i = -32768; i <= -129; ++i)
+                    for (int32_t i = -32768; i <= -129; i = utils::next_integer_sample(i, static_cast<int32_t>(-129), 7))
                     {
                         CAPTURE(i)
 
@@ -424,7 +424,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("256..32767 (int16)")
                 {
-                    for (size_t i = 256; i <= 32767; ++i)
+                    for (size_t i = 256; i <= 32767; i = utils::next_integer_sample(i, static_cast<size_t>(32767), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -630,7 +630,7 @@ TEST_CASE("UBJSON")
 
                 SECTION("256..32767 (int16)")
                 {
-                    for (size_t i = 256; i <= 32767; ++i)
+                    for (size_t i = 256; i <= 32767; i = utils::next_integer_sample(i, static_cast<size_t>(32767), static_cast<size_t>(7)))
                     {
                         CAPTURE(i)
 
@@ -2597,60 +2597,34 @@ TEST_CASE("UBJSON roundtrips" * doctest::skip())
         {
             CAPTURE(filename)
 
+            std::ifstream f_json(filename);
+            json const j1 = json::parse(f_json);
+            auto const packed = utils::read_binary_file(filename + ".ubjson");
+
             {
                 INFO_WITH_TEMP(filename + ": std::vector<uint8_t>");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                json const j1 = json::parse(f_json);
-
-                // parse UBJSON file
-                auto const packed = utils::read_binary_file(filename + ".ubjson");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_ubjson(packed));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": std::ifstream");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                json const j1 = json::parse(f_json);
-
-                // parse UBJSON file
                 std::ifstream f_ubjson(filename + ".ubjson", std::ios::binary);
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_ubjson(f_ubjson));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": uint8_t* and size");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                const json j1 = json::parse(f_json);
-
-                // parse UBJSON file
-                auto const packed = utils::read_binary_file(filename + ".ubjson");
                 json j2;
                 CHECK_NOTHROW(j2 = json::from_ubjson({packed.data(), packed.size()}));
-
-                // compare parsed JSON values
                 CHECK(j1 == j2);
             }
 
             {
                 INFO_WITH_TEMP(filename + ": output to output adapters");
-                // parse JSON file
-                std::ifstream f_json(filename);
-                json const j1 = json::parse(f_json);
-
-                // parse UBJSON file
-                auto const packed = utils::read_binary_file(filename + ".ubjson");
-
                 {
                     INFO_WITH_TEMP(filename + ": output adapters: std::vector<uint8_t>");
                     std::vector<uint8_t> vec;


### PR DESCRIPTION
See #5418.

Linux CI runs `--no-skip`, so the expensive binary roundtrip cases actually run there. Each corpus file was parsed four times (once per input adapter). Parse once and reuse it.

The 16-bit integer sweeps still prove width selection: stride 7 hits every low-byte residue, and the endpoints stay in the loop.

`unit-large_json` used depth 5,000,000 to check the non-recursive destructor from #1419. 500,000 is enough. `jeopardy.json` is ~500 MB of serialization output, so it is now its own skipped test; canada/twitter/citm/sample keep running.

Unicode byte sweeps are left to #5426.

- [x] The changes are described in detail, both the what and why.
- [x] If applicable, an existing issue is referenced.
- [x] The Code coverage remained at 100%. A test case for every new line of code.
- [x] If applicable, the documentation is updated.
- [x] The source code is amalgamated by running `make amalgamate`.