### PR TITLE
Mark container_frame top as const in CBOR/UBJSON readers

### DIFF
--- a/include/nlohmann/detail/input/binary_reader.hpp
+++ b/include/nlohmann/detail/input/binary_reader.hpp
@@ -1434,7 +1434,7 @@ class binary_reader
                 // a copy, not a reference: it must stay valid across the
                 // pop_back() below, which destroys the container_stack element
                 // it would otherwise alias
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
                 bool at_end = false;
 
                 if (top.remaining != npos)
@@ -2211,7 +2211,7 @@ class binary_reader
             // would otherwise alias.
             for (;;)
             {
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
 
                 if (top.remaining != npos)
                 {

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -13383,7 +13383,7 @@ class binary_reader
                 // a copy, not a reference: it must stay valid across the
                 // pop_back() below, which destroys the container_stack element
                 // it would otherwise alias
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
                 bool at_end = false;
 
                 if (top.remaining != npos)
@@ -14160,7 +14160,7 @@ class binary_reader
             // would otherwise alias.
             for (;;)
             {
-                container_frame top = container_stack.back();
+                const container_frame top = container_stack.back();
 
                 if (top.remaining != npos)
                 {


### PR DESCRIPTION
## What

clang-tidy's `misc-const-correctness` check (surfaced via PR #5520's CI) flagged two `container_frame top` local copies in `binary_reader.hpp` as could-be-const: the CBOR reader's `parse_cbor_internal()` and the UBJSON/BJData advance loop. The BSON sibling copy was already `const`; these two were left mutable even though the only mutation is applied through `container_stack.back().remaining` directly, never through `top` itself.

## Why

`top` was deliberately made a copy (not a reference) so it stays valid across the `container_stack.pop_back()` call that follows, which destroys the element it would otherwise alias. It was never meant to be reassigned, so `const` is correct and closes the lint finding.

## Testing

Compiled and ran `unit-cbor`, `unit-ubjson`, `unit-bjdata`, `unit-bson`, and `unit-msgpack` directly against the modular headers; only the pre-existing stub-test-data failures (unrelated to this change) were observed.

## Breaking change?

No breaking changes — this is a `const` qualifier added to a function-local variable, not part of the public API.

Signed-off-by: Niels Lohmann <mail@nlohmann.me>