### PR TITLE
Fix two develop CI regressions: dump() nodiscard warning and binary-reader const-correctness

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -1434,7 +1434,7 @@ class binary_reader
                 // a copy, not a reference: it must stay valid across the
                 // pop_back() below, which destroys the container_stack element
                 // it would otherwise alias
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
                 bool at_end = false;
 
                 if (top.remaining != npos)
@@ -2211,7 +2211,7 @@ class binary_reader
             // would otherwise alias.
             for (;;)
             {
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
 
                 if (top.remaining != npos)
                 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13383,7 +13383,7 @@ class binary_reader
                 // a copy, not a reference: it must stay valid across the
                 // pop_back() below, which destroys the container_stack element
                 // it would otherwise alias
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
                 bool at_end = false;
 
                 if (top.remaining != npos)
@@ -14160,7 +14160,7 @@ class binary_reader
             // would otherwise alias.
             for (;;)
             {
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
 
                 if (top.remaining != npos)
                 {

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -469,7 +469,7 @@ TEST_CASE("serialization of strings (bulk fast path)")
     SECTION("invalid UTF-8 handling is unaffected by the fast path")
     {
         const json j = std::string("valid\xff" "more");
-        CHECK_THROWS_WITH_AS(j.dump(), "[json.exception.type_error.316] invalid UTF-8 byte at index 5: 0xFF", json::type_error&);
+        CHECK_THROWS_WITH_AS(utils::ignore_return_value(j.dump()), "[json.exception.type_error.316] invalid UTF-8 byte at index 5: 0xFF", json::type_error&);
         CHECK(j.dump(-1, ' ', false, json::error_handler_t::replace) == "\"valid\xef\xbf\xbd" "more\"");
         CHECK(j.dump(-1, ' ', true, json::error_handler_t::replace) == "\"valid\\ufffdmore\"");
         CHECK(j.dump(-1, ' ', false, json::error_handler_t::ignore) == "\"validmore\"");


### PR DESCRIPTION
## What & why

This PR bundles two small, independent `develop` regressions, both surfaced by this branch's own CI run.

### 1. `dump()`'s `[[nodiscard]]` return value discarded in a test

`tests/src/unit-serialization.cpp`'s "invalid UTF-8 handling is unaffected
by the fast path" section called `CHECK_THROWS_WITH_AS(j.dump(), ...)` only
to trigger and catch the expected exception, never using the return value.
`dump()` is `[[nodiscard]]`/`JSON_HEDLEY_WARN_UNUSED_RESULT`, so GCC's
pedantic CI build (`-Werror --all-warnings --extra-warnings`) rejects the
discarded result as `-Werror=unused-result`, which currently breaks
`ci_test_gcc` on `develop`.

**Fix:** wrap the call in `utils::ignore_return_value(...)`, matching every
other exception-only `dump()` call already in this file (see lines 90-115).

### 2. `container_frame top` not marked `const` in the CBOR/UBJSON readers

clang-tidy's `misc-const-correctness` check flagged two `container_frame top`
local copies in `include/nlohmann/detail/input/binary_reader.hpp` (CBOR's
`parse_cbor_internal()` and the UBJSON/BJData advance loop) as could-be-const.
`top` is deliberately a copy rather than a reference, so it stays valid
across the following `container_stack.pop_back()`, which destroys the
element it would otherwise alias — but it's never reassigned, and the only
mutation goes through `container_stack.back().remaining` directly. The BSON
sibling copy was already `const`; these two were a leftover oversight.
`ci_clang_tidy` currently fails on `develop` because of this.

**Fix:** add `const` to both declarations.

## Testing

- Fix 1: rebuilt with `clang++ -Werror=unused-result` to independently
  confirm the warning is gone.
- Fix 2: compiled and ran `unit-cbor`, `unit-ubjson`, `unit-bjdata`,
  `unit-bson`, and `unit-msgpack` directly against the modular headers;
  only the pre-existing stub-test-data failures (unrelated to this change)
  were observed.

## Public API impact

**No breaking changes.** Fix 1 is test-only. Fix 2 adds a `const` qualifier
to a function-local variable inside `binary_reader.hpp`, not part of the
public API.

- [x] The changes are described in detail, both the what and why.
- [ ] If applicable, an existing issue is referenced. _(none; both are build/lint regressions, not filed issues)_
- [x] The code coverage remained at 100%. No new lines were added.
- [ ] If applicable, the documentation is updated. _(no public API or option changes)_
- [x] The source code is amalgamated by running `make amalgamate`.
